### PR TITLE
feat: 新增邮箱密码登录方式添加 Windsurf 账号

### DIFF
--- a/src-tauri/src/commands/windsurf.rs
+++ b/src-tauri/src/commands/windsurf.rs
@@ -163,6 +163,26 @@ pub async fn add_windsurf_account_with_token(
 }
 
 #[tauri::command]
+pub async fn add_windsurf_account_with_password(
+    app: AppHandle,
+    email: String,
+    password: String,
+) -> Result<WindsurfAccount, String> {
+    logger::log_info(&format!(
+        "[Windsurf Command] 邮箱密码登录开始: email={}",
+        email
+    ));
+    let payload = windsurf_oauth::build_payload_from_password(&email, &password).await?;
+    let account = windsurf_account::upsert_account(payload)?;
+    logger::log_info(&format!(
+        "[Windsurf Command] 邮箱密码登录成功: account_id={}, login={}",
+        account.id, account.github_login
+    ));
+    let _ = crate::modules::tray::update_tray_menu(&app);
+    Ok(account)
+}
+
+#[tauri::command]
 pub async fn update_windsurf_account_tags(
     account_id: String,
     tags: Vec<String>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -245,6 +245,7 @@ pub fn run() {
             commands::windsurf::windsurf_oauth_login_complete,
             commands::windsurf::windsurf_oauth_login_cancel,
             commands::windsurf::add_windsurf_account_with_token,
+            commands::windsurf::add_windsurf_account_with_password,
             commands::windsurf::update_windsurf_account_tags,
             commands::windsurf::get_windsurf_accounts_index_path,
             commands::windsurf::inject_windsurf_to_vscode,

--- a/src/services/windsurfService.ts
+++ b/src/services/windsurfService.ts
@@ -71,6 +71,11 @@ export async function addWindsurfAccountWithToken(githubAccessToken: string): Pr
   return await invoke('add_windsurf_account_with_token', { githubAccessToken });
 }
 
+/** 通过邮箱密码添加 Windsurf 账号 */
+export async function addWindsurfAccountWithPassword(email: string, password: string): Promise<WindsurfAccount> {
+  return await invoke('add_windsurf_account_with_password', { email, password });
+}
+
 export async function updateWindsurfAccountTags(accountId: string, tags: string[]): Promise<WindsurfAccount> {
   return await invoke('update_windsurf_account_tags', { accountId, tags });
 }


### PR DESCRIPTION
## 概述

新增第四种账号导入方式：**邮箱 + 密码登录**，通过 Firebase Authentication 实现。在"添加账号"弹窗中新增"邮箱密码"标签页，与 OAuth、Token/JSON、本地导入并列。

## 动机

部分用户通过邮箱密码管理 Windsurf 账号，无需依赖浏览器 OAuth 授权流程或手动提取 Token，直接输入邮箱密码即可完成账号添加。

## 实现

### 后端（Rust/Tauri）

- `windsurf_oauth.rs`：新增 `build_payload_from_password()`
  1. 调用 Firebase `signInWithPassword` API 获取 `idToken`
  2. 复用现有 `build_payload_from_firebase_token()` 流程（RegisterUser → GetOneTimeAuthToken → GetPlanStatus → GetUserStatus）
  3. 返回完整的 `WindsurfOAuthCompletePayload` 用于账号写入
- `commands/windsurf.rs`：新增 `add_windsurf_account_with_password` Tauri 命令
- `lib.rs`：注册新命令

### 前端（React/TypeScript）

- `windsurfService.ts`：新增 `addWindsurfAccountWithPassword()` 服务函数
- `WindsurfAccountsPage.tsx`：新增"邮箱密码"标签页
  - 邮箱和密码输入框
  - 登录按钮（含加载状态）
  - Firebase 常见错误的中文友好提示
  - 支持 Enter 快捷提交

## 错误处理

| Firebase 错误 | 用户提示 |
|---|---|
| `EMAIL_NOT_FOUND` | 邮箱不存在 |
| `INVALID_PASSWORD` | 密码错误 |
| `INVALID_LOGIN_CREDENTIALS` | 邮箱或密码错误 |
| `USER_DISABLED` | 账号已被禁用 |
| `TOO_MANY_ATTEMPTS_TRY_LATER` | 尝试次数过多，请稍后再试 |