### PR TITLE
Fix Codex session provider repair after provider switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Codex account loading now accepts more portable managed-account files**: token/API-key detail files with portable JSON shapes can be recovered into the current account model, including API provider metadata, timestamps, account IDs, organization IDs, and subscription/plan fields.
 - **Codex account overview now treats the Local API Service as the current entry when it is active**: the current marker moves from the underlying account to the API Service card on this page, while the rest of the app keeps its existing current-account logic.
 - **Codex Local API Service cards now align with regular account cards**: the card keeps the same action-bar rhythm and hover styling as normal accounts while keeping member previews and quota-pool stats stacked in the body.
+- **Codex OAuth switches now clear legacy top-level Base URL config**: switching back from API-provider mode removes stale `base_url` entries from `config.toml`, avoiding OAuth tokens being sent through a previous custom endpoint.
 - **Codex instance account selection now identifies API Key providers**: API Key accounts show their provider inline in instance quota previews and can be searched by provider name.
 - **File writes for account/config state now use a shared synced atomic path**: account indexes, OAuth pending state, `config.toml`, group/sync settings, OpenCode/OpenClaw auth files, and backup files write through temp-file replacement with validated backup restore behavior.
 - **Quota and token refreshes now use the primary refresh path directly**: provider refresh flows no longer wait on a hidden delayed retry before surfacing the actual failure.
@@ -69,7 +70,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Windsurf Devin accounts switch into instances with fresher IDE credentials**: instance launch pre-refreshes Devin accounts, writes stable installation/onboarding/sign-in/user fields, and includes Devin account/org/protobuf status data to avoid launch-time signed-out or permission-denied states.
 - **Account lists no longer disappear when storage temporarily returns an unexpected empty result**: shared account stores keep the current cached accounts/current account during abnormal empty reads, while still allowing real empty results after intentional deletion.
 - **Backup restore and retention now handle JSON/ZIP pairs consistently**: backup reads can fall back from a damaged or missing JSON file to its archive, and cleanup removes expired JSON and ZIP backups together.
-- **Codex provider switches repair stale session providers before launch**: switching between OAuth, API Key, and Local API Service providers now repairs the affected Codex profile's rollout and `state_5.sqlite` provider metadata before starting that profile, preventing old sessions from reconnecting through the previous provider.
+- **Codex provider switches repair stale session providers before launch**: switching between OAuth, API Key, and Local API Service providers now repairs the affected Codex profile's rollout and `state_5.sqlite` provider metadata before starting that profile, including every `session_meta` record inside rollout JSONL files, preventing old sessions from reconnecting through the previous provider.
 
 ---
 ## [0.22.19] - 2026-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Windsurf Devin accounts switch into instances with fresher IDE credentials**: instance launch pre-refreshes Devin accounts, writes stable installation/onboarding/sign-in/user fields, and includes Devin account/org/protobuf status data to avoid launch-time signed-out or permission-denied states.
 - **Account lists no longer disappear when storage temporarily returns an unexpected empty result**: shared account stores keep the current cached accounts/current account during abnormal empty reads, while still allowing real empty results after intentional deletion.
 - **Backup restore and retention now handle JSON/ZIP pairs consistently**: backup reads can fall back from a damaged or missing JSON file to its archive, and cleanup removes expired JSON and ZIP backups together.
+- **Codex provider switches repair stale session providers before launch**: switching between OAuth, API Key, and Local API Service providers now repairs the affected Codex profile's rollout and `state_5.sqlite` provider metadata before starting that profile, preventing old sessions from reconnecting through the previous provider.
 
 ---
 ## [0.22.19] - 2026-05-05

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -69,6 +69,7 @@
 - **Windsurf Devin 账号切入实例时会使用更新的 IDE 凭据**：实例启动前会预刷新 Devin 账号，写入稳定的 installation、onboarding、sign-in 与 user 字段，并带上 Devin account/org/protobuf 状态数据，避免启动后显示未登录或出现权限拒绝。
 - **账号列表不再因存储临时返回异常空结果而消失**：共享账号 store 在异常空读取时会保留当前缓存账号与当前账号，同时仍允许用户主动删除后的真实空列表。
 - **备份恢复与保留清理现一致处理 JSON/ZIP 配对文件**：读取备份时可从损坏或缺失的 JSON 回退到对应压缩包，过期清理也会同时清理 JSON 与 ZIP 备份。
+- **Codex provider 切换后会在启动前修复旧会话 provider**：在 OAuth、API Key 与本地 API 服务之间切换时，会在启动对应 Codex 配置目录前修复 rollout 与 `state_5.sqlite` 里的 provider 元数据，避免旧会话继续按上一个 provider 重连。
 
 ---
 ## [0.22.19] - 2026-05-05

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -60,6 +60,7 @@
 - **Codex 账号读取现兼容更多便携账号文件**：可把便携 token/API-key JSON 详情文件恢复到当前账号模型，并保留 API 供应商、时间戳、账号 ID、组织 ID、套餐与订阅字段。
 - **Codex 账号总览会在本地 API 服务启用时把“当前”标识移到 API 服务入口**：该变化仅影响此账号列表页的展示，应用其他位置仍沿用原有当前账号逻辑。
 - **Codex 本地 API 服务卡片现与普通账号卡片对齐**：卡片操作栏和悬浮样式跟随普通账号，主体内保留成员预览并在其下方竖排展示额度池统计。
+- **Codex 切回 OAuth 现会清理旧版顶层 Base URL 配置**：从 API provider 切回 OAuth 时会移除 `config.toml` 中遗留的顶层 `base_url`，避免 OAuth token 继续被发往上一个自定义端点。
 - **Codex 实例账号选择现可识别 API Key 供应商**：API Key 账号在实例配额预览中展示供应商，也可按供应商名称搜索。
 - **账号与配置文件写入现统一使用同步原子写入路径**：账号索引、OAuth pending 状态、`config.toml`、分组/同步设置、OpenCode/OpenClaw auth 文件和备份文件都会通过临时文件替换写入，并只从有效备份恢复。
 - **配额和 Token 刷新现直接使用主刷新链路**：各平台刷新不再等待隐藏的延迟重试，失败时会更快暴露真实错误。
@@ -69,7 +70,7 @@
 - **Windsurf Devin 账号切入实例时会使用更新的 IDE 凭据**：实例启动前会预刷新 Devin 账号，写入稳定的 installation、onboarding、sign-in 与 user 字段，并带上 Devin account/org/protobuf 状态数据，避免启动后显示未登录或出现权限拒绝。
 - **账号列表不再因存储临时返回异常空结果而消失**：共享账号 store 在异常空读取时会保留当前缓存账号与当前账号，同时仍允许用户主动删除后的真实空列表。
 - **备份恢复与保留清理现一致处理 JSON/ZIP 配对文件**：读取备份时可从损坏或缺失的 JSON 回退到对应压缩包，过期清理也会同时清理 JSON 与 ZIP 备份。
-- **Codex provider 切换后会在启动前修复旧会话 provider**：在 OAuth、API Key 与本地 API 服务之间切换时，会在启动对应 Codex 配置目录前修复 rollout 与 `state_5.sqlite` 里的 provider 元数据，避免旧会话继续按上一个 provider 重连。
+- **Codex provider 切换后会在启动前修复旧会话 provider**：在 OAuth、API Key 与本地 API 服务之间切换时，会在启动对应 Codex 配置目录前修复 rollout 与 `state_5.sqlite` 里的 provider 元数据，并覆盖 rollout JSONL 内所有 `session_meta` 记录，避免旧会话继续按上一个 provider 重连。
 
 ---
 ## [0.22.19] - 2026-05-05

--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -52,6 +52,7 @@ fn repair_codex_session_visibility_after_provider_change(before_provider: Option
         &codex_home,
         "__default__",
         "默认实例",
+        process::is_codex_running(),
     ) {
         Ok(item) => {
             logger::log_info(&format!(

--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -5,7 +5,8 @@ use crate::models::codex_local_access::{
     CodexLocalAccessPortCleanupResult, CodexLocalAccessRoutingStrategy, CodexLocalAccessState,
 };
 use crate::modules::{
-    codex_account, codex_local_access, codex_oauth, codex_quota, codex_wakeup,
+    codex_account, codex_local_access, codex_oauth, codex_quota, codex_session_visibility,
+    codex_wakeup,
     codex_wakeup_scheduler, config, logger, openclaw_auth, opencode_auth, process,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -14,6 +15,58 @@ use tauri::Emitter;
 use tauri_plugin_opener::OpenerExt;
 
 static CODEX_POST_REFRESH_CHECK_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+fn read_codex_history_visibility_provider_for_default_home() -> Option<String> {
+    let codex_home = codex_account::get_codex_home();
+    match codex_session_visibility::read_history_visibility_provider_for_dir(&codex_home) {
+        Ok(provider) => Some(provider),
+        Err(error) => {
+            logger::log_warn(&format!(
+                "读取 Codex 历史会话 provider 失败，后续会尝试按当前状态修复: {}",
+                error
+            ));
+            None
+        }
+    }
+}
+
+fn repair_codex_session_visibility_after_provider_change(before_provider: Option<String>) {
+    let Some(after_provider) = read_codex_history_visibility_provider_for_default_home() else {
+        return;
+    };
+    if before_provider.as_deref() == Some(after_provider.as_str()) {
+        logger::log_info(&format!(
+            "Codex provider 未变化，跳过自动会话可见性修复: provider={}",
+            after_provider
+        ));
+        return;
+    }
+
+    logger::log_info(&format!(
+        "检测到 Codex provider 变化，开始自动修复历史会话可见性: from={}, to={}",
+        before_provider.as_deref().unwrap_or("unknown"),
+        after_provider
+    ));
+    let codex_home = codex_account::get_codex_home();
+    match codex_session_visibility::repair_session_visibility_for_dir(
+        &codex_home,
+        "__default__",
+        "默认实例",
+    ) {
+        Ok(item) => {
+            logger::log_info(&format!(
+                "Codex 默认实例历史会话可见性自动修复完成: rollout_files={}, sqlite_rows={}",
+                item.changed_rollout_file_count, item.updated_sqlite_row_count
+            ));
+        }
+        Err(error) => {
+            logger::log_warn(&format!(
+                "Codex 历史会话可见性自动修复失败，账号切换已保留，可稍后在会话管理中手动重试: {}",
+                error
+            ));
+        }
+    }
+}
 
 fn restart_codex_specified_app_if_enabled(user_config: &config::UserConfig) {
     if !user_config.codex_restart_specified_app_on_switch {
@@ -92,8 +145,11 @@ pub async fn switch_codex_account(
     app: AppHandle,
     account_id: String,
 ) -> Result<CodexAccount, String> {
+    let before_provider = read_codex_history_visibility_provider_for_default_home();
+
     // 切换账号（写入 auth.json）
     let account = codex_account::switch_account_managed(&account_id).await?;
+    repair_codex_session_visibility_after_provider_change(before_provider);
 
     // 同步更新 Codex 默认实例的绑定账号（不同步到 Antigravity，因为账号体系不同）
     if let Err(e) = crate::modules::codex_instance::update_default_settings(
@@ -778,7 +834,9 @@ pub async fn codex_local_access_set_enabled(
 #[tauri::command]
 pub async fn codex_local_access_activate(app: AppHandle) -> Result<CodexLocalAccessState, String> {
     let codex_home = codex_account::get_codex_home();
+    let before_provider = read_codex_history_visibility_provider_for_default_home();
     let state = codex_local_access::activate_local_access_for_dir(&codex_home).await?;
+    repair_codex_session_visibility_after_provider_change(before_provider);
 
     let mut index = codex_account::load_account_index();
     index.current_account_id = None;

--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -82,16 +82,70 @@ fn resolve_local_account_id() -> Option<String> {
     Some(account.id)
 }
 
+fn read_profile_visibility_provider(profile_dir: &Path) -> Option<String> {
+    match modules::codex_session_visibility::read_history_visibility_provider_for_dir(profile_dir) {
+        Ok(provider) => Some(provider),
+        Err(error) => {
+            modules::logger::log_warn(&format!(
+                "读取 Codex 实例 provider 失败，启动前会跳过会话可见性自动修复: dir={}, error={}",
+                profile_dir.display(),
+                error
+            ));
+            None
+        }
+    }
+}
+
+fn repair_profile_visibility_after_provider_change(
+    profile_dir: &Path,
+    before_provider: Option<String>,
+) {
+    let Some(after_provider) = read_profile_visibility_provider(profile_dir) else {
+        return;
+    };
+    if before_provider.as_deref() == Some(after_provider.as_str()) {
+        return;
+    }
+
+    match modules::codex_session_visibility::repair_session_visibility_for_dir(
+        profile_dir,
+        "__launch__",
+        "启动实例",
+    ) {
+        Ok(item) => {
+            modules::logger::log_info(&format!(
+                "Codex 实例启动前已修复会话可见性: dir={}, from={}, to={}, rollout_files={}, sqlite_rows={}",
+                profile_dir.display(),
+                before_provider.as_deref().unwrap_or("unknown"),
+                item.target_provider,
+                item.changed_rollout_file_count,
+                item.updated_sqlite_row_count
+            ));
+        }
+        Err(error) => {
+            modules::logger::log_warn(&format!(
+                "Codex 实例启动前会话可见性修复失败，仍继续启动: dir={}, error={}",
+                profile_dir.display(),
+                error
+            ));
+        }
+    }
+}
+
 async fn inject_bound_account_to_profile(
     profile_dir: &Path,
     bind_account_id: &str,
 ) -> Result<(), String> {
+    let before_provider = read_profile_visibility_provider(profile_dir);
     if modules::codex_instance::is_api_service_bind_account_id(bind_account_id) {
         modules::codex_local_access::activate_local_access_for_dir(profile_dir).await?;
+        repair_profile_visibility_after_provider_change(profile_dir, before_provider);
         return Ok(());
     }
 
-    modules::codex_instance::inject_account_to_profile(profile_dir, bind_account_id).await
+    modules::codex_instance::inject_account_to_profile(profile_dir, bind_account_id).await?;
+    repair_profile_visibility_after_provider_change(profile_dir, before_provider);
+    Ok(())
 }
 
 fn default_instance_view(

--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -98,6 +98,9 @@ fn read_profile_visibility_provider(profile_dir: &Path) -> Option<String> {
 
 fn repair_profile_visibility_after_provider_change(
     profile_dir: &Path,
+    instance_id: &str,
+    instance_name: &str,
+    running: bool,
     before_provider: Option<String>,
 ) {
     let Some(after_provider) = read_profile_visibility_provider(profile_dir) else {
@@ -109,8 +112,9 @@ fn repair_profile_visibility_after_provider_change(
 
     match modules::codex_session_visibility::repair_session_visibility_for_dir(
         profile_dir,
-        "__launch__",
-        "启动实例",
+        instance_id,
+        instance_name,
+        running,
     ) {
         Ok(item) => {
             modules::logger::log_info(&format!(
@@ -134,17 +138,32 @@ fn repair_profile_visibility_after_provider_change(
 
 async fn inject_bound_account_to_profile(
     profile_dir: &Path,
+    instance_id: &str,
+    instance_name: &str,
+    running: bool,
     bind_account_id: &str,
 ) -> Result<(), String> {
     let before_provider = read_profile_visibility_provider(profile_dir);
     if modules::codex_instance::is_api_service_bind_account_id(bind_account_id) {
         modules::codex_local_access::activate_local_access_for_dir(profile_dir).await?;
-        repair_profile_visibility_after_provider_change(profile_dir, before_provider);
+        repair_profile_visibility_after_provider_change(
+            profile_dir,
+            instance_id,
+            instance_name,
+            running,
+            before_provider,
+        );
         return Ok(());
     }
 
     modules::codex_instance::inject_account_to_profile(profile_dir, bind_account_id).await?;
-    repair_profile_visibility_after_provider_change(profile_dir, before_provider);
+    repair_profile_visibility_after_provider_change(
+        profile_dir,
+        instance_id,
+        instance_name,
+        running,
+        before_provider,
+    );
     Ok(())
 }
 
@@ -585,7 +604,14 @@ pub async fn codex_start_instance(instance_id: String) -> Result<CodexInstancePr
             let _ = modules::codex_instance::update_default_pid(None)?;
         }
         if let Some(ref account_id) = default_bind_account_id {
-            inject_bound_account_to_profile(&default_dir, account_id).await?;
+            inject_bound_account_to_profile(
+                &default_dir,
+                DEFAULT_INSTANCE_ID,
+                "默认实例",
+                false,
+                account_id,
+            )
+            .await?;
         }
 
         if default_settings.launch_mode == InstanceLaunchMode::Cli {
@@ -632,7 +658,14 @@ pub async fn codex_start_instance(instance_id: String) -> Result<CodexInstancePr
     }
 
     if let Some(ref account_id) = instance.bind_account_id {
-        inject_bound_account_to_profile(Path::new(&instance.user_data_dir), account_id).await?;
+        inject_bound_account_to_profile(
+            Path::new(&instance.user_data_dir),
+            &instance.id,
+            &instance.name,
+            false,
+            account_id,
+        )
+        .await?;
     }
 
     if instance.launch_mode == InstanceLaunchMode::Cli {

--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -27,6 +27,7 @@ const API_KEY_LOGIN_PLAN_TYPE: &str = "API_KEY";
 const API_KEY_EMAIL_PREFIX: &str = "api-key";
 const API_KEY_AUTH_MODE: &str = "apikey";
 const CODEX_CONFIG_FILE_NAME: &str = "config.toml";
+const CODEX_CONFIG_LEGACY_BASE_URL_KEY: &str = "base_url";
 const CODEX_CONFIG_OPENAI_BASE_URL_KEY: &str = "openai_base_url";
 const CODEX_CONFIG_MODEL_PROVIDER_KEY: &str = "model_provider";
 const CODEX_CONFIG_MODEL_PROVIDERS_KEY: &str = "model_providers";
@@ -778,6 +779,8 @@ fn write_api_provider_to_config_toml(
             .parse::<Document>()
             .map_err(|e| format!("解析 config.toml 失败: {}", e))?
     };
+
+    let _ = doc.remove(CODEX_CONFIG_LEGACY_BASE_URL_KEY);
 
     match provider_config.mode {
         CodexApiProviderMode::OpenaiBuiltin => {
@@ -4335,6 +4338,54 @@ mod tests {
             latest_tokens.refresh_token.as_deref()
         );
         assert!(synced.token_generation > stored.token_generation);
+    }
+
+    #[test]
+    fn config_toml_removes_legacy_top_level_base_url_when_switching_to_official_oauth() {
+        let base_dir = make_temp_dir("codex-config-remove-legacy-base-url-test");
+        let config_path = base_dir.join("config.toml");
+        fs::write(
+            &config_path,
+            r#"base_url = "https://relay.example.com/v1"
+model_provider = "relay"
+model = "gpt-5.5"
+
+[model_providers.relay]
+name = "Relay"
+base_url = "https://relay.example.com/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#,
+        )
+        .expect("write config");
+        let provider_config = ApiProviderConfig {
+            mode: CodexApiProviderMode::OpenaiBuiltin,
+            base_url: None,
+            provider_id: None,
+            provider_name: None,
+        };
+
+        write_api_provider_to_config_toml(&base_dir, &provider_config).expect("write config");
+
+        let content = fs::read_to_string(&config_path).expect("read config");
+        assert!(!content
+            .lines()
+            .take_while(|line| !line.trim_start().starts_with('['))
+            .any(|line| line.trim_start().starts_with("base_url =")));
+        assert!(!content.contains("model_provider ="));
+        assert!(!content.contains("openai_base_url"));
+        assert!(content.contains("[model_providers.relay]"));
+        assert_eq!(
+            read_api_provider_from_config_toml(&base_dir),
+            ApiProviderConfig {
+                mode: CodexApiProviderMode::OpenaiBuiltin,
+                base_url: None,
+                provider_id: None,
+                provider_name: None,
+            }
+        );
+
+        fs::remove_dir_all(&base_dir).expect("cleanup temp dir");
     }
 
     #[test]

--- a/src-tauri/src/modules/codex_session_visibility.rs
+++ b/src-tauri/src/modules/codex_session_visibility.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -110,6 +110,7 @@ pub fn repair_session_visibility_across_instances(
             &rollout_changes,
             sqlite_rows_to_update > 0,
             &instance.id,
+            &instance.name,
             &target_provider,
         )?;
         let backup_dir_string = backup_dir.to_string_lossy().to_string();
@@ -195,6 +196,7 @@ pub fn repair_session_visibility_for_dir(
     data_dir: &Path,
     instance_id: &str,
     instance_name: &str,
+    running: bool,
 ) -> Result<CodexSessionVisibilityRepairItem, String> {
     let target_provider = read_target_provider(data_dir)?;
     let rollout_changes = collect_rollout_provider_changes(data_dir, &target_provider)?;
@@ -210,7 +212,7 @@ pub fn repair_session_visibility_for_dir(
             updated_sqlite_row_count: 0,
             skipped_sqlite_file: sqlite_scan.skipped_unusable_database,
             backup_dir: None,
-            running: false,
+            running,
         });
     }
 
@@ -219,6 +221,7 @@ pub fn repair_session_visibility_for_dir(
         &rollout_changes,
         sqlite_rows_to_update > 0,
         instance_id,
+        instance_name,
         &target_provider,
     )?;
     let backup_dir_string = backup_dir.to_string_lossy().to_string();
@@ -271,7 +274,7 @@ pub fn repair_session_visibility_for_dir(
         updated_sqlite_row_count: sqlite_rows_updated,
         skipped_sqlite_file: sqlite_scan.skipped_unusable_database,
         backup_dir: Some(backup_dir_string),
-        running: false,
+        running,
     })
 }
 
@@ -723,17 +726,10 @@ fn backup_instance_files(
     rollout_changes: &[RolloutProviderChange],
     include_sqlite: bool,
     instance_id: &str,
+    instance_name: &str,
     target_provider: &str,
 ) -> Result<PathBuf, String> {
-    let backup_dir_name = format!(
-        "{}{}{}",
-        SESSION_VISIBILITY_REPAIR_BACKUP_PREFIX,
-        Utc::now().format("%Y%m%d-%H%M%S"),
-        SESSION_VISIBILITY_REPAIR_BACKUP_SUFFIX
-    );
-    let backup_dir = data_dir.join(backup_dir_name);
-    fs::create_dir_all(&backup_dir)
-        .map_err(|error| format!("创建备份目录失败 ({}): {}", backup_dir.display(), error))?;
+    let backup_dir = create_session_visibility_repair_backup_dir(data_dir)?;
 
     let mut backed_up_files = Vec::new();
     for change in rollout_changes {
@@ -775,6 +771,7 @@ fn backup_instance_files(
 
     let manifest = json!({
         "instanceId": instance_id,
+        "instanceName": instance_name,
         "instanceRoot": data_dir,
         "targetProvider": target_provider,
         "createdAt": Utc::now().to_rfc3339(),
@@ -800,10 +797,46 @@ fn backup_instance_files(
     Ok(backup_dir)
 }
 
+fn create_session_visibility_repair_backup_dir(data_dir: &Path) -> Result<PathBuf, String> {
+    for attempt in 0..16 {
+        let now = Utc::now();
+        let backup_dir_name = format!(
+            "{}{}-{:09}-{}-{}{}",
+            SESSION_VISIBILITY_REPAIR_BACKUP_PREFIX,
+            now.format("%Y%m%d-%H%M%S"),
+            now.timestamp_subsec_nanos(),
+            std::process::id(),
+            attempt,
+            SESSION_VISIBILITY_REPAIR_BACKUP_SUFFIX
+        );
+        let backup_dir = data_dir.join(backup_dir_name);
+        match fs::create_dir(&backup_dir) {
+            Ok(()) => return Ok(backup_dir),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(format!(
+                    "创建备份目录失败 ({}): {}",
+                    backup_dir.display(),
+                    error
+                ));
+            }
+        }
+    }
+
+    Err(format!(
+        "创建备份目录失败 ({})：连续生成的备份目录名均已存在",
+        data_dir.display()
+    ))
+}
+
 fn parse_session_visibility_repair_backup_timestamp(name: &str) -> Option<&str> {
-    let timestamp = name
+    let sort_key = name
         .strip_prefix(SESSION_VISIBILITY_REPAIR_BACKUP_PREFIX)?
         .strip_suffix(SESSION_VISIBILITY_REPAIR_BACKUP_SUFFIX)?;
+    if sort_key.len() < 15 {
+        return None;
+    }
+    let timestamp = &sort_key[..15];
     if timestamp.len() != 15 {
         return None;
     }
@@ -816,7 +849,17 @@ fn parse_session_visibility_repair_backup_timestamp(name: &str) -> Option<&str> 
     }) {
         return None;
     }
-    Some(timestamp)
+    let extra = &sort_key[15..];
+    if !extra.is_empty()
+        && (!extra.starts_with('-')
+            || extra.len() == 1
+            || !extra[1..]
+                .chars()
+                .all(|value| value.is_ascii_digit() || value == '-'))
+    {
+        return None;
+    }
+    Some(sort_key)
 }
 
 fn prune_session_visibility_repair_backups(instances: &[CodexSyncInstance]) {
@@ -1022,13 +1065,22 @@ mod tests {
         .expect("rollout should be written");
         create_threads_db(&data_dir, "openai");
 
-        let item = repair_session_visibility_for_dir(&data_dir, "test", "Test")
+        let item = repair_session_visibility_for_dir(&data_dir, "test", "Test", true)
             .expect("repair should succeed");
 
         assert_eq!(item.target_provider, "relay");
         assert_eq!(item.changed_rollout_file_count, 1);
         assert_eq!(item.updated_sqlite_row_count, 1);
         assert!(item.backup_dir.is_some());
+        assert!(item.running);
+        let backup_dir = PathBuf::from(item.backup_dir.as_deref().expect("backup dir"));
+        let manifest: JsonValue = serde_json::from_str(
+            &fs::read_to_string(backup_dir.join("manifest.json"))
+                .expect("backup manifest should be readable"),
+        )
+        .expect("backup manifest should be valid json");
+        assert_eq!(manifest["instanceId"].as_str(), Some("test"));
+        assert_eq!(manifest["instanceName"].as_str(), Some("Test"));
         assert_eq!(read_thread_provider(&data_dir), "relay");
 
         let first_line = fs::read_to_string(&rollout_path)
@@ -1055,14 +1107,54 @@ mod tests {
             .expect("config should be written");
         create_threads_db(&data_dir, "relay");
 
-        let item = repair_session_visibility_for_dir(&data_dir, "test", "Test")
+        let item = repair_session_visibility_for_dir(&data_dir, "test", "Test", false)
             .expect("repair should succeed");
 
         assert_eq!(item.target_provider, "relay");
         assert_eq!(item.changed_rollout_file_count, 0);
         assert_eq!(item.updated_sqlite_row_count, 0);
         assert!(item.backup_dir.is_none());
+        assert!(!item.running);
         assert_eq!(read_thread_provider(&data_dir), "relay");
+
+        fs::remove_dir_all(&data_dir).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn backup_dir_names_are_collision_resistant_and_prunable() {
+        let data_dir = unique_temp_dir("backup");
+        fs::create_dir_all(&data_dir).expect("temp dir should be created");
+
+        let first = create_session_visibility_repair_backup_dir(&data_dir)
+            .expect("first backup dir should be created");
+        let second = create_session_visibility_repair_backup_dir(&data_dir)
+            .expect("second backup dir should be created");
+
+        assert_ne!(first, second);
+        assert!(
+            parse_session_visibility_repair_backup_timestamp(
+                first
+                    .file_name()
+                    .and_then(|item| item.to_str())
+                    .expect("backup dir should have utf-8 name"),
+            )
+            .is_some()
+        );
+        assert!(
+            parse_session_visibility_repair_backup_timestamp(
+                second
+                    .file_name()
+                    .and_then(|item| item.to_str())
+                    .expect("backup dir should have utf-8 name"),
+            )
+            .is_some()
+        );
+        assert!(
+            parse_session_visibility_repair_backup_timestamp(
+                "backup-20260509-152944-session-visibility-repair",
+            )
+            .is_some()
+        );
 
         fs::remove_dir_all(&data_dir).expect("temp dir should be removed");
     }

--- a/src-tauri/src/modules/codex_session_visibility.rs
+++ b/src-tauri/src/modules/codex_session_visibility.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader, ErrorKind};
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -59,7 +59,7 @@ struct CodexSyncInstance {
 struct RolloutProviderChange {
     relative_path: PathBuf,
     absolute_path: PathBuf,
-    updated_first_line: String,
+    updated_content: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -406,35 +406,27 @@ fn collect_rollout_provider_changes(
         }
         let rollout_paths = list_rollout_files(&root_dir)?;
         for rollout_path in rollout_paths {
-            let Some((first_line, _separator)) = read_first_line(&rollout_path)? else {
+            let bytes = fs::read(&rollout_path).map_err(|error| {
+                format!(
+                    "读取 rollout 文件失败 ({}): {}",
+                    rollout_path.display(),
+                    error
+                )
+            })?;
+            let Some(updated_content) = rewrite_rollout_session_meta_providers(
+                &bytes,
+                target_provider,
+                &rollout_path,
+            )? else {
                 continue;
             };
-            let Some(mut parsed) = parse_session_meta_record(&first_line) else {
-                continue;
-            };
-            let current_provider = parsed["payload"]
-                .get("model_provider")
-                .and_then(JsonValue::as_str)
-                .unwrap_or("");
-            if current_provider == target_provider {
-                continue;
-            }
-
-            if let Some(payload) = parsed.get_mut("payload").and_then(JsonValue::as_object_mut) {
-                payload.insert(
-                    "model_provider".to_string(),
-                    JsonValue::String(target_provider.to_string()),
-                );
-            }
-
             let relative_path = rollout_path
                 .strip_prefix(data_dir)
                 .map_err(|_| format!("无法计算 rollout 相对路径: {}", rollout_path.display()))?;
             changes.push(RolloutProviderChange {
                 relative_path: relative_path.to_path_buf(),
                 absolute_path: rollout_path,
-                updated_first_line: serde_json::to_string(&parsed)
-                    .map_err(|error| format!("序列化 session_meta 失败: {}", error))?,
+                updated_content,
             });
         }
     }
@@ -474,36 +466,6 @@ fn list_rollout_files(root_dir: &Path) -> Result<Vec<PathBuf>, String> {
     Ok(result)
 }
 
-fn read_first_line(path: &Path) -> Result<Option<(String, String)>, String> {
-    let file = fs::File::open(path)
-        .map_err(|error| format!("打开 rollout 文件失败 ({}): {}", path.display(), error))?;
-    let mut reader = BufReader::new(file);
-    let mut buffer = Vec::new();
-    let bytes_read = reader
-        .read_until(b'\n', &mut buffer)
-        .map_err(|error| format!("读取 rollout 首行失败 ({}): {}", path.display(), error))?;
-    if bytes_read == 0 {
-        return Ok(None);
-    }
-
-    let (line_bytes, separator) = if buffer.ends_with(b"\r\n") {
-        (&buffer[..buffer.len() - 2], "\r\n")
-    } else if buffer.ends_with(b"\n") {
-        (&buffer[..buffer.len() - 1], "\n")
-    } else {
-        (&buffer[..], "")
-    };
-
-    let line = String::from_utf8(line_bytes.to_vec()).map_err(|error| {
-        format!(
-            "解析 rollout 首行 UTF-8 失败 ({}): {}",
-            path.display(),
-            error
-        )
-    })?;
-    Ok(Some((line, separator.to_string())))
-}
-
 fn parse_session_meta_record(first_line: &str) -> Option<JsonValue> {
     if first_line.trim().is_empty() {
         return None;
@@ -517,6 +479,72 @@ fn parse_session_meta_record(first_line: &str) -> Option<JsonValue> {
         return None;
     }
     Some(parsed)
+}
+
+fn rewrite_rollout_session_meta_providers(
+    bytes: &[u8],
+    target_provider: &str,
+    path: &Path,
+) -> Result<Option<Vec<u8>>, String> {
+    let mut changed = false;
+    let mut next_bytes = Vec::with_capacity(bytes.len());
+
+    for (line_bytes, separator) in split_jsonl_lines(bytes) {
+        let line = String::from_utf8(line_bytes.to_vec()).map_err(|error| {
+            format!(
+                "解析 rollout JSONL UTF-8 失败 ({}): {}",
+                path.display(),
+                error
+            )
+        })?;
+        let next_line = if let Some(mut parsed) = parse_session_meta_record(&line) {
+            let current_provider = parsed["payload"]
+                .get("model_provider")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("");
+            if current_provider == target_provider {
+                line
+            } else {
+                if let Some(payload) = parsed.get_mut("payload").and_then(JsonValue::as_object_mut)
+                {
+                    payload.insert(
+                        "model_provider".to_string(),
+                        JsonValue::String(target_provider.to_string()),
+                    );
+                }
+                changed = true;
+                serde_json::to_string(&parsed)
+                    .map_err(|error| format!("序列化 session_meta 失败: {}", error))?
+            }
+        } else {
+            line
+        };
+
+        next_bytes.extend_from_slice(next_line.as_bytes());
+        next_bytes.extend_from_slice(separator);
+    }
+
+    Ok(changed.then_some(next_bytes))
+}
+
+fn split_jsonl_lines(bytes: &[u8]) -> Vec<(&[u8], &'static [u8])> {
+    let mut lines = Vec::new();
+    let mut start = 0usize;
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte != b'\n' {
+            continue;
+        }
+        if index > start && bytes[index - 1] == b'\r' {
+            lines.push((&bytes[start..index - 1], b"\r\n".as_slice()));
+        } else {
+            lines.push((&bytes[start..index], b"\n".as_slice()));
+        }
+        start = index + 1;
+    }
+    if start < bytes.len() {
+        lines.push((&bytes[start..], b"".as_slice()));
+    }
+    lines
 }
 
 fn is_missing_threads_table_error(error: &rusqlite::Error) -> bool {
@@ -670,31 +698,7 @@ fn format_sqlite_write_error(path: &Path, error: &rusqlite::Error) -> String {
 }
 
 fn rewrite_rollout_provider(change: &RolloutProviderChange) -> Result<(), String> {
-    let bytes = fs::read(&change.absolute_path).map_err(|error| {
-        format!(
-            "读取 rollout 文件失败 ({}): {}",
-            change.absolute_path.display(),
-            error
-        )
-    })?;
-    let (offset, separator) = detect_first_line_boundary(&bytes);
-    let mut next_bytes = Vec::with_capacity(change.updated_first_line.len() + bytes.len());
-    next_bytes.extend_from_slice(change.updated_first_line.as_bytes());
-    next_bytes.extend_from_slice(separator.as_bytes());
-    next_bytes.extend_from_slice(&bytes[offset..]);
-    write_bytes_atomic(&change.absolute_path, &next_bytes)
-}
-
-fn detect_first_line_boundary(bytes: &[u8]) -> (usize, &'static str) {
-    for (index, byte) in bytes.iter().enumerate() {
-        if *byte == b'\n' {
-            if index > 0 && bytes[index - 1] == b'\r' {
-                return (index + 1, "\r\n");
-            }
-            return (index + 1, "\n");
-        }
-    }
-    (bytes.len(), "")
+    write_bytes_atomic(&change.absolute_path, &change.updated_content)
 }
 
 fn write_bytes_atomic(path: &Path, content: &[u8]) -> Result<(), String> {
@@ -1047,6 +1051,20 @@ mod tests {
             .expect("thread provider should be readable")
     }
 
+    fn read_rollout_session_meta_providers(path: &Path) -> Vec<String> {
+        fs::read_to_string(path)
+            .expect("rollout should be readable")
+            .lines()
+            .filter_map(|line| serde_json::from_str::<JsonValue>(line).ok())
+            .filter(|value| value.get("type").and_then(JsonValue::as_str) == Some("session_meta"))
+            .filter_map(|value| {
+                value["payload"]["model_provider"]
+                    .as_str()
+                    .map(str::to_string)
+            })
+            .collect()
+    }
+
     #[test]
     fn repair_profile_dir_rewrites_rollout_and_sqlite_to_target_provider() {
         let data_dir = unique_temp_dir("rewrite");
@@ -1094,6 +1112,39 @@ mod tests {
         assert_eq!(
             parsed["payload"]["model_provider"].as_str(),
             Some("relay")
+        );
+
+        fs::remove_dir_all(&data_dir).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn repair_profile_dir_rewrites_every_session_meta_in_rollout_jsonl() {
+        let data_dir = unique_temp_dir("multi-session-meta");
+        fs::create_dir_all(data_dir.join("sessions/2026/05/09"))
+            .expect("session dir should be created");
+        fs::write(data_dir.join(CONFIG_FILE_NAME), "model_provider = \"relay\"\n")
+            .expect("config should be written");
+        let rollout_path = data_dir.join("sessions/2026/05/09/rollout-test.jsonl");
+        fs::write(
+            &rollout_path,
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread-1\",\"model_provider\":\"relay\"}}\n",
+                "{\"type\":\"event\",\"payload\":{}}\n",
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread-1\",\"model_provider\":\"openai\"}}\n"
+            ),
+        )
+        .expect("rollout should be written");
+        create_threads_db(&data_dir, "relay");
+
+        let item = repair_session_visibility_for_dir(&data_dir, "test", "Test", false)
+            .expect("repair should succeed");
+
+        assert_eq!(item.target_provider, "relay");
+        assert_eq!(item.changed_rollout_file_count, 1);
+        assert_eq!(item.updated_sqlite_row_count, 0);
+        assert_eq!(
+            read_rollout_session_meta_providers(&rollout_path),
+            vec!["relay".to_string(), "relay".to_string()]
         );
 
         fs::remove_dir_all(&data_dir).expect("temp dir should be removed");

--- a/src-tauri/src/modules/codex_session_visibility.rs
+++ b/src-tauri/src/modules/codex_session_visibility.rs
@@ -191,6 +191,90 @@ pub fn read_history_visibility_provider_for_dir(data_dir: &Path) -> Result<Strin
     read_target_provider(data_dir)
 }
 
+pub fn repair_session_visibility_for_dir(
+    data_dir: &Path,
+    instance_id: &str,
+    instance_name: &str,
+) -> Result<CodexSessionVisibilityRepairItem, String> {
+    let target_provider = read_target_provider(data_dir)?;
+    let rollout_changes = collect_rollout_provider_changes(data_dir, &target_provider)?;
+    let sqlite_scan = count_sqlite_rows_to_update(data_dir, &target_provider)?;
+    let sqlite_rows_to_update = sqlite_scan.rows_to_update;
+
+    if rollout_changes.is_empty() && sqlite_rows_to_update == 0 {
+        return Ok(CodexSessionVisibilityRepairItem {
+            instance_id: instance_id.to_string(),
+            instance_name: instance_name.to_string(),
+            target_provider,
+            changed_rollout_file_count: 0,
+            updated_sqlite_row_count: 0,
+            skipped_sqlite_file: sqlite_scan.skipped_unusable_database,
+            backup_dir: None,
+            running: false,
+        });
+    }
+
+    let backup_dir = backup_instance_files(
+        data_dir,
+        &rollout_changes,
+        sqlite_rows_to_update > 0,
+        instance_id,
+        &target_provider,
+    )?;
+    let backup_dir_string = backup_dir.to_string_lossy().to_string();
+
+    let repaired = repair_single_instance(
+        data_dir,
+        &target_provider,
+        &rollout_changes,
+        sqlite_rows_to_update > 0,
+    );
+    let sqlite_rows_updated = match repaired {
+        Ok(value) => value,
+        Err(error) => {
+            let restore_result = restore_instance_files_from_backup(
+                data_dir,
+                &backup_dir,
+                sqlite_rows_to_update > 0,
+            );
+            if let Err(restore_error) = restore_result {
+                return Err(format!(
+                    "修复实例历史会话可见性失败 ({}): {}；自动回滚也失败: {}；备份目录: {}",
+                    instance_name,
+                    error,
+                    restore_error,
+                    backup_dir.display()
+                ));
+            }
+            return Err(format!(
+                "修复实例历史会话可见性失败 ({}): {}；已自动回滚，备份目录: {}",
+                instance_name,
+                error,
+                backup_dir.display()
+            ));
+        }
+    };
+
+    if let Err(error) = prune_instance_session_visibility_repair_backups(data_dir) {
+        modules::logger::log_warn(&format!(
+            "清理 Codex 会话可见性修复旧备份失败 ({}): {}",
+            data_dir.display(),
+            error
+        ));
+    }
+
+    Ok(CodexSessionVisibilityRepairItem {
+        instance_id: instance_id.to_string(),
+        instance_name: instance_name.to_string(),
+        target_provider,
+        changed_rollout_file_count: rollout_changes.len(),
+        updated_sqlite_row_count: sqlite_rows_updated,
+        skipped_sqlite_file: sqlite_scan.skipped_unusable_database,
+        backup_dir: Some(backup_dir_string),
+        running: false,
+    })
+}
+
 fn repair_single_instance(
     data_dir: &Path,
     target_provider: &str,
@@ -871,4 +955,115 @@ fn restore_directory_contents(source_root: &Path, target_root: &Path) -> Result<
         })?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be available")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "cockpit-tools-codex-session-visibility-{}-{}-{}",
+            name,
+            std::process::id(),
+            nonce
+        ))
+    }
+
+    fn create_threads_db(data_dir: &Path, provider: &str) {
+        let connection =
+            Connection::open(data_dir.join(STATE_DB_FILE)).expect("state db should open");
+        connection
+            .execute(
+                "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)",
+                [],
+            )
+            .expect("threads table should be created");
+        connection
+            .execute(
+                "INSERT INTO threads (id, model_provider) VALUES (?1, ?2)",
+                rusqlite::params!["thread-1", provider],
+            )
+            .expect("thread row should be inserted");
+    }
+
+    fn read_thread_provider(data_dir: &Path) -> String {
+        let connection =
+            Connection::open(data_dir.join(STATE_DB_FILE)).expect("state db should open");
+        connection
+            .query_row(
+                "SELECT model_provider FROM threads WHERE id = ?1",
+                ["thread-1"],
+                |row| row.get::<usize, String>(0),
+            )
+            .expect("thread provider should be readable")
+    }
+
+    #[test]
+    fn repair_profile_dir_rewrites_rollout_and_sqlite_to_target_provider() {
+        let data_dir = unique_temp_dir("rewrite");
+        fs::create_dir_all(data_dir.join("sessions/2026/05/09"))
+            .expect("session dir should be created");
+        fs::write(data_dir.join(CONFIG_FILE_NAME), "model_provider = \"relay\"\n")
+            .expect("config should be written");
+        let rollout_path = data_dir.join("sessions/2026/05/09/rollout-test.jsonl");
+        fs::write(
+            &rollout_path,
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread-1\",\"model_provider\":\"openai\"}}\n",
+                "{\"type\":\"event\",\"payload\":{}}\n"
+            ),
+        )
+        .expect("rollout should be written");
+        create_threads_db(&data_dir, "openai");
+
+        let item = repair_session_visibility_for_dir(&data_dir, "test", "Test")
+            .expect("repair should succeed");
+
+        assert_eq!(item.target_provider, "relay");
+        assert_eq!(item.changed_rollout_file_count, 1);
+        assert_eq!(item.updated_sqlite_row_count, 1);
+        assert!(item.backup_dir.is_some());
+        assert_eq!(read_thread_provider(&data_dir), "relay");
+
+        let first_line = fs::read_to_string(&rollout_path)
+            .expect("rollout should be readable")
+            .lines()
+            .next()
+            .expect("rollout should have first line")
+            .to_string();
+        let parsed: JsonValue =
+            serde_json::from_str(&first_line).expect("session meta should stay valid json");
+        assert_eq!(
+            parsed["payload"]["model_provider"].as_str(),
+            Some("relay")
+        );
+
+        fs::remove_dir_all(&data_dir).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn repair_profile_dir_noops_when_provider_metadata_already_matches() {
+        let data_dir = unique_temp_dir("noop");
+        fs::create_dir_all(&data_dir).expect("temp dir should be created");
+        fs::write(data_dir.join(CONFIG_FILE_NAME), "model_provider = \"relay\"\n")
+            .expect("config should be written");
+        create_threads_db(&data_dir, "relay");
+
+        let item = repair_session_visibility_for_dir(&data_dir, "test", "Test")
+            .expect("repair should succeed");
+
+        assert_eq!(item.target_provider, "relay");
+        assert_eq!(item.changed_rollout_file_count, 0);
+        assert_eq!(item.updated_sqlite_row_count, 0);
+        assert!(item.backup_dir.is_none());
+        assert_eq!(read_thread_provider(&data_dir), "relay");
+
+        fs::remove_dir_all(&data_dir).expect("temp dir should be removed");
+    }
 }

--- a/src/stores/usePlatformLayoutStore.ts
+++ b/src/stores/usePlatformLayoutStore.ts
@@ -101,7 +101,7 @@ interface NormalizedLayoutStateData {
   sidebarEntryIds: PlatformLayoutEntryId[];
 }
 
-let trayLayoutSyncTimer: ReturnType<typeof setTimeout> | null = null;
+let trayLayoutSyncTimer: number | null = null;
 
 export function makePlatformEntryId(platformId: PlatformId): PlatformLayoutEntryId {
   return `${PLATFORM_ENTRY_PREFIX}${platformId}` as PlatformLayoutEntryId;


### PR DESCRIPTION
## Summary
- repair stale Codex session provider metadata after switching the default profile between OAuth, API Key, and Local API Service providers
- repair the affected Codex profile before instance launch when bound account injection changes its provider
- add directory-level session visibility repair coverage for rollout files and state_5.sqlite rows
- fix an existing browser timer type so frontend typecheck/build can pass

## Verification
- npm run typecheck
- npm run build
- git diff --check

## Not run
- cargo fmt: not run because this local machine does not have rustfmt installed
- cargo test codex_session_visibility: not run because this local machine does not have cargo installed
