### PR TITLE
feat(gemini): support syncing default instance credentials to wsl

### DIFF
--- a/crates/cockpit-core/src/modules/config.rs
+++ b/crates/cockpit-core/src/modules/config.rs
@@ -100,6 +100,9 @@ pub struct UserConfig {
     /// Gemini 自动刷新间隔（分钟），-1 表示禁用
     #[serde(default = "default_gemini_auto_refresh")]
     pub gemini_auto_refresh_minutes: i32,
+    /// Gemini 切号时是否同步覆盖 WSL 配置 (Windows Only)
+    #[serde(default = "default_gemini_sync_wsl")]
+    pub gemini_sync_wsl: bool,
     /// CodeBuddy 自动刷新间隔（分钟），-1 表示禁用
     #[serde(default = "default_codebuddy_auto_refresh")]
     pub codebuddy_auto_refresh_minutes: i32,
@@ -445,6 +448,9 @@ fn default_cursor_auto_refresh() -> i32 {
 fn default_gemini_auto_refresh() -> i32 {
     10
 }
+fn default_gemini_sync_wsl() -> bool {
+    true
+}
 fn default_codebuddy_auto_refresh() -> i32 {
     10
 }
@@ -725,6 +731,7 @@ impl Default for UserConfig {
             kiro_auto_refresh_minutes: default_kiro_auto_refresh(),
             cursor_auto_refresh_minutes: default_cursor_auto_refresh(),
             gemini_auto_refresh_minutes: default_gemini_auto_refresh(),
+            gemini_sync_wsl: default_gemini_sync_wsl(),
             codebuddy_auto_refresh_minutes: default_codebuddy_auto_refresh(),
             codebuddy_cn_auto_refresh_minutes: default_codebuddy_cn_auto_refresh(),
             workbuddy_auto_refresh_minutes: default_workbuddy_auto_refresh(),
@@ -1018,6 +1025,13 @@ pub fn load_user_config() -> Result<UserConfig, String> {
             obj.insert(
                 "gemini_auto_refresh_minutes".to_string(),
                 json!(inherited_refresh),
+            );
+        }
+
+        if !obj.contains_key("gemini_sync_wsl") {
+            obj.insert(
+                "gemini_sync_wsl".to_string(),
+                json!(default_gemini_sync_wsl()),
             );
         }
 

--- a/crates/cockpit-core/src/modules/gemini_account.rs
+++ b/crates/cockpit-core/src/modules/gemini_account.rs
@@ -1710,7 +1710,7 @@ fn sync_default_gemini_home_to_wsl() {
     let target_home_str = target_home.to_string_lossy().to_string();
 
     let script = format!(
-        "mkdir -p ~/.gemini && cp -rf \"$(wslpath -u '{}')\"/* ~/.gemini/ 2>/dev/null || true",
+        "mkdir -p ~/.gemini && cd \"$(wslpath -u '{}')\" && cp -f oauth_creds.json google_accounts.json ~/.gemini/ 2>/dev/null || true && rm -f ~/.gemini/gemini-credentials.json 2>/dev/null || true",
         target_home_str.replace('\'', "'\\''")
     );
 

--- a/crates/cockpit-core/src/modules/gemini_account.rs
+++ b/crates/cockpit-core/src/modules/gemini_account.rs
@@ -1702,6 +1702,28 @@ pub async fn refresh_all_tokens() -> Result<Vec<(String, Result<GeminiAccount, S
     Ok(results)
 }
 
+#[cfg(target_os = "windows")]
+fn sync_default_gemini_home_to_wsl() {
+    let Ok(target_home) = resolve_gemini_home(None) else {
+        return;
+    };
+    let target_home_str = target_home.to_string_lossy().to_string();
+
+    let script = format!(
+        "mkdir -p ~/.gemini && cp -rf \"$(wslpath -u '{}')\"/* ~/.gemini/ 2>/dev/null || true",
+        target_home_str.replace('\'', "'\\''")
+    );
+
+    use std::os::windows::process::CommandExt;
+    let _ = std::process::Command::new("wsl.exe")
+        .arg("-e")
+        .arg("sh")
+        .arg("-c")
+        .arg(&script)
+        .creation_flags(0x0800_0000)
+        .spawn();
+}
+
 pub fn inject_to_gemini_home(account_id: &str, cli_home_root: Option<&Path>) -> Result<(), String> {
     let mut account =
         load_account_file(account_id).ok_or_else(|| "Gemini 账号不存在".to_string())?;
@@ -1711,6 +1733,13 @@ pub fn inject_to_gemini_home(account_id: &str, cli_home_root: Option<&Path>) -> 
     clear_local_file_keychain_to_path(cli_home_root)?;
     update_local_active_account_with_path(&account.email, cli_home_root)?;
     write_local_selected_auth_type_to_path("oauth-personal", cli_home_root)?;
+
+    #[cfg(target_os = "windows")]
+    if cli_home_root.is_none() {
+        if crate::modules::config::get_user_config().gemini_sync_wsl {
+            sync_default_gemini_home_to_wsl();
+        }
+    }
 
     account.selected_auth_type = Some("oauth-personal".to_string());
     account.last_used = now_ts();

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -74,6 +74,8 @@ pub struct GeneralConfig {
     pub cursor_auto_refresh_minutes: i32,
     /// Gemini 自动刷新间隔（分钟），-1 表示禁用
     pub gemini_auto_refresh_minutes: i32,
+    /// Gemini 切号时是否同步覆盖 WSL 配置 (Windows Only)
+    pub gemini_sync_wsl: bool,
     /// CodeBuddy 自动刷新间隔（分钟），-1 表示禁用
     pub codebuddy_auto_refresh_minutes: i32,
     /// CodeBuddy CN 自动刷新间隔（分钟），-1 表示禁用
@@ -687,6 +689,7 @@ pub fn save_network_config(
         kiro_auto_refresh_minutes: current.kiro_auto_refresh_minutes,
         cursor_auto_refresh_minutes: current.cursor_auto_refresh_minutes,
         gemini_auto_refresh_minutes: current.gemini_auto_refresh_minutes,
+        gemini_sync_wsl: current.gemini_sync_wsl,
         codebuddy_auto_refresh_minutes: current.codebuddy_auto_refresh_minutes,
         codebuddy_cn_auto_refresh_minutes: current.codebuddy_cn_auto_refresh_minutes,
         workbuddy_auto_refresh_minutes: current.workbuddy_auto_refresh_minutes,
@@ -951,6 +954,7 @@ pub fn get_general_config(app: tauri::AppHandle) -> Result<GeneralConfig, String
         kiro_auto_refresh_minutes: user_config.kiro_auto_refresh_minutes,
         cursor_auto_refresh_minutes: user_config.cursor_auto_refresh_minutes,
         gemini_auto_refresh_minutes: user_config.gemini_auto_refresh_minutes,
+        gemini_sync_wsl: user_config.gemini_sync_wsl,
         codebuddy_auto_refresh_minutes: user_config.codebuddy_auto_refresh_minutes,
         codebuddy_cn_auto_refresh_minutes: user_config.codebuddy_cn_auto_refresh_minutes,
         workbuddy_auto_refresh_minutes: user_config.workbuddy_auto_refresh_minutes,
@@ -1077,6 +1081,7 @@ pub fn save_general_config(
     kiro_auto_refresh_minutes: Option<i32>,
     cursor_auto_refresh_minutes: Option<i32>,
     gemini_auto_refresh_minutes: Option<i32>,
+    gemini_sync_wsl: Option<bool>,
     codebuddy_auto_refresh_minutes: Option<i32>,
     codebuddy_cn_auto_refresh_minutes: Option<i32>,
     workbuddy_auto_refresh_minutes: Option<i32>,
@@ -1280,6 +1285,8 @@ pub fn save_general_config(
             .unwrap_or(current.cursor_auto_refresh_minutes),
         gemini_auto_refresh_minutes: gemini_auto_refresh_minutes
             .unwrap_or(current.gemini_auto_refresh_minutes),
+        gemini_sync_wsl: gemini_sync_wsl
+            .unwrap_or(current.gemini_sync_wsl),
         codebuddy_auto_refresh_minutes: codebuddy_auto_refresh_minutes
             .unwrap_or(current.codebuddy_auto_refresh_minutes),
         codebuddy_cn_auto_refresh_minutes: codebuddy_cn_auto_refresh_minutes

--- a/src-tauri/src/modules/config.rs
+++ b/src-tauri/src/modules/config.rs
@@ -100,6 +100,9 @@ pub struct UserConfig {
     /// Gemini 自动刷新间隔（分钟），-1 表示禁用
     #[serde(default = "default_gemini_auto_refresh")]
     pub gemini_auto_refresh_minutes: i32,
+    /// Gemini 切号时是否同步覆盖 WSL 配置 (Windows Only)
+    #[serde(default = "default_gemini_sync_wsl")]
+    pub gemini_sync_wsl: bool,
     /// CodeBuddy 自动刷新间隔（分钟），-1 表示禁用
     #[serde(default = "default_codebuddy_auto_refresh")]
     pub codebuddy_auto_refresh_minutes: i32,
@@ -463,6 +466,9 @@ fn default_cursor_auto_refresh() -> i32 {
 fn default_gemini_auto_refresh() -> i32 {
     10
 }
+fn default_gemini_sync_wsl() -> bool {
+    true
+}
 fn default_codebuddy_auto_refresh() -> i32 {
     10
 }
@@ -761,6 +767,7 @@ impl Default for UserConfig {
             kiro_auto_refresh_minutes: default_kiro_auto_refresh(),
             cursor_auto_refresh_minutes: default_cursor_auto_refresh(),
             gemini_auto_refresh_minutes: default_gemini_auto_refresh(),
+            gemini_sync_wsl: default_gemini_sync_wsl(),
             codebuddy_auto_refresh_minutes: default_codebuddy_auto_refresh(),
             codebuddy_cn_auto_refresh_minutes: default_codebuddy_cn_auto_refresh(),
             workbuddy_auto_refresh_minutes: default_workbuddy_auto_refresh(),
@@ -1060,6 +1067,13 @@ pub fn load_user_config() -> Result<UserConfig, String> {
             obj.insert(
                 "gemini_auto_refresh_minutes".to_string(),
                 json!(inherited_refresh),
+            );
+        }
+
+        if !obj.contains_key("gemini_sync_wsl") {
+            obj.insert(
+                "gemini_sync_wsl".to_string(),
+                json!(default_gemini_sync_wsl()),
             );
         }
 

--- a/src-tauri/src/modules/gemini_account.rs
+++ b/src-tauri/src/modules/gemini_account.rs
@@ -1696,6 +1696,28 @@ pub async fn refresh_all_tokens() -> Result<Vec<(String, Result<GeminiAccount, S
     Ok(results)
 }
 
+#[cfg(target_os = "windows")]
+fn sync_default_gemini_home_to_wsl() {
+    let Ok(target_home) = resolve_gemini_home(None) else {
+        return;
+    };
+    let target_home_str = target_home.to_string_lossy().to_string();
+
+    let script = format!(
+        "mkdir -p ~/.gemini && cp -rf \"$(wslpath -u '{}')\"/* ~/.gemini/ 2>/dev/null || true",
+        target_home_str.replace('\'', "'\\''")
+    );
+
+    use std::os::windows::process::CommandExt;
+    let _ = std::process::Command::new("wsl.exe")
+        .arg("-e")
+        .arg("sh")
+        .arg("-c")
+        .arg(&script)
+        .creation_flags(0x0800_0000)
+        .spawn();
+}
+
 pub fn inject_to_gemini_home(account_id: &str, cli_home_root: Option<&Path>) -> Result<(), String> {
     let mut account =
         load_account_file(account_id).ok_or_else(|| "Gemini 账号不存在".to_string())?;
@@ -1705,6 +1727,13 @@ pub fn inject_to_gemini_home(account_id: &str, cli_home_root: Option<&Path>) -> 
     clear_local_file_keychain_to_path(cli_home_root)?;
     update_local_active_account_with_path(&account.email, cli_home_root)?;
     write_local_selected_auth_type_to_path("oauth-personal", cli_home_root)?;
+
+    #[cfg(target_os = "windows")]
+    if cli_home_root.is_none() {
+        if crate::modules::config::get_user_config().gemini_sync_wsl {
+            sync_default_gemini_home_to_wsl();
+        }
+    }
 
     account.selected_auth_type = Some("oauth-personal".to_string());
     account.last_used = now_ts();

--- a/src-tauri/src/modules/gemini_account.rs
+++ b/src-tauri/src/modules/gemini_account.rs
@@ -1704,7 +1704,7 @@ fn sync_default_gemini_home_to_wsl() {
     let target_home_str = target_home.to_string_lossy().to_string();
 
     let script = format!(
-        "mkdir -p ~/.gemini && cp -rf \"$(wslpath -u '{}')\"/* ~/.gemini/ 2>/dev/null || true",
+        "mkdir -p ~/.gemini && cd \"$(wslpath -u '{}')\" && cp -f oauth_creds.json google_accounts.json ~/.gemini/ 2>/dev/null || true && rm -f ~/.gemini/gemini-credentials.json 2>/dev/null || true",
         target_home_str.replace('\'', "'\\''")
     );
 

--- a/src/components/QuickSettingsPopover.tsx
+++ b/src/components/QuickSettingsPopover.tsx
@@ -59,6 +59,7 @@ interface GeneralConfig {
   kiro_auto_refresh_minutes: number;
   cursor_auto_refresh_minutes: number;
   gemini_auto_refresh_minutes: number;
+  gemini_sync_wsl: boolean;
   codebuddy_auto_refresh_minutes: number;
   codebuddy_cn_auto_refresh_minutes: number;
   qoder_auto_refresh_minutes: number;
@@ -820,6 +821,7 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
           kiroAutoRefreshMinutes: merged.kiro_auto_refresh_minutes,
           cursorAutoRefreshMinutes: merged.cursor_auto_refresh_minutes,
           geminiAutoRefreshMinutes: merged.gemini_auto_refresh_minutes,
+          geminiSyncWsl: merged.gemini_sync_wsl,
           codebuddyAutoRefreshMinutes: merged.codebuddy_auto_refresh_minutes,
           codebuddyCnAutoRefreshMinutes: merged.codebuddy_cn_auto_refresh_minutes,
           workbuddyAutoRefreshMinutes: merged.workbuddy_auto_refresh_minutes,

--- a/src/components/QuickSettingsPopover.tsx
+++ b/src/components/QuickSettingsPopover.tsx
@@ -40,6 +40,7 @@ import {
 import type { Account } from '../types/account';
 import type { CodexAccount, CodexQuickConfig } from '../types/codex';
 import { getDisplayGroups, type DisplayGroup } from '../services/groupService';
+import { usePlatformRuntimeSupport } from '../hooks/usePlatformRuntimeSupport';
 import {
   readAccountsOverviewFilterPersistenceEnabled,
   resolveAccountsOverviewScopeFromQuickSettingsType,
@@ -291,6 +292,7 @@ const normalizeAutoSwitchAccountScopeMode = (
 
 export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
   const { t } = useTranslation();
+  const isWindows = usePlatformRuntimeSupport('windows-only');
   const overviewFilterScope = useMemo(
     () => resolveAccountsOverviewScopeFromQuickSettingsType(type),
     [type],
@@ -1790,6 +1792,33 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
                     'settings.general.codexLocalAccessEntryVisibleDesc',
                     '仅控制 Codex 总览中的 API 服务入口显示，不会停止本地 API 服务；关闭后可在这里重新打开。',
                   )}
+                </div>
+              </div>
+            )}
+
+            {type === 'gemini' && isWindows && (
+              <div className="qs-section">
+                <div className="qs-row">
+                  <div className="qs-row-label">
+                    <span>
+                      {t('quickSettings.gemini.syncWsl', '同步 WSL 配置')}
+                    </span>
+                  </div>
+                  <div className="qs-row-control">
+                    <label className="qs-switch">
+                      <input
+                        type="checkbox"
+                        checked={config.gemini_sync_wsl}
+                        onChange={(e) =>
+                          saveConfig({ gemini_sync_wsl: e.target.checked })
+                        }
+                      />
+                      <span className="qs-switch-slider"></span>
+                    </label>
+                  </div>
+                </div>
+                <div className="qs-hint">
+                  {t('quickSettings.gemini.syncWslDesc', '切号时自动覆盖 WSL 下的 .gemini 配置')}
                 </div>
               </div>
             )}

--- a/src/hooks/useAutoRefresh.ts
+++ b/src/hooks/useAutoRefresh.ts
@@ -33,6 +33,7 @@ interface GeneralConfig {
   kiro_auto_refresh_minutes: number;
   cursor_auto_refresh_minutes: number;
   gemini_auto_refresh_minutes: number;
+  gemini_sync_wsl: boolean;
   codebuddy_auto_refresh_minutes: number;
   codebuddy_cn_auto_refresh_minutes: number;
   workbuddy_auto_refresh_minutes: number;

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -2664,7 +2664,9 @@
     },
     "gemini": {
       "title": "Gemini Cli Settings",
-      "appPath": "Gemini Cli Path"
+      "appPath": "Gemini Cli Path",
+      "syncWsl": "Sync WSL Configuration",
+      "syncWslDesc": "Automatically overwrite the .gemini configuration in WSL when switching accounts"
     },
     "geminiRefreshInterval": "Quota Auto Refresh",
     "error": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2664,7 +2664,9 @@
     },
     "gemini": {
       "title": "Gemini Cli Settings",
-      "appPath": "Gemini Cli Path"
+      "appPath": "Gemini Cli Path",
+      "syncWsl": "Sync WSL Configuration",
+      "syncWslDesc": "Automatically overwrite the .gemini configuration in WSL when switching accounts"
     },
     "geminiRefreshInterval": "Quota Auto Refresh",
     "error": {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -84,6 +84,7 @@ interface GeneralConfig {
   kiro_auto_refresh_minutes: number;
   cursor_auto_refresh_minutes: number;
   gemini_auto_refresh_minutes: number;
+  gemini_sync_wsl: boolean;
   close_behavior: 'ask' | 'minimize' | 'quit';
   minimize_behavior?: 'dock_and_tray' | 'tray_only';
   hide_dock_icon?: boolean;
@@ -337,6 +338,7 @@ export function SettingsPage() {
   const [kiroAutoRefresh, setKiroAutoRefresh] = useState('10');
   const [cursorAutoRefresh, setCursorAutoRefresh] = useState('10');
   const [geminiAutoRefresh, setGeminiAutoRefresh] = useState('10');
+  const [geminiSyncWsl, setGeminiSyncWsl] = useState(true);
   const [closeBehavior, setCloseBehavior] = useState<'ask' | 'minimize' | 'quit'>('ask');
   const [minimizeBehavior, setMinimizeBehavior] = useState<'dock_and_tray' | 'tray_only'>('dock_and_tray');
   const [hideDockIcon, setHideDockIcon] = useState(false);
@@ -772,6 +774,7 @@ export function SettingsPage() {
           zedAutoRefreshMinutes: zedAutoRefreshNum,
           cursorAutoRefreshMinutes: cursorAutoRefreshNum,
           geminiAutoRefreshMinutes: geminiAutoRefreshNum,
+          geminiSyncWsl,
           closeBehavior,
           minimizeBehavior,
           hideDockIcon,
@@ -1172,6 +1175,7 @@ export function SettingsPage() {
       setKiroAutoRefresh(String(config.kiro_auto_refresh_minutes ?? 10));
       setCursorAutoRefresh(String(config.cursor_auto_refresh_minutes ?? 10));
       setGeminiAutoRefresh(String(config.gemini_auto_refresh_minutes ?? 10));
+      setGeminiSyncWsl(Boolean(config.gemini_sync_wsl ?? true));
       setCloseBehavior(config.close_behavior || 'ask');
       setMinimizeBehavior(config.minimize_behavior || 'dock_and_tray');
       setHideDockIcon(Boolean(config.hide_dock_icon));
@@ -4867,6 +4871,25 @@ export function SettingsPage() {
                       </div>
                     </div>
                   </div>
+
+                  {isWindows && (
+                    <div className="settings-row">
+                      <div className="row-label">
+                        <div className="row-title">{t('quickSettings.gemini.syncWsl', '同步 WSL 配置')}</div>
+                        <div className="row-desc">{t('quickSettings.gemini.syncWslDesc', '切号时自动覆盖 WSL 下的 .gemini 配置')}</div>
+                      </div>
+                      <div className="row-control">
+                        <label className="switch">
+                          <input
+                            type="checkbox"
+                            checked={geminiSyncWsl}
+                            onChange={(e) => setGeminiSyncWsl(e.target.checked)}
+                          />
+                          <span className="slider"></span>
+                        </label>
+                      </div>
+                    </div>
+                  )}
 
                   {renderCurrentAccountRefreshRow('gemini')}
 


### PR DESCRIPTION
 ## Motivation / 动机
**English:**
Development on Windows frequently involves using WSL2. This feature allows users to install the Gemini CLI directly within their WSL2 environment while using Cockpit Tools on the Windows host to manage Gemini and other AI providers. By syncing the active `.gemini` configuration across the OS boundary, it ensures a seamless developer experience without needing to manually copy credentials when switching accounts.

**中文:**
在 Windows 上进行开发通常会深度依赖 WSL2。此功能允许用户在 WSL2 环境中直接安装 Gemini CLI，同时在 Windows 宿主机上使用 Cockpit Tools 来管理 Gemini 和其他 AI 驱动。通过跨系统边界自动同步 `.gemini` 配置，它确保了无缝的开发者体验，避免了在切换账号时手动复制凭据的麻烦。

## Summary / 摘要
**English:**
Implemented logic using `wsl.exe` to automatically sync `~/.gemini` to the default WSL distribution when switching the active Gemini instance.
Added a `gemini_sync_wsl` configuration option (enabled by default) to control this behavior.
Added a "Sync WSL Configuration" toggle to both the main Settings page and the Gemini Quick Settings popover (visible only on Windows).
Added English and Chinese translations for the new WSL sync settings.

**中文:**
使用 `wsl.exe` 实现了在切换 Gemini 活跃实例时，自动将 `~/.gemini` 同步到默认的 WSL 发行版的逻辑。
添加了 `gemini_sync_wsl` 配置选项（默认启用）来控制此行为。
在主设置页面和 Gemini 快捷设置弹出窗口中添加了“同步 WSL 配置”开关（仅在 Windows 上可见）。
为新的 WSL 同步设置添加了中英文翻译。

## Test Plan / 测试计划
**English:**
[ ] On Windows, verify that the "Sync WSL Configuration" toggle appears in the Settings page and the Gemini Quick Settings popover.
[ ] With the setting enabled, switch the active Gemini account and verify that the credentials in `~/.gemini` inside WSL are updated accordingly.
[ ] With the setting disabled, verify that switching the active Gemini account does not modify the WSL `.gemini` directory.
[ ] Verify the toggle does not appear on macOS/Linux.

**中文:**
[ ] 在 Windows 上，验证“同步 WSL 配置”开关正常显示在设置页面和 Gemini 快捷设置弹出窗口中。
[ ] 启用该设置后，切换活跃的 Gemini 账号，验证 WSL 内的 `~/.gemini` 目录凭据是否相应更新。
[ ] 禁用该设置后，验证切换活跃的 Gemini 账号不会修改 WSL 中的 `.gemini` 目录。
[ ] 验证该开关在 macOS/Linux 上不显示。
