### PR TITLE
fix: checkpoint WebKit LocalStorage WAL on startup to prevent unbounded growth

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,11 @@ pub fn run() {
             // 存储全局 AppHandle
             let _ = APP_HANDLE.set(app.handle().clone());
 
+            // 启动时清理 WebKit LocalStorage WAL，防止无限膨胀
+            std::thread::spawn(|| {
+                modules::webkit_cache_maintenance::checkpoint_webkit_localstorage();
+            });
+
             // 初始化 Updater 插件
             #[cfg(desktop)]
             {

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -74,6 +74,7 @@ pub mod wakeup_history;
 pub mod wakeup_scheduler;
 pub mod wakeup_verification;
 pub mod web_report;
+pub mod webkit_cache_maintenance;
 pub mod websocket;
 pub mod windsurf_account;
 pub mod windsurf_instance;

--- a/src-tauri/src/modules/webkit_cache_maintenance.rs
+++ b/src-tauri/src/modules/webkit_cache_maintenance.rs
@@ -1,0 +1,84 @@
+use rusqlite::Connection;
+use std::path::PathBuf;
+
+fn webkit_data_root() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let home = dirs::home_dir()?;
+        Some(home.join("Library/WebKit/com.jlcodes.cockpit-tools/WebsiteData"))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+fn find_localstorage_dbs(root: &std::path::Path) -> Vec<PathBuf> {
+    let mut results = Vec::new();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return results;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let candidate = path.join("LocalStorage").join("localstorage.sqlite3");
+            if candidate.exists() {
+                results.push(candidate);
+            }
+            results.extend(find_localstorage_dbs(&path));
+        }
+    }
+    results
+}
+
+/// Checkpoint WAL on all WebKit LocalStorage SQLite databases.
+///
+/// WebKit WKWebView uses WAL mode for LocalStorage but does not
+/// periodically checkpoint. When the app writes large blobs frequently
+/// (e.g. account caches with quota snapshots), the WAL file grows
+/// unbounded — in production it has been observed at 13 GB for only
+/// ~5 MB of actual data.
+///
+/// Running this at startup keeps the WAL from accumulating over time.
+pub fn checkpoint_webkit_localstorage() {
+    let Some(root) = webkit_data_root() else {
+        return;
+    };
+    if !root.exists() {
+        return;
+    }
+
+    let dbs = find_localstorage_dbs(&root);
+    if dbs.is_empty() {
+        return;
+    }
+
+    for db_path in dbs {
+        let label = db_path.display();
+        match Connection::open(&db_path) {
+            Ok(conn) => {
+                match conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+                    Ok(()) => {
+                        crate::modules::logger::log_info(&format!(
+                            "[WebkitCache] WAL checkpoint 成功: {}",
+                            label
+                        ));
+                    }
+                    Err(e) => {
+                        crate::modules::logger::log_warn(&format!(
+                            "[WebkitCache] WAL checkpoint 失败 (可能 WebView 正在占用): {} — {}",
+                            label, e
+                        ));
+                    }
+                }
+                drop(conn);
+            }
+            Err(e) => {
+                crate::modules::logger::log_warn(&format!(
+                    "[WebkitCache] 无法打开数据库: {} — {}",
+                    label, e
+                ));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

WebKit WKWebView uses WAL mode for LocalStorage SQLite databases but never checkpoints them. When the app writes large blobs frequently (e.g. Windsurf/Codex account caches with quota snapshots, written every few minutes via auto-refresh), the WAL file grows unbounded.

**Observed on my machine: 13 GB WAL file for only ~5 MB of actual data** (45 key-value pairs).

```
~/Library/WebKit/com.jlcodes.cockpit-tools/WebsiteData/.../LocalStorage/
  localstorage.sqlite3     5.0 MB   (actual data)
  localstorage.sqlite3-wal  13 GB   (should be ~0)
  localstorage.sqlite3-shm  27 MB
```

After running `PRAGMA wal_checkpoint(TRUNCATE)` manually, the WAL dropped to 0 bytes.

## Root Cause

The frontend writes full JSON-serialized account arrays to localStorage on:
- Every page navigation/mount
- Every auto-refresh cycle (configurable, ~5-30 min per platform)
- Every user action (switch account, refresh token, etc.)

11 platform account stores + 11 instance stores = 22 caches being rewritten continuously. The heaviest key (`agtools.windsurf.accounts.cache` at ~5 MB) includes raw API response blobs (`copilot_quota_snapshots`, `windsurf_user_status`, etc.) with no size reduction.

WKWebView doesn't auto-checkpoint its SQLite databases, so the WAL accumulates indefinitely.

## Fix

Add a startup maintenance step (`modules/webkit_cache_maintenance.rs`) that:
1. Locates all `localstorage.sqlite3` files under the WebKit data directory
2. Runs `PRAGMA wal_checkpoint(TRUNCATE)` on each
3. Runs in a background thread to avoid blocking startup
4. Logs success/failure for observability

Runs at startup in `lib.rs` setup, before the WebView is fully loaded — so the lock is available.

## Testing

- Compiled successfully with `cargo check` (no new warnings)
- Manual test: WAL went from 13 GB → 0 bytes after checkpoint

## Future Improvements (not in this PR)

- Add periodic checkpoint during runtime (e.g. every 30 min)
- Strip large API response blobs before persisting to localStorage
- Add size-based eviction for old cache entries
- Consider moving heavy caches to Tauri's Rust-side SQLite instead of WebKit LocalStorage