### PR TITLE
Reduce tray idle memory by unloading the main WebView

### DIFF
--- a/crates/cockpit-core/Cargo.toml
+++ b/crates/cockpit-core/Cargo.toml
@@ -32,7 +32,6 @@ tracing-appender.workspace = true
 tracing-log.workspace = true
 trash.workspace = true
 tauri.workspace = true
-mac-notification-sys.workspace = true
 rand.workspace = true
 sha2.workspace = true
 tokio-tungstenite.workspace = true
@@ -48,3 +47,6 @@ sha1.workspace = true
 tiny_http.workspace = true
 rsa.workspace = true
 serde_urlencoded.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mac-notification-sys.workspace = true

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["staticlib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
-swift-rs = { version = "1.0.7", features = ["build"] }
 
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
@@ -71,13 +70,16 @@ pbkdf2 = "0.12"
 sha1 = "0.10"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58", features = ["Win32_Foundation", "Win32_Security_Cryptography"] }
+windows = { version = "0.58", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_System_ProcessStatus", "Win32_System_Threading"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mac-notification-sys = "0.6"
 objc2 = "0.6.3"
 objc2-foundation = "0.3.2"
 objc2-app-kit = "0.3.2"
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+swift-rs = { version = "1.0.7", features = ["build"] }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-process = "2.3.1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["staticlib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
-swift-rs = { version = "1.0.7", features = ["build"] }
 
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
@@ -75,13 +74,16 @@ pbkdf2 = "0.12"
 sha1 = "0.10"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_UI_Shell"] }
+windows = { version = "0.58", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_ProcessStatus", "Win32_System_Threading", "Win32_UI_Shell"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mac-notification-sys = "0.6"
 objc2 = "0.6.3"
 objc2-foundation = "0.3.2"
 objc2-app-kit = "0.3.2"
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+swift-rs = { version = "1.0.7", features = ["build"] }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-process = "2.3.1"

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1597,10 +1597,11 @@ pub fn handle_window_close(
     // 执行操作
     match action.as_str() {
         "minimize" => {
-            let _ = window.hide();
-            modules::logger::log_info("[Window] 窗口已最小化到托盘");
+            modules::floating_card_window::destroy_main_window_to_tray(&window)?;
+            modules::logger::log_info("[Window] 窗口已关闭到托盘");
         }
         "quit" => {
+            modules::floating_card_window::request_app_exit();
             window.app_handle().exit(0);
         }
         _ => {
@@ -1609,6 +1610,11 @@ pub fn handle_window_close(
     }
 
     Ok(())
+}
+
+#[tauri::command]
+pub fn main_window_take_pending_navigation() -> Result<Option<String>, String> {
+    modules::floating_card_window::take_pending_main_window_navigation()
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -3595,10 +3595,11 @@ pub fn handle_window_close(
     // 执行操作
     match action.as_str() {
         "minimize" => {
-            let _ = window.hide();
-            modules::logger::log_info("[Window] 窗口已最小化到托盘");
+            modules::floating_card_window::destroy_main_window_to_tray(&window)?;
+            modules::logger::log_info("[Window] 窗口已关闭到托盘");
         }
         "quit" => {
+            modules::floating_card_window::request_app_exit();
             window.app_handle().exit(0);
         }
         _ => {
@@ -3607,6 +3608,11 @@ pub fn handle_window_close(
     }
 
     Ok(())
+}
+
+#[tauri::command]
+pub fn main_window_take_pending_navigation() -> Result<Option<String>, String> {
+    modules::floating_card_window::take_pending_main_window_navigation()
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,6 @@ use modules::logger;
 use std::sync::OnceLock;
 #[cfg(target_os = "macos")]
 use tauri::ActivationPolicy;
-#[cfg(target_os = "macos")]
 use tauri::RunEvent;
 use tauri::WindowEvent;
 use tauri::{Emitter, Manager};
@@ -268,10 +267,19 @@ pub fn run() {
                 match config.close_behavior {
                     CloseWindowBehavior::Minimize => {
                         api.prevent_close();
-                        let _ = window.hide();
-                        info!("[Window] 窗口已最小化到托盘");
+                        if let Err(err) =
+                            modules::floating_card_window::destroy_main_window_to_tray(window)
+                        {
+                            logger::log_warn(&format!(
+                                "[Window] 销毁主窗口 WebView 失败，回退为隐藏窗口: {}",
+                                err
+                            ));
+                            let _ = window.hide();
+                        }
+                        info!("[Window] 窗口已关闭到托盘");
                     }
                     CloseWindowBehavior::Quit => {
+                        modules::floating_card_window::request_app_exit();
                         info!("[Window] 用户选择退出应用");
                     }
                     CloseWindowBehavior::Ask => {
@@ -372,6 +380,7 @@ pub fn run() {
             commands::system::detect_app_path,
             commands::system::set_wakeup_override,
             commands::system::handle_window_close,
+            commands::system::main_window_take_pending_navigation,
             commands::system::show_floating_card_window,
             commands::system::show_instance_floating_card_window,
             commands::system::get_floating_card_context,
@@ -819,6 +828,13 @@ pub fn run() {
         .expect("error while building tauri application");
 
     app.run(|app_handle, event| {
+        if let RunEvent::ExitRequested { api, .. } = &event {
+            if modules::floating_card_window::should_keep_alive_after_main_window_destroyed() {
+                api.prevent_exit();
+                logger::log_info("[Window] 主窗口已销毁，应用继续在托盘运行");
+            }
+        }
+
         #[cfg(target_os = "macos")]
         {
             match event {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -476,10 +476,19 @@ pub fn run() {
                 match config.close_behavior {
                     CloseWindowBehavior::Minimize => {
                         api.prevent_close();
-                        let _ = window.hide();
-                        info!("[Window] 窗口已最小化到托盘");
+                        if let Err(err) =
+                            modules::floating_card_window::destroy_main_window_to_tray(window)
+                        {
+                            logger::log_warn(&format!(
+                                "[Window] 销毁主窗口 WebView 失败，回退为隐藏窗口: {}",
+                                err
+                            ));
+                            let _ = window.hide();
+                        }
+                        info!("[Window] 窗口已关闭到托盘");
                     }
                     CloseWindowBehavior::Quit => {
+                        modules::floating_card_window::request_app_exit();
                         info!("[Window] 用户选择退出应用");
                         window.app_handle().exit(0);
                     }
@@ -616,6 +625,7 @@ pub fn run() {
             commands::system::get_antigravity_installed_version_info,
             commands::system::set_wakeup_override,
             commands::system::handle_window_close,
+            commands::system::main_window_take_pending_navigation,
             commands::system::show_floating_card_window,
             commands::system::show_instance_floating_card_window,
             commands::system::get_floating_card_context,
@@ -1202,7 +1212,19 @@ pub fn run() {
 
     app.run(|app_handle, event| {
         match &event {
-            RunEvent::ExitRequested { .. } | RunEvent::Exit => {
+            RunEvent::ExitRequested { api, .. } => {
+                if modules::floating_card_window::should_keep_alive_after_main_window_destroyed() {
+                    api.prevent_exit();
+                    logger::log_info("[Window] 主窗口已销毁，应用继续在托盘运行");
+                } else {
+                    modules::platform_adapter::shutdown_codex_runtime_for_app_exit();
+                    tauri::async_runtime::spawn(async {
+                        modules::codex_local_access::shutdown_local_access_gateway_for_app_exit().await;
+                    });
+                }
+            }
+            RunEvent::Exit => {
+                modules::platform_adapter::shutdown_codex_runtime_for_app_exit();
                 tauri::async_runtime::spawn(async {
                     modules::codex_local_access::shutdown_local_access_gateway_for_app_exit().await;
                 });

--- a/src-tauri/src/modules/floating_card_window.rs
+++ b/src-tauri/src/modules/floating_card_window.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
 
 use serde::{Deserialize, Serialize};
 use tauri::{
     AppHandle, Emitter, Manager, PhysicalPosition, Runtime, WebviewWindow, WebviewWindowBuilder,
+    Window,
 };
 
 use crate::modules::{config, i18n, logger};
@@ -11,12 +13,16 @@ use crate::modules::{config, i18n, logger};
 pub const FLOATING_CARD_WINDOW_LABEL: &str = "floating-card";
 pub const INSTANCE_FLOATING_CARD_WINDOW_LABEL_PREFIX: &str = "instance-floating-card-";
 pub const FLOATING_CARD_CONTEXT_CHANGED_EVENT: &str = "floating-card:context-changed";
+const MAIN_WINDOW_LABEL: &str = "main";
 const FLOATING_CARD_DEFAULT_MARGIN: i32 = 20;
 const INSTANCE_FLOATING_CARD_WINDOW_OFFSET_STEP: i32 = 28;
 const FLOATING_CARD_NATIVE_CORNER_RADIUS: f64 = 15.0;
 static FLOATING_CARD_INSTANCE_CONTEXTS: LazyLock<
     Mutex<HashMap<String, FloatingCardInstanceContext>>,
 > = LazyLock::new(|| Mutex::new(HashMap::new()));
+static PENDING_MAIN_WINDOW_NAVIGATION: LazyLock<Mutex<Option<String>>> =
+    LazyLock::new(|| Mutex::new(None));
+static APP_EXIT_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -120,6 +126,64 @@ fn clone_floating_card_window_config(
     config.create = false;
     config.visible = false;
     Ok(config)
+}
+
+fn main_window_config(
+    app: &AppHandle<impl Runtime>,
+) -> Result<&tauri::utils::config::WindowConfig, String> {
+    app.config()
+        .app
+        .windows
+        .iter()
+        .find(|item| item.label == MAIN_WINDOW_LABEL)
+        .ok_or_else(|| "main_window_config_not_found".to_string())
+}
+
+fn clone_main_window_config(
+    app: &AppHandle<impl Runtime>,
+) -> Result<tauri::utils::config::WindowConfig, String> {
+    let mut config = main_window_config(app)?.clone();
+    config.create = false;
+    config.visible = false;
+    Ok(config)
+}
+
+fn ensure_main_window<R: Runtime>(app: &AppHandle<R>) -> Result<(WebviewWindow<R>, bool), String> {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        return Ok((window, false));
+    }
+
+    let window_config = clone_main_window_config(app)?;
+    let window = WebviewWindowBuilder::from_config(app, &window_config)
+        .map_err(|err| err.to_string())?
+        .build()
+        .map_err(|err| err.to_string())?;
+
+    logger::log_info("[Window] WebView 主窗口已重新创建");
+    Ok((window, true))
+}
+
+fn set_pending_main_window_navigation(page: &str) -> Result<(), String> {
+    let mut pending = PENDING_MAIN_WINDOW_NAVIGATION
+        .lock()
+        .map_err(|_| "main_window_navigation_lock_failed".to_string())?;
+    *pending = Some(page.to_string());
+    Ok(())
+}
+
+pub fn take_pending_main_window_navigation() -> Result<Option<String>, String> {
+    PENDING_MAIN_WINDOW_NAVIGATION
+        .lock()
+        .map_err(|_| "main_window_navigation_lock_failed".to_string())
+        .map(|mut pending| pending.take())
+}
+
+pub fn request_app_exit() {
+    APP_EXIT_REQUESTED.store(true, Ordering::SeqCst);
+}
+
+pub fn should_keep_alive_after_main_window_destroyed() -> bool {
+    !APP_EXIT_REQUESTED.load(Ordering::SeqCst)
 }
 
 fn ensure_floating_card_window_with_label<R: Runtime>(
@@ -438,6 +502,7 @@ pub fn show_main_window_and_navigate<R: Runtime>(
     app: &AppHandle<R>,
     page: &str,
 ) -> Result<(), String> {
+    set_pending_main_window_navigation(page)?;
     show_main_window(app)?;
     app.emit("tray:navigate", page.to_string())
         .map_err(|err| err.to_string())?;
@@ -445,9 +510,7 @@ pub fn show_main_window_and_navigate<R: Runtime>(
 }
 
 pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
-    let Some(window) = app.get_webview_window("main") else {
-        return Err("main_window_not_found".to_string());
-    };
+    let (window, created) = ensure_main_window(app)?;
 
     logger::log_info("[Window] 尝试恢复主窗口");
     window.show().map_err(|err| err.to_string())?;
@@ -462,8 +525,80 @@ pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
         logger::log_warn(&format!("[Window] Windows 原生前置主窗口失败: {}", err));
     }
 
+    if created {
+        logger::log_info("[Window] 主窗口恢复完成，前端将重新加载");
+    }
+
     Ok(())
 }
+
+pub fn destroy_main_window_to_tray<R: Runtime>(window: &Window<R>) -> Result<(), String> {
+    window.destroy().map_err(|err| err.to_string())?;
+    trim_process_working_set_after_main_window_destroyed();
+    logger::log_info("[Window] 主窗口 WebView 已销毁并保留托盘进程");
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn trim_process_working_set_after_main_window_destroyed() {
+    use windows::Win32::System::ProcessStatus::EmptyWorkingSet;
+    use windows::Win32::System::Threading::{GetCurrentProcess, SetProcessWorkingSetSize};
+
+    unsafe {
+        let process = GetCurrentProcess();
+        if let Err(err) = EmptyWorkingSet(process) {
+            logger::log_warn(&format!("[Window] EmptyWorkingSet 调整内存失败: {}", err));
+        }
+        if let Err(err) = SetProcessWorkingSetSize(process, usize::MAX, usize::MAX) {
+            logger::log_warn(&format!(
+                "[Window] SetProcessWorkingSetSize 调整内存失败: {}",
+                err
+            ));
+        }
+    }
+
+    logger::log_info("[Window] 已请求 Windows 回收空闲工作集页面");
+}
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn trim_process_working_set_after_main_window_destroyed() {
+    let trimmed = unsafe { libc::malloc_trim(0) };
+    if trimmed == 0 {
+        logger::log_info("[Window] Linux malloc_trim 未回收额外页面");
+    } else {
+        logger::log_info("[Window] 已请求 Linux glibc 回收空闲堆页面");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn trim_process_working_set_after_main_window_destroyed() {
+    unsafe extern "C" {
+        fn malloc_default_zone() -> *mut libc::c_void;
+        fn malloc_zone_pressure_relief(zone: *mut libc::c_void, goal: libc::size_t)
+            -> libc::size_t;
+    }
+
+    let relieved = unsafe {
+        let zone = malloc_default_zone();
+        if zone.is_null() {
+            0
+        } else {
+            malloc_zone_pressure_relief(zone, 0)
+        }
+    };
+
+    logger::log_info(&format!(
+        "[Window] 已请求 macOS 回收空闲堆页面: relieved={} bytes",
+        relieved
+    ));
+}
+
+#[cfg(not(any(
+    target_os = "windows",
+    all(target_os = "linux", target_env = "gnu"),
+    target_os = "macos"
+)))]
+fn trim_process_working_set_after_main_window_destroyed() {}
 
 #[cfg(not(target_os = "macos"))]
 fn send_hidden_notification<R: Runtime>(app: &AppHandle<R>) {

--- a/src-tauri/src/modules/floating_card_window.rs
+++ b/src-tauri/src/modules/floating_card_window.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
 
 use serde::{Deserialize, Serialize};
 use tauri::{
     AppHandle, Emitter, Manager, PhysicalPosition, Runtime, WebviewWindow, WebviewWindowBuilder,
+    Window,
 };
 
 use crate::modules::{config, i18n, logger};
@@ -11,12 +13,17 @@ use crate::modules::{config, i18n, logger};
 pub const FLOATING_CARD_WINDOW_LABEL: &str = "floating-card";
 pub const INSTANCE_FLOATING_CARD_WINDOW_LABEL_PREFIX: &str = "instance-floating-card-";
 pub const FLOATING_CARD_CONTEXT_CHANGED_EVENT: &str = "floating-card:context-changed";
+const MAIN_WINDOW_LABEL: &str = "main";
 const FLOATING_CARD_DEFAULT_MARGIN: i32 = 20;
 const INSTANCE_FLOATING_CARD_WINDOW_OFFSET_STEP: i32 = 28;
 const FLOATING_CARD_NATIVE_CORNER_RADIUS: f64 = 15.0;
 static FLOATING_CARD_INSTANCE_CONTEXTS: LazyLock<
     Mutex<HashMap<String, FloatingCardInstanceContext>>,
 > = LazyLock::new(|| Mutex::new(HashMap::new()));
+static PENDING_MAIN_WINDOW_NAVIGATION: LazyLock<Mutex<Option<String>>> =
+    LazyLock::new(|| Mutex::new(None));
+static APP_EXIT_REQUESTED: AtomicBool = AtomicBool::new(false);
+static MAIN_WINDOW_DESTROYED_TO_TRAY: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -120,6 +127,65 @@ fn clone_floating_card_window_config(
     config.create = false;
     config.visible = false;
     Ok(config)
+}
+
+fn main_window_config(
+    app: &AppHandle<impl Runtime>,
+) -> Result<&tauri::utils::config::WindowConfig, String> {
+    app.config()
+        .app
+        .windows
+        .iter()
+        .find(|item| item.label == MAIN_WINDOW_LABEL)
+        .ok_or_else(|| "main_window_config_not_found".to_string())
+}
+
+fn clone_main_window_config(
+    app: &AppHandle<impl Runtime>,
+) -> Result<tauri::utils::config::WindowConfig, String> {
+    let mut config = main_window_config(app)?.clone();
+    config.create = false;
+    config.visible = false;
+    Ok(config)
+}
+
+fn ensure_main_window<R: Runtime>(app: &AppHandle<R>) -> Result<(WebviewWindow<R>, bool), String> {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        return Ok((window, false));
+    }
+
+    let window_config = clone_main_window_config(app)?;
+    let window = WebviewWindowBuilder::from_config(app, &window_config)
+        .map_err(|err| err.to_string())?
+        .build()
+        .map_err(|err| err.to_string())?;
+
+    logger::log_info("[Window] WebView 主窗口已重新创建");
+    Ok((window, true))
+}
+
+fn set_pending_main_window_navigation(page: &str) -> Result<(), String> {
+    let mut pending = PENDING_MAIN_WINDOW_NAVIGATION
+        .lock()
+        .map_err(|_| "main_window_navigation_lock_failed".to_string())?;
+    *pending = Some(page.to_string());
+    Ok(())
+}
+
+pub fn take_pending_main_window_navigation() -> Result<Option<String>, String> {
+    PENDING_MAIN_WINDOW_NAVIGATION
+        .lock()
+        .map_err(|_| "main_window_navigation_lock_failed".to_string())
+        .map(|mut pending| pending.take())
+}
+
+pub fn request_app_exit() {
+    APP_EXIT_REQUESTED.store(true, Ordering::SeqCst);
+}
+
+pub fn should_keep_alive_after_main_window_destroyed() -> bool {
+    MAIN_WINDOW_DESTROYED_TO_TRAY.load(Ordering::SeqCst)
+        && !APP_EXIT_REQUESTED.load(Ordering::SeqCst)
 }
 
 fn ensure_floating_card_window_with_label<R: Runtime>(
@@ -438,16 +504,31 @@ pub fn show_main_window_and_navigate<R: Runtime>(
     app: &AppHandle<R>,
     page: &str,
 ) -> Result<(), String> {
-    show_main_window(app)?;
-    app.emit("tray:navigate", page.to_string())
-        .map_err(|err| err.to_string())?;
+    let should_defer_navigation = app.get_webview_window(MAIN_WINDOW_LABEL).is_none();
+    if should_defer_navigation {
+        set_pending_main_window_navigation(page)?;
+    }
+    if let Err(err) = show_main_window_internal(app) {
+        if should_defer_navigation {
+            let _ = take_pending_main_window_navigation();
+        }
+        return Err(err);
+    }
+    if let Err(err) = app.emit("tray:navigate", page.to_string()) {
+        if should_defer_navigation {
+            let _ = take_pending_main_window_navigation();
+        }
+        return Err(err.to_string());
+    }
     Ok(())
 }
 
 pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
-    let Some(window) = app.get_webview_window("main") else {
-        return Err("main_window_not_found".to_string());
-    };
+    show_main_window_internal(app).map(|_| ())
+}
+
+fn show_main_window_internal<R: Runtime>(app: &AppHandle<R>) -> Result<bool, String> {
+    let (window, created) = ensure_main_window(app)?;
 
     logger::log_info("[Window] 尝试恢复主窗口");
     #[cfg(target_os = "macos")]
@@ -468,13 +549,60 @@ pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
         logger::log_warn(&format!("[Window] Windows 原生前置主窗口失败: {}", err));
     }
 
-    Ok(())
+    if created {
+        MAIN_WINDOW_DESTROYED_TO_TRAY.store(false, Ordering::SeqCst);
+        logger::log_info("[Window] 主窗口恢复完成，前端将重新加载");
+    }
+
+    Ok(created)
 }
 
 #[cfg(target_os = "macos")]
 fn show_macos_application<R: Runtime>(app: &AppHandle<R>) {
     if let Err(err) = app.show() {
         logger::log_warn(&format!("[Window] macOS 应用取消隐藏失败: {}", err));
+    }
+}
+
+pub fn destroy_main_window_to_tray<R: Runtime>(window: &Window<R>) -> Result<(), String> {
+    MAIN_WINDOW_DESTROYED_TO_TRAY.store(true, Ordering::SeqCst);
+    if let Err(err) = window.destroy() {
+        MAIN_WINDOW_DESTROYED_TO_TRAY.store(false, Ordering::SeqCst);
+        return Err(err.to_string());
+    }
+    trim_process_working_set_after_main_window_destroyed();
+    logger::log_info("[Window] 主窗口 WebView 已销毁并保留托盘进程");
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn trim_process_working_set_after_main_window_destroyed() {
+    use windows::Win32::System::ProcessStatus::EmptyWorkingSet;
+    use windows::Win32::System::Threading::{GetCurrentProcess, SetProcessWorkingSetSize};
+
+    unsafe {
+        let process = GetCurrentProcess();
+        if let Err(err) = EmptyWorkingSet(process) {
+            logger::log_warn(&format!("[Window] EmptyWorkingSet 调整内存失败: {}", err));
+        }
+        if let Err(err) = SetProcessWorkingSetSize(process, usize::MAX, usize::MAX) {
+            logger::log_warn(&format!(
+                "[Window] SetProcessWorkingSetSize 调整内存失败: {}",
+                err
+            ));
+        }
+    }
+
+    logger::log_info("[Window] 已请求 Windows 回收空闲工作集页面");
+}
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn trim_process_working_set_after_main_window_destroyed() {
+    let trimmed = unsafe { libc::malloc_trim(0) };
+    if trimmed == 0 {
+        logger::log_info("[Window] Linux malloc_trim 未回收额外页面");
+    } else {
+        logger::log_info("[Window] 已请求 Linux glibc 回收空闲堆页面");
     }
 }
 
@@ -494,6 +622,36 @@ fn activate_macos_application<R: Runtime>(app: &AppHandle<R>) {
         logger::log_warn(&format!("[Window] macOS 应用激活失败: {}", err));
     }
 }
+
+#[cfg(target_os = "macos")]
+fn trim_process_working_set_after_main_window_destroyed() {
+    unsafe extern "C" {
+        fn malloc_default_zone() -> *mut libc::c_void;
+        fn malloc_zone_pressure_relief(zone: *mut libc::c_void, goal: libc::size_t)
+            -> libc::size_t;
+    }
+
+    let relieved = unsafe {
+        let zone = malloc_default_zone();
+        if zone.is_null() {
+            0
+        } else {
+            malloc_zone_pressure_relief(zone, 0)
+        }
+    };
+
+    logger::log_info(&format!(
+        "[Window] 已请求 macOS 回收空闲堆页面: relieved={} bytes",
+        relieved
+    ));
+}
+
+#[cfg(not(any(
+    target_os = "windows",
+    all(target_os = "linux", target_env = "gnu"),
+    target_os = "macos"
+)))]
+fn trim_process_working_set_after_main_window_destroyed() {}
 
 #[cfg(not(target_os = "macos"))]
 fn send_hidden_notification<R: Runtime>(app: &AppHandle<R>) {

--- a/src-tauri/src/modules/macos_native_menu.rs
+++ b/src-tauri/src/modules/macos_native_menu.rs
@@ -474,6 +474,7 @@ mod imp {
             }
             "quit" => {
                 if let Some(app) = crate::get_app_handle() {
+                    modules::floating_card_window::request_app_exit();
                     app.exit(0);
                 }
             }

--- a/src-tauri/src/modules/macos_native_menu.rs
+++ b/src-tauri/src/modules/macos_native_menu.rs
@@ -480,6 +480,7 @@ mod imp {
             }
             "quit" => {
                 if let Some(app) = crate::get_app_handle() {
+                    modules::floating_card_window::request_app_exit();
                     app.exit(0);
                 }
             }

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -3223,6 +3223,7 @@ fn handle_menu_event<R: Runtime>(app: &tauri::AppHandle<R>, event: tauri::menu::
         }
         menu_ids::QUIT => {
             info!("[Tray] 用户选择退出应用");
+            crate::modules::floating_card_window::request_app_exit();
             app.exit(0);
         }
         _ => {

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -3677,6 +3677,7 @@ fn handle_menu_event<R: Runtime>(app: &tauri::AppHandle<R>, event: tauri::menu::
         }
         menu_ids::QUIT => {
             info!("[Tray] 用户选择退出应用");
+            crate::modules::floating_card_window::request_app_exit();
             app.exit(0);
         }
         _ => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2624,6 +2624,30 @@ function MainApp() {
     }
   };
 
+  const applyMainWindowNavigationTarget = useCallback((target: string) => {
+    switch (target) {
+      case 'overview':
+      case 'codex':
+      case 'github-copilot':
+      case 'windsurf':
+      case 'kiro':
+      case 'cursor':
+      case 'gemini':
+      case 'codebuddy':
+      case 'codebuddy-cn':
+      case 'qoder':
+      case 'trae':
+      case 'workbuddy':
+      case 'zed':
+      case 'manual':
+      case 'settings':
+        setPage(target as Page);
+        break;
+      default:
+        break;
+    }
+  }, []);
+
   // 监听窗口关闭请求事件
   useEffect(() => {
     let unlisten: UnlistenFn | undefined;
@@ -2644,35 +2668,25 @@ function MainApp() {
 
         listen<string>('tray:navigate', (event) => {
           const target = String(event.payload || '');
-          switch (target) {
-            case 'overview':
-            case 'codex':
-            case 'github-copilot':
-            case 'windsurf':
-            case 'kiro':
-            case 'cursor':
-            case 'gemini':
-            case 'codebuddy':
-            case 'codebuddy-cn':
-            case 'qoder':
-            case 'trae':
-            case 'workbuddy':
-            case 'zed':
-            case 'manual':
-            case 'settings':
-              setPage(target as Page);
-              break;
-            default:
-              break;
-          }
+          applyMainWindowNavigationTarget(target);
         }).then((fn) => { unlisten = fn; });
+
+    void invoke<string | null>('main_window_take_pending_navigation')
+      .then((target) => {
+        if (target) {
+          applyMainWindowNavigationTarget(target);
+        }
+      })
+      .catch((error) => {
+        console.warn('[Window] 读取待处理导航失败:', error);
+      });
 
     return () => {
       if (unlisten) {
         unlisten();
       }
     };
-  }, []);
+  }, [applyMainWindowNavigationTarget]);
 
   useEffect(() => {
     let unlisten: UnlistenFn | undefined;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3359,6 +3359,38 @@ function MainApp() {
     setAppPathDraft(candidate.target);
   };
 
+  const applyMainWindowNavigationTarget = useCallback((target: string) => {
+    switch (target) {
+      case 'overview':
+      case 'api-relay':
+      case 'codex':
+      case 'codex-api-service':
+      case 'claude':
+      case 'claude-cli':
+      case 'github-copilot':
+      case 'windsurf':
+      case 'kiro':
+      case 'cursor':
+      case 'gemini':
+      case 'grok':
+      case 'codebuddy':
+      case 'codebuddy-cn':
+      case 'qoder':
+      case 'trae':
+      case 'trae-solo':
+      case 'trae-cn':
+      case 'trae-solo-cn':
+      case 'workbuddy':
+      case 'zed':
+      case 'manual':
+      case 'settings':
+        setPageWithRuntimeGate(target as Page);
+        break;
+      default:
+        break;
+    }
+  }, [setPageWithRuntimeGate]);
+
   // 监听窗口关闭请求事件
   useEffect(() => {
     let unlisten: UnlistenFn | undefined;
@@ -3379,43 +3411,25 @@ function MainApp() {
 
         listen<string>('tray:navigate', (event) => {
           const target = String(event.payload || '');
-          switch (target) {
-            case 'overview':
-            case 'api-relay':
-            case 'codex':
-            case 'codex-api-service':
-            case 'claude':
-            case 'claude-cli':
-            case 'github-copilot':
-            case 'windsurf':
-            case 'kiro':
-            case 'cursor':
-            case 'gemini':
-            case 'grok':
-            case 'codebuddy':
-            case 'codebuddy-cn':
-            case 'qoder':
-            case 'trae':
-            case 'trae-solo':
-            case 'trae-cn':
-            case 'trae-solo-cn':
-            case 'workbuddy':
-            case 'zed':
-            case 'manual':
-            case 'settings':
-              setPage(target as Page);
-              break;
-            default:
-              break;
-          }
+          applyMainWindowNavigationTarget(target);
         }).then((fn) => { unlisten = fn; });
+
+    void invoke<string | null>('main_window_take_pending_navigation')
+      .then((target) => {
+        if (target) {
+          applyMainWindowNavigationTarget(target);
+        }
+      })
+      .catch((error) => {
+        console.warn('[Window] 读取待处理导航失败:', error);
+      });
 
     return () => {
       if (unlisten) {
         unlisten();
       }
     };
-  }, []);
+  }, [applyMainWindowNavigationTarget]);
 
   useEffect(() => {
     let unlisten: UnlistenFn | undefined;


### PR DESCRIPTION
## Summary

This PR reduces idle memory usage when the main window is closed to the tray.

Instead of hiding the main Tauri window, the app now destroys the main WebView when the close behavior is set to minimize to tray. The Rust backend, tray icon, and background services remain alive, and the main window/WebView is recreated on demand when the user opens the app from the tray or navigates from tray menu actions.

## Why

Previously, closing the window to the tray only called `hide()`, so the React frontend and WebView stayed loaded in memory even while the app appeared closed. This made the tray-only idle state much heavier than necessary.

## Changes

- Destroy the main WebView when closing to tray instead of only hiding it.
- Keep the Tauri event loop alive after the main window is destroyed, while still allowing explicit Quit actions to exit normally.
- Recreate the main window from Tauri config when it is shown again.
- Preserve tray navigation targets across WebView recreation so tray menu actions still land on the requested page.
- Request platform-specific idle memory trimming after the WebView is destroyed:
  - Windows: `EmptyWorkingSet` and `SetProcessWorkingSetSize`
  - Linux/glibc: `malloc_trim(0)`
  - macOS: `malloc_zone_pressure_relief`
- Move macOS-only build/runtime dependencies behind macOS target cfg so Windows builds do not pull Apple-only crates.

## Validation

- `npm run typecheck`
- `cargo check -p cockpit-tools`
- Manual Windows dev test: closing to tray unloads the frontend/WebView while the backend and tray remain running; opening from tray recreates the frontend window.

## Notes

The memory trimming APIs are best-effort requests to the OS/runtime allocator. They reduce the resident working set where possible, but exact idle memory values are still controlled by the operating system.
