### PR TITLE
feat: adicionar porta de depuração remota para suporte ao auto-accept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.agent/
 
 # Editor directories and files
 .vscode/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cockpit-tools",
-  "version": "0.9.12",
+  "version": "0.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cockpit-tools",
-      "version": "0.9.12",
+      "version": "0.14.5",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -1565,7 +1565,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1868,7 +1868,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/daisyui": {
@@ -3023,7 +3023,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -5328,6 +5328,7 @@ pub fn start_antigravity_with_args(
         if !force_new_instance {
             args.push("--reuse-window".to_string());
         }
+        args.push("--remote-debugging-port=9333".to_string());
         for arg in extra_args {
             if !arg.trim().is_empty() {
                 args.push(arg.to_string());
@@ -5373,6 +5374,7 @@ pub fn start_antigravity_with_args(
             cmd.arg(user_data_dir.trim());
         }
         cmd.arg("--reuse-window");
+        cmd.arg("--remote-debugging-port=9333");
         for arg in extra_args {
             if !arg.trim().is_empty() {
                 cmd.arg(arg);
@@ -5400,6 +5402,7 @@ pub fn start_antigravity_with_args(
             cmd.arg(user_data_dir.trim());
         }
         cmd.arg("--reuse-window");
+        cmd.arg("--remote-debugging-port=9333");
         for arg in extra_args {
             if !arg.trim().is_empty() {
                 cmd.arg(arg);


### PR DESCRIPTION
### 🚀 feat: add remote debugging port for auto-accept support

This Pull Request introduces the remote debugging port `9333` when initializing Antigravity.

**Motivation:**
This change specifically enables the [AntiGravity-AutoAccept](https://github.com/yazanbaker94/AntiGravity-AutoAccept) extension to function correctly. With port `9333` open, the extension can automatically connect and perform the "auto accept" whenever there is an account switch or initialization, eliminating the need for manual intervention.

**Changes:**
- **Backend (Rust)**: Added `--remote-debugging-port=9333` to the launch command in [src-tauri/src/modules/process.rs](cci:7://file:///c:/Users/cs191/Documents/Projetos/cockpit-tools/src-tauri/src/modules/process.rs:0:0-0:0).
- **Configuration**: Updated [.gitignore](cci:7://file:///c:/Users/cs191/Documents/Projetos/cockpit-tools/.gitignore:0:0-0:0) to ignore agent context directories and runtime caches.
- **Dependencies**: Updated `package-lock.json`.

**Internal Documentation:**
Updated [.agent/context.md](cci:7://file:///c:/Users/cs191/Documents/Projetos/cockpit-tools/.agent/context.md:0:0-0:0) with the technical decision made on 2026-03-15.

**Extension Credits:** [yazanbaker94/AntiGravity-AutoAccept](https://github.com/yazanbaker94/AntiGravity-AutoAccept)
