### PR TITLE
feat(windsurf): add static recommended account sorting

### DIFF
--- a/src/hooks/useProviderAccountsPage.ts
+++ b/src/hooks/useProviderAccountsPage.ts
@@ -133,6 +133,7 @@ export interface ProviderPageConfig<TAccount extends ProviderAccountBase> {
   }) => void | Promise<void>;
   /** OAuth 成功后的提示文案（可选） */
   resolveOauthSuccessMessage?: () => string;
+  defaultSortBy?: string;
 }
 
 export interface ProviderAccountBase {
@@ -360,7 +361,9 @@ export function useProviderAccountsPage<TAccount extends ProviderAccountBase>(
     oauthService,
     oauthTabKeys: oauthTabKeysConfig,
     dataService,
+    defaultSortBy: defaultSortByConfig,
   } = config;
+  const defaultSortBy = defaultSortByConfig?.trim() || DEFAULT_SORT_BY;
 
   const oauthTabKeys = useMemo(() => {
     const normalized = (oauthTabKeysConfig || [])
@@ -469,14 +472,14 @@ export function useProviderAccountsPage<TAccount extends ProviderAccountBase>(
   // ─── Sort ─────────────────────────────────────────────────────────────
   const [sortBy, setSortBy] = useState<string>(() => {
     if (!readAccountsOverviewFilterPersistenceEnabled(filterPersistenceScope)) {
-      return DEFAULT_SORT_BY;
+      return defaultSortBy;
     }
     const saved = readAccountsOverviewFilterField<string | null>(
       filterPersistenceScope,
       FILTER_FIELD_SORT_BY,
       null,
     );
-    return saved?.trim() ? saved : DEFAULT_SORT_BY;
+    return saved?.trim() ? saved : defaultSortBy;
   });
   const [sortDirection, setSortDirection] = useState<SortDirection>(() => {
     if (!readAccountsOverviewFilterPersistenceEnabled(filterPersistenceScope)) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -112,6 +112,9 @@
         "ascTooltip": "Current: Ascending. Click to switch to descending",
         "createdAt": "Created time",
         "descTooltip": "Current: Descending. Click to switch to ascending",
+        "recommended": "Recommended",
+        "recommendedAscTooltip": "Recommended (least worthwhile first)",
+        "recommendedDescTooltip": "Recommended (most worthwhile first)",
         "toggleDirection": "Toggle sort direction",
         "credits": "By remaining credits",
         "planEnd": "By cycle end time"

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -112,6 +112,9 @@
         "ascTooltip": "当前：升序，点击切换为降序",
         "createdAt": "按创建时间",
         "descTooltip": "当前：降序，点击切换为升序",
+        "recommended": "按推荐",
+        "recommendedAscTooltip": "按推荐度升序（最不值得切去的在前）",
+        "recommendedDescTooltip": "按推荐度降序（最值得切去的在前）",
         "toggleDirection": "切换排序方向",
         "credits": "按剩余 Credits",
         "planEnd": "按配额周期结束时间"

--- a/src/pages/WindsurfAccountsPage.tsx
+++ b/src/pages/WindsurfAccountsPage.tsx
@@ -40,6 +40,7 @@ import {
   getWindsurfQuotaUsageSummary,
   formatWindsurfResetTime,
   hasWindsurfQuotaData,
+  getWindsurfUsage,
 } from '../types/windsurf';
 import { buildWindsurfAccountPresentation } from '../presentation/platformAccountPresentation';
 
@@ -51,6 +52,7 @@ import { MultiSelectFilterDropdown, type MultiSelectFilterOption } from '../comp
 import { SingleSelectFilterDropdown } from '../components/SingleSelectFilterDropdown';
 import type { WindsurfAccount, WindsurfPlanBadge } from '../types/windsurf';
 import { compareCurrentAccountFirst } from '../utils/currentAccountSort';
+import { computeWindsurfRecommendScoreStatic } from '../utils/windsurfRecommend';
 import { emitAccountsChanged } from '../utils/accountSyncEvents';
 import {
   buildValidAccountsFilterOption,
@@ -319,6 +321,7 @@ export function WindsurfAccountsPage() {
     flowNoticeCollapsedKey: WINDSURF_FLOW_NOTICE_COLLAPSED_KEY,
     currentAccountIdKey: WINDSURF_CURRENT_ACCOUNT_ID_KEY,
     exportFilePrefix: 'windsurf_accounts',
+    defaultSortBy: 'recommended',
     store: {
       accounts: store.accounts,
       currentAccountId: store.currentAccountId,
@@ -406,6 +409,7 @@ export function WindsurfAccountsPage() {
 
   const accounts = store.accounts;
   const loading = store.loading;
+  const recommendNowSec = useMemo(() => Math.floor(Date.now() / 1000), [accounts]);
   const [passwordEmail, setPasswordEmail] = useState('');
   const [passwordPassword, setPasswordPassword] = useState('');
   const [passwordMode, setPasswordMode] = useState<WindsurfPasswordMode>('single');
@@ -1052,11 +1056,27 @@ export function WindsurfAccountsPage() {
       if (bReset == null) return -1;
       return sortDirection === 'desc' ? bReset - aReset : aReset - bReset;
     }
+    if (sortBy === 'recommended') {
+      const aScore = computeWindsurfRecommendScoreStatic(a, {
+        nowSec: recommendNowSec,
+        usage: getWindsurfUsage(a),
+        quotaSummary: resolveQuotaSummary(a),
+        summary: resolveCreditsSummary(a),
+      });
+      const bScore = computeWindsurfRecommendScoreStatic(b, {
+        nowSec: recommendNowSec,
+        usage: getWindsurfUsage(b),
+        quotaSummary: resolveQuotaSummary(b),
+        summary: resolveCreditsSummary(b),
+      });
+      const diff = bScore - aScore;
+      return sortDirection === 'desc' ? diff : -diff;
+    }
     const aValue = resolveCreditsSummary(a).creditsLeft ?? -1;
     const bValue = resolveCreditsSummary(b).creditsLeft ?? -1;
     const diff = bValue - aValue;
     return sortDirection === 'desc' ? diff : -diff;
-  }, [currentAccountId, resolveCreditsSummary, sortBy, sortDirection]);
+  }, [currentAccountId, recommendNowSec, resolveCreditsSummary, resolveQuotaSummary, sortBy, sortDirection]);
 
   const sortedAccountsForInstances = useMemo(
     () => [...accounts].sort(compareAccountsBySort),
@@ -1369,6 +1389,7 @@ export function WindsurfAccountsPage() {
           <SingleSelectFilterDropdown
             value={sortBy}
             options={[
+              { value: 'recommended', label: t('common.shared.sort.recommended', '按推荐') },
               { value: 'created_at', label: t('common.shared.sort.createdAt', '按创建时间') },
               { value: 'credits', label: t('common.shared.sort.credits', '按剩余 Credits') },
               { value: 'plan_end', label: t('common.shared.sort.planEnd', '按配额周期结束时间') },
@@ -1378,7 +1399,13 @@ export function WindsurfAccountsPage() {
             onChange={setSortBy}
           />
           <button className="sort-direction-btn" onClick={() => setSortDirection((prev) => (prev === 'desc' ? 'asc' : 'desc'))}
-            title={sortDirection === 'desc' ? t('common.shared.sort.descTooltip', '当前：降序，点击切换为升序') : t('common.shared.sort.ascTooltip', '当前：升序，点击切换为降序')}
+            title={sortBy === 'recommended'
+              ? (sortDirection === 'desc'
+                ? t('common.shared.sort.recommendedDescTooltip', '按推荐度降序（最值得切去的在前）')
+                : t('common.shared.sort.recommendedAscTooltip', '按推荐度升序（最不值得切去的在前）'))
+              : (sortDirection === 'desc'
+                ? t('common.shared.sort.descTooltip', '当前：降序，点击切换为升序')
+                : t('common.shared.sort.ascTooltip', '当前：升序，点击切换为降序'))}
             aria-label={t('common.shared.sort.toggleDirection', '切换排序方向')}>{sortDirection === 'desc' ? '⬇' : '⬆'}</button>
         </div>
         <div className="toolbar-right">

--- a/src/utils/windsurfRecommend.ts
+++ b/src/utils/windsurfRecommend.ts
@@ -1,0 +1,56 @@
+import {
+  getWindsurfCreditsSummary,
+  getWindsurfQuotaUsageSummary,
+  getWindsurfUsage,
+  type WindsurfAccount,
+  type WindsurfCreditsSummary,
+  type WindsurfQuotaUsageSummary,
+  type WindsurfUsage,
+} from '../types/windsurf';
+
+const DAILY_RESET_WINDOW_SEC = 24 * 3600;
+const WEEKLY_RESET_WINDOW_SEC = 7 * 24 * 3600;
+const PLAN_CYCLE_WINDOW_SEC = 14 * 24 * 3600;
+const URGENCY_WEIGHT = 1;
+
+type ComputeWindsurfRecommendScoreStaticOptions = {
+  nowSec?: number;
+  usage?: WindsurfUsage;
+  quotaSummary?: WindsurfQuotaUsageSummary;
+  summary?: WindsurfCreditsSummary;
+};
+
+function normalizeRemainingQuotaPct(usedPercent: number | null): number {
+  if (usedPercent == null || !Number.isFinite(usedPercent)) return 1;
+  return Math.max(0, Math.min(1, 1 - usedPercent / 100));
+}
+
+function computeTimeUrgency(targetSec: number | null | undefined, nowSec: number, windowSec: number): number {
+  if (targetSec == null || targetSec <= nowSec) return 0;
+  const timeLeftSec = targetSec - nowSec;
+  return Math.max(0, Math.min(1, 1 - timeLeftSec / windowSec));
+}
+
+export function computeWindsurfRecommendScoreStatic(
+  account: WindsurfAccount,
+  options: ComputeWindsurfRecommendScoreStaticOptions = {},
+): number {
+  const nowSec = options.nowSec ?? Math.floor(Date.now() / 1000);
+  const usage = options.usage ?? getWindsurfUsage(account);
+  const quotaSummary = options.quotaSummary ?? getWindsurfQuotaUsageSummary(account);
+  const summary = options.summary ?? getWindsurfCreditsSummary(account);
+  const dailyUsedPercent = quotaSummary.dailyUsedPercent ?? usage.inlineSuggestionsUsedPercent;
+  const weeklyUsedPercent = quotaSummary.weeklyUsedPercent ?? usage.chatMessagesUsedPercent;
+
+  const dailyRemainingPct = normalizeRemainingQuotaPct(dailyUsedPercent);
+  const weeklyRemainingPct = normalizeRemainingQuotaPct(weeklyUsedPercent);
+  const availableQuota = (dailyRemainingPct + weeklyRemainingPct) / 2;
+
+  const urgencyBoost = Math.max(
+    computeTimeUrgency(quotaSummary.dailyResetAt ?? usage.allowanceResetAt, nowSec, DAILY_RESET_WINDOW_SEC),
+    computeTimeUrgency(quotaSummary.weeklyResetAt, nowSec, WEEKLY_RESET_WINDOW_SEC),
+    computeTimeUrgency(summary.planEndsAt, nowSec, PLAN_CYCLE_WINDOW_SEC),
+  );
+
+  return availableQuota * (1 + URGENCY_WEIGHT * urgencyBoost);
+}


### PR DESCRIPTION
## Motivation

Users managing many Windsurf Trial accounts get very little value from the existing `By remaining credits` sort, because most Trial accounts report identical or null prompt/add-on credits. Sorting by credits therefore produces an order that doesn't answer the practical question: **"which account is most worth switching to right now?"**

The new Recommended sort answers that question directly by combining daily/weekly quota remaining with reset/plan-cycle urgency, using exactly the numbers already shown on each account card. This is purely additive — the existing `By remaining credits` sort is untouched.

## Summary

Adds a static "Recommended" sort mode to the Windsurf accounts page, so users with many similar Trial accounts can quickly spot which account is worth switching to based on remaining quota and urgency.

### Changes

- New [computeWindsurfRecommendScoreStatic](cci:1://file:///d:/Work/cockpit-tools-main/src/utils/windsurfRecommend.ts:29:0-47:1) util: score = available quota × (1 + urgency boost), where quota is daily/weekly remaining % from the same summary the UI displays, and urgency comes from daily/weekly reset and plan cycle countdowns.
- [useProviderAccountsPage](cci:1://file:///d:/Work/cockpit-tools-main/src/hooks/useProviderAccountsPage.ts:346:0-1820:1) now accepts `defaultSortBy` so each page can override the initial sort; Windsurf defaults to `recommended` when no persisted preference exists.
- Windsurf sort dropdown gains a "按推荐 / Recommended" option; desc/asc tooltips and labels are recommendation-aware.
- Current account stays pinned to the top under all sort modes, including recommended asc/desc.
- zh-CN and en locale strings for the new sort mode.

### Scope intentionally excluded

- Only zh-CN and en labels are added; other locales fall back to English.
- Recommendation weights (half-life, urgency weight, quota weight) stay as code constants.
- No multi-account day-level route planning.
- No telemetry disclosure panel or first-run splash.

## Validation

- `npx tsc --noEmit`
- `npx vite build`
- `git diff --check`
- `npm run tauri dev` launched from a VS 2022 Build Tools + Rust environment on Windows.
- Verified in the real Windsurf page:
  - Recommended desc keeps the current account first; low-usage accounts rank ahead of high-usage ones; more urgent quota cycles outrank less urgent ones at equal usage.
  - Recommended asc keeps the current account first and reverses non-current ordering as expected.
  - Clicking the second recommended card triggered a real account switch and moved the "当前" badge to the clicked card.

## Risk

Low. The change only adds a new sort mode plus a small hook parameter, and keeps the existing sort modes untouched. Default sort change only affects Windsurf users with no persisted sort preference; anyone with a saved sort keeps their current behavior.