### PR TITLE
feat: account refresh feedback, disable reason & verification error m…

### DIFF
--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -71,11 +71,13 @@ pub async fn set_current_account(app: tauri::AppHandle, account_id: String) -> R
 }
 
 #[tauri::command]
-pub async fn fetch_account_quota(account_id: String) -> AppResult<models::QuotaData> {
+pub async fn fetch_account_quota(account_id: String) -> AppResult<models::Account> {
     let mut account = modules::load_account(&account_id).map_err(AppError::Account)?;
     let quota = modules::fetch_quota_with_retry(&mut account, true).await?;
-    modules::update_account_quota(&account_id, quota.clone()).map_err(AppError::Account)?;
-    Ok(quota)
+    modules::update_account_quota(&account_id, quota).map_err(AppError::Account)?;
+    // 重载账号，包含写入的 quota_error 等最新信息
+    let updated_account = modules::load_account(&account_id).map_err(AppError::Account)?;
+    Ok(updated_account)
 }
 
 #[tauri::command]

--- a/src-tauri/src/models/account.rs
+++ b/src-tauri/src/models/account.rs
@@ -66,6 +66,22 @@ impl Account {
     pub fn update_quota(&mut self, quota: QuotaData) {
         self.quota = Some(quota);
     }
+
+    /// Token 失效（invalid_grant）导致的禁用，刷新成功后可自动解除
+    pub fn is_invalid_grant_disabled(&self) -> bool {
+        self.disabled
+            && self
+                .disabled_reason
+                .as_deref()
+                .is_some_and(|r| r.starts_with("invalid_grant"))
+    }
+
+    /// 清除禁用状态（三个字段一起重置）
+    pub fn clear_disabled(&mut self) {
+        self.disabled = false;
+        self.disabled_reason = None;
+        self.disabled_at = None;
+    }
 }
 
 /// 配额错误信息

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -1316,15 +1316,14 @@ pub async fn fetch_quota_with_retry(
         modules::quota::fetch_quota_for_token(&account.token, &account.email, skip_cache).await;
     match result {
         Ok(payload) => {
-            // 配额获取成功，说明 Token 有效，清除之前可能存在的 disabled 状态
-            if account.disabled {
+            // 配额获取成功，Token 有效
+            // 只解除 invalid_grant 类禁用，其他（verification_required / tos_violation / unknown）不解除
+            if account.is_invalid_grant_disabled() {
                 modules::logger::log_info(&format!(
                     "账号配额获取成功，自动解除禁用状态: {}",
                     account.email
                 ));
-                account.disabled = false;
-                account.disabled_reason = None;
-                account.disabled_at = None;
+                account.clear_disabled();
             }
             account.quota_error = payload.error.map(|err| QuotaErrorInfo {
                 code: err.code,

--- a/src-tauri/src/modules/wakeup_scheduler.rs
+++ b/src-tauri/src/modules/wakeup_scheduler.rs
@@ -626,20 +626,14 @@ async fn run_task_with_models(
                 .max(0) as u64;
             let (success, message) = match result {
                 Ok(resp) => {
-                    // 唤醒成功说明 Token 有效，清除 disabled 和 quota_error
+                    // 唤醒成功，账号可正常发起请求，解除所有类型的禁用
                     if let Ok(mut acc) = modules::load_account(&account.id) {
-                        let mut changed = false;
                         if acc.disabled {
                             modules::logger::log_info(&format!(
                                 "[WakeupScheduler] 唤醒成功，自动解除禁用状态: {}",
                                 acc.email
                             ));
-                            acc.disabled = false;
-                            acc.disabled_reason = None;
-                            acc.disabled_at = None;
-                            changed = true;
-                        }
-                        if changed {
+                            acc.clear_disabled();
                             acc.quota_error = None;
                             let _ = modules::save_account(&acc);
                         }

--- a/src-tauri/src/modules/wakeup_verification.rs
+++ b/src-tauri/src/modules/wakeup_verification.rs
@@ -453,27 +453,40 @@ pub async fn run_batch(
         match item.status.as_str() {
             STATUS_SUCCESS => {
                 success_count += 1;
-                // 唤醒成功说明 Token 有效，清除 disabled 和 quota_error
+                // 账号检测成功，账号完全可用，解除所有类型的禁用
+                // （包括 verification_required / tos_violation / invalid_grant）
                 if let Ok(mut account) = modules::load_account(&item.account_id) {
-                    let mut changed = false;
                     if account.disabled {
                         modules::logger::log_info(&format!(
-                            "[WakeupVerification] 唤醒成功，自动解除禁用状态: {}",
+                            "[WakeupVerification] 验证成功，自动解除禁用状态: {}",
                             account.email
                         ));
-                        account.disabled = false;
-                        account.disabled_reason = None;
-                        account.disabled_at = None;
-                        changed = true;
-                    }
-                    if changed {
+                        account.clear_disabled();
                         account.quota_error = None;
                         let _ = modules::save_account(&account);
                     }
                 }
             }
-            STATUS_VERIFICATION_REQUIRED => verification_required_count += 1,
-            STATUS_TOS_VIOLATION => tos_violation_count += 1,
+            STATUS_VERIFICATION_REQUIRED => {
+                verification_required_count += 1;
+                // 身份验证失败，禁用账号
+                if let Ok(mut account) = modules::load_account(&item.account_id) {
+                    account.disabled = true;
+                    account.disabled_reason = Some("verification_required".to_string());
+                    account.disabled_at = Some(chrono::Utc::now().timestamp());
+                    let _ = modules::save_account(&account);
+                }
+            }
+            STATUS_TOS_VIOLATION => {
+                tos_violation_count += 1;
+                // TOS 违规，禁用账号
+                if let Ok(mut account) = modules::load_account(&item.account_id) {
+                    account.disabled = true;
+                    account.disabled_reason = Some("tos_violation".to_string());
+                    account.disabled_at = Some(chrono::Utc::now().timestamp());
+                    let _ = modules::save_account(&account);
+                }
+            }
             STATUS_AUTH_EXPIRED | STATUS_FAILED => failed_count += 1,
             _ => failed_count += 1,
         }

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -32,7 +32,8 @@ import {
   EyeOff,
   Tag,
   BookOpen,
-  FileUp
+  FileUp,
+  ExternalLink
 } from 'lucide-react'
 import { useTranslation, Trans } from 'react-i18next'
 import { useAccountStore } from '../stores/useAccountStore'
@@ -46,7 +47,9 @@ import {
   getSubscriptionTier,
 } from '../utils/account'
 import { listen, UnlistenFn } from '@tauri-apps/api/event'
+import { invoke } from '@tauri-apps/api/core'
 import { open as openFileDialog } from '@tauri-apps/plugin-dialog'
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { GroupSettingsModal } from '../components/GroupSettingsModal'
 import { TagEditModal } from '../components/TagEditModal'
 import { ExportJsonModal } from '../components/ExportJsonModal'
@@ -86,7 +89,53 @@ interface AccountsPageProps {
 }
 
 type ViewMode = 'grid' | 'list' | 'compact'
-type FilterType = 'all' | 'PRO' | 'ULTRA' | 'FREE' | 'UNKNOWN'
+type FilterType = 'all' | 'PRO' | 'ULTRA' | 'FREE' | 'UNKNOWN' | 'VERIFICATION_REQUIRED' | 'TOS_VIOLATION'
+
+interface VerificationDetailRecord {
+  status: string
+  lastMessage?: string | null
+  lastErrorCode?: number | null
+  validationUrl?: string | null
+  appealUrl?: string | null
+}
+
+interface VerificationHistoryRecord {
+  accountId: string
+  status: string
+  lastMessage?: string | null
+  lastErrorCode?: number | null
+  validationUrl?: string | null
+  appealUrl?: string | null
+}
+
+interface VerificationHistoryBatch {
+  batchId: string
+  verifiedAt: number
+  records?: VerificationHistoryRecord[]
+}
+
+const buildVerificationHistoryMaps = (batches: VerificationHistoryBatch[] = []) => {
+  const sorted = [...batches].sort((a, b) => b.verifiedAt - a.verifiedAt)
+  const statusMap: Record<string, string> = {}
+  const detailMap: Record<string, VerificationDetailRecord> = {}
+
+  for (const batch of sorted) {
+    for (const record of batch.records || []) {
+      if (!(record.accountId in statusMap)) {
+        statusMap[record.accountId] = record.status
+        detailMap[record.accountId] = {
+          status: record.status,
+          lastMessage: record.lastMessage,
+          lastErrorCode: record.lastErrorCode,
+          validationUrl: record.validationUrl,
+          appealUrl: record.appealUrl,
+        }
+      }
+    }
+  }
+
+  return { statusMap, detailMap }
+}
 
 interface ExtensionImportProgressPayload {
   phase?: string
@@ -119,6 +168,43 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     switchAccount,
     updateAccountTags
   } = useAccountStore()
+
+  // ─── 验证状态标记 ────────────────────────────────────────────────────
+  // 优先读 disabled_reason（新版后端写入），没有则回退到验证历史（向后兼容）
+  const [verificationStatusMap, setVerificationStatusMap] = useState<Record<string, string>>({})
+  const [verificationDetailMap, setVerificationDetailMap] = useState<Record<string, VerificationDetailRecord>>({})
+
+  const loadVerificationHistory = useCallback(async () => {
+    const requestId = verificationHistoryRequestIdRef.current + 1
+    verificationHistoryRequestIdRef.current = requestId
+
+    try {
+      const batches = await invoke<VerificationHistoryBatch[]>('wakeup_verification_load_history')
+      if (verificationHistoryRequestIdRef.current !== requestId) {
+        return
+      }
+      const { statusMap, detailMap } = buildVerificationHistoryMaps(batches || [])
+      setVerificationStatusMap(statusMap)
+      setVerificationDetailMap(detailMap)
+    } catch (error) {
+      if (verificationHistoryRequestIdRef.current !== requestId) {
+        return
+      }
+      console.error('Failed to load verification history:', error)
+    }
+  }, [])
+
+  const getVerificationBadge = useCallback((account: Account) => {
+    // 优先从 disabled_reason 读（新版），回退到验证历史（旧数据兼容）
+    const reason = account.disabled_reason || verificationStatusMap[account.id]
+    if (reason === 'verification_required') {
+      return { label: t('wakeup.errorUi.verificationRequiredTitle', 'Need Verify'), className: 'is-warning' }
+    }
+    if (reason === 'tos_violation') {
+      return { label: t('wakeup.errorUi.tosViolationTitle', 'TOS'), className: 'is-tos-violation' }
+    }
+    return null
+  }, [verificationStatusMap, t])
 
   // 文件损坏错误状态
   const [fileCorruptedError, setFileCorruptedError] = useState<FileCorruptedError | null>(null)
@@ -173,13 +259,14 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [showAddModal, setShowAddModal] = useState(false)
   const [addTab, setAddTab] = useState<'oauth' | 'token' | 'import'>('oauth')
-  const [refreshing, setRefreshing] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState<Set<string>>(new Set())
   const [refreshingAll, setRefreshingAll] = useState(false)
   const [switching, setSwitching] = useState<string | null>(null)
   const [importing, setImporting] = useState(false)
   const [refreshWarnings, setRefreshWarnings] = useState<
     Record<string, { kind: 'auth' | 'error'; message: string }>
   >({})
+  const [refreshResult, setRefreshResult] = useState<Record<string, 'success' | 'error'>>({})
   const [message, setMessage] = useState<{
     text: string
     tone?: 'error'
@@ -224,6 +311,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
   // Quota Detail Modal
   const [showQuotaModal, setShowQuotaModal] = useState<string | null>(null)
   const [showErrorModal, setShowErrorModal] = useState<string | null>(null)
+  const [showVerificationErrorModal, setShowVerificationErrorModal] = useState<string | null>(null)
 
   // 标签编辑弹窗
   const [showTagModal, setShowTagModal] = useState<string | null>(null)
@@ -270,6 +358,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
   const addTabRef = useRef(addTab)
   const oauthUrlRef = useRef(oauthUrl)
   const addStatusRef = useRef(addStatus)
+  const verificationHistoryRequestIdRef = useRef(0)
   const colorPickerRef = useRef<HTMLDivElement>(null)
   const tagFilterRef = useRef<HTMLDivElement | null>(null)
 
@@ -390,9 +479,19 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
 
     // 类型过滤
     if (filterType !== 'all') {
-      result = result.filter(
-        (acc) => getSubscriptionTier(acc.quota) === filterType
-      )
+      if (filterType === 'VERIFICATION_REQUIRED') {
+        result = result.filter((acc) =>
+          (acc.disabled_reason || verificationStatusMap[acc.id]) === 'verification_required'
+        )
+      } else if (filterType === 'TOS_VIOLATION') {
+        result = result.filter((acc) =>
+          (acc.disabled_reason || verificationStatusMap[acc.id]) === 'tos_violation'
+        )
+      } else {
+        result = result.filter(
+          (acc) => getSubscriptionTier(acc.quota) === filterType
+        )
+      }
     }
 
     // 标签过滤
@@ -411,6 +510,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     filterType,
     tagFilter,
     accountSortComparator,
+    verificationStatusMap,
   ])
 
   const groupedAccounts = useMemo(() => {
@@ -446,16 +546,19 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
 
   // 统计数量
   const tierCounts = useMemo(() => {
-    const counts = { all: accounts.length, PRO: 0, ULTRA: 0, FREE: 0, UNKNOWN: 0 }
+    const counts = { all: accounts.length, PRO: 0, ULTRA: 0, FREE: 0, UNKNOWN: 0, VERIFICATION_REQUIRED: 0, TOS_VIOLATION: 0 }
     accounts.forEach((acc) => {
       const tier = getSubscriptionTier(acc.quota)
       if (tier === 'PRO') counts.PRO++
       else if (tier === 'ULTRA') counts.ULTRA++
       else if (tier === 'FREE') counts.FREE++
       else counts.UNKNOWN++
+      const vStatus = acc.disabled_reason || verificationStatusMap[acc.id]
+      if (vStatus === 'verification_required') counts.VERIFICATION_REQUIRED++
+      else if (vStatus === 'tos_violation') counts.TOS_VIOLATION++
     })
     return counts
-  }, [accounts])
+  }, [accounts, verificationStatusMap])
 
   const loadFingerprints = async () => {
     try {
@@ -618,6 +721,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     fetchCurrentAccount()
     loadFingerprints()
     loadDisplayGroups()
+    loadVerificationHistory()
 
     let unlisten: UnlistenFn | undefined
     let unlistenGroups: UnlistenFn | undefined
@@ -635,6 +739,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
         )
         await fetchAccounts()
       }
+      await loadVerificationHistory()
     }).then((fn) => {
       unlisten = fn
     })
@@ -650,7 +755,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
       if (unlisten) unlisten()
       if (unlistenGroups) unlistenGroups()
     }
-  }, [fetchAccounts, fetchCurrentAccount, refreshQuota])
+  }, [fetchAccounts, fetchCurrentAccount, loadVerificationHistory, refreshQuota])
 
   // Click outside to close color picker
   useEffect(() => {
@@ -749,33 +854,18 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
   }, [showAddModal, addTab, oauthUrl])
 
   const handleRefresh = async (accountId: string) => {
-    setRefreshing(accountId)
+    setRefreshing((prev) => new Set(prev).add(accountId))
     try {
       await refreshQuota(accountId)
-      const target = accounts.find((acc) => acc.id === accountId)
-      if (target) {
-        setRefreshWarnings((prev) => {
-          if (!prev[target.email]) return prev
-          const next = { ...prev }
-          delete next[target.email]
-          return next
-        })
-      }
+      setRefreshResult((prev) => ({ ...prev, [accountId]: 'success' }))
+      setTimeout(() => setRefreshResult((prev) => { const next = { ...prev }; delete next[accountId]; return next }), 2000)
     } catch (e) {
       console.error(e)
-      const target = accounts.find((acc) => acc.id === accountId)
-      if (target) {
-        const reason = normalizeWarningMessage(String(e))
-        setRefreshWarnings((prev) => ({
-          ...prev,
-          [target.email]: {
-            kind: isAuthFailure(reason) ? 'auth' : 'error',
-            message: reason
-          }
-        }))
-      }
+      setRefreshResult((prev) => ({ ...prev, [accountId]: 'error' }))
+      setTimeout(() => setRefreshResult((prev) => { const next = { ...prev }; delete next[accountId]; return next }), 2000)
     } finally {
-      setRefreshing(null)
+      await loadVerificationHistory()
+      setRefreshing((prev) => { const next = new Set(prev); next.delete(accountId); return next })
     }
   }
 
@@ -787,6 +877,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     } catch (e) {
       console.error(e)
     } finally {
+      await loadVerificationHistory()
       setRefreshingAll(false)
     }
   }
@@ -1406,6 +1497,8 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
       const disabledTitle = isDisabled
         ? `${t('accounts.status.disabled')}${account.disabled_reason ? `: ${account.disabled_reason}` : ''}`
         : ''
+      const verificationReason = account.disabled_reason || verificationStatusMap[account.id]
+      const hasVerificationIssue = verificationReason === 'verification_required' || verificationReason === 'tos_violation'
 
       if (quotaDisplayItems.length === 0) {
         console.log('[AccountsPage] 账号无配额数据:', {
@@ -1460,6 +1553,14 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
             <span className={`tier-badge ${tierBadge.className}`}>
               {tierBadge.label}
             </span>
+            {(() => {
+              const vBadge = getVerificationBadge(account)
+              return vBadge ? (
+                <span className={`verification-status-pill ${vBadge.className}`} title={vBadge.label}>
+                  {vBadge.label}
+                </span>
+              ) : null
+            })()}
           </div>
 
           {accountTags.length > 0 && (
@@ -1515,6 +1616,19 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
           <div className="card-footer">
             <span className="card-date">{formatDate(account.created_at)}</span>
             <div className="card-actions">
+              {(hasQuotaError || hasVerificationIssue) && (
+                <button
+                  className="card-action-btn is-danger"
+                  onClick={() =>
+                    hasVerificationIssue
+                      ? setShowVerificationErrorModal(account.id)
+                      : setShowErrorModal(account.id)
+                  }
+                  title={t('accounts.actions.viewError')}
+                >
+                  <AlertTriangle size={14} />
+                </button>
+              )}
               <button
                 className="card-action-btn"
                 onClick={() => setShowQuotaModal(account.id)}
@@ -1522,15 +1636,6 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
               >
                 <CircleAlert size={14} />
               </button>
-              {hasQuotaError && (
-                <button
-                  className="card-action-btn"
-                  onClick={() => setShowErrorModal(account.id)}
-                  title={t('accounts.actions.viewError')}
-                >
-                  <AlertTriangle size={14} />
-                </button>
-              )}
               <button
                 className="card-action-btn"
                 onClick={() => openFpSelectModal(account.id)}
@@ -1562,17 +1667,20 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
                 )}
               </button>
               <button
-                className="card-action-btn"
+                className={`card-action-btn${refreshResult[account.id] === 'success' ? ' is-success' : refreshResult[account.id] === 'error' ? ' is-danger' : ''}`}
                 onClick={() => handleRefresh(account.id)}
-                disabled={refreshing === account.id}
+                disabled={refreshing.has(account.id)}
                 title={t('accounts.refreshQuota')}
               >
-                <RotateCw
-                  size={14}
-                  className={
-                    refreshing === account.id ? 'loading-spinner' : ''
-                  }
-                />
+                {refreshing.has(account.id) ? (
+                  <RotateCw size={14} className="loading-spinner" />
+                ) : refreshResult[account.id] === 'success' ? (
+                  <Check size={16} className="text-success" />
+                ) : refreshResult[account.id] === 'error' ? (
+                  <X size={16} className="text-danger" />
+                ) : (
+                  <RotateCw size={14} />
+                )}
               </button>
               <button
                 className="card-action-btn export-btn"
@@ -1926,6 +2034,8 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
       const disabledTitle = account.disabled
         ? `${t('accounts.status.disabled')}${account.disabled_reason ? `: ${account.disabled_reason}` : ''}`
         : ''
+      const verificationReason = account.disabled_reason || verificationStatusMap[account.id]
+      const hasVerificationIssue = verificationReason === 'verification_required' || verificationReason === 'tos_violation'
 
       return (
         <tr
@@ -1955,6 +2065,14 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
                 <span className={`tier-badge ${tierBadge.className}`}>
                   {tierBadge.label}
                 </span>
+                {(() => {
+                  const vBadge = getVerificationBadge(account)
+                  return vBadge ? (
+                    <span className={`verification-status-pill ${vBadge.className}`} title={vBadge.label}>
+                      {vBadge.label}
+                    </span>
+                  ) : null
+                })()}
                 {warning && (
                   <span className="status-pill warning" title={warningTitle}>
                     <CircleAlert size={12} />
@@ -2032,6 +2150,19 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
           </td>
           <td className="sticky-action-cell table-action-cell">
             <div className="action-buttons">
+              {(hasQuotaError || hasVerificationIssue) && (
+                <button
+                  className="action-btn is-danger"
+                  onClick={() =>
+                    hasVerificationIssue
+                      ? setShowVerificationErrorModal(account.id)
+                      : setShowErrorModal(account.id)
+                  }
+                  title={t('accounts.actions.viewError')}
+                >
+                  <AlertTriangle size={16} />
+                </button>
+              )}
               <button
                 className="action-btn"
                 onClick={() => setShowQuotaModal(account.id)}
@@ -2039,15 +2170,6 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
               >
                 <CircleAlert size={16} />
               </button>
-              {hasQuotaError && (
-                <button
-                  className="action-btn"
-                  onClick={() => setShowErrorModal(account.id)}
-                  title={t('accounts.actions.viewError')}
-                >
-                  <AlertTriangle size={16} />
-                </button>
-              )}
               <button
                 className="action-btn"
                 onClick={() => openTagModal(account.id)}
@@ -2072,15 +2194,20 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
                 )}
               </button>
               <button
-                className="action-btn"
+                className={`action-btn${refreshResult[account.id] === 'success' ? ' is-success' : refreshResult[account.id] === 'error' ? ' is-danger' : ''}`}
                 onClick={() => handleRefresh(account.id)}
-                disabled={refreshing === account.id}
+                disabled={refreshing.has(account.id)}
                 title={t('accounts.refreshQuota')}
               >
-                <RotateCw
-                  size={16}
-                  className={refreshing === account.id ? 'loading-spinner' : ''}
-                />
+                {refreshing.has(account.id) ? (
+                  <RotateCw size={16} className="loading-spinner" />
+                ) : refreshResult[account.id] === 'success' ? (
+                  <Check size={18} className="text-success" />
+                ) : refreshResult[account.id] === 'error' ? (
+                  <X size={18} className="text-danger" />
+                ) : (
+                  <RotateCw size={16} />
+                )}
               </button>
               <button
                 className="action-btn"
@@ -2207,6 +2334,8 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
                 <option value="PRO">{`PRO (${tierCounts.PRO})`}</option>
                 <option value="ULTRA">{`ULTRA (${tierCounts.ULTRA})`}</option>
                 <option value="FREE">{`FREE (${tierCounts.FREE})`}</option>
+                <option value="VERIFICATION_REQUIRED">{`${t('wakeup.errorUi.verificationRequiredTitle')} (${tierCounts.VERIFICATION_REQUIRED})`}</option>
+                <option value="TOS_VIOLATION">{`${t('wakeup.errorUi.tosViolationTitle')} (${tierCounts.TOS_VIOLATION})`}</option>
                 <option value="UNKNOWN">{`UNKNOWN (${tierCounts.UNKNOWN})`}</option>
               </select>
             </div>
@@ -2981,7 +3110,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
                         handleRefresh(account.id)
                       }}
                     >
-                      {refreshing === account.id ? (
+                      {refreshing.has(account.id) ? (
                         <div className="loading-spinner small" />
                       ) : (
                         <RefreshCw size={16} />
@@ -3053,6 +3182,123 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
                     <button
                       className="btn btn-secondary"
                       onClick={() => setShowErrorModal(null)}
+                    >
+                      {t('common.close')}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )
+        })()}
+
+      {/* Verification Error Modal (verification_required / tos_violation) */}
+      {showVerificationErrorModal &&
+        (() => {
+          const account = accounts.find((a) => a.id === showVerificationErrorModal)
+          if (!account) return null
+          const vReason = account.disabled_reason || verificationStatusMap[account.id]
+          const vDetail = verificationDetailMap[account.id]
+          const isTos = vReason === 'tos_violation'
+          const title = isTos
+            ? t('wakeup.errorUi.tosViolationTitle', 'TOS 违规')
+            : t('wakeup.errorUi.verificationRequiredTitle', '需要验证')
+
+          const openLink = async (url: string) => {
+            try {
+              await openUrl(url)
+            } catch {
+              window.open(url, '_blank', 'noopener,noreferrer')
+            }
+          }
+
+          const copyLink = async (url: string) => {
+            try {
+              await navigator.clipboard.writeText(url)
+            } catch (e) {
+              console.error('复制失败', e)
+            }
+          }
+
+          return (
+            <div
+              className="modal-overlay"
+              onClick={() => setShowVerificationErrorModal(null)}
+            >
+              <div
+                className="modal modal-lg"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="modal-header">
+                  <h2>{title}</h2>
+                  <button
+                    className="close-btn"
+                    onClick={() => setShowVerificationErrorModal(null)}
+                  >
+                    <X size={20} />
+                  </button>
+                </div>
+                <div className="modal-body">
+                  <div className="error-detail">
+                    <div className="error-detail-meta">
+                      <span>{t('modals.errors.account')}: {maskAccountText(account.email)}</span>
+                      {vDetail?.lastErrorCode && (
+                        <span>{t('wakeup.errorUi.errorCode', { code: vDetail.lastErrorCode })}</span>
+                      )}
+                    </div>
+                    {vDetail?.lastMessage && (
+                      <div className="error-detail-message" style={{ marginTop: 12 }}>
+                        {vDetail.lastMessage}
+                      </div>
+                    )}
+                  </div>
+                  {!vDetail && (
+                    <div className="empty-state-small" style={{ marginTop: 12 }}>
+                      {t('modals.errors.empty', '暂无验证详情')}
+                    </div>
+                  )}
+
+                  {/* Action buttons based on error type */}
+                  <div className="modal-actions" style={{ marginTop: 20, gap: 8, flexWrap: 'wrap' }}>
+                    {!isTos && vDetail?.validationUrl && (
+                      <>
+                        <button
+                          className="btn btn-primary"
+                          onClick={() => openLink(vDetail.validationUrl!)}
+                        >
+                          <ExternalLink size={14} />
+                          {t('wakeup.errorUi.completeVerification', '立即验证')}
+                        </button>
+                        <button
+                          className="btn btn-secondary"
+                          onClick={() => copyLink(vDetail.validationUrl!)}
+                        >
+                          <Copy size={14} />
+                          {t('wakeup.errorUi.copyValidationUrl', '复制验证地址')}
+                        </button>
+                      </>
+                    )}
+                    {isTos && vDetail?.appealUrl && (
+                      <>
+                        <button
+                          className="btn btn-primary"
+                          onClick={() => openLink(vDetail.appealUrl!)}
+                        >
+                          <ExternalLink size={14} />
+                          {t('wakeup.errorUi.submitAppeal', '立即提交保证书')}
+                        </button>
+                        <button
+                          className="btn btn-secondary"
+                          onClick={() => copyLink(vDetail.appealUrl!)}
+                        >
+                          <Copy size={14} />
+                          {t('wakeup.errorUi.copyAppealUrl', '复制链接')}
+                        </button>
+                      </>
+                    )}
+                    <button
+                      className="btn btn-secondary"
+                      onClick={() => setShowVerificationErrorModal(null)}
                     >
                       {t('common.close')}
                     </button>

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -495,8 +495,12 @@ export function CodexAccountsPage() {
   );
 
   const tierCounts = useMemo(() => {
-    const counts = { all: accounts.length, FREE: 0, PLUS: 0, PRO: 0, TEAM: 0, ENTERPRISE: 0 };
-    accounts.forEach((a) => { const tier = resolvePlanKey(a); if (tier in counts) counts[tier as keyof typeof counts] += 1; });
+    const counts = { all: accounts.length, FREE: 0, PLUS: 0, PRO: 0, TEAM: 0, ENTERPRISE: 0, ERROR: 0 };
+    accounts.forEach((a) => {
+      const tier = resolvePlanKey(a);
+      if (tier in counts) counts[tier as keyof typeof counts] += 1;
+      if (a.quota_error) counts.ERROR += 1;
+    });
     return counts;
   }, [accounts, resolvePlanKey]);
 
@@ -530,7 +534,11 @@ export function CodexAccountsPage() {
       const query = searchQuery.toLowerCase();
       result = result.filter((a) => resolvePresentation(a).displayName.toLowerCase().includes(query));
     }
-    if (filterType !== 'all') result = result.filter((a) => resolvePlanKey(a) === filterType);
+    if (filterType === 'ERROR') {
+      result = result.filter((a) => !!a.quota_error);
+    } else if (filterType !== 'all') {
+      result = result.filter((a) => resolvePlanKey(a) === filterType);
+    }
     if (tagFilter.length > 0) {
       const selectedTags = new Set(tagFilter.map(normalizeTag));
       result = result.filter((a) => (a.tags || []).map(normalizeTag).some((tag) => selectedTags.has(tag)));
@@ -720,6 +728,7 @@ export function CodexAccountsPage() {
                 <option value="PRO">{`PRO (${tierCounts.PRO})`}</option>
                 <option value="TEAM">{`TEAM (${tierCounts.TEAM})`}</option>
                 <option value="ENTERPRISE">{`ENTERPRISE (${tierCounts.ENTERPRISE})`}</option>
+                <option value="ERROR">{`ERROR (${tierCounts.ERROR})`}</option>
               </select>
             </div>
             <div className="tag-filter" ref={tagFilterRef}>

--- a/src/pages/WakeupVerificationPage.tsx
+++ b/src/pages/WakeupVerificationPage.tsx
@@ -928,7 +928,7 @@ export function WakeupVerificationPage({ onNavigate }: WakeupVerificationPagePro
                     <span className="verification-count-badge is-warning">{batch.verificationRequiredCount}</span>
                   </td>
                   <td>
-                    <span className="verification-count-badge is-failed">{batch.tosViolationCount ?? 0}</span>
+                    <span className="verification-count-badge is-tos-violation">{batch.tosViolationCount ?? 0}</span>
                   </td>
                   <td>
                     <span className="verification-count-badge is-failed">{batch.failedCount}</span>
@@ -1101,7 +1101,7 @@ export function WakeupVerificationPage({ onNavigate }: WakeupVerificationPagePro
                 </button>
                 <button
                   type="button"
-                  className={`pill pill-danger verification-filter-pill ${detailFilter === 'tos_violation' ? 'active' : ''}`}
+                  className={`pill pill-warning verification-filter-pill ${detailFilter === 'tos_violation' ? 'active' : ''}`}
                   onClick={() => setDetailFilter('tos_violation')}
                 >
                   {t('wakeup.errorUi.tosViolationTitle')} {detailCounts.tosViolation}

--- a/src/services/accountService.ts
+++ b/src/services/accountService.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { Account, QuotaData, DeviceProfile, DeviceProfiles, RefreshStats, Fingerprint, FingerprintWithStats } from '../types/account';
+import { Account, DeviceProfile, DeviceProfiles, RefreshStats, Fingerprint, FingerprintWithStats } from '../types/account';
 
 export interface PreviewCurrentProfileResult {
     profile: DeviceProfile;
@@ -38,7 +38,7 @@ export async function setCurrentAccount(accountId: string): Promise<void> {
     return await invoke('set_current_account', { accountId });
 }
 
-export async function fetchAccountQuota(accountId: string): Promise<QuotaData> {
+export async function fetchAccountQuota(accountId: string): Promise<Account> {
     return await invoke('fetch_account_quota', { accountId });
 }
 

--- a/src/stores/useAccountStore.ts
+++ b/src/stores/useAccountStore.ts
@@ -157,8 +157,40 @@ export const useAccountStore = create<AccountState>((set, get) => ({
     },
 
     refreshQuota: async (accountId: string) => {
-        await accountService.fetchAccountQuota(accountId);
-        await get().fetchAccounts();
+        try {
+            const updatedAccount = await accountService.fetchAccountQuota(accountId);
+            // 成功：后端已更新该账号并返回最新状态（包含 quota_error），局部更新该账号，保持滚动位置不变
+            set((state) => ({
+                accounts: state.accounts.map((acc) =>
+                    acc.id === accountId ? updatedAccount : acc
+                ),
+            }));
+            
+            // 如果刷新的是当前账号，需要同时更新 currentAccount
+            const { currentAccount } = get();
+            if (currentAccount?.id === accountId) {
+                set({ currentAccount: updatedAccount });
+            }
+
+            // 如果后端返回了配额错误信息，需要抛出异常让 UI 捕获并显示为失败（红叉）
+            if (updatedAccount.quota_error) {
+                throw new Error(updatedAccount.quota_error.message);
+            }
+            if (updatedAccount.quota?.is_forbidden) {
+                throw new Error("403 Forbidden");
+            }
+        } catch (e) {
+            // Token 级别失败（如 invalid_grant 会改变 disabled 状态）：全量刷新确保数据正确
+            // 如果是我们自己 throw 的配额错误，因为状态已经局部更新，不再需要全量刷新
+            const isQuotaError = e instanceof Error && (
+                get().accounts.find(a => a.id === accountId)?.quota_error?.message === e.message ||
+                e.message === "403 Forbidden"
+            );
+            if (!isQuotaError) {
+                await get().fetchAccounts();
+            }
+            throw e;
+        }
     },
 
     refreshAllQuotas: async () => {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -264,6 +264,12 @@
   border-color: rgba(239, 68, 68, 0.3);
 }
 
+.pill-warning {
+  background: rgba(245, 158, 11, 0.12);
+  color: #b45309;
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
 @keyframes floatIn {
   from {
     opacity: 0;
@@ -698,7 +704,8 @@
 .account-sub-line {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
+  flex-wrap: wrap;
 }
 
 /* Badges & Tags */
@@ -878,12 +885,20 @@
   color: var(--text-secondary);
 }
 
-.action-btn.danger:hover {
+.action-btn.is-danger {
+  color: var(--danger);
+}
+
+.action-btn.is-danger:hover {
   background: rgba(239, 68, 68, 0.1);
   color: var(--danger);
 }
 
-.action-btn.success:hover {
+.action-btn.is-success {
+  color: var(--success);
+}
+
+.action-btn.is-success:hover {
   background: rgba(34, 197, 94, 0.1);
   color: var(--success);
 }
@@ -958,7 +973,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  box-shadow: 
+  box-shadow:
     0 25px 50px -12px rgba(0, 0, 0, 0.35),
     0 0 15px rgba(0, 0, 0, 0.1);
   animation: scaleIn 0.25s cubic-bezier(0.16, 1, 0.3, 1);

--- a/src/styles/pages/accounts-aurora.css
+++ b/src/styles/pages/accounts-aurora.css
@@ -647,13 +647,16 @@
   border-radius: var(--radius-full);
 }
 
-.accounts-page .tier-badge {
-  padding: 3px 8px;
+.accounts-page .tier-badge,
+.accounts-page .verification-status-pill {
+  padding: 2px 6px;
   border-radius: 999px;
-  font-size: 10px;
-  letter-spacing: 0.08em;
+  font-size: 9px;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   border: 1px solid rgba(15, 23, 42, 0.12);
+  min-height: 18px;
+  white-space: nowrap;
 }
 
 .accounts-page .tier-badge.pro {
@@ -701,12 +704,12 @@
 .accounts-page .status-pill {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
+  gap: 3px;
+  padding: 2px 6px;
   border-radius: 999px;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 700;
-  line-height: 1;
+  line-height: 1.2;
   letter-spacing: 0.02em;
   border: 1px solid transparent;
 }
@@ -875,12 +878,20 @@
   color: var(--accounts-primary);
 }
 
-.accounts-page .card-action-btn.success:hover:not(:disabled) {
+.accounts-page .card-action-btn.is-success {
+  color: var(--success);
+}
+
+.accounts-page .card-action-btn.is-success:hover:not(:disabled) {
   background: rgba(34, 197, 94, 0.15);
   color: var(--success);
 }
 
-.accounts-page .card-action-btn.danger:hover:not(:disabled) {
+.accounts-page .card-action-btn.is-danger {
+  color: var(--danger);
+}
+
+.accounts-page .card-action-btn.is-danger:hover:not(:disabled) {
   background: rgba(239, 68, 68, 0.15);
   color: var(--danger);
 }

--- a/src/styles/pages/wakeup-verification.css
+++ b/src/styles/pages/wakeup-verification.css
@@ -57,9 +57,9 @@
 }
 
 .wakeup-verification-page .verification-notice.is-warning {
-  border-color: rgba(245, 158, 11, 0.35);
-  background: rgba(245, 158, 11, 0.12);
-  color: #b45309;
+  border-color: rgba(37, 99, 235, 0.35);
+  background: rgba(37, 99, 235, 0.12);
+  color: #2563eb;
 }
 
 .wakeup-verification-page .verification-notice.is-error {
@@ -144,15 +144,23 @@
   border-color: rgba(239, 68, 68, 0.4);
 }
 
+.verification-count-badge.is-tos-violation {
+  color: #b45309;
+  background: rgba(245, 158, 11, 0.12);
+  border-color: rgba(245, 158, 11, 0.4);
+}
+
 .verification-status-pill {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   min-height: 24px;
   padding: 2px 10px;
   border-radius: 999px;
   font-size: 12px;
   font-weight: 500;
   border: 1px solid transparent;
+  white-space: nowrap;
 }
 
 .verification-status-pill.is-idle {
@@ -174,9 +182,9 @@
 }
 
 .verification-status-pill.is-warning {
-  color: #b45309;
-  background: rgba(245, 158, 11, 0.12);
-  border-color: rgba(245, 158, 11, 0.28);
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.12);
+  border-color: rgba(37, 99, 235, 0.28);
 }
 
 .verification-status-pill.is-failed {
@@ -186,9 +194,9 @@
 }
 
 .verification-status-pill.is-tos-violation {
-  color: #dc2626;
-  background: rgba(220, 38, 38, 0.12);
-  border-color: rgba(220, 38, 38, 0.35);
+  color: #b45309;
+  background: rgba(245, 158, 11, 0.12);
+  border-color: rgba(245, 158, 11, 0.28);
 }
 
 .verification-empty-cell {
@@ -221,19 +229,6 @@
 
 .verification-select-wrap {
   position: relative;
-}
-
-.verification-select-wrap::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 12px;
-  width: 8px;
-  height: 8px;
-  border-right: 2px solid var(--text-secondary);
-  border-bottom: 2px solid var(--text-secondary);
-  transform: translateY(-60%) rotate(45deg);
-  pointer-events: none;
 }
 
 .verification-select {


### PR DESCRIPTION
1. 新增反重力账号标记
前端：
- 异常账号在卡片上显示对应状态标签（优化了标签大小）
  - Need Verify（蓝色）— 需要验证
  - TOS（橙色）— TOS 违规
- 账号筛选下拉新增「需要验证」和「TOS 违规」分类，( Codex 账号页也新增 ERROR 筛选项)
- 查看错误按钮改为红色，点击弹窗显示验证/保证书链接，方便快速定位并解决异常
后端：
- 账号检测失败时，自动写入失败原因并禁用账号（需要验证 / TOS 违规）
- 配额刷新成功时，只解除「授权异常」类禁用，不解除「需要验证 / TOS 违规」类禁用
- 账号唤醒/检测成功时，解除所有类型的禁用

2. 账号刷新优化
- 修改单个账号刷新方法，刷新单个反重力账号额度后，不再重新加载整个账号列表，改为局部更新该账号数据，页面滚动位置保持不变，刷新结果反馈为：成功显示 ✓（绿色），失败显示 ✕（红色），2 秒后自动恢复刷新按钮
- 修复刷新成功无法更新账号订阅类型的问题

3. 删除检测页重复的原生下拉箭头
- 移除账号检测页面选择模型下拉框上多余的原生 CSS 箭头
<img width="1804" height="1247" alt="c7e992fb-c09a-4c80-af48-c98c92eef0b9" src="https://github.com/user-attachments/assets/3791006d-1b2d-450d-85b5-fdb16011bf62" />
<img width="1804" height="1247" alt="84a53e7c-e923-4620-a688-3d89301bc3ae" src="https://github.com/user-attachments/assets/2f07b1d3-cf0c-486e-bdf6-62735bee3888" />
<img width="1804" height="1247" alt="49566b8f-7153-4c95-b63a-dd6d8c1f8ded" src="https://github.com/user-attachments/assets/63ef5de3-3c2d-4934-ba24-eda173140db6" />
<img width="1804" height="1247" alt="0e9f3c05-d19c-4fbb-b4d5-15d0e8aa6f98" src="https://github.com/user-attachments/assets/f7f2e339-d5a9-458c-b58b-9ee43d202e25" />