### PR TITLE
feat(windsurf): support Devin Auth (2026-04+) for new accounts

### DIFF
--- a/crates/cockpit-core/src/models/windsurf.rs
+++ b/crates/cockpit-core/src/models/windsurf.rs
@@ -51,6 +51,26 @@ pub struct WindsurfAccount {
     pub quota_query_last_error_at: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage_updated_at: Option<i64>,
+    // ===== Devin Auth (2026-04+) 新账号体系字段 =====
+    // 老账号 (Firebase) 读取这些字段时为 None，与现有逻辑完全兼容
+    /// 账号类型: "firebase" (老 sk-ws- 体系) | "devin-session" (新 auth1 体系)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windsurf_token_type: Option<String>,
+    /// Devin 长期凭证（refresh_token 等价物，每次切号用它换出新 ide_token）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_auth1_token: Option<String>,
+    /// Devin 账号 ID (account-xxx)，注入 IDE 时作为 x-devin-account-id header
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_account_id: Option<String>,
+    /// Devin 组织 ID (org-xxx)，注入 IDE 时作为 x-devin-primary-org-id header
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_org_id: Option<String>,
+    /// Devin 短期 session token (devin-session-token$...)，主要用于 web 端
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_session_token: Option<String>,
+    /// UserStatus protobuf 的 base64 编码，写入 windsurfAuthStatus.userStatusProtoBinaryBase64
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_user_status_proto_b64: Option<String>,
     pub created_at: i64,
     pub last_used: i64,
 }
@@ -103,7 +123,7 @@ pub struct WindsurfOAuthStartResponse {
     pub callback_url: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct WindsurfOAuthCompletePayload {
     pub github_login: String,
     pub github_id: u64,
@@ -127,6 +147,13 @@ pub struct WindsurfOAuthCompletePayload {
     pub windsurf_user_status: Option<serde_json::Value>,
     pub windsurf_plan_status: Option<serde_json::Value>,
     pub windsurf_auth_status_raw: Option<serde_json::Value>,
+    // ===== Devin Auth 字段 =====
+    pub windsurf_token_type: Option<String>,
+    pub devin_auth1_token: Option<String>,
+    pub devin_account_id: Option<String>,
+    pub devin_org_id: Option<String>,
+    pub devin_session_token: Option<String>,
+    pub devin_user_status_proto_b64: Option<String>,
 }
 
 impl WindsurfAccount {

--- a/crates/cockpit-core/src/modules/mod.rs
+++ b/crates/cockpit-core/src/modules/mod.rs
@@ -73,6 +73,7 @@ pub mod wakeup_gateway;
 // pub mod web_report;
 pub mod websocket;
 pub mod windsurf_account;
+pub mod windsurf_devin_oauth;
 pub mod windsurf_instance;
 pub mod windsurf_oauth;
 pub mod workbuddy_account;

--- a/crates/cockpit-core/src/modules/windsurf_devin_oauth.rs
+++ b/crates/cockpit-core/src/modules/windsurf_devin_oauth.rs
@@ -1,0 +1,708 @@
+//! Windsurf Devin Auth (2026-04+) 协议实现
+//!
+//! Windsurf 在 2026-04 把账号体系从 Firebase (sk-ws-XXX 格式) 迁移到了 Devin Auth
+//! (auth1_XXX / devin-session-token$XXX 格式)。新注册的账号都属于 Devin 体系，
+//! 而老的 Firebase 邮密登录端点对它们返回 EMAIL_NOT_FOUND。
+//!
+//! 本模块实现 Devin Auth 的协议级登录与刷新流程。
+//!
+//! # 流程
+//!
+//! ```text
+//! 邮箱+密码                               (LoginWithPassword)
+//!   ↓
+//! POST /_devin-auth/password/login        → auth1_token (长期凭证)
+//!   ↓
+//! WindsurfPostAuth(auth1)                 → session_token + account_id + org_id
+//!   ↓
+//! GetOneTimeAuthToken(session)            → ott
+//!   ↓
+//! RegisterUser(ott)                       → ide_token (机器绑定，能发消息)
+//!   ↓
+//! GetCurrentUser(session)                 → user_status_proto (UI 显示)
+//! ```
+//!
+//! # 切号场景
+//!
+//! 切号时只需要 `auth1_token`（长期凭证，与 refresh_token 等价），调一次
+//! `full_refresh_from_auth1` 就能拿到所有 IDE 注入需要的字段。
+
+use base64::Engine;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::json;
+use std::time::Duration;
+
+use crate::modules::logger;
+
+// ========== 端点 ==========
+
+const PASSWORD_LOGIN_URL: &str = "https://windsurf.com/_devin-auth/password/login";
+const CONNECTIONS_URL: &str = "https://windsurf.com/_devin-auth/connections";
+const POST_AUTH_URL: &str =
+    "https://windsurf.com/_backend/exa.seat_management_pb.SeatManagementService/WindsurfPostAuth";
+const GET_OTT_URL: &str =
+    "https://windsurf.com/_backend/exa.seat_management_pb.SeatManagementService/GetOneTimeAuthToken";
+const REGISTER_USER_URL: &str =
+    "https://register.windsurf.com/exa.seat_management_pb.SeatManagementService/RegisterUser";
+const GET_CURRENT_USER_URL: &str =
+    "https://windsurf.com/_backend/exa.seat_management_pb.SeatManagementService/GetCurrentUser";
+
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+const SEC_CH_UA: &str =
+    r#""Google Chrome";v="147", "Not.A/Brand";v="8", "Chromium";v="147""#;
+
+// ========== 公共数据结构 ==========
+
+/// 邮密登录的产物
+#[derive(Debug, Clone)]
+pub struct DevinPasswordLoginResult {
+    pub auth1_token: String,
+    pub user_id: Option<String>,
+    pub email: Option<String>,
+}
+
+/// `full_refresh_from_auth1` 的产物
+#[derive(Debug, Clone)]
+pub struct DevinFullRefreshResult {
+    pub ide_token: String,
+    pub session_token: String,
+    pub auth1_token: String,
+    pub account_id: String,
+    pub org_id: String,
+    /// UserStatus protobuf 的 base64 编码（写入 windsurfAuthStatus.userStatusProtoBinaryBase64）
+    pub user_status_proto_b64: Option<String>,
+}
+
+// ========== protobuf 编解码（仅 varint + length-delimited，够用） ==========
+
+fn encode_varint(mut n: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(10);
+    while n > 0x7F {
+        out.push(((n & 0x7F) as u8) | 0x80);
+        n >>= 7;
+    }
+    out.push(n as u8);
+    out
+}
+
+fn proto_string_field(field_num: u32, value: &str) -> Vec<u8> {
+    let tag = (field_num << 3) | 2;
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len() + 10);
+    out.extend(encode_varint(tag as u64));
+    out.extend(encode_varint(bytes.len() as u64));
+    out.extend_from_slice(bytes);
+    out
+}
+
+/// 简单 protobuf 解析：返回 field_num → list of (string | varint).
+/// 仅支持 wire type 0 (varint) 和 2 (length-delimited string)，足够当前用途。
+#[derive(Debug, Clone)]
+pub enum ProtoValue {
+    Varint(u64),
+    Bytes(Vec<u8>),
+}
+
+impl ProtoValue {
+    pub fn as_string(&self) -> Option<String> {
+        match self {
+            ProtoValue::Bytes(b) => String::from_utf8(b.clone()).ok(),
+            _ => None,
+        }
+    }
+}
+
+fn proto_parse(raw: &[u8]) -> std::collections::HashMap<u32, Vec<ProtoValue>> {
+    let mut result: std::collections::HashMap<u32, Vec<ProtoValue>> =
+        std::collections::HashMap::new();
+    let mut pos = 0;
+    while pos < raw.len() {
+        // 先读 tag (varint)
+        let (tag, consumed) = match read_varint(&raw[pos..]) {
+            Some(v) => v,
+            None => break,
+        };
+        pos += consumed;
+        let field_num = (tag >> 3) as u32;
+        let wire_type = tag & 0x07;
+        match wire_type {
+            0 => {
+                // varint
+                let (val, consumed) = match read_varint(&raw[pos..]) {
+                    Some(v) => v,
+                    None => break,
+                };
+                pos += consumed;
+                result
+                    .entry(field_num)
+                    .or_default()
+                    .push(ProtoValue::Varint(val));
+            }
+            2 => {
+                // length-delimited
+                let (length, consumed) = match read_varint(&raw[pos..]) {
+                    Some(v) => v,
+                    None => break,
+                };
+                pos += consumed;
+                let length = length as usize;
+                if pos + length > raw.len() {
+                    break;
+                }
+                let bytes = raw[pos..pos + length].to_vec();
+                pos += length;
+                result
+                    .entry(field_num)
+                    .or_default()
+                    .push(ProtoValue::Bytes(bytes));
+            }
+            _ => break, // 不支持的 wire type，提前结束（足以满足当前需求）
+        }
+    }
+    result
+}
+
+fn read_varint(buf: &[u8]) -> Option<(u64, usize)> {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    let mut consumed = 0usize;
+    for &b in buf {
+        consumed += 1;
+        result |= ((b & 0x7F) as u64) << shift;
+        if b & 0x80 == 0 {
+            return Some((result, consumed));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return None;
+        }
+    }
+    None
+}
+
+fn proto_get_string(
+    fields: &std::collections::HashMap<u32, Vec<ProtoValue>>,
+    field_num: u32,
+) -> Option<String> {
+    fields
+        .get(&field_num)?
+        .first()?
+        .as_string()
+        .filter(|s| !s.is_empty())
+}
+
+// ========== HTTP client 构造 ==========
+
+fn build_client() -> Result<Client, String> {
+    Client::builder()
+        .user_agent(UA)
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("构建 HTTP client 失败: {}", e))
+}
+
+// ========== 1. 邮密登录: /_devin-auth/password/login ==========
+
+#[derive(Debug, Deserialize)]
+struct PasswordLoginResponse {
+    token: Option<String>,
+    user_id: Option<String>,
+    email: Option<String>,
+}
+
+/// 协议级邮密登录（无 OTP、无浏览器、无外部依赖）
+///
+/// 实测端点（2026-05）。返回 `auth1_token`（Devin 长期凭证）。
+pub async fn login_with_password(
+    email: &str,
+    password: &str,
+) -> Result<DevinPasswordLoginResult, String> {
+    let email = email.trim();
+    if email.is_empty() || password.is_empty() {
+        return Err("邮箱和密码不能为空".to_string());
+    }
+
+    logger::log_info(&format!(
+        "[Windsurf Devin] /_devin-auth/password/login (email={})",
+        email
+    ));
+
+    let client = build_client()?;
+    let resp = client
+        .post(PASSWORD_LOGIN_URL)
+        .header("Accept", "*/*")
+        .header("Accept-Language", "zh-CN,zh;q=0.9")
+        .header("Content-Type", "application/json")
+        .header("Origin", "https://windsurf.com")
+        .header("Referer", "https://windsurf.com/account/login")
+        .header("Sec-Fetch-Dest", "empty")
+        .header("Sec-Fetch-Mode", "cors")
+        .header("Sec-Fetch-Site", "same-origin")
+        .header("sec-ch-ua", SEC_CH_UA)
+        .header("sec-ch-ua-mobile", "?0")
+        .header("sec-ch-ua-platform", "\"Windows\"")
+        .json(&json!({
+            "email": email,
+            "password": password,
+            "product": "Windsurf",
+        }))
+        .send()
+        .await
+        .map_err(|e| format!("Devin 邮密登录请求失败: {}", e))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .unwrap_or_else(|_| "<no-body>".to_string());
+
+    if !status.is_success() {
+        // 服务端常见错误码映射成友好提示
+        let friendly = if status.as_u16() == 401 || status.as_u16() == 403 {
+            "邮箱或密码错误".to_string()
+        } else if status.as_u16() == 404 {
+            // 未注册账号 connections 接口会先告诉，登录直接 404
+            "邮箱未注册".to_string()
+        } else if status.as_u16() == 429 {
+            "请求过于频繁，请稍后再试".to_string()
+        } else {
+            format!("Devin 登录失败 (HTTP {}): {}", status.as_u16(), truncate(&text, 200))
+        };
+        return Err(friendly);
+    }
+
+    let parsed: PasswordLoginResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("解析 Devin 登录响应失败: {} (原始 body: {})", e, truncate(&text, 200)))?;
+
+    let auth1 = parsed
+        .token
+        .filter(|t| t.starts_with("auth1_"))
+        .ok_or_else(|| format!("Devin 登录响应未含 auth1_token: {}", truncate(&text, 200)))?;
+
+    Ok(DevinPasswordLoginResult {
+        auth1_token: auth1,
+        user_id: parsed.user_id,
+        email: parsed.email,
+    })
+}
+
+// ========== 2. WindsurfPostAuth: auth1 → session + account + org ==========
+
+async fn windsurf_post_auth(
+    client: &Client,
+    auth1_token: &str,
+) -> Result<(String, String, String, String), String> {
+    let body = proto_string_field(1, auth1_token);
+
+    let mut last_err = String::new();
+    for attempt in 1..=3u32 {
+        logger::log_info(&format!(
+            "[Windsurf Devin] WindsurfPostAuth (attempt {}/3, auth1={}...)",
+            attempt,
+            &auth1_token[..auth1_token.len().min(20)]
+        ));
+        let resp = client
+            .post(POST_AUTH_URL)
+            .header("Content-Type", "application/proto")
+            .header("connect-protocol-version", "1")
+            .header("Accept", "application/proto")
+            .header("Origin", "https://windsurf.com")
+            .header("Referer", "https://windsurf.com/account/login")
+            // 关键: 服务端 2026-05 起强制要求此 header
+            .header("x-devin-auth1-token", auth1_token)
+            .body(body.clone())
+            .send()
+            .await;
+        match resp {
+            Ok(r) => {
+                let status = r.status();
+                if !status.is_success() {
+                    let body_text = r.text().await.unwrap_or_default();
+                    last_err = format!("HTTP {}: {}", status.as_u16(), truncate(&body_text, 200));
+                    if attempt < 3 {
+                        let wait = if status.as_u16() >= 400 && status.as_u16() < 500 {
+                            // 4xx 大概率 auth1 未就绪 (刚生成的 auth1 服务端可能要 1-2 秒索引)
+                            Duration::from_millis((3000 * attempt) as u64)
+                        } else {
+                            Duration::from_millis((2000 * attempt) as u64)
+                        };
+                        tokio::time::sleep(wait).await;
+                        continue;
+                    }
+                    return Err(format!("WindsurfPostAuth 失败: {}", last_err));
+                }
+                let raw = r.bytes().await.map_err(|e| format!("读取响应失败: {}", e))?;
+                let parsed = proto_parse(&raw);
+                let session_token = proto_get_string(&parsed, 1)
+                    .filter(|s| s.starts_with("devin-session-token$"))
+                    .ok_or_else(|| {
+                        format!(
+                            "WindsurfPostAuth 响应未含 session_token (proto fields: {:?})",
+                            parsed.keys().collect::<Vec<_>>()
+                        )
+                    })?;
+                let auth1_back = proto_get_string(&parsed, 3).unwrap_or_else(|| auth1_token.to_string());
+                let account_id = proto_get_string(&parsed, 4)
+                    .ok_or_else(|| "WindsurfPostAuth 响应未含 account_id".to_string())?;
+                let org_id = proto_get_string(&parsed, 5)
+                    .ok_or_else(|| "WindsurfPostAuth 响应未含 org_id".to_string())?;
+                return Ok((session_token, auth1_back, account_id, org_id));
+            }
+            Err(e) => {
+                last_err = format!("请求异常: {}", e);
+                if attempt < 3 {
+                    tokio::time::sleep(Duration::from_millis(2000)).await;
+                    continue;
+                }
+                return Err(format!("WindsurfPostAuth 失败: {}", last_err));
+            }
+        }
+    }
+    Err(format!("WindsurfPostAuth 重试 3 次仍失败: {}", last_err))
+}
+
+// ========== 3. GetOneTimeAuthToken: session → ott ==========
+
+async fn get_one_time_auth_token(
+    client: &Client,
+    session_token: &str,
+    auth1: &str,
+    account_id: &str,
+    org_id: &str,
+) -> Result<String, String> {
+    let body = proto_string_field(1, session_token);
+
+    let mut last_err = String::new();
+    for attempt in 1..=3u32 {
+        let resp = client
+            .post(GET_OTT_URL)
+            .header("Content-Type", "application/proto")
+            .header("connect-protocol-version", "1")
+            .header("Accept", "application/proto")
+            .header("Origin", "https://windsurf.com")
+            .header("Referer", "https://windsurf.com/editor/auth-success")
+            .header("x-auth-token", session_token)
+            .header("x-devin-session-token", session_token)
+            .header("x-devin-account-id", account_id)
+            .header("x-devin-primary-org-id", org_id)
+            .header("x-devin-auth1-token", auth1)
+            .body(body.clone())
+            .send()
+            .await;
+        match resp {
+            Ok(r) => {
+                let status = r.status();
+                if !status.is_success() {
+                    let body_text = r.text().await.unwrap_or_default();
+                    last_err = format!("HTTP {}: {}", status.as_u16(), truncate(&body_text, 200));
+                    if attempt < 3 {
+                        tokio::time::sleep(Duration::from_millis((2000 * attempt) as u64)).await;
+                        continue;
+                    }
+                    return Err(format!("GetOneTimeAuthToken 失败: {}", last_err));
+                }
+                let raw = r.bytes().await.map_err(|e| format!("读取响应失败: {}", e))?;
+                let parsed = proto_parse(&raw);
+                let ott = proto_get_string(&parsed, 1)
+                    .filter(|s| s.starts_with("ott$"))
+                    .ok_or_else(|| "GetOTT 响应未含 ott".to_string())?;
+                return Ok(ott);
+            }
+            Err(e) => {
+                last_err = format!("请求异常: {}", e);
+                if attempt < 3 {
+                    tokio::time::sleep(Duration::from_millis(2000)).await;
+                    continue;
+                }
+                return Err(format!("GetOneTimeAuthToken 失败: {}", last_err));
+            }
+        }
+    }
+    Err(format!("GetOneTimeAuthToken 重试 3 次仍失败: {}", last_err))
+}
+
+// ========== 4. RegisterUser: ott → ide_token ==========
+
+async fn register_user(client: &Client, ott: &str) -> Result<String, String> {
+    let body = proto_string_field(1, ott);
+
+    let mut last_err = String::new();
+    for attempt in 1..=3u32 {
+        let resp = client
+            .post(REGISTER_USER_URL)
+            .header("Content-Type", "application/proto")
+            .header("connect-protocol-version", "1")
+            // register.windsurf.com 期望 connect-es 风格 UA，不要带 x-devin-* headers
+            .header("User-Agent", "connect-es/1.5.0")
+            .body(body.clone())
+            .send()
+            .await;
+        match resp {
+            Ok(r) => {
+                let status = r.status();
+                if !status.is_success() {
+                    let body_text = r.text().await.unwrap_or_default();
+                    last_err = format!("HTTP {}: {}", status.as_u16(), truncate(&body_text, 200));
+                    if attempt < 3 {
+                        tokio::time::sleep(Duration::from_millis((2000 * attempt) as u64)).await;
+                        continue;
+                    }
+                    return Err(format!("RegisterUser 失败: {}", last_err));
+                }
+                let raw = r.bytes().await.map_err(|e| format!("读取响应失败: {}", e))?;
+                // 找第一个 "devin-session-token$" 开头的 ASCII 字符串就是 ide_token
+                let needle = b"devin-session-token$";
+                if let Some(idx) = find_subslice(&raw, needle) {
+                    let mut end = idx;
+                    while end < raw.len() && (0x20..0x7F).contains(&raw[end]) {
+                        end += 1;
+                    }
+                    let ide_token = String::from_utf8(raw[idx..end].to_vec())
+                        .map_err(|e| format!("ide_token 不是合法 UTF-8: {}", e))?;
+                    return Ok(ide_token);
+                }
+                last_err = "RegisterUser 响应未含 ide_token".to_string();
+                if attempt < 3 {
+                    tokio::time::sleep(Duration::from_millis(1500)).await;
+                    continue;
+                }
+                return Err(last_err);
+            }
+            Err(e) => {
+                last_err = format!("请求异常: {}", e);
+                if attempt < 3 {
+                    tokio::time::sleep(Duration::from_millis(2000)).await;
+                    continue;
+                }
+                return Err(format!("RegisterUser 失败: {}", last_err));
+            }
+        }
+    }
+    Err(format!("RegisterUser 重试 3 次仍失败: {}", last_err))
+}
+
+// ========== 5. GetCurrentUser: session → UserStatusProto ==========
+
+async fn get_current_user_proto(
+    client: &Client,
+    session_token: &str,
+    auth1: &str,
+    account_id: &str,
+    org_id: &str,
+) -> Result<Vec<u8>, String> {
+    // body = proto field 1 (string session) + 0x10 0x01 0x20 0x01 (field 2/4 varint=1)
+    let mut body = proto_string_field(1, session_token);
+    body.extend_from_slice(&[0x10, 0x01, 0x20, 0x01]);
+
+    let resp = client
+        .post(GET_CURRENT_USER_URL)
+        .header("Content-Type", "application/proto")
+        .header("connect-protocol-version", "1")
+        .header("Accept", "application/proto")
+        .header("Origin", "https://windsurf.com")
+        .header("Referer", "https://windsurf.com/")
+        .header("x-auth-token", session_token)
+        .header("x-devin-session-token", session_token)
+        .header("x-devin-account-id", account_id)
+        .header("x-devin-primary-org-id", org_id)
+        .header("x-devin-auth1-token", auth1)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("GetCurrentUser 请求失败: {}", e))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "GetCurrentUser HTTP {}: {}",
+            status.as_u16(),
+            truncate(&text, 200)
+        ));
+    }
+    let raw = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("读取 GetCurrentUser 响应失败: {}", e))?;
+    Ok(raw.to_vec())
+}
+
+// ========== 组合：完整刷新 ==========
+
+/// 用 auth1_token 跑完整 4 步链路，拿到 IDE 切号注入需要的所有字段
+///
+/// 任何一步失败都返回 Err，避免产出"能登录但不能对话"的脏号。
+pub async fn full_refresh_from_auth1(
+    auth1_token: &str,
+) -> Result<DevinFullRefreshResult, String> {
+    let auth1 = auth1_token.trim();
+    if !auth1.starts_with("auth1_") {
+        return Err(format!(
+            "auth1_token 格式错误，应以 'auth1_' 开头，实际: {}",
+            truncate(auth1, 30)
+        ));
+    }
+
+    let client = build_client()?;
+
+    // Step 1: WindsurfPostAuth
+    let (session_token, auth1_back, account_id, org_id) =
+        windsurf_post_auth(&client, auth1).await?;
+    logger::log_info(&format!(
+        "[Windsurf Devin] PostAuth ok: account={}, org={}",
+        account_id, org_id
+    ));
+
+    // 浏览器里 PostAuth → GetOTT 之间有自然 RTT
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Step 2: GetOneTimeAuthToken
+    let ott = get_one_time_auth_token(&client, &session_token, &auth1_back, &account_id, &org_id).await?;
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    // Step 3: RegisterUser → ide_token (机器绑定)
+    let ide_token = register_user(&client, &ott).await?;
+    logger::log_info(&format!(
+        "[Windsurf Devin] RegisterUser ok: ide_token len={}",
+        ide_token.len()
+    ));
+
+    // Step 4: GetCurrentUser → UserStatusProto
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let user_status_proto_b64 = match get_current_user_proto(
+        &client,
+        &session_token,
+        &auth1_back,
+        &account_id,
+        &org_id,
+    )
+    .await
+    {
+        Ok(bytes) => Some(base64::engine::general_purpose::STANDARD.encode(bytes)),
+        Err(err) => {
+            // GetCurrentUser 失败不致命，UI 显示信息缺失但能正常发消息
+            logger::log_warn(&format!(
+                "[Windsurf Devin] GetCurrentUser 失败（不致命，将继续）: {}",
+                err
+            ));
+            None
+        }
+    };
+
+    Ok(DevinFullRefreshResult {
+        ide_token,
+        session_token,
+        auth1_token: auth1_back,
+        account_id,
+        org_id,
+        user_status_proto_b64,
+    })
+}
+
+// ========== 辅助：查询邮箱可用 auth_method (诊断用，可选调用) ==========
+
+#[derive(Debug, Deserialize)]
+struct ConnectionsAuthMethod {
+    method: Option<String>,
+    has_password: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnectionsResponse {
+    auth_method: Option<ConnectionsAuthMethod>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConnectionsInfo {
+    pub method: String,
+    pub has_password: bool,
+}
+
+/// 调 /_devin-auth/connections 询问服务端：这个邮箱目前可用哪种 auth_method
+///
+/// 用法：在用户输入邮箱后、提交密码前先调一次，决定走 Devin 邮密 / Devin OTP / SSO。
+/// 网络失败时返回 Err；服务端正常返回但字段缺失时返回默认值（method=email, has_password=false）。
+pub async fn query_connections(email: &str) -> Result<ConnectionsInfo, String> {
+    let email = email.trim();
+    if email.is_empty() {
+        return Err("邮箱不能为空".to_string());
+    }
+    let client = build_client()?;
+    let resp = client
+        .post(CONNECTIONS_URL)
+        .header("Content-Type", "application/json")
+        .header("Origin", "https://windsurf.com")
+        .header("Referer", "https://windsurf.com/account/login")
+        .json(&json!({"product": "windsurf", "email": email}))
+        .send()
+        .await
+        .map_err(|e| format!("查询 connections 失败: {}", e))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "connections HTTP {}: {}",
+            status.as_u16(),
+            truncate(&body, 200)
+        ));
+    }
+    let parsed: ConnectionsResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("解析 connections 响应失败: {}", e))?;
+    let am = parsed.auth_method.unwrap_or(ConnectionsAuthMethod {
+        method: Some("email".to_string()),
+        has_password: Some(false),
+    });
+    Ok(ConnectionsInfo {
+        method: am.method.unwrap_or_else(|| "email".to_string()),
+        has_password: am.has_password.unwrap_or(false),
+    })
+}
+
+// ========== 工具 ==========
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...({} more chars)", &s[..max], s.len() - max)
+    }
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn varint_roundtrip() {
+        for &n in &[0u64, 1, 127, 128, 16383, 16384, u32::MAX as u64] {
+            let bytes = encode_varint(n);
+            let (decoded, _) = read_varint(&bytes).unwrap();
+            assert_eq!(decoded, n, "varint roundtrip failed for {}", n);
+        }
+    }
+
+    #[test]
+    fn proto_string_field_format() {
+        // 字段 1 string "hi" → tag(0x0A) + len(0x02) + "hi"
+        let bytes = proto_string_field(1, "hi");
+        assert_eq!(bytes, vec![0x0A, 0x02, b'h', b'i']);
+    }
+
+    #[test]
+    fn proto_parse_basic() {
+        let bytes = proto_string_field(1, "hello");
+        let parsed = proto_parse(&bytes);
+        assert_eq!(proto_get_string(&parsed, 1).as_deref(), Some("hello"));
+    }
+}

--- a/src-tauri/src/commands/windsurf_instance.rs
+++ b/src-tauri/src/commands/windsurf_instance.rs
@@ -16,7 +16,7 @@ fn is_profile_initialized(user_data_dir: &str) -> bool {
     }
 }
 
-fn inject_bound_account_for_instance_start(
+async fn inject_bound_account_for_instance_start(
     user_data_dir: &str,
     bind_account_id: Option<&str>,
 ) -> Result<(), String> {
@@ -37,6 +37,34 @@ fn inject_bound_account_for_instance_start(
         "实例启动检测到绑定账号，准备注入: bind_account_id={}, dir_name={}",
         bind_id, safe_dir
     ));
+
+    // ===== Devin 账号: 切号前用 auth1 预刷新 token =====
+    // ide_token 是机器绑定 + 短期有效，每次切号必须重新走 4 步链路拿新鲜 token，
+    // 否则切号成功但 IDE 启动后用过期 token 调消息接口会被服务端 deny (error 12)。
+    // Firebase 账号没这个机制，跳过。
+    let is_devin = account
+        .devin_auth1_token
+        .as_deref()
+        .map(|s| s.starts_with("auth1_"))
+        .unwrap_or(false);
+    if is_devin {
+        modules::logger::log_info(&format!(
+            "[Windsurf Switch] Devin 账号 preflight refresh: account_id={}",
+            bind_id
+        ));
+        match modules::windsurf_account::refresh_account_token(bind_id).await {
+            Ok(_) => {
+                modules::logger::log_info("[Windsurf Switch] Devin preflight refresh 成功");
+            }
+            Err(err) => {
+                // 失败不致命：降级用账号文件里的旧 token，IDE 可能能登录但发消息会失败
+                modules::logger::log_warn(&format!(
+                    "[Windsurf Switch] Devin preflight refresh 失败（继续切号，可能影响发消息）: {}",
+                    err
+                ));
+            }
+        }
+    }
 
     modules::windsurf_instance::inject_account_to_profile(Path::new(user_data_dir), bind_id)?;
     modules::logger::log_info(&format!("Windsurf 账号注入完成: {}", account.github_login));
@@ -230,7 +258,8 @@ pub async fn windsurf_start_instance(instance_id: String) -> Result<InstanceProf
         inject_bound_account_for_instance_start(
             &default_dir_str,
             default_settings.bind_account_id.as_deref(),
-        )?;
+        )
+        .await?;
         let extra_args = modules::process::parse_extra_args(&default_settings.extra_args);
         let pid = modules::windsurf_instance::start_windsurf_default_with_args_with_new_window(
             &extra_args,
@@ -267,7 +296,8 @@ pub async fn windsurf_start_instance(instance_id: String) -> Result<InstanceProf
     inject_bound_account_for_instance_start(
         &instance.user_data_dir,
         instance.bind_account_id.as_deref(),
-    )?;
+    )
+    .await?;
     let extra_args = modules::process::parse_extra_args(&instance.extra_args);
     let pid = modules::windsurf_instance::start_windsurf_with_args_with_new_window(
         &instance.user_data_dir,

--- a/src-tauri/src/models/windsurf.rs
+++ b/src-tauri/src/models/windsurf.rs
@@ -51,6 +51,26 @@ pub struct WindsurfAccount {
     pub quota_query_last_error_at: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage_updated_at: Option<i64>,
+    // ===== Devin Auth (2026-04+) 新账号体系字段 =====
+    // 老账号 (Firebase) 读取这些字段时为 None，与现有逻辑完全兼容
+    /// 账号类型: "firebase" (老 sk-ws- 体系) | "devin-session" (新 auth1 体系)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windsurf_token_type: Option<String>,
+    /// Devin 长期凭证（refresh_token 等价物，每次切号用它换出新 ide_token）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_auth1_token: Option<String>,
+    /// Devin 账号 ID (account-xxx)，注入 IDE 时作为 x-devin-account-id header
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_account_id: Option<String>,
+    /// Devin 组织 ID (org-xxx)，注入 IDE 时作为 x-devin-primary-org-id header
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_org_id: Option<String>,
+    /// Devin 短期 session token (devin-session-token$...)，主要用于 web 端
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_session_token: Option<String>,
+    /// UserStatus protobuf 的 base64 编码，写入 windsurfAuthStatus.userStatusProtoBinaryBase64
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devin_user_status_proto_b64: Option<String>,
     pub created_at: i64,
     pub last_used: i64,
 }
@@ -103,7 +123,7 @@ pub struct WindsurfOAuthStartResponse {
     pub callback_url: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct WindsurfOAuthCompletePayload {
     pub github_login: String,
     pub github_id: u64,
@@ -127,6 +147,13 @@ pub struct WindsurfOAuthCompletePayload {
     pub windsurf_user_status: Option<serde_json::Value>,
     pub windsurf_plan_status: Option<serde_json::Value>,
     pub windsurf_auth_status_raw: Option<serde_json::Value>,
+    // ===== Devin Auth 字段 =====
+    pub windsurf_token_type: Option<String>,
+    pub devin_auth1_token: Option<String>,
+    pub devin_account_id: Option<String>,
+    pub devin_org_id: Option<String>,
+    pub devin_session_token: Option<String>,
+    pub devin_user_status_proto_b64: Option<String>,
 }
 
 impl WindsurfAccount {

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -76,6 +76,7 @@ pub mod wakeup_verification;
 pub mod web_report;
 pub mod websocket;
 pub mod windsurf_account;
+pub mod windsurf_devin_oauth;
 pub mod windsurf_instance;
 pub mod windsurf_oauth;
 pub mod workbuddy_account;

--- a/src-tauri/src/modules/windsurf_account.rs
+++ b/src-tauri/src/modules/windsurf_account.rs
@@ -869,6 +869,12 @@ pub fn upsert_account(payload: WindsurfOAuthCompletePayload) -> Result<WindsurfA
         quota_query_last_error: None,
         quota_query_last_error_at: None,
         usage_updated_at: None,
+        windsurf_token_type: payload.windsurf_token_type.clone(),
+        devin_auth1_token: payload.devin_auth1_token.clone(),
+        devin_account_id: payload.devin_account_id.clone(),
+        devin_org_id: payload.devin_org_id.clone(),
+        devin_session_token: payload.devin_session_token.clone(),
+        devin_user_status_proto_b64: payload.devin_user_status_proto_b64.clone(),
         created_at,
         last_used: now,
     });

--- a/src-tauri/src/modules/windsurf_devin_oauth.rs
+++ b/src-tauri/src/modules/windsurf_devin_oauth.rs
@@ -1,0 +1,644 @@
+//! Windsurf Devin Auth (2026-04+) 协议实现
+//!
+//! Windsurf 在 2026-04 把账号体系从 Firebase (sk-ws-XXX 格式) 迁移到了 Devin Auth
+//! (auth1_XXX / devin-session-token$XXX 格式)。新注册的账号都属于 Devin 体系，
+//! 而老的 Firebase 邮密登录端点对它们返回 EMAIL_NOT_FOUND。
+//!
+//! 本模块实现 Devin Auth 的协议级登录与刷新流程（2026-05 实测验证）。
+//!
+//! # 流程
+//!
+//! ```text
+//! 邮箱+密码                               (login_with_password)
+//!   ↓
+//! POST /_devin-auth/password/login        → auth1_token (长期凭证)
+//!   ↓
+//! WindsurfPostAuth(auth1)                 → session_token + account_id + org_id
+//!   ↓
+//! GetOneTimeAuthToken(session)            → ott
+//!   ↓
+//! RegisterUser(ott)                       → ide_token (机器绑定，能发消息)
+//!   ↓
+//! GetCurrentUser(session)                 → user_status_proto (UI 显示)
+//! ```
+//!
+//! 切号场景：只需要 `auth1_token`，调一次 `full_refresh_from_auth1` 拿全所需字段。
+
+use base64::Engine;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::json;
+use std::time::Duration;
+
+use crate::modules::logger;
+use crate::utils::protobuf::{encode_string_field, read_varint, skip_field};
+
+// ========== 端点 ==========
+
+const PASSWORD_LOGIN_URL: &str = "https://windsurf.com/_devin-auth/password/login";
+const CONNECTIONS_URL: &str = "https://windsurf.com/_devin-auth/connections";
+const POST_AUTH_URL: &str =
+    "https://windsurf.com/_backend/exa.seat_management_pb.SeatManagementService/WindsurfPostAuth";
+const GET_OTT_URL: &str =
+    "https://windsurf.com/_backend/exa.seat_management_pb.SeatManagementService/GetOneTimeAuthToken";
+const REGISTER_USER_URL: &str =
+    "https://register.windsurf.com/exa.seat_management_pb.SeatManagementService/RegisterUser";
+const GET_CURRENT_USER_URL: &str =
+    "https://windsurf.com/_backend/exa.seat_management_pb.SeatManagementService/GetCurrentUser";
+/// GetUserStatus: Devin 号查配额/计划，必须用 self-serve 域 + Bearer ide_token
+pub const GET_USER_STATUS_URL: &str =
+    "https://server.self-serve.windsurf.com/exa.seat_management_pb.SeatManagementService/GetUserStatus";
+
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+const SEC_CH_UA: &str =
+    r#""Google Chrome";v="147", "Not.A/Brand";v="8", "Chromium";v="147""#;
+
+// ========== 公共数据结构 ==========
+
+#[derive(Debug, Clone)]
+pub struct DevinPasswordLoginResult {
+    pub auth1_token: String,
+    pub user_id: Option<String>,
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DevinFullRefreshResult {
+    pub ide_token: String,
+    pub session_token: String,
+    pub auth1_token: String,
+    pub account_id: String,
+    pub org_id: String,
+    /// UserStatus protobuf 的 base64 编码（写入 windsurfAuthStatus.userStatusProtoBinaryBase64）
+    pub user_status_proto_b64: Option<String>,
+}
+
+// ========== protobuf 辅助：解析所有 length-delimited string 字段 ==========
+
+/// 从 proto 字节流里取出指定 field_num 的第一个 string 值。
+/// 仅支持 wire type 0 (varint) 和 2 (length-delimited)，足够当前需求。
+fn proto_get_first_string(data: &[u8], target_field: u32) -> Option<String> {
+    let mut offset = 0usize;
+    while offset < data.len() {
+        let (tag, new_offset) = read_varint(data, offset).ok()?;
+        let wire_type = (tag & 7) as u8;
+        let field_num = (tag >> 3) as u32;
+        if wire_type == 2 {
+            let (length, content_offset) = read_varint(data, new_offset).ok()?;
+            let length = length as usize;
+            if content_offset + length > data.len() {
+                return None;
+            }
+            if field_num == target_field {
+                return String::from_utf8(data[content_offset..content_offset + length].to_vec())
+                    .ok();
+            }
+            offset = content_offset + length;
+        } else {
+            offset = skip_field(data, new_offset, wire_type).ok()?;
+        }
+    }
+    None
+}
+
+// ========== HTTP client ==========
+
+fn build_client() -> Result<Client, String> {
+    Client::builder()
+        .user_agent(UA)
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("构建 HTTP client 失败: {}", e))
+}
+
+// ========== 1. 邮密登录: /_devin-auth/password/login ==========
+
+#[derive(Debug, Deserialize)]
+struct PasswordLoginResponse {
+    token: Option<String>,
+    user_id: Option<String>,
+    email: Option<String>,
+}
+
+/// 协议级邮密登录（无 OTP、无浏览器）。返回 auth1_token。
+pub async fn login_with_password(
+    email: &str,
+    password: &str,
+) -> Result<DevinPasswordLoginResult, String> {
+    let email = email.trim();
+    if email.is_empty() || password.is_empty() {
+        return Err("邮箱和密码不能为空".to_string());
+    }
+
+    logger::log_info(&format!(
+        "[Windsurf Devin] /_devin-auth/password/login (email={})",
+        email
+    ));
+
+    let client = build_client()?;
+    let resp = client
+        .post(PASSWORD_LOGIN_URL)
+        .header("Accept", "*/*")
+        .header("Accept-Language", "zh-CN,zh;q=0.9")
+        .header("Content-Type", "application/json")
+        .header("Origin", "https://windsurf.com")
+        .header("Referer", "https://windsurf.com/account/login")
+        .header("Sec-Fetch-Dest", "empty")
+        .header("Sec-Fetch-Mode", "cors")
+        .header("Sec-Fetch-Site", "same-origin")
+        .header("sec-ch-ua", SEC_CH_UA)
+        .header("sec-ch-ua-mobile", "?0")
+        .header("sec-ch-ua-platform", "\"Windows\"")
+        .json(&json!({
+            "email": email,
+            "password": password,
+            "product": "Windsurf",
+        }))
+        .send()
+        .await
+        .map_err(|e| format!("Devin 邮密登录请求失败: {}", e))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .unwrap_or_else(|_| "<no-body>".to_string());
+
+    if !status.is_success() {
+        let friendly = if status.as_u16() == 401 || status.as_u16() == 403 {
+            "邮箱或密码错误".to_string()
+        } else if status.as_u16() == 404 {
+            "邮箱未注册".to_string()
+        } else if status.as_u16() == 429 {
+            "请求过于频繁，请稍后再试".to_string()
+        } else {
+            format!(
+                "Devin 登录失败 (HTTP {}): {}",
+                status.as_u16(),
+                truncate(&text, 200)
+            )
+        };
+        return Err(friendly);
+    }
+
+    let parsed: PasswordLoginResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("解析 Devin 登录响应失败: {} (body: {})", e, truncate(&text, 200)))?;
+
+    let auth1 = parsed
+        .token
+        .filter(|t| t.starts_with("auth1_"))
+        .ok_or_else(|| format!("Devin 登录响应未含 auth1_token: {}", truncate(&text, 200)))?;
+
+    Ok(DevinPasswordLoginResult {
+        auth1_token: auth1,
+        user_id: parsed.user_id,
+        email: parsed.email,
+    })
+}
+
+// ========== 2. WindsurfPostAuth: auth1 → session + account + org ==========
+
+async fn windsurf_post_auth(
+    client: &Client,
+    auth1_token: &str,
+) -> Result<(String, String, String, String), String> {
+    let body = encode_string_field(1, auth1_token);
+
+    let mut last_err = String::new();
+    for attempt in 1..=3u32 {
+        logger::log_info(&format!(
+            "[Windsurf Devin] WindsurfPostAuth (attempt {}/3)",
+            attempt
+        ));
+        let resp = client
+            .post(POST_AUTH_URL)
+            .header("Content-Type", "application/proto")
+            .header("connect-protocol-version", "1")
+            .header("Accept", "application/proto")
+            .header("Origin", "https://windsurf.com")
+            .header("Referer", "https://windsurf.com/account/login")
+            // 关键: 服务端 2026-05 起强制要求此 header
+            .header("x-devin-auth1-token", auth1_token)
+            .body(body.clone())
+            .send()
+            .await;
+        match resp {
+            Ok(r) => {
+                let status = r.status();
+                if !status.is_success() {
+                    let body_text = r.text().await.unwrap_or_default();
+                    last_err = format!("HTTP {}: {}", status.as_u16(), truncate(&body_text, 200));
+                    if attempt < 3 {
+                        // 4xx 大概率 auth1 未就绪 (服务端索引需要 1-2 秒)，等更久
+                        let wait_ms = if status.as_u16() >= 400 && status.as_u16() < 500 {
+                            (3000 * attempt) as u64
+                        } else {
+                            (2000 * attempt) as u64
+                        };
+                        tokio::time::sleep(Duration::from_millis(wait_ms)).await;
+                        continue;
+                    }
+                    return Err(format!("WindsurfPostAuth 失败: {}", last_err));
+                }
+                let raw = r.bytes().await.map_err(|e| format!("读取响应失败: {}", e))?;
+                let session_token = proto_get_first_string(&raw, 1)
+                    .filter(|s| s.starts_with("devin-session-token$"))
+                    .ok_or_else(|| "WindsurfPostAuth 响应未含 session_token".to_string())?;
+                let auth1_back = proto_get_first_string(&raw, 3)
+                    .unwrap_or_else(|| auth1_token.to_string());
+                let account_id = proto_get_first_string(&raw, 4)
+                    .ok_or_else(|| "WindsurfPostAuth 响应未含 account_id".to_string())?;
+                let org_id = proto_get_first_string(&raw, 5)
+                    .ok_or_else(|| "WindsurfPostAuth 响应未含 org_id".to_string())?;
+                return Ok((session_token, auth1_back, account_id, org_id));
+            }
+            Err(e) => {
+                last_err = format!("请求异常: {}", e);
+                if attempt < 3 {
+                    tokio::time::sleep(Duration::from_millis(2000)).await;
+                    continue;
+                }
+                return Err(format!("WindsurfPostAuth 失败: {}", last_err));
+            }
+        }
+    }
+    Err(format!("WindsurfPostAuth 重试 3 次仍失败: {}", last_err))
+}
+
+// ========== 3. GetOneTimeAuthToken: session → ott ==========
+
+async fn get_one_time_auth_token(
+    client: &Client,
+    session_token: &str,
+    auth1: &str,
+    account_id: &str,
+    org_id: &str,
+) -> Result<String, String> {
+    let body = encode_string_field(1, session_token);
+
+    let mut last_err = String::new();
+    for attempt in 1..=3u32 {
+        let resp = client
+            .post(GET_OTT_URL)
+            .header("Content-Type", "application/proto")
+            .header("connect-protocol-version", "1")
+            .header("Accept", "application/proto")
+            .header("Origin", "https://windsurf.com")
+            .header("Referer", "https://windsurf.com/editor/auth-success")
+            .header("x-auth-token", session_token)
+            .header("x-devin-session-token", session_token)
+            .header("x-devin-account-id", account_id)
+            .header("x-devin-primary-org-id", org_id)
+            .header("x-devin-auth1-token", auth1)
+            .body(body.clone())
+            .send()
+            .await;
+        match resp {
+            Ok(r) => {
+                let status = r.status();
+                if !status.is_success() {
+                    let body_text = r.text().await.unwrap_or_default();
+                    last_err = format!("HTTP {}: {}", status.as_u16(), truncate(&body_text, 200));
+                    if attempt < 3 {
+                        tokio::time::sleep(Duration::from_millis((2000 * attempt) as u64)).await;
+                        continue;
+                    }
+                    return Err(format!("GetOneTimeAuthToken 失败: {}", last_err));
+                }
+                let raw = r.bytes().await.map_err(|e| format!("读取响应失败: {}", e))?;
+                let ott = proto_get_first_string(&raw, 1)
+                    .filter(|s| s.starts_with("ott$"))
+                    .ok_or_else(|| "GetOTT 响应未含 ott".to_string())?;
+                return Ok(ott);
+            }
+            Err(e) => {
+                last_err = format!("请求异常: {}", e);
+                if attempt < 3 {
+                    tokio::time::sleep(Duration::from_millis(2000)).await;
+                    continue;
+                }
+                return Err(format!("GetOneTimeAuthToken 失败: {}", last_err));
+            }
+        }
+    }
+    Err(format!("GetOneTimeAuthToken 重试 3 次仍失败: {}", last_err))
+}
+
+// ========== 4. RegisterUser: ott → ide_token ==========
+
+async fn register_user(client: &Client, ott: &str) -> Result<String, String> {
+    let body = encode_string_field(1, ott);
+
+    let mut last_err = String::new();
+    for attempt in 1..=3u32 {
+        let resp = client
+            .post(REGISTER_USER_URL)
+            .header("Content-Type", "application/proto")
+            .header("connect-protocol-version", "1")
+            // 关键：UA 必须用 IDE 真实使用的 Go connect 客户端版本。
+            // 服务端在 RegisterUser 时把 ide_token 与 UA 绑定，后续 IDE 发消息
+            // UA 不匹配会被服务端 deny (error 12 — 能登录但不能对话)。
+            // 不要带 x-devin-* headers，register.windsurf.com 不识别。
+            .header("User-Agent", "connect-go/1.18.1 (go1.26.1)")
+            .body(body.clone())
+            .send()
+            .await;
+        match resp {
+            Ok(r) => {
+                let status = r.status();
+                if !status.is_success() {
+                    let body_text = r.text().await.unwrap_or_default();
+                    last_err = format!("HTTP {}: {}", status.as_u16(), truncate(&body_text, 200));
+                    if attempt < 3 {
+                        tokio::time::sleep(Duration::from_millis((2000 * attempt) as u64)).await;
+                        continue;
+                    }
+                    return Err(format!("RegisterUser 失败: {}", last_err));
+                }
+                let raw = r.bytes().await.map_err(|e| format!("读取响应失败: {}", e))?;
+                // 找第一个 "devin-session-token$" 开头的 ASCII 字符串
+                let needle = b"devin-session-token$";
+                if let Some(idx) = find_subslice(&raw, needle) {
+                    let mut end = idx;
+                    while end < raw.len() && (0x20..0x7F).contains(&raw[end]) {
+                        end += 1;
+                    }
+                    let ide_token = String::from_utf8(raw[idx..end].to_vec())
+                        .map_err(|e| format!("ide_token 不是合法 UTF-8: {}", e))?;
+                    return Ok(ide_token);
+                }
+                last_err = "RegisterUser 响应未含 ide_token".to_string();
+                if attempt < 3 {
+                    tokio::time::sleep(Duration::from_millis(1500)).await;
+                    continue;
+                }
+                return Err(last_err);
+            }
+            Err(e) => {
+                last_err = format!("请求异常: {}", e);
+                if attempt < 3 {
+                    tokio::time::sleep(Duration::from_millis(2000)).await;
+                    continue;
+                }
+                return Err(format!("RegisterUser 失败: {}", last_err));
+            }
+        }
+    }
+    Err(format!("RegisterUser 重试 3 次仍失败: {}", last_err))
+}
+
+// ========== 5. GetCurrentUser: session → UserStatusProto ==========
+
+async fn get_current_user_proto(
+    client: &Client,
+    session_token: &str,
+    auth1: &str,
+    account_id: &str,
+    org_id: &str,
+) -> Result<Vec<u8>, String> {
+    // body = proto field 1 (string session) + 0x10 0x01 0x20 0x01 (field 2/4 varint=1)
+    let mut body = encode_string_field(1, session_token);
+    body.extend_from_slice(&[0x10, 0x01, 0x20, 0x01]);
+
+    let resp = client
+        .post(GET_CURRENT_USER_URL)
+        .header("Content-Type", "application/proto")
+        .header("connect-protocol-version", "1")
+        .header("Accept", "application/proto")
+        .header("Origin", "https://windsurf.com")
+        .header("Referer", "https://windsurf.com/")
+        .header("x-auth-token", session_token)
+        .header("x-devin-session-token", session_token)
+        .header("x-devin-account-id", account_id)
+        .header("x-devin-primary-org-id", org_id)
+        .header("x-devin-auth1-token", auth1)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("GetCurrentUser 请求失败: {}", e))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "GetCurrentUser HTTP {}: {}",
+            status.as_u16(),
+            truncate(&text, 200)
+        ));
+    }
+    let raw = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("读取 GetCurrentUser 响应失败: {}", e))?;
+    Ok(raw.to_vec())
+}
+
+// ========== 组合：完整刷新 ==========
+
+/// 用 auth1_token 跑完整 4 步链路，拿到 IDE 切号注入需要的所有字段
+///
+/// 任何一步失败都返回 Err（GetCurrentUser 除外，它失败不致命），
+/// 避免产出"能登录但不能对话"的脏号。
+pub async fn full_refresh_from_auth1(
+    auth1_token: &str,
+) -> Result<DevinFullRefreshResult, String> {
+    let auth1 = auth1_token.trim();
+    if !auth1.starts_with("auth1_") {
+        return Err(format!(
+            "auth1_token 格式错误，应以 'auth1_' 开头，实际: {}",
+            truncate(auth1, 30)
+        ));
+    }
+
+    let client = build_client()?;
+
+    // Step 1: WindsurfPostAuth
+    let (session_token, auth1_back, account_id, org_id) =
+        windsurf_post_auth(&client, auth1).await?;
+    logger::log_info(&format!(
+        "[Windsurf Devin] PostAuth ok: account={}, org={}",
+        account_id, org_id
+    ));
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Step 2: GetOneTimeAuthToken
+    let ott = get_one_time_auth_token(&client, &session_token, &auth1_back, &account_id, &org_id)
+        .await?;
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    // Step 3: RegisterUser → ide_token (机器绑定)
+    let ide_token = register_user(&client, &ott).await?;
+    logger::log_info(&format!(
+        "[Windsurf Devin] RegisterUser ok: ide_token len={}",
+        ide_token.len()
+    ));
+
+    // Step 4: GetCurrentUser → UserStatusProto（失败不致命）
+    // 注意：必须用 RegisterUser 产出的 ide_token（机器绑定）调用，
+    // 用 session_token 调可能会拿到旧/错的 UserStatus。
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let user_status_proto_b64 = match get_current_user_proto(
+        &client,
+        &ide_token,
+        &auth1_back,
+        &account_id,
+        &org_id,
+    )
+    .await
+    {
+        Ok(bytes) => Some(base64::engine::general_purpose::STANDARD.encode(bytes)),
+        Err(err) => {
+            logger::log_warn(&format!(
+                "[Windsurf Devin] GetCurrentUser 失败（不致命）: {}",
+                err
+            ));
+            None
+        }
+    };
+
+    Ok(DevinFullRefreshResult {
+        ide_token,
+        session_token,
+        auth1_token: auth1_back,
+        account_id,
+        org_id,
+        user_status_proto_b64,
+    })
+}
+
+// ========== GetUserStatus: 查 Devin 账号的计划/配额 ==========
+
+/// 用 ide_token 查询当前账号的 plan + 配额
+///
+/// 端点是 server.self-serve.windsurf.com（Devin 号专用），鉴权用 `Authorization: Bearer <ide_token>`。
+/// 返回 raw JSON Value，调用方按需提取 userStatus / planStatus / planInfo 等字段。
+///
+/// # 关键响应字段（实测）
+///
+/// ```text
+/// userStatus.planStatus.availablePromptCredits  // 剩余 (× 100)
+/// userStatus.planStatus.availableFlowCredits    // flow 剩余 (× 100)
+/// userStatus.planStatus.usedPromptCredits       // 已用 (× 100)
+/// userStatus.planStatus.planEnd                 // 计划结束时间
+/// userStatus.planStatus.dailyRemainingPercent / dailyQuotaRemainingPercent
+/// userStatus.planStatus.weeklyRemainingPercent / weeklyQuotaRemainingPercent
+/// userStatus.planStatus.dailyResetAtUnix / dailyQuotaResetAtUnix
+/// userStatus.planStatus.weeklyResetAtUnix / weeklyQuotaResetAtUnix
+/// userStatus.userUsedPromptCredits              // 备用已用字段
+/// planInfo.planName                             // FREE | PRO | TEAM | ENTERPRISE
+/// planInfo.monthlyPromptCredits                 // 月度总额度
+/// planInfo.monthlyFlowCredits                   // 月度 flow 总额度
+/// ```
+pub async fn fetch_devin_user_status(ide_token: &str) -> Result<serde_json::Value, String> {
+    let token = ide_token.trim();
+    if token.is_empty() {
+        return Err("ide_token 不能为空".to_string());
+    }
+    let client = build_client()?;
+    let body = json!({
+        "metadata": {
+            "ide_name": "WINDSURF",
+            "ide_version": "1.0.0",
+            "extension_version": "1.0.0",
+            "api_key": token,
+        }
+    });
+    let resp = client
+        .post(GET_USER_STATUS_URL)
+        .header("Content-Type", "application/json")
+        .header("Connect-Protocol-Version", "1")
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("GetUserStatus 请求失败: {}", e))?;
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(format!(
+            "GetUserStatus HTTP {}: {}",
+            status.as_u16(),
+            truncate(&text, 200)
+        ));
+    }
+    serde_json::from_str::<serde_json::Value>(&text)
+        .map_err(|e| format!("解析 GetUserStatus 响应失败: {} (body_len={})", e, text.len()))
+}
+
+// ========== 辅助：查询邮箱可用 auth_method（诊断用） ==========
+
+#[derive(Debug, Deserialize)]
+struct ConnectionsAuthMethod {
+    method: Option<String>,
+    has_password: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnectionsResponse {
+    auth_method: Option<ConnectionsAuthMethod>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConnectionsInfo {
+    pub method: String,
+    pub has_password: bool,
+}
+
+/// 调 /_devin-auth/connections 询问服务端：这个邮箱可用哪种 auth_method
+pub async fn query_connections(email: &str) -> Result<ConnectionsInfo, String> {
+    let email = email.trim();
+    if email.is_empty() {
+        return Err("邮箱不能为空".to_string());
+    }
+    let client = build_client()?;
+    let resp = client
+        .post(CONNECTIONS_URL)
+        .header("Content-Type", "application/json")
+        .header("Origin", "https://windsurf.com")
+        .header("Referer", "https://windsurf.com/account/login")
+        .json(&json!({"product": "windsurf", "email": email}))
+        .send()
+        .await
+        .map_err(|e| format!("查询 connections 失败: {}", e))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "connections HTTP {}: {}",
+            status.as_u16(),
+            truncate(&body, 200)
+        ));
+    }
+    let parsed: ConnectionsResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("解析 connections 响应失败: {}", e))?;
+    let am = parsed.auth_method.unwrap_or(ConnectionsAuthMethod {
+        method: Some("email".to_string()),
+        has_password: Some(false),
+    });
+    Ok(ConnectionsInfo {
+        method: am.method.unwrap_or_else(|| "email".to_string()),
+        has_password: am.has_password.unwrap_or(false),
+    })
+}
+
+// ========== 工具 ==========
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...({} more chars)", &s[..max], s.len() - max)
+    }
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}

--- a/src-tauri/src/modules/windsurf_instance.rs
+++ b/src-tauri/src/modules/windsurf_instance.rs
@@ -500,6 +500,19 @@ fn upsert_windsurf_extension_state(
         } else {
             obj.remove("windsurf.pendingApiKeyMigration");
         }
+        // 关键: codeium.installationId 必须存在 — 缺这个字段 Windsurf 反作弊会把这次切号
+        // 当作"新机器登录"，触发额外验证 / Permission denied (error 12)。
+        // 优先保留原有值（同一机器多次切号要稳定），不存在才生成新的。
+        if !obj
+            .get("codeium.installationId")
+            .map(|v| v.is_string() && !v.as_str().unwrap_or("").trim().is_empty())
+            .unwrap_or(false)
+        {
+            obj.insert(
+                "codeium.installationId".to_string(),
+                Value::String(Uuid::new_v4().to_string()),
+            );
+        }
     }
 
     let serialized = serde_json::to_string(&state)
@@ -550,6 +563,19 @@ fn write_windsurf_auth_data(
 
     upsert_item(conn, WINDSURF_SELECTED_AUTH_KEY, account_label)?;
     upsert_windsurf_extension_state(conn, api_server_url, access_token)?;
+
+    // Onboarding 状态：标记新手向导已完成，避免 Windsurf 启动后弹引导浮窗
+    let onboarding = serde_json::json!({
+        "completed": true,
+        "version": 1,
+        "timestamp": Utc::now().timestamp_millis(),
+    });
+    upsert_item(
+        conn,
+        "windsurfOnboarding",
+        &serde_json::to_string(&onboarding)
+            .map_err(|e| format!("序列化 windsurfOnboarding 失败: {}", e))?,
+    )?;
 
     conn.execute("DELETE FROM ItemTable WHERE key LIKE 'windsurf_auth-%'", [])
         .map_err(|e| format!("清理旧 windsurf_auth-* 键失败: {}", e))?;
@@ -2181,17 +2207,34 @@ pub fn inject_account_to_profile(profile_dir: &Path, account_id: &str) -> Result
 
     if let Some(obj) = auth_status.as_object_mut() {
         obj.insert("apiKey".to_string(), Value::String(api_key.clone()));
-        if let Some(name) = normalize_non_empty_text(account.github_name.as_deref()) {
-            obj.insert("name".to_string(), Value::String(name));
-        } else {
-            obj.insert("name".to_string(), Value::String(account_label.clone()));
-        }
-        if let Some(email) = normalize_non_empty_text(account.github_email.as_deref()) {
+        let display_name = normalize_non_empty_text(account.github_name.as_deref())
+            .unwrap_or_else(|| account_label.clone());
+        let display_email = normalize_non_empty_text(account.github_email.as_deref());
+        obj.insert("name".to_string(), Value::String(display_name.clone()));
+        if let Some(email) = display_email.clone() {
             obj.insert("email".to_string(), Value::String(email));
         }
         obj.insert(
             "apiServerUrl".to_string(),
             Value::String(api_server_url.clone()),
+        );
+        // 关键: IDE 通过 status="SignedIn" 判断已登录，缺这个字段会显示未登录
+        obj.insert("status".to_string(), Value::String("SignedIn".to_string()));
+        // 关键: IDE 头像旁边显示用户名/邮箱靠这个嵌套对象
+        let mut user_obj = serde_json::Map::new();
+        user_obj.insert("name".to_string(), Value::String(display_name));
+        user_obj.insert(
+            "email".to_string(),
+            display_email
+                .as_ref()
+                .map(|e| Value::String(e.clone()))
+                .unwrap_or(Value::Null),
+        );
+        obj.insert("user".to_string(), Value::Object(user_obj));
+        // 时间戳标记本次切号
+        obj.insert(
+            "timestamp".to_string(),
+            Value::Number(serde_json::Number::from(Utc::now().timestamp_millis())),
         );
         if is_auth1_token {
             obj.insert(
@@ -2199,6 +2242,42 @@ pub fn inject_account_to_profile(profile_dir: &Path, account_id: &str) -> Result
                 Value::String(access_token.clone()),
             );
             obj.insert("authMethod".to_string(), Value::String("auth1".to_string()));
+            // Devin 账号: 写入 UserStatus protobuf 让 IDE 启动时 UI 显示信息完整
+            // (账号名/邮箱/计划状态等都从这个 proto 解出来)
+            if let Some(proto_b64) = account
+                .devin_user_status_proto_b64
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                obj.insert(
+                    "userStatusProtoBinaryBase64".to_string(),
+                    Value::String(proto_b64.to_string()),
+                );
+            }
+            // 同时把 account_id / org_id 也塞进去，IDE 启动时可能会读
+            if let Some(account_id) = account
+                .devin_account_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                obj.insert(
+                    "accountId".to_string(),
+                    Value::String(account_id.to_string()),
+                );
+            }
+            if let Some(org_id) = account
+                .devin_org_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                obj.insert(
+                    "primaryOrgId".to_string(),
+                    Value::String(org_id.to_string()),
+                );
+            }
         }
     }
 

--- a/src-tauri/src/modules/windsurf_oauth.rs
+++ b/src-tauri/src/modules/windsurf_oauth.rs
@@ -946,6 +946,7 @@ fn build_payload_from_remote(
         windsurf_user_status: user_status_resp,
         windsurf_plan_status: plan_status_resp,
         windsurf_auth_status_raw,
+        ..Default::default()
     }
 }
 
@@ -1271,14 +1272,290 @@ pub async fn build_payload_from_token(token: &str) -> Result<WindsurfOAuthComple
         return build_payload_from_firebase_token(trimmed, None).await;
     }
 
+    // Devin Auth: auth1_xxx 长期凭证（注册机产物 / 用户从其他来源粘贴）
+    // 走完整 4 步链路 (PostAuth → GetOTT → RegisterUser → GetCurrentUser) 拿可用的 IDE token
+    if trimmed.starts_with("auth1_") {
+        return build_payload_from_devin_auth1_token(trimmed, None).await;
+    }
+
     if trimmed.starts_with("devin-session-token$") {
         return build_payload_from_auth1_session_token(trimmed, None).await;
     }
 
     Err(
-        "Token 格式不支持：请使用 Windsurf API Key、Firebase JWT 或 Devin Session Token"
+        "Token 格式不支持：请使用 Windsurf API Key、Firebase JWT、Devin auth1 凭证 或 Devin Session Token"
             .to_string(),
     )
+}
+
+/// 用 Devin auth1 长期凭证构造 payload。
+///
+/// 这是 Devin 体系的"主入口"——走完整 4 步链路拿到机器绑定的 ide_token，
+/// 同时把 auth1/account/org/proto 都写入 payload 的 Devin 字段以备后续刷新。
+async fn build_payload_from_devin_auth1_token(
+    auth1_token: &str,
+    email_hint: Option<&str>,
+) -> Result<WindsurfOAuthCompletePayload, String> {
+    let refresh = crate::modules::windsurf_devin_oauth::full_refresh_from_auth1(auth1_token)
+        .await
+        .map_err(|err| format!("Devin auth1 刷新失败: {}", err))?;
+    Ok(build_devin_payload(email_hint, None, &refresh).await)
+}
+
+/// 把 DevinFullRefreshResult 转成 WindsurfOAuthCompletePayload。
+///
+/// 设计要点：
+/// - `windsurf_api_key` 填 `ide_token`，注入 IDE 时直接用作 sessions.accessToken
+/// - `windsurf_api_server_url` 用 Devin 专用的 self-serve 域名
+/// - `devin_*` 字段全填，便于 refresh 时识别走 Devin 路径
+/// - GitHub 字段用 email 兜底（Devin 账号没有 GitHub 概念）
+/// - 调用 GetUserStatus 拉配额数据填 plan_status/quota（失败不致命）
+async fn build_devin_payload(
+    email_hint: Option<&str>,
+    name_hint: Option<&str>,
+    refresh: &crate::modules::windsurf_devin_oauth::DevinFullRefreshResult,
+) -> WindsurfOAuthCompletePayload {
+    let email = email_hint.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+    let github_login = email
+        .as_ref()
+        .map(|e| e.split('@').next().unwrap_or(e).to_string())
+        .unwrap_or_else(|| {
+            // user_id 取 hash 做 login fallback
+            format!("devin_{}", &refresh.account_id)
+        });
+    // github_id 用 account_id 的 md5 取低 64 位，保证相同账号 ID 稳定（不与 sk-ws 体系冲突）
+    let github_id = {
+        let digest = md5::compute(&refresh.account_id);
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&digest.0[..8]);
+        u64::from_be_bytes(buf)
+    };
+
+    // 拉 Devin 配额数据（GetUserStatus），失败不致命
+    let user_status_resp = match crate::modules::windsurf_devin_oauth::fetch_devin_user_status(
+        &refresh.ide_token,
+    )
+    .await
+    {
+        Ok(value) => Some(value),
+        Err(err) => {
+            logger::log_warn(&format!(
+                "[Windsurf Devin] GetUserStatus 失败（配额信息将缺失）: {}",
+                err
+            ));
+            None
+        }
+    };
+
+    // 解析配额响应
+    let user_status = user_status_resp
+        .as_ref()
+        .and_then(|v| v.get("userStatus"))
+        .cloned();
+    let mut plan_status = user_status
+        .as_ref()
+        .and_then(|v| v.get("planStatus"))
+        .cloned();
+    let plan_info = user_status_resp
+        .as_ref()
+        .and_then(|v| v.get("planInfo"))
+        .cloned()
+        .or_else(|| {
+            user_status
+                .as_ref()
+                .and_then(|v| v.get("planInfo"))
+                .cloned()
+        });
+    let plan_name = plan_info
+        .as_ref()
+        .and_then(|v| pick_string_from_object(Some(v), &["planName"]))
+        .filter(|s| !s.trim().is_empty());
+
+    // Free 账号服务端不返回 planEnd（计划无限期），但前端 UI「配额周期」需要这个字段。
+    // Fallback 顺序: weeklyResetAtUnix → dailyResetAtUnix（按下一次配额重置当作周期结束）
+    if let Some(ps) = plan_status.as_mut() {
+        if let Some(obj) = ps.as_object_mut() {
+            // 调试：列出 planStatus 顶层 key，方便排查字段名变化
+            let key_list: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+            logger::log_info(&format!(
+                "[Windsurf Devin] planStatus 顶层 keys: {:?}",
+                key_list
+            ));
+
+            let has_plan_end = obj
+                .get("planEnd")
+                .map(|v| !v.is_null())
+                .unwrap_or(false);
+            if !has_plan_end {
+                // 兼容 i64 / f64 / 字符串 三种类型（服务端返回不一定）
+                let extract_unix_secs = |v: &Value| -> Option<i64> {
+                    if let Some(n) = v.as_i64() {
+                        return Some(n);
+                    }
+                    if let Some(f) = v.as_f64() {
+                        if f.is_finite() && f > 0.0 {
+                            return Some(f as i64);
+                        }
+                    }
+                    if let Some(s) = v.as_str() {
+                        let trimmed = s.trim();
+                        if let Ok(n) = trimmed.parse::<i64>() {
+                            return Some(n);
+                        }
+                        if let Ok(f) = trimmed.parse::<f64>() {
+                            if f.is_finite() && f > 0.0 {
+                                return Some(f as i64);
+                            }
+                        }
+                    }
+                    None
+                };
+                let candidates = [
+                    "weeklyResetAtUnix",
+                    "weeklyQuotaResetAtUnix",
+                    "weekly_reset_at_unix",
+                    "weekly_quota_reset_at_unix",
+                    "dailyResetAtUnix",
+                    "dailyQuotaResetAtUnix",
+                    "daily_reset_at_unix",
+                    "daily_quota_reset_at_unix",
+                ];
+                let mut fallback_reset: Option<(&str, i64)> = None;
+                for key in &candidates {
+                    if let Some(v) = obj.get(*key) {
+                        if let Some(n) = extract_unix_secs(v) {
+                            fallback_reset = Some((key, n));
+                            break;
+                        }
+                    }
+                }
+                // 也试试嵌套 quotaUsage 子对象（用户切号器代码里见过这个结构）
+                if fallback_reset.is_none() {
+                    if let Some(qu) = obj.get("quotaUsage").and_then(|v| v.as_object()) {
+                        for key in &candidates {
+                            if let Some(v) = qu.get(*key) {
+                                if let Some(n) = extract_unix_secs(v) {
+                                    fallback_reset = Some((key, n));
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                match fallback_reset {
+                    Some((key, reset)) => {
+                        logger::log_info(&format!(
+                            "[Windsurf Devin] planEnd fallback 命中 {} = {}",
+                            key, reset
+                        ));
+                        obj.insert("planEnd".to_string(), json!(reset));
+                    }
+                    None => {
+                        logger::log_warn(
+                            "[Windsurf Devin] planEnd fallback 失败：planStatus 里没找到任何重置时间字段",
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // 构造与 Firebase 路径兼容的配额快照（前端读这些字段）
+    let copilot_quota_snapshots = if user_status_resp.is_some() {
+        Some(json!({
+            "windsurfPlanStatus": plan_status,
+            "windsurfPlanInfo": plan_info,
+            "windsurfUserStatus": user_status,
+            "windsurfCurrentUser": serde_json::Value::Null,
+        }))
+    } else {
+        None
+    };
+
+    // 限额快照（提取关键数字字段，前端 extract_quota_metrics 会读 chat/completions 等键）
+    let copilot_limited_user_quotas = plan_status.as_ref().and_then(|ps| {
+        let obj = ps.as_object()?;
+        let mut limited = serde_json::Map::new();
+        // 通用字段映射（前端 extract_limited_metrics 会优先读这些）
+        for key in &[
+            "completions",
+            "chat",
+            "availablePromptCredits",
+            "availableFlowCredits",
+            "usedPromptCredits",
+            "usedFlowCredits",
+        ] {
+            if let Some(v) = obj.get(*key) {
+                limited.insert(key.to_string(), v.clone());
+            }
+        }
+        if limited.is_empty() {
+            None
+        } else {
+            Some(Value::Object(limited))
+        }
+    });
+
+    let copilot_limited_user_reset_date = plan_status.as_ref().and_then(|ps| {
+        ps.get("dailyResetAtUnix")
+            .or_else(|| ps.get("dailyQuotaResetAtUnix"))
+            .and_then(|v| v.as_i64())
+    });
+
+    // 写入 state.vscdb 的 windsurfAuthStatus 用，IDE 启动时读取
+    let mut auth_status_raw = json!({
+        "apiKey": refresh.ide_token,
+        "apiServerUrl": "https://server.self-serve.windsurf.com",
+        "authMethod": "auth1",
+    });
+    if let Some(obj) = auth_status_raw.as_object_mut() {
+        if let Some(e) = email.as_ref() {
+            obj.insert("email".to_string(), Value::String(e.clone()));
+        }
+        if let Some(n) = name_hint.map(|s| s.trim()).filter(|s| !s.is_empty()) {
+            obj.insert("name".to_string(), Value::String(n.to_string()));
+        }
+        if let Some(proto) = refresh.user_status_proto_b64.as_ref() {
+            obj.insert(
+                "userStatusProtoBinaryBase64".to_string(),
+                Value::String(proto.clone()),
+            );
+        }
+    }
+
+    WindsurfOAuthCompletePayload {
+        github_login,
+        github_id,
+        github_name: name_hint.map(|s| s.to_string()),
+        github_email: email.clone(),
+        // ide_token 也存到 access_token，与现有刷新逻辑兼容（虽然 Devin 主刷新用 auth1）
+        github_access_token: refresh.ide_token.clone(),
+        github_token_type: Some("Bearer".to_string()),
+        github_scope: None,
+        copilot_token: refresh.ide_token.clone(),
+        copilot_plan: plan_name,
+        copilot_chat_enabled: Some(true),
+        copilot_expires_at: None,
+        copilot_refresh_in: None,
+        copilot_quota_snapshots,
+        copilot_quota_reset_date: None,
+        copilot_limited_user_quotas,
+        copilot_limited_user_reset_date,
+        windsurf_api_key: Some(refresh.ide_token.clone()),
+        windsurf_api_server_url: Some("https://server.self-serve.windsurf.com".to_string()),
+        windsurf_auth_token: Some(refresh.session_token.clone()),
+        windsurf_user_status: user_status,
+        windsurf_plan_status: plan_status,
+        windsurf_auth_status_raw: Some(auth_status_raw),
+        // 标记为 Devin 账号，refresh_payload_for_account 据此分流
+        windsurf_token_type: Some("devin-session".to_string()),
+        devin_auth1_token: Some(refresh.auth1_token.clone()),
+        devin_account_id: Some(refresh.account_id.clone()),
+        devin_org_id: Some(refresh.org_id.clone()),
+        devin_session_token: Some(refresh.session_token.clone()),
+        devin_user_status_proto_b64: refresh.user_status_proto_b64.clone(),
+    }
 }
 
 fn parse_error_message_from_body_text(body_text: &str) -> Option<String> {
@@ -1830,19 +2107,26 @@ pub async fn build_payload_from_password(
                 );
             }
 
-            logger::log_info("[Windsurf PasswordLogin] Auth1 登录开始");
-            let auth1_token = login_with_auth1_password(email, password).await?;
-            let (session_token, account_id, primary_org_id) =
-                exchange_auth1_for_session(&auth1_token).await?;
-            let auth_status_raw = Some(json!({
-                "authMethod": "auth1",
-                "sessionToken": session_token.clone(),
-                "devinAccountId": account_id,
-                "devinPrimaryOrgId": primary_org_id,
-                "email": email
-            }));
-            logger::log_info("[Windsurf PasswordLogin] Auth1 登录成功，开始获取账号信息");
-            build_payload_from_auth1_session_token(&session_token, auth_status_raw).await
+            logger::log_info("[Windsurf PasswordLogin] Auth1 登录开始 (走完整 4 步链路)");
+            let login_result = crate::modules::windsurf_devin_oauth::login_with_password(
+                email, password,
+            )
+            .await?;
+            logger::log_info(&format!(
+                "[Windsurf PasswordLogin] Auth1 邮密换 auth1 成功 (user_id={:?})",
+                login_result.user_id
+            ));
+
+            let refresh = crate::modules::windsurf_devin_oauth::full_refresh_from_auth1(
+                &login_result.auth1_token,
+            )
+            .await?;
+            logger::log_info(&format!(
+                "[Windsurf PasswordLogin] Auth1 完整链路成功: account_id={}, org_id={}",
+                refresh.account_id, refresh.org_id
+            ));
+
+            Ok(build_devin_payload(Some(email), None, &refresh).await)
         }
     }
 }
@@ -1898,6 +2182,30 @@ pub async fn build_payload_from_local_auth_status(
 pub async fn refresh_payload_for_account(
     account: &WindsurfAccount,
 ) -> Result<WindsurfOAuthCompletePayload, String> {
+    // ===== Devin 账号: auth1 是长期凭证，优先走完整 4 步链路刷新 =====
+    // 这条路径产出真正的机器绑定 ide_token + 新鲜 user_status_proto，
+    // IDE 启动后能立即对话；旧的 build_payload_from_auth1_session_token 路径
+    // 因为漏了 RegisterUser 步骤，产出的只是 sessionToken，不能机器对话。
+    if let Some(auth1) = account
+        .devin_auth1_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| s.starts_with("auth1_"))
+    {
+        logger::log_info(&format!(
+            "[Windsurf Refresh] 使用 Devin auth1 刷新: account_id={}, login={}",
+            account.id, account.github_login
+        ));
+        let refresh =
+            crate::modules::windsurf_devin_oauth::full_refresh_from_auth1(auth1).await?;
+        return Ok(build_devin_payload(
+            account.github_email.as_deref(),
+            account.github_name.as_deref(),
+            &refresh,
+        )
+        .await);
+    }
+
     let mut auth_status_hint = account
         .windsurf_auth_status_raw
         .clone()


### PR DESCRIPTION
## Summary

新增对 Windsurf Devin Auth 账号的支持。

Windsurf 在 2026 年 4 月把账号体系从 Firebase 迁移到了 Devin Auth：新注册的
账号使用 `auth1_*` 长期凭证 + `devin-session-token$...` 格式（取代原来的
`sk-ws-` API key）。现有代码只支持 Firebase，导致这类新账号既无法添加，也
无法切号。

主要改动：
- 新增 `windsurf_devin_oauth` 模块，实现 Devin 协议邮密登录和完整的 4 步换号链路。
- 邮密登录、token 导入、账号刷新、切号注入、配额查询全部接入 Devin 路径。
- 老的 Firebase 账号路径不受影响。

## Test plan

- [x] 用 Devin 账号邮密登录添加 → 成功
- [x] 切号 → Windsurf IDE 启动后正常显示已登录
- [x] 在 Cascade 发消息 → 正常收到回复
- [x] 刷新配额 → Plan、每日/每周配额、重置时间全部正确显示
- [x] 现有 Firebase 账号切号仍正常
- [x] `cargo check` 通过

测试环境：Windows。