### PR TITLE
feat(dashboard): add quick hide action for platform cards

### DIFF
--- a/src/pages/DashboardPage.css
+++ b/src/pages/DashboardPage.css
@@ -288,6 +288,12 @@
   padding: 0;
 }
 
+.header-icon-btn {
+  width: 28px;
+  min-width: 28px;
+  padding: 0;
+}
+
 .collapse-arrow {
   transition: transform 0.2s ease;
 }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -22,7 +22,7 @@ import {
   usePlatformLayoutStore,
 } from '../stores/usePlatformLayoutStore';
 import { Page } from '../types/navigation';
-import { Users, CheckCircle2, Sparkles, RotateCw, Play, Github, Tag, ChevronDown } from 'lucide-react';
+import { Users, CheckCircle2, Sparkles, RotateCw, Play, Github, Tag, ChevronDown, EyeOff } from 'lucide-react';
 import { TagEditModal } from '../components/TagEditModal';
 import { Account } from '../types/account';
 import {
@@ -179,7 +179,7 @@ export function DashboardPage({
   topCenterBanner,
 }: DashboardPageProps) {
   const { t } = useTranslation();
-  
+
   const [tagModalState, setTagModalState] = React.useState<{ accountId: string; platform: PlatformId | 'codebuddy_cn'; tags: string[] } | null>(null);
   const [dashboardCardCollapse, setDashboardCardCollapse] = React.useState<DashboardCardCollapseState>({
     workbuddy: false,
@@ -243,7 +243,7 @@ export function DashboardPage({
     }
   };
 
-  const { orderedEntryIds, hiddenEntryIds, platformGroups } = usePlatformLayoutStore();
+  const { orderedEntryIds, hiddenEntryIds, platformGroups, setHiddenEntry } = usePlatformLayoutStore();
   const hiddenEntrySet = useMemo(() => new Set(hiddenEntryIds), [hiddenEntryIds]);
   const visibleEntryOrder = useMemo(
     () => orderedEntryIds.filter((entryId) => !hiddenEntrySet.has(entryId)),
@@ -286,10 +286,10 @@ export function DashboardPage({
     };
   }, []);
 
-  
+
   // Antigravity Data
-  const { 
-    accounts: agAccounts, 
+  const {
+    accounts: agAccounts,
     currentAccount: agCurrent,
     switchAccount: switchAgAccount,
     fetchAccounts: fetchAgAccounts,
@@ -297,8 +297,8 @@ export function DashboardPage({
   } = useAccountStore();
 
   // Codex Data
-  const { 
-    accounts: codexAccounts, 
+  const {
+    accounts: codexAccounts,
     currentAccount: codexCurrent,
     switchAccount: switchCodexAccount,
     fetchAccounts: fetchCodexAccounts,
@@ -1157,7 +1157,7 @@ export function DashboardPage({
   // Antigravity Recommendation Logic
   const agRecommended = useMemo(() => {
     if (agAccounts.length <= 1) return null;
-    
+
     // Simple logic: find account with highest overall quota that isn't current
     const others = agAccounts.filter((a) => {
       if (a.id === agCurrentId) return false;
@@ -1176,7 +1176,7 @@ export function DashboardPage({
         const total = acc.quota.models.reduce((sum, m) => sum + m.percentage, 0);
         return total / acc.quota.models.length;
       };
-      
+
       return getScore(curr) > getScore(prev) ? curr : prev;
     });
   }, [agAccounts, agCurrentId]);
@@ -1351,9 +1351,9 @@ export function DashboardPage({
 
       const totalUsedPercent = toFiniteNumber(
         usage.totalPercentUsed ??
-          (hasPlanBudget && planUsed != null && planLimit != null && planLimit > 0
-            ? (planUsed / planLimit) * 100
-            : null),
+        (hasPlanBudget && planUsed != null && planLimit != null && planLimit > 0
+          ? (planUsed / planLimit) * 100
+          : null),
       );
       const usedPercentList = [
         totalUsedPercent,
@@ -1752,14 +1752,14 @@ export function DashboardPage({
     return (
       <div className="account-mini-card">
         <div className="account-mini-header">
-           <div className="account-info-row">
-             <span className="account-email" title={maskAccountText(presentation.displayName)}>
-               {maskAccountText(presentation.displayName)}
-             </span>
-             <span className={`tier-badge ${presentation.planClass}`}>{presentation.planLabel}</span>
-           </div>
+          <div className="account-info-row">
+            <span className="account-email" title={maskAccountText(presentation.displayName)}>
+              {maskAccountText(presentation.displayName)}
+            </span>
+            <span className={`tier-badge ${presentation.planClass}`}>{presentation.planLabel}</span>
+          </div>
         </div>
-        
+
         <div className="account-mini-quotas">
           {quotaDisplayItems.map((item) => (
             <div key={item.key} className="mini-quota-row-stacked">
@@ -1768,7 +1768,7 @@ export function DashboardPage({
                 <span className={`model-pct ${item.quotaClass}`}>{item.valueText}</span>
               </div>
               <div className="mini-progress-track">
-                <div 
+                <div
                   className={`mini-progress-bar ${item.quotaClass}`}
                   style={{ width: `${item.percentage}%` }}
                 />
@@ -1784,28 +1784,28 @@ export function DashboardPage({
         </div>
 
         <div className="account-mini-actions icon-only-row">
-           <button 
-             className="mini-icon-btn"
-             onClick={() => setTagModalState({ accountId: account.id, platform: 'antigravity', tags: account.tags || [] })}
-             title={t('accounts.editTags', '编辑标签')}
-           >
-             <Tag size={14} />
-           </button>
-           <button 
-             className="mini-icon-btn" 
-             onClick={() => handleRefreshAg(account.id)}
-             title={t('common.refresh', '刷新')}
-             disabled={refreshing.has(account.id)}
-           >
-             <RotateCw size={14} className={refreshing.has(account.id) ? 'loading-spinner' : ''} />
-           </button>
-           <button 
-             className="mini-icon-btn"
-             onClick={() => switchAgAccount(account.id)}
-             title={t('dashboard.switch', '切换')}
-           >
-             <Play size={14} />
-           </button>
+          <button
+            className="mini-icon-btn"
+            onClick={() => setTagModalState({ accountId: account.id, platform: 'antigravity', tags: account.tags || [] })}
+            title={t('accounts.editTags', '编辑标签')}
+          >
+            <Tag size={14} />
+          </button>
+          <button
+            className="mini-icon-btn"
+            onClick={() => handleRefreshAg(account.id)}
+            title={t('common.refresh', '刷新')}
+            disabled={refreshing.has(account.id)}
+          >
+            <RotateCw size={14} className={refreshing.has(account.id) ? 'loading-spinner' : ''} />
+          </button>
+          <button
+            className="mini-icon-btn"
+            onClick={() => switchAgAccount(account.id)}
+            title={t('dashboard.switch', '切换')}
+          >
+            <Play size={14} />
+          </button>
         </div>
       </div>
     );
@@ -2060,6 +2060,27 @@ export function DashboardPage({
     return rows;
   }, [visibleCardPlatformIds]);
 
+  const handleHidePlatformCard = useCallback((platformId: PlatformId) => {
+    const entryId = orderedEntryIds.find(
+      (candidate) => resolveEntryDefaultPlatformId(candidate, platformGroups) === platformId,
+    );
+    if (!entryId) {
+      return;
+    }
+    setHiddenEntry(entryId, true);
+  }, [orderedEntryIds, platformGroups, setHiddenEntry]);
+
+  const renderHideCardButton = (platformId: PlatformId) => (
+    <button
+      className="header-action-btn header-icon-btn"
+      onClick={() => handleHidePlatformCard(platformId)}
+      title={t('accounts.compact.hide', '隐藏')}
+      aria-label={t('accounts.compact.hide', '隐藏')}
+    >
+      <EyeOff size={14} />
+    </button>
+  );
+
   const renderPlatformCard = (platformId: PlatformId) => {
     if (platformId === 'antigravity') {
       return (
@@ -2069,15 +2090,18 @@ export function DashboardPage({
               <RobotIcon className="" style={{ width: 18, height: 18 }} />
               <h3>{getPlatformLabel(platformId, t)}</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshAgCard}
-              disabled={cardRefreshing.ag}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.ag ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshAgCard}
+                disabled={cardRefreshing.ag}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.ag ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2113,15 +2137,18 @@ export function DashboardPage({
               <CodexIcon size={18} />
               <h3>{getPlatformLabel(platformId, t)}</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshCodexCard}
-              disabled={cardRefreshing.codex}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.codex ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshCodexCard}
+                disabled={cardRefreshing.codex}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.codex ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2157,15 +2184,18 @@ export function DashboardPage({
               {renderPlatformIcon(platformId, 18)}
               <h3>{getPlatformLabel(platformId, t)}</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshZedCard}
-              disabled={cardRefreshing.zed}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.zed ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshZedCard}
+                disabled={cardRefreshing.zed}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.zed ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2201,15 +2231,18 @@ export function DashboardPage({
               <Github size={18} />
               <h3>{getPlatformLabel(platformId, t)}</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshGitHubCopilotCard}
-              disabled={cardRefreshing.githubCopilot}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.githubCopilot ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshGitHubCopilotCard}
+                disabled={cardRefreshing.githubCopilot}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.githubCopilot ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2245,15 +2278,18 @@ export function DashboardPage({
               <WindsurfIcon className="" style={{ width: 18, height: 18 }} />
               <h3>Windsurf</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshWindsurfCard}
-              disabled={cardRefreshing.windsurf}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.windsurf ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshWindsurfCard}
+                disabled={cardRefreshing.windsurf}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.windsurf ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2289,15 +2325,18 @@ export function DashboardPage({
               <KiroIcon style={{ width: 18, height: 18 }} />
               <h3>Kiro</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshKiroCard}
-              disabled={cardRefreshing.kiro}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.kiro ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshKiroCard}
+                disabled={cardRefreshing.kiro}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.kiro ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2333,15 +2372,18 @@ export function DashboardPage({
               <CursorIcon style={{ width: 18, height: 18 }} />
               <h3>Cursor</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshCursorCard}
-              disabled={cardRefreshing.cursor}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.cursor ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshCursorCard}
+                disabled={cardRefreshing.cursor}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.cursor ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2377,15 +2419,18 @@ export function DashboardPage({
               <GeminiIcon style={{ width: 18, height: 18 }} />
               <h3>Gemini Cli</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshGeminiCard}
-              disabled={cardRefreshing.gemini}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.gemini ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshGeminiCard}
+                disabled={cardRefreshing.gemini}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.gemini ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2421,15 +2466,18 @@ export function DashboardPage({
               <CodebuddyIcon style={{ width: 18, height: 18 }} />
               <h3>{getPlatformLabel(platformId, t)}</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshCodebuddyCard}
-              disabled={cardRefreshing.codebuddy}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.codebuddy ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshCodebuddyCard}
+                disabled={cardRefreshing.codebuddy}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.codebuddy ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2465,15 +2513,18 @@ export function DashboardPage({
               <CodebuddyIcon style={{ width: 18, height: 18 }} />
               <h3>{getPlatformLabel(platformId, t)}</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshCodebuddyCnCard}
-              disabled={cardRefreshing.codebuddyCn}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.codebuddyCn ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshCodebuddyCnCard}
+                disabled={cardRefreshing.codebuddyCn}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.codebuddyCn ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2509,15 +2560,18 @@ export function DashboardPage({
               <QoderIcon style={{ width: 18, height: 18 }} />
               <h3>{getPlatformLabel(platformId, t)}</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshQoderCard}
-              disabled={cardRefreshing.qoder}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.qoder ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshQoderCard}
+                disabled={cardRefreshing.qoder}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.qoder ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2553,15 +2607,18 @@ export function DashboardPage({
               <TraeIcon style={{ width: 18, height: 18 }} />
               <h3>{getPlatformLabel(platformId, t)}</h3>
             </div>
-            <button
-              className="header-action-btn"
-              onClick={handleRefreshTraeCard}
-              disabled={cardRefreshing.trae}
-              title={t('common.refresh', '刷新')}
-            >
-              <RotateCw size={14} className={cardRefreshing.trae ? 'loading-spinner' : ''} />
-              <span>{t('common.refresh', '刷新')}</span>
-            </button>
+            <div className="header-action-group">
+              <button
+                className="header-action-btn"
+                onClick={handleRefreshTraeCard}
+                disabled={cardRefreshing.trae}
+                title={t('common.refresh', '刷新')}
+              >
+                <RotateCw size={14} className={cardRefreshing.trae ? 'loading-spinner' : ''} />
+                <span>{t('common.refresh', '刷新')}</span>
+              </button>
+              {renderHideCardButton(platformId)}
+            </div>
           </div>
 
           <div className="split-content">
@@ -2611,6 +2668,7 @@ export function DashboardPage({
                 <RotateCw size={14} className={cardRefreshing.workbuddy ? 'loading-spinner' : ''} />
                 <span>{t('common.refresh', '刷新')}</span>
               </button>
+              {renderHideCardButton(platformId)}
               <button
                 className="header-action-btn header-collapse-btn"
                 onClick={() => toggleDashboardCardCollapse('workbuddy')}
@@ -2655,6 +2713,9 @@ export function DashboardPage({
             {renderPlatformIcon(platformId, 18)}
             <h3>{getPlatformLabel(platformId, t)}</h3>
           </div>
+          <div className="header-action-group">
+            {renderHideCardButton(platformId)}
+          </div>
         </div>
 
         <div className="split-content">
@@ -2681,17 +2742,17 @@ export function DashboardPage({
   return (
     <main className="main-content dashboard-page fade-in">
       <div className="page-tabs-row" style={{ minHeight: '60px' }}>
-         <div className="page-tabs-label dashboard-title-label">
-           <span>{t('nav.dashboard', '仪表盘')}</span>
-           <ManualHelpIconButton className="header-action-btn dashboard-manual-btn dashboard-title-manual-btn" />
-         </div>
-         {topCenterBanner}
-         <div className="dashboard-top-actions">
-           <button className="header-action-btn" onClick={onOpenPlatformLayout}>
-             <span>{t('platformLayout.title', '平台布局')}</span>
-           </button>
-           <AnnouncementCenter onNavigate={onNavigate} variant="inline" trigger="button" />
-         </div>
+        <div className="page-tabs-label dashboard-title-label">
+          <span>{t('nav.dashboard', '仪表盘')}</span>
+          <ManualHelpIconButton className="header-action-btn dashboard-manual-btn dashboard-title-manual-btn" />
+        </div>
+        {topCenterBanner}
+        <div className="dashboard-top-actions">
+          <button className="header-action-btn" onClick={onOpenPlatformLayout}>
+            <span>{t('platformLayout.title', '平台布局')}</span>
+          </button>
+          <AnnouncementCenter onNavigate={onNavigate} variant="inline" trigger="button" />
+        </div>
       </div>
 
       {/* Top Stats */}
@@ -2713,8 +2774,8 @@ export function DashboardPage({
           const group = groupId ? platformGroups.find((item) => item.id === groupId) : null;
           const groupChildLabels = group
             ? group.platformIds.map((childPlatformId) =>
-                resolveGroupChildName(group, childPlatformId, getPlatformLabel(childPlatformId, t)),
-              )
+              resolveGroupChildName(group, childPlatformId, getPlatformLabel(childPlatformId, t)),
+            )
             : [];
           const groupExtraCount = Math.max(groupChildLabels.length - 1, 0);
           const groupTooltip = groupChildLabels.join(', ');
@@ -2725,18 +2786,18 @@ export function DashboardPage({
             platformId === 'antigravity'
               ? 'success'
               : platformId === 'codex'
-              ? 'info'
-              : platformId === 'zed'
                 ? 'info'
-              : platformId === 'github-copilot'
-              ? 'github'
-              : platformId === 'kiro'
-                ? 'github'
-              : platformId === 'cursor'
-                ? 'info'
-              : platformId === 'gemini'
-                ? 'info'
-              : 'windsurf';
+                : platformId === 'zed'
+                  ? 'info'
+                  : platformId === 'github-copilot'
+                    ? 'github'
+                    : platformId === 'kiro'
+                      ? 'github'
+                      : platformId === 'cursor'
+                        ? 'info'
+                        : platformId === 'gemini'
+                          ? 'info'
+                          : 'windsurf';
           return (
             <button
               className="stat-card stat-card-button"


### PR DESCRIPTION
## Summary
This PR adds a quick hide control to dashboard platform cards. Users can now hide a platform card directly from the card header without opening platform layout settings.

## What changed
- Added an icon-only hide button in each platform card header
- Hooked hide action into existing dashboard/platform layout visibility state
- Added compact header icon button styling for consistent layout

## Behavior
- Clicking the hide icon immediately removes that platform card from the current dashboard view
- Existing card actions (refresh, switch, collapse where applicable) continue to work as before

## Validation
- Type check passes successfully
- No new compile errors introduced in dashboard page/styles