### PR TITLE
fix: parseTokenMap truncates sku field in windsurf synthetic tokens

### DIFF
--- a/src/types/windsurf.ts
+++ b/src/types/windsurf.ts
@@ -375,12 +375,15 @@ export interface WindsurfQuota {
 
 function parseTokenMap(token: string): Record<string, string> {
   const map: Record<string, string> = {};
-  const prefix = token.split(':')[0] ?? token;
-  for (const part of prefix.split(';')) {
-    const [k, v] = part.split('=');
-    const key = (k || '').trim();
+  // Windsurf synthetic tokens contain ";sku=" and may have colons in values (e.g. rd=timestamp:0),
+  // so skip the colon-based prefix split for them to avoid losing sku/source fields.
+  const tokenStr = token.includes(';sku=') ? token : (token.split(':')[0] ?? token);
+  for (const part of tokenStr.split(';')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx < 0) continue;
+    const key = part.substring(0, eqIdx).trim();
     if (!key) continue;
-    map[key] = (v || '').trim();
+    map[key] = part.substring(eqIdx + 1).trim();
   }
   return map;
 }


### PR DESCRIPTION
## Problem
Some Windsurf accounts show UNKNOWN plan badge even though they have valid credit data.

## Root Cause
parseTokenMap() splits token on : first (token.split(':')[0]), but windsurf synthetic tokens contain colons in values: cq=100;tq=0;rd=1742774400:0;sku=windsurf;source=windsurf. The split truncates at rd=1742774400, losing sku and source fields. Without sku, accounts lacking planInfo.planName from API cannot resolve plan via SKU fallback.

## Fix
- Detect windsurf synthetic tokens by checking for ;sku= and skip colon-based prefix split
- Use indexOf('=') + substring instead of split('=') to handle = in values

## Testing
Built and tested on macOS aarch64. Accounts previously showing UNKNOWN now display correct plan badge.