### PR TITLE
[codex] 支持 Windows Codex 多开实例

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ name = "cockpit-core"
 version = "0.1.0"
 dependencies = [
  "aes",
+ "aes-gcm",
  "anyhow",
  "base64 0.22.1",
  "cbc",
@@ -765,6 +766,7 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tauri",
+ "tauri-plugin-notification",
  "thiserror 2.0.18",
  "tiny_http",
  "tokio",
@@ -779,6 +781,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "windows 0.58.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 tracing-appender = "0.2"
 tracing-log = "0.2"
 trash = "5"
-tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 mac-notification-sys = "0.6"
+tauri-plugin-notification = "2"
 rand = "0.8"
 sha2 = "0.10"
 tokio-tungstenite = "0.26"
@@ -38,9 +39,11 @@ rcgen = "0.13"
 tokio-rustls = "0.26"
 libc = "0.2"
 aes = "0.8"
+aes-gcm = "0.10"
 cbc = "0.1"
 pbkdf2 = "0.12"
 sha1 = "0.10"
 tiny_http = "0.12"
 rsa = "0.9"
 serde_urlencoded = "0.7"
+windows = { version = "0.58", features = ["Win32_Foundation", "Win32_Security_Cryptography"] }

--- a/crates/cockpit-core/Cargo.toml
+++ b/crates/cockpit-core/Cargo.toml
@@ -32,7 +32,7 @@ tracing-appender.workspace = true
 tracing-log.workspace = true
 trash.workspace = true
 tauri.workspace = true
-mac-notification-sys.workspace = true
+tauri-plugin-notification.workspace = true
 rand.workspace = true
 sha2.workspace = true
 tokio-tungstenite.workspace = true
@@ -42,9 +42,16 @@ rcgen.workspace = true
 tokio-rustls.workspace = true
 libc.workspace = true
 aes.workspace = true
+aes-gcm.workspace = true
 cbc.workspace = true
 pbkdf2.workspace = true
 sha1.workspace = true
 tiny_http.workspace = true
 rsa.workspace = true
 serde_urlencoded.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mac-notification-sys.workspace = true
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows.workspace = true

--- a/crates/cockpit-core/src/modules/codex_instance.rs
+++ b/crates/cockpit-core/src/modules/codex_instance.rs
@@ -18,6 +18,8 @@ const CODEX_SHARED_SKILLS_DIR_NAME: &str = "skills";
 const CODEX_SHARED_RULES_DIR_NAME: &str = "rules";
 const CODEX_SHARED_AGENTS_FILE_NAME: &str = "AGENTS.md";
 const CODEX_SHARED_VENDOR_IMPORTS_SKILLS_DIR: &str = "vendor_imports/skills";
+#[cfg(target_os = "windows")]
+const CODEX_WINDOWS_APP_DATA_DIR_NAME: &str = "codex-app-data";
 
 #[derive(Debug, Clone)]
 pub struct CreateInstanceParams {
@@ -111,8 +113,15 @@ pub fn get_default_instances_root_dir() -> Result<PathBuf, String> {
         return Ok(home.join(".antigravity_cockpit/instances/codex"));
     }
 
+    #[cfg(target_os = "windows")]
+    {
+        let appdata =
+            std::env::var("APPDATA").map_err(|_| "无法获取 APPDATA 环境变量".to_string())?;
+        return Ok(PathBuf::from(appdata).join(".antigravity_cockpit\\instances\\codex"));
+    }
+
     #[allow(unreachable_code)]
-    Err("Codex 多开实例仅支持 macOS".to_string())
+    Err("Codex 多开实例仅支持 macOS 和 Windows".to_string())
 }
 
 pub fn get_instance_defaults() -> Result<InstanceDefaults, String> {
@@ -122,6 +131,29 @@ pub fn get_instance_defaults() -> Result<InstanceDefaults, String> {
         root_dir: root_dir.to_string_lossy().to_string(),
         default_user_data_dir: default_user_data_dir.to_string_lossy().to_string(),
     })
+}
+
+#[cfg(target_os = "windows")]
+fn normalize_windows_codex_home_for_hash(path: &Path) -> String {
+    let resolved = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    resolved.to_string_lossy().replace('/', "\\").to_lowercase()
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_windows_app_user_data_dir(codex_home: &Path) -> Result<PathBuf, String> {
+    let root = get_default_instances_root_dir()?
+        .parent()
+        .ok_or("无法获取 Codex 实例根目录")?
+        .join(CODEX_WINDOWS_APP_DATA_DIR_NAME);
+    let normalized = normalize_windows_codex_home_for_hash(codex_home);
+    let digest = format!("{:x}", md5::compute(normalized.as_bytes()));
+    Ok(root.join(digest))
+}
+
+#[cfg(target_os = "windows")]
+pub fn delete_windows_app_user_data_dir(codex_home: &Path) -> Result<(), String> {
+    let app_user_data_dir = get_windows_app_user_data_dir(codex_home)?;
+    modules::instance::delete_instance_directory(&app_user_data_dir)
 }
 
 #[cfg(unix)]
@@ -733,6 +765,8 @@ pub fn delete_instance(instance_id: &str) -> Result<(), String> {
     if !user_data_dir.trim().is_empty() {
         let dir_path = PathBuf::from(&user_data_dir);
         modules::instance::delete_instance_directory(&dir_path)?;
+        #[cfg(target_os = "windows")]
+        delete_windows_app_user_data_dir(&dir_path)?;
     }
 
     store.instances.remove(index);

--- a/crates/cockpit-core/src/modules/process.rs
+++ b/crates/cockpit-core/src/modules/process.rs
@@ -2918,6 +2918,13 @@ fn resolve_codex_launch_path() -> Result<std::path::PathBuf, String> {
         return Err(app_path_missing_error("codex"));
     }
 
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(detected) = detect_codex_exec_path() {
+            return Ok(detected);
+        }
+    }
+
     Err(app_path_missing_error("codex"))
 }
 
@@ -4037,6 +4044,44 @@ fn resolve_workbuddy_target_and_fallback(user_data_dir: Option<&str>) -> Option<
     )
 }
 
+#[cfg(target_os = "windows")]
+fn get_default_codex_windows_app_user_data_dir() -> Option<String> {
+    let appdata = std::env::var("APPDATA").ok()?;
+    Some(
+        std::path::PathBuf::from(appdata)
+            .join("Codex")
+            .to_string_lossy()
+            .to_string(),
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn get_managed_codex_windows_app_user_data_dir(codex_home: &str) -> Option<String> {
+    let trimmed = codex_home.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    crate::modules::codex_instance::get_windows_app_user_data_dir(Path::new(trimmed))
+        .ok()
+        .map(|value| value.to_string_lossy().to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_codex_windows_target_and_fallback(codex_home: Option<&str>) -> Option<(String, bool)> {
+    match codex_home {
+        Some(home) => build_user_data_dir_match_target(
+            get_managed_codex_windows_app_user_data_dir(home).as_deref(),
+            get_default_codex_windows_app_user_data_dir(),
+            false,
+        ),
+        None => build_user_data_dir_match_target(
+            None,
+            get_default_codex_windows_app_user_data_dir(),
+            true,
+        ),
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn collect_qoder_process_entries_macos() -> Vec<(u32, Option<String>)> {
     let mut entries = Vec::new();
@@ -4335,27 +4380,27 @@ pub fn resolve_codex_pid_from_entries(
 #[cfg(target_os = "windows")]
 pub fn resolve_codex_pid_from_entries(
     last_pid: Option<u32>,
-    _codex_home: Option<&str>,
+    codex_home: Option<&str>,
     entries: &[(u32, Option<String>)],
 ) -> Option<u32> {
-    let mut pids: Vec<u32> = entries.iter().map(|(pid, _)| *pid).collect();
-    pids.sort();
-    pids.dedup();
+    let (target, allow_none_for_target) = resolve_codex_windows_target_and_fallback(codex_home)?;
+    let matches = collect_matching_pids_by_user_data_dir(entries, &target, allow_none_for_target);
 
     if let Some(pid) = last_pid {
-        if is_pid_running(pid) && pids.contains(&pid) {
+        if is_pid_running(pid) && matches.contains(&pid) {
             return Some(pid);
         }
-        if is_pid_running(pid) && !pids.is_empty() {
+        if is_pid_running(pid) && !matches.is_empty() {
             crate::modules::logger::log_warn(&format!(
-                "[Codex Resolve] 忽略不匹配的 last_pid={}，matched_pids={}",
+                "[Codex Resolve] 忽略不匹配的 last_pid={}，target={}，matched_pids={}",
                 pid,
-                summarize_pid_list_for_log(&pids)
+                summarize_text_for_process_log(&target, 96),
+                summarize_pid_list_for_log(&matches)
             ));
         }
     }
 
-    pick_preferred_pid(pids)
+    pick_preferred_pid(matches)
 }
 
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
@@ -4374,9 +4419,9 @@ pub fn resolve_codex_pid(last_pid: Option<u32>, codex_home: Option<&str>) -> Opt
 }
 
 #[cfg(target_os = "windows")]
-pub fn resolve_codex_pid(last_pid: Option<u32>, _codex_home: Option<&str>) -> Option<u32> {
+pub fn resolve_codex_pid(last_pid: Option<u32>, codex_home: Option<&str>) -> Option<u32> {
     let entries = collect_codex_process_entries();
-    resolve_codex_pid_from_entries(last_pid, None, &entries)
+    resolve_codex_pid_from_entries(last_pid, codex_home, &entries)
 }
 
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
@@ -6384,39 +6429,117 @@ pub fn collect_codex_process_entries() -> Vec<(u32, Option<String>)> {
 }
 
 #[cfg(target_os = "windows")]
-fn collect_codex_process_entries_from_powershell() -> Vec<(u32, Option<String>)> {
+fn collect_codex_process_entries_from_powershell(
+    expected_exe_path: &str,
+) -> Vec<(u32, Option<String>)> {
     let mut entries: Vec<(u32, Option<String>)> = Vec::new();
-    let script = r#"Get-CimInstance Win32_Process -Filter "Name='Codex.exe'" -ErrorAction SilentlyContinue |
-  ForEach-Object { "$($_.ProcessId)|$($_.CommandLine)" }"#;
+    let process = escape_powershell_single_quoted("Codex.exe");
+    let expected = escape_powershell_single_quoted(expected_exe_path);
+    let script = format!(
+        r#"$processName='{process}';
+$expectedRaw='{expected}';
+function Normalize-ExePath([string]$path) {{
+  if ([string]::IsNullOrWhiteSpace($path)) {{ return $null }}
+  $value = $path.Trim().Trim('"')
+  $value = [Environment]::ExpandEnvironmentVariables($value)
+  if ($value.StartsWith('\\?\UNC\', [System.StringComparison]::OrdinalIgnoreCase)) {{
+    $value = '\\' + $value.Substring(8)
+  }} elseif ($value.StartsWith('\\?\', [System.StringComparison]::OrdinalIgnoreCase)) {{
+    $value = $value.Substring(4)
+  }}
+  $value = $value -replace '/', '\'
+  try {{ $value = [System.IO.Path]::GetFullPath($value) }} catch {{}}
+  if ($value.StartsWith('\\?\UNC\', [System.StringComparison]::OrdinalIgnoreCase)) {{
+    $value = '\\' + $value.Substring(8)
+  }} elseif ($value.StartsWith('\\?\', [System.StringComparison]::OrdinalIgnoreCase)) {{
+    $value = $value.Substring(4)
+  }}
+  return $value.ToLowerInvariant()
+}}
+function Get-ExePathFromCmdLine([string]$cmdline) {{
+  if ([string]::IsNullOrWhiteSpace($cmdline)) {{ return $null }}
+  $value = $cmdline.Trim()
+  if ($value.StartsWith('"')) {{
+    $end = $value.IndexOf('"', 1)
+    if ($end -gt 1) {{ return $value.Substring(1, $end - 1) }}
+  }}
+  $exeMatch = [regex]::Match($value, '^[^""]+?\.exe', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+  if ($exeMatch.Success) {{ return $exeMatch.Value.Trim() }}
+  $space = $value.IndexOf(' ')
+  if ($space -gt 0) {{ return $value.Substring(0, $space) }}
+  return $value
+}}
+$expected = Normalize-ExePath $expectedRaw
+if ([string]::IsNullOrWhiteSpace($expected)) {{ exit 0 }}
+Get-CimInstance Win32_Process -Filter ("Name='" + $processName + "'") |
+  Where-Object {{
+    $exe = Normalize-ExePath $_.ExecutablePath
+    if (-not $exe) {{ $exe = Normalize-ExePath (Get-ExePathFromCmdLine $_.CommandLine) }}
+    $exe -eq $expected
+  }} |
+  ForEach-Object {{ "$($_.ProcessId)|$($_.ParentProcessId)|$($_.CommandLine)" }}"#
+    );
 
-    let output = match powershell_output(&["-Command", script]) {
+    let output = match powershell_output_with_timeout(
+        &["-NoProfile", "-Command", &script],
+        WINDOWS_PROCESS_PROBE_TIMEOUT,
+    ) {
         Ok(value) => value,
-        Err(_) => return entries,
+        Err(err) => {
+            if err.kind() == std::io::ErrorKind::TimedOut {
+                crate::modules::logger::log_warn("[Codex Probe] PowerShell 进程探测超时（5s）");
+            } else {
+                crate::modules::logger::log_warn(&format!(
+                    "[Codex Probe] PowerShell 进程探测失败: {}",
+                    err
+                ));
+            }
+            return entries;
+        }
     };
     if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        crate::modules::logger::log_warn(&format!(
+            "[Codex Probe] PowerShell 进程探测返回非 0 状态: {}, stderr={}",
+            output.status,
+            stderr.trim()
+        ));
         return entries;
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut main_entries: Vec<(u32, Option<String>)> = Vec::new();
+    let mut child_user_data_by_parent: HashMap<u32, String> = HashMap::new();
     for line in stdout.lines() {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
-        let mut parts = line.splitn(2, '|');
+        let mut parts = line.splitn(3, '|');
         let pid_str = parts.next().unwrap_or("").trim();
+        let parent_pid_str = parts.next().unwrap_or("").trim();
         let cmdline = parts.next().unwrap_or("").trim();
         let pid = match pid_str.parse::<u32>() {
             Ok(value) => value,
             Err(_) => continue,
         };
+        let parent_pid = parent_pid_str.parse::<u32>().ok();
         let lower = cmdline.to_lowercase();
+        let dir = extract_user_data_dir_from_command_line(cmdline);
         if !lower.is_empty()
             && (is_helper_command_line(&lower) || lower.contains("crashpad_handler"))
         {
+            if let (Some(parent_pid), Some(dir)) = (parent_pid, dir) {
+                child_user_data_by_parent.entry(parent_pid).or_insert(dir);
+            }
             continue;
         }
-        entries.push((pid, None));
+        main_entries.push((pid, dir));
+    }
+
+    for (pid, dir) in main_entries {
+        let resolved_dir = dir.or_else(|| child_user_data_by_parent.get(&pid).cloned());
+        entries.push((pid, resolved_dir));
     }
 
     entries.sort_by_key(|(pid, _)| *pid);
@@ -6425,7 +6548,14 @@ fn collect_codex_process_entries_from_powershell() -> Vec<(u32, Option<String>)>
 }
 
 #[cfg(target_os = "windows")]
-fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<String>)> {
+fn collect_codex_process_entries_from_sysinfo_fallback(
+    expected_exe_path: &str,
+) -> Vec<(u32, Option<String>)> {
+    let expected = normalize_path_for_compare(expected_exe_path);
+    if expected.is_empty() {
+        return Vec::new();
+    }
+
     let mut entries: Vec<(u32, Option<String>)> = Vec::new();
     let mut system = System::new();
     system.refresh_processes_specifics(
@@ -6436,6 +6566,8 @@ fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<Str
             .with_cmd(UpdateKind::OnlyIfNotSet),
     );
     let current_pid = std::process::id();
+    let mut main_entries: Vec<(u32, Option<String>)> = Vec::new();
+    let mut child_user_data_by_parent: HashMap<u32, String> = HashMap::new();
     for (pid, process) in system.processes() {
         let pid_u32 = pid.as_u32();
         if pid_u32 == current_pid {
@@ -6451,6 +6583,10 @@ fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<Str
         if name != "codex.exe" && !exe_path.ends_with("\\codex.exe") {
             continue;
         }
+        let (resolved_exe, _) = resolve_windows_process_exe_for_match(process);
+        if resolved_exe.as_deref() != Some(expected.as_str()) {
+            continue;
+        }
 
         let args_line = process
             .cmd()
@@ -6458,13 +6594,24 @@ fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<Str
             .map(|arg| arg.to_string_lossy().to_lowercase())
             .collect::<Vec<String>>()
             .join(" ");
+        let dir = extract_user_data_dir(process.cmd());
         if !args_line.is_empty()
             && (is_helper_command_line(&args_line) || args_line.contains("crashpad_handler"))
         {
+            if let (Some(parent_pid), Some(dir)) = (process.parent(), dir) {
+                child_user_data_by_parent
+                    .entry(parent_pid.as_u32())
+                    .or_insert(dir);
+            }
             continue;
         }
 
-        entries.push((pid_u32, None));
+        main_entries.push((pid_u32, dir));
+    }
+
+    for (pid, dir) in main_entries {
+        let resolved_dir = dir.or_else(|| child_user_data_by_parent.get(&pid).cloned());
+        entries.push((pid, resolved_dir));
     }
     entries.sort_by_key(|(pid, _)| *pid);
     entries.dedup_by(|a, b| a.0 == b.0);
@@ -6473,11 +6620,22 @@ fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<Str
 
 #[cfg(target_os = "windows")]
 pub fn collect_codex_process_entries() -> Vec<(u32, Option<String>)> {
-    let entries = collect_codex_process_entries_from_powershell();
+    let launch_path = match resolve_codex_launch_path() {
+        Ok(path) => path,
+        Err(err) => {
+            crate::modules::logger::log_warn(&format!(
+                "[Codex Probe] 启动路径未配置或无效，跳过 PID 匹配: {}",
+                err
+            ));
+            return Vec::new();
+        }
+    };
+    let expected = launch_path.to_string_lossy().to_string();
+    let entries = collect_codex_process_entries_from_powershell(&expected);
     if !entries.is_empty() {
         return entries;
     }
-    collect_codex_process_entries_from_sysinfo_fallback()
+    collect_codex_process_entries_from_sysinfo_fallback(&expected)
 }
 
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
@@ -6566,10 +6724,73 @@ pub fn start_codex_with_args(codex_home: &str, extra_args: &[String]) -> Result<
         return Ok(open_pid);
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+
+        let codex_home_trimmed = codex_home.trim();
+        if codex_home_trimmed.is_empty() {
+            return Err("实例目录为空，无法启动".to_string());
+        }
+
+        let launch_path = resolve_codex_launch_path()?;
+        let app_user_data_dir = crate::modules::codex_instance::get_windows_app_user_data_dir(
+            Path::new(codex_home_trimmed),
+        )?;
+        std::fs::create_dir_all(&app_user_data_dir).map_err(|e| {
+            format!(
+                "创建 Codex Windows 实例运行目录失败 ({}): {}",
+                app_user_data_dir.to_string_lossy(),
+                e
+            )
+        })?;
+
+        let mut cmd = Command::new(&launch_path);
+        apply_managed_proxy_env_to_command(&mut cmd);
+        cmd.env("CODEX_HOME", codex_home_trimmed);
+        cmd.env("CODEX_ELECTRON_USER_DATA_PATH", &app_user_data_dir);
+        if should_detach_child() {
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
+            cmd.stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+        }
+        for arg in extra_args {
+            let trimmed = arg.trim();
+            if !trimmed.is_empty() {
+                cmd.arg(trimmed);
+            }
+        }
+
+        let child =
+            spawn_command_with_trace(&mut cmd).map_err(|e| format!("启动 Codex 失败: {}", e))?;
+        crate::modules::logger::log_info(&format!(
+            "[Codex Start] Windows 实例启动命令已发送 launch_path={} codex_home={} app_user_data_dir={} pid={}",
+            launch_path.to_string_lossy(),
+            summarize_text_for_process_log(codex_home_trimmed, 96),
+            app_user_data_dir.to_string_lossy(),
+            child.id()
+        ));
+
+        let probe_started = Instant::now();
+        let timeout = Duration::from_secs(15);
+        while probe_started.elapsed() < timeout {
+            if let Some(resolved_pid) = resolve_codex_pid(None, Some(codex_home_trimmed)) {
+                return Ok(resolved_pid);
+            }
+            thread::sleep(Duration::from_millis(250));
+        }
+        crate::modules::logger::log_warn(&format!(
+            "[Codex Start] Windows 实例启动后 15s 内未匹配到实例 PID，回退 spawn pid={}",
+            child.id()
+        ));
+        Ok(child.id())
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
         let _ = (codex_home, extra_args);
-        Err("Codex 多开实例仅支持 macOS".to_string())
+        Err("Codex 多开实例仅支持 macOS 和 Windows".to_string())
     }
 }
 
@@ -6788,10 +7009,90 @@ pub fn close_codex_instances(codex_homes: &[String], timeout_secs: u64) -> Resul
         return Ok(());
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    {
+        crate::modules::logger::log_info("正在关闭受管 Codex 实例...");
+
+        let default_home = normalize_path_for_compare(
+            &crate::modules::codex_account::get_codex_home()
+                .to_string_lossy()
+                .to_string(),
+        );
+        let mut target_app_dirs: HashSet<String> = HashSet::new();
+        let mut includes_default = false;
+
+        for home in codex_homes {
+            let normalized_home = normalize_path_for_compare(home);
+            if normalized_home.is_empty() {
+                continue;
+            }
+            if normalized_home == default_home {
+                includes_default = true;
+                continue;
+            }
+            if let Some(app_dir) = get_managed_codex_windows_app_user_data_dir(home) {
+                let normalized_app_dir = normalize_path_for_compare(&app_dir);
+                if !normalized_app_dir.is_empty() {
+                    target_app_dirs.insert(normalized_app_dir);
+                }
+            }
+        }
+
+        let default_app_dir = get_default_codex_windows_app_user_data_dir()
+            .map(|value| normalize_path_for_compare(&value))
+            .filter(|value| !value.is_empty());
+
+        if target_app_dirs.is_empty() && !includes_default {
+            crate::modules::logger::log_info("未提供可关闭的 Codex 实例目录");
+            return Ok(());
+        }
+
+        let matches_target =
+            |dir: Option<&String>, target_app_dirs: &HashSet<String>, includes_default: bool| {
+                match dir {
+                    Some(value) => {
+                        let normalized = normalize_path_for_compare(value);
+                        (!normalized.is_empty() && target_app_dirs.contains(&normalized))
+                            || (includes_default
+                                && default_app_dir.as_deref() == Some(normalized.as_str()))
+                    }
+                    None => includes_default,
+                }
+            };
+
+        let entries = collect_codex_process_entries();
+        let mut pids: Vec<u32> = entries
+            .iter()
+            .filter_map(|(pid, dir)| {
+                matches_target(dir.as_ref(), &target_app_dirs, includes_default).then_some(*pid)
+            })
+            .collect();
+        pids.sort();
+        pids.dedup();
+        if pids.is_empty() {
+            crate::modules::logger::log_info("受管 Codex 实例未在运行，无需关闭");
+            return Ok(());
+        }
+
+        crate::modules::logger::log_info(&format!(
+            "准备关闭 {} 个受管 Codex 主进程...",
+            pids.len()
+        ));
+        let _ = close_pids(&pids, timeout_secs);
+
+        let still_running = collect_codex_process_entries()
+            .into_iter()
+            .any(|(_, dir)| matches_target(dir.as_ref(), &target_app_dirs, includes_default));
+        if still_running {
+            return Err("无法关闭受管 Codex 实例进程，请手动关闭后重试".to_string());
+        }
+        Ok(())
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
         let _ = (codex_homes, timeout_secs);
-        Err("Codex 多开实例仅支持 macOS".to_string())
+        Err("Codex 多开实例仅支持 macOS 和 Windows".to_string())
     }
 }
 

--- a/crates/cockpit-core/src/modules/windsurf_account.rs
+++ b/crates/cockpit-core/src/modules/windsurf_account.rs
@@ -869,6 +869,12 @@ pub fn upsert_account(payload: WindsurfOAuthCompletePayload) -> Result<WindsurfA
         quota_query_last_error: None,
         quota_query_last_error_at: None,
         usage_updated_at: None,
+        windsurf_token_type: payload.windsurf_token_type.clone(),
+        devin_auth1_token: payload.devin_auth1_token.clone(),
+        devin_account_id: payload.devin_account_id.clone(),
+        devin_org_id: payload.devin_org_id.clone(),
+        devin_session_token: payload.devin_session_token.clone(),
+        devin_user_status_proto_b64: payload.devin_user_status_proto_b64.clone(),
         created_at,
         last_used: now,
     });

--- a/crates/cockpit-core/src/modules/windsurf_oauth.rs
+++ b/crates/cockpit-core/src/modules/windsurf_oauth.rs
@@ -916,6 +916,7 @@ fn build_payload_from_remote(
         windsurf_user_status: user_status_resp,
         windsurf_plan_status: plan_status_resp,
         windsurf_auth_status_raw,
+        ..Default::default()
     }
 }
 

--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::process::Command;
 
 use serde::Serialize;
@@ -181,6 +181,11 @@ fn posix_shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
+#[cfg(target_os = "windows")]
+fn powershell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
 fn build_launch_command(context: &CodexLaunchContext) -> Result<String, String> {
     let runtime = modules::codex_wakeup::resolve_cli_runtime()?;
     let parsed_args = modules::process::parse_extra_args(&context.extra_args);
@@ -214,6 +219,46 @@ fn build_launch_command(context: &CodexLaunchContext) -> Result<String, String> 
 
         command_parts.push(codex_cmd);
         return Ok(command_parts.join(" && "));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let mut command_parts = Vec::new();
+        command_parts.push(format!(
+            "$env:CODEX_HOME={}",
+            powershell_quote(&context.user_data_dir)
+        ));
+
+        if let Some(ref dir) = context.working_dir {
+            if !dir.trim().is_empty() {
+                command_parts.push(format!(
+                    "Set-Location -LiteralPath {}",
+                    powershell_quote(dir)
+                ));
+            }
+        }
+
+        let mut codex_cmd = String::new();
+        if let Some(node_path) = runtime.node_path.as_deref() {
+            codex_cmd.push_str("& ");
+            codex_cmd.push_str(&powershell_quote(node_path));
+            codex_cmd.push(' ');
+            codex_cmd.push_str(&powershell_quote(&runtime.binary_path));
+        } else {
+            codex_cmd.push_str("& ");
+            codex_cmd.push_str(&powershell_quote(&runtime.binary_path));
+        }
+
+        for arg in parsed_args {
+            let trimmed = arg.trim();
+            if !trimmed.is_empty() {
+                codex_cmd.push(' ');
+                codex_cmd.push_str(&powershell_quote(trimmed));
+            }
+        }
+
+        command_parts.push(codex_cmd);
+        return Ok(command_parts.join("; "));
     }
 
     #[allow(unreachable_code)]
@@ -662,13 +707,6 @@ pub async fn codex_execute_instance_launch_command(
 ) -> Result<String, String> {
     let context = resolve_instance_launch_context(&instance_id)?;
 
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = terminal;
-        let _ = context;
-    }
-
-    #[cfg(target_os = "macos")]
     let command = build_launch_command(&context)?;
 
     #[cfg(target_os = "macos")]
@@ -735,6 +773,44 @@ pub async fn codex_execute_instance_launch_command(
         return Ok(format!("已在 {} 执行 Codex CLI 命令", app_name));
     }
 
+    #[cfg(target_os = "windows")]
+    {
+        let config = crate::modules::config::get_user_config();
+        let terminal = terminal
+            .unwrap_or(config.default_terminal)
+            .trim()
+            .to_string();
+
+        let mut cmd = if terminal == "pwsh" {
+            let mut command_process = Command::new("pwsh");
+            command_process.args(["-NoExit", "-Command", &command]);
+            command_process
+        } else if terminal == "wt" {
+            let mut command_process = Command::new("wt");
+            command_process.args(["powershell", "-NoExit", "-Command", &command]);
+            command_process
+        } else if terminal == "cmd" {
+            let mut command_process = Command::new("cmd");
+            command_process.args([
+                "/C",
+                "start",
+                "",
+                "powershell",
+                "-NoExit",
+                "-Command",
+                &command,
+            ]);
+            command_process
+        } else {
+            let mut command_process = Command::new("powershell");
+            command_process.args(["-NoExit", "-Command", &command]);
+            command_process
+        };
+
+        cmd.spawn().map_err(|e| format!("打开终端失败: {}", e))?;
+        return Ok("已在终端执行 Codex CLI 命令".to_string());
+    }
+
     #[allow(unreachable_code)]
-    Err("Codex CLI 终端执行仅支持 macOS".to_string())
+    Err("Codex CLI 终端执行仅支持 macOS 和 Windows".to_string())
 }

--- a/src-tauri/src/modules/codex_instance.rs
+++ b/src-tauri/src/modules/codex_instance.rs
@@ -19,6 +19,8 @@ const CODEX_SHARED_SKILLS_DIR_NAME: &str = "skills";
 const CODEX_SHARED_RULES_DIR_NAME: &str = "rules";
 const CODEX_SHARED_AGENTS_FILE_NAME: &str = "AGENTS.md";
 const CODEX_SHARED_VENDOR_IMPORTS_SKILLS_DIR: &str = "vendor_imports/skills";
+#[cfg(target_os = "windows")]
+const CODEX_WINDOWS_APP_DATA_DIR_NAME: &str = "codex-app-data";
 
 pub fn is_api_service_bind_account_id(account_id: &str) -> bool {
     account_id.trim() == CODEX_API_SERVICE_BIND_ACCOUNT_ID
@@ -116,8 +118,15 @@ pub fn get_default_instances_root_dir() -> Result<PathBuf, String> {
         return Ok(home.join(".antigravity_cockpit/instances/codex"));
     }
 
+    #[cfg(target_os = "windows")]
+    {
+        let appdata =
+            std::env::var("APPDATA").map_err(|_| "无法获取 APPDATA 环境变量".to_string())?;
+        return Ok(PathBuf::from(appdata).join(".antigravity_cockpit\\instances\\codex"));
+    }
+
     #[allow(unreachable_code)]
-    Err("Codex 多开实例仅支持 macOS".to_string())
+    Err("Codex 多开实例仅支持 macOS 和 Windows".to_string())
 }
 
 pub fn get_instance_defaults() -> Result<InstanceDefaults, String> {
@@ -127,6 +136,29 @@ pub fn get_instance_defaults() -> Result<InstanceDefaults, String> {
         root_dir: root_dir.to_string_lossy().to_string(),
         default_user_data_dir: default_user_data_dir.to_string_lossy().to_string(),
     })
+}
+
+#[cfg(target_os = "windows")]
+fn normalize_windows_codex_home_for_hash(path: &Path) -> String {
+    let resolved = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    resolved.to_string_lossy().replace('/', "\\").to_lowercase()
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_windows_app_user_data_dir(codex_home: &Path) -> Result<PathBuf, String> {
+    let root = get_default_instances_root_dir()?
+        .parent()
+        .ok_or("无法获取 Codex 实例根目录")?
+        .join(CODEX_WINDOWS_APP_DATA_DIR_NAME);
+    let normalized = normalize_windows_codex_home_for_hash(codex_home);
+    let digest = format!("{:x}", md5::compute(normalized.as_bytes()));
+    Ok(root.join(digest))
+}
+
+#[cfg(target_os = "windows")]
+pub fn delete_windows_app_user_data_dir(codex_home: &Path) -> Result<(), String> {
+    let app_user_data_dir = get_windows_app_user_data_dir(codex_home)?;
+    modules::instance::delete_instance_directory(&app_user_data_dir)
 }
 
 #[cfg(unix)]
@@ -738,6 +770,8 @@ pub fn delete_instance(instance_id: &str) -> Result<(), String> {
     if !user_data_dir.trim().is_empty() {
         let dir_path = PathBuf::from(&user_data_dir);
         modules::instance::delete_instance_directory(&dir_path)?;
+        #[cfg(target_os = "windows")]
+        delete_windows_app_user_data_dir(&dir_path)?;
     }
 
     store.instances.remove(index);

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -2918,6 +2918,13 @@ fn resolve_codex_launch_path() -> Result<std::path::PathBuf, String> {
         return Err(app_path_missing_error("codex"));
     }
 
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(detected) = detect_codex_exec_path() {
+            return Ok(detected);
+        }
+    }
+
     Err(app_path_missing_error("codex"))
 }
 
@@ -4139,6 +4146,44 @@ fn resolve_workbuddy_target_and_fallback(user_data_dir: Option<&str>) -> Option<
     )
 }
 
+#[cfg(target_os = "windows")]
+fn get_default_codex_windows_app_user_data_dir() -> Option<String> {
+    let appdata = std::env::var("APPDATA").ok()?;
+    Some(
+        std::path::PathBuf::from(appdata)
+            .join("Codex")
+            .to_string_lossy()
+            .to_string(),
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn get_managed_codex_windows_app_user_data_dir(codex_home: &str) -> Option<String> {
+    let trimmed = codex_home.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    crate::modules::codex_instance::get_windows_app_user_data_dir(Path::new(trimmed))
+        .ok()
+        .map(|value| value.to_string_lossy().to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_codex_windows_target_and_fallback(codex_home: Option<&str>) -> Option<(String, bool)> {
+    match codex_home {
+        Some(home) => build_user_data_dir_match_target(
+            get_managed_codex_windows_app_user_data_dir(home).as_deref(),
+            get_default_codex_windows_app_user_data_dir(),
+            false,
+        ),
+        None => build_user_data_dir_match_target(
+            None,
+            get_default_codex_windows_app_user_data_dir(),
+            true,
+        ),
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn collect_qoder_process_entries_macos() -> Vec<(u32, Option<String>)> {
     let mut entries = Vec::new();
@@ -4437,27 +4482,27 @@ pub fn resolve_codex_pid_from_entries(
 #[cfg(target_os = "windows")]
 pub fn resolve_codex_pid_from_entries(
     last_pid: Option<u32>,
-    _codex_home: Option<&str>,
+    codex_home: Option<&str>,
     entries: &[(u32, Option<String>)],
 ) -> Option<u32> {
-    let mut pids: Vec<u32> = entries.iter().map(|(pid, _)| *pid).collect();
-    pids.sort();
-    pids.dedup();
+    let (target, allow_none_for_target) = resolve_codex_windows_target_and_fallback(codex_home)?;
+    let matches = collect_matching_pids_by_user_data_dir(entries, &target, allow_none_for_target);
 
     if let Some(pid) = last_pid {
-        if is_pid_running(pid) && pids.contains(&pid) {
+        if is_pid_running(pid) && matches.contains(&pid) {
             return Some(pid);
         }
-        if is_pid_running(pid) && !pids.is_empty() {
+        if is_pid_running(pid) && !matches.is_empty() {
             crate::modules::logger::log_warn(&format!(
-                "[Codex Resolve] 忽略不匹配的 last_pid={}，matched_pids={}",
+                "[Codex Resolve] 忽略不匹配的 last_pid={}，target={}，matched_pids={}",
                 pid,
-                summarize_pid_list_for_log(&pids)
+                summarize_text_for_process_log(&target, 96),
+                summarize_pid_list_for_log(&matches)
             ));
         }
     }
 
-    pick_preferred_pid(pids)
+    pick_preferred_pid(matches)
 }
 
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
@@ -4476,9 +4521,9 @@ pub fn resolve_codex_pid(last_pid: Option<u32>, codex_home: Option<&str>) -> Opt
 }
 
 #[cfg(target_os = "windows")]
-pub fn resolve_codex_pid(last_pid: Option<u32>, _codex_home: Option<&str>) -> Option<u32> {
+pub fn resolve_codex_pid(last_pid: Option<u32>, codex_home: Option<&str>) -> Option<u32> {
     let entries = collect_codex_process_entries();
-    resolve_codex_pid_from_entries(last_pid, None, &entries)
+    resolve_codex_pid_from_entries(last_pid, codex_home, &entries)
 }
 
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
@@ -6486,39 +6531,117 @@ pub fn collect_codex_process_entries() -> Vec<(u32, Option<String>)> {
 }
 
 #[cfg(target_os = "windows")]
-fn collect_codex_process_entries_from_powershell() -> Vec<(u32, Option<String>)> {
+fn collect_codex_process_entries_from_powershell(
+    expected_exe_path: &str,
+) -> Vec<(u32, Option<String>)> {
     let mut entries: Vec<(u32, Option<String>)> = Vec::new();
-    let script = r#"Get-CimInstance Win32_Process -Filter "Name='Codex.exe'" -ErrorAction SilentlyContinue |
-  ForEach-Object { "$($_.ProcessId)|$($_.CommandLine)" }"#;
+    let process = escape_powershell_single_quoted("Codex.exe");
+    let expected = escape_powershell_single_quoted(expected_exe_path);
+    let script = format!(
+        r#"$processName='{process}';
+$expectedRaw='{expected}';
+function Normalize-ExePath([string]$path) {{
+  if ([string]::IsNullOrWhiteSpace($path)) {{ return $null }}
+  $value = $path.Trim().Trim('"')
+  $value = [Environment]::ExpandEnvironmentVariables($value)
+  if ($value.StartsWith('\\?\UNC\', [System.StringComparison]::OrdinalIgnoreCase)) {{
+    $value = '\\' + $value.Substring(8)
+  }} elseif ($value.StartsWith('\\?\', [System.StringComparison]::OrdinalIgnoreCase)) {{
+    $value = $value.Substring(4)
+  }}
+  $value = $value -replace '/', '\'
+  try {{ $value = [System.IO.Path]::GetFullPath($value) }} catch {{}}
+  if ($value.StartsWith('\\?\UNC\', [System.StringComparison]::OrdinalIgnoreCase)) {{
+    $value = '\\' + $value.Substring(8)
+  }} elseif ($value.StartsWith('\\?\', [System.StringComparison]::OrdinalIgnoreCase)) {{
+    $value = $value.Substring(4)
+  }}
+  return $value.ToLowerInvariant()
+}}
+function Get-ExePathFromCmdLine([string]$cmdline) {{
+  if ([string]::IsNullOrWhiteSpace($cmdline)) {{ return $null }}
+  $value = $cmdline.Trim()
+  if ($value.StartsWith('"')) {{
+    $end = $value.IndexOf('"', 1)
+    if ($end -gt 1) {{ return $value.Substring(1, $end - 1) }}
+  }}
+  $exeMatch = [regex]::Match($value, '^[^""]+?\.exe', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+  if ($exeMatch.Success) {{ return $exeMatch.Value.Trim() }}
+  $space = $value.IndexOf(' ')
+  if ($space -gt 0) {{ return $value.Substring(0, $space) }}
+  return $value
+}}
+$expected = Normalize-ExePath $expectedRaw
+if ([string]::IsNullOrWhiteSpace($expected)) {{ exit 0 }}
+Get-CimInstance Win32_Process -Filter ("Name='" + $processName + "'") |
+  Where-Object {{
+    $exe = Normalize-ExePath $_.ExecutablePath
+    if (-not $exe) {{ $exe = Normalize-ExePath (Get-ExePathFromCmdLine $_.CommandLine) }}
+    $exe -eq $expected
+  }} |
+  ForEach-Object {{ "$($_.ProcessId)|$($_.ParentProcessId)|$($_.CommandLine)" }}"#
+    );
 
-    let output = match powershell_output(&["-Command", script]) {
+    let output = match powershell_output_with_timeout(
+        &["-NoProfile", "-Command", &script],
+        WINDOWS_PROCESS_PROBE_TIMEOUT,
+    ) {
         Ok(value) => value,
-        Err(_) => return entries,
+        Err(err) => {
+            if err.kind() == std::io::ErrorKind::TimedOut {
+                crate::modules::logger::log_warn("[Codex Probe] PowerShell 进程探测超时（5s）");
+            } else {
+                crate::modules::logger::log_warn(&format!(
+                    "[Codex Probe] PowerShell 进程探测失败: {}",
+                    err
+                ));
+            }
+            return entries;
+        }
     };
     if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        crate::modules::logger::log_warn(&format!(
+            "[Codex Probe] PowerShell 进程探测返回非 0 状态: {}, stderr={}",
+            output.status,
+            stderr.trim()
+        ));
         return entries;
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut main_entries: Vec<(u32, Option<String>)> = Vec::new();
+    let mut child_user_data_by_parent: HashMap<u32, String> = HashMap::new();
     for line in stdout.lines() {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
-        let mut parts = line.splitn(2, '|');
+        let mut parts = line.splitn(3, '|');
         let pid_str = parts.next().unwrap_or("").trim();
+        let parent_pid_str = parts.next().unwrap_or("").trim();
         let cmdline = parts.next().unwrap_or("").trim();
         let pid = match pid_str.parse::<u32>() {
             Ok(value) => value,
             Err(_) => continue,
         };
+        let parent_pid = parent_pid_str.parse::<u32>().ok();
         let lower = cmdline.to_lowercase();
+        let dir = extract_user_data_dir_from_command_line(cmdline);
         if !lower.is_empty()
             && (is_helper_command_line(&lower) || lower.contains("crashpad_handler"))
         {
+            if let (Some(parent_pid), Some(dir)) = (parent_pid, dir) {
+                child_user_data_by_parent.entry(parent_pid).or_insert(dir);
+            }
             continue;
         }
-        entries.push((pid, None));
+        main_entries.push((pid, dir));
+    }
+
+    for (pid, dir) in main_entries {
+        let resolved_dir = dir.or_else(|| child_user_data_by_parent.get(&pid).cloned());
+        entries.push((pid, resolved_dir));
     }
 
     entries.sort_by_key(|(pid, _)| *pid);
@@ -6527,7 +6650,14 @@ fn collect_codex_process_entries_from_powershell() -> Vec<(u32, Option<String>)>
 }
 
 #[cfg(target_os = "windows")]
-fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<String>)> {
+fn collect_codex_process_entries_from_sysinfo_fallback(
+    expected_exe_path: &str,
+) -> Vec<(u32, Option<String>)> {
+    let expected = normalize_path_for_compare(expected_exe_path);
+    if expected.is_empty() {
+        return Vec::new();
+    }
+
     let mut entries: Vec<(u32, Option<String>)> = Vec::new();
     let mut system = System::new();
     system.refresh_processes_specifics(
@@ -6538,6 +6668,8 @@ fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<Str
             .with_cmd(UpdateKind::OnlyIfNotSet),
     );
     let current_pid = std::process::id();
+    let mut main_entries: Vec<(u32, Option<String>)> = Vec::new();
+    let mut child_user_data_by_parent: HashMap<u32, String> = HashMap::new();
     for (pid, process) in system.processes() {
         let pid_u32 = pid.as_u32();
         if pid_u32 == current_pid {
@@ -6553,6 +6685,10 @@ fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<Str
         if name != "codex.exe" && !exe_path.ends_with("\\codex.exe") {
             continue;
         }
+        let (resolved_exe, _) = resolve_windows_process_exe_for_match(process);
+        if resolved_exe.as_deref() != Some(expected.as_str()) {
+            continue;
+        }
 
         let args_line = process
             .cmd()
@@ -6560,13 +6696,24 @@ fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<Str
             .map(|arg| arg.to_string_lossy().to_lowercase())
             .collect::<Vec<String>>()
             .join(" ");
+        let dir = extract_user_data_dir(process.cmd());
         if !args_line.is_empty()
             && (is_helper_command_line(&args_line) || args_line.contains("crashpad_handler"))
         {
+            if let (Some(parent_pid), Some(dir)) = (process.parent(), dir) {
+                child_user_data_by_parent
+                    .entry(parent_pid.as_u32())
+                    .or_insert(dir);
+            }
             continue;
         }
 
-        entries.push((pid_u32, None));
+        main_entries.push((pid_u32, dir));
+    }
+
+    for (pid, dir) in main_entries {
+        let resolved_dir = dir.or_else(|| child_user_data_by_parent.get(&pid).cloned());
+        entries.push((pid, resolved_dir));
     }
     entries.sort_by_key(|(pid, _)| *pid);
     entries.dedup_by(|a, b| a.0 == b.0);
@@ -6575,11 +6722,22 @@ fn collect_codex_process_entries_from_sysinfo_fallback() -> Vec<(u32, Option<Str
 
 #[cfg(target_os = "windows")]
 pub fn collect_codex_process_entries() -> Vec<(u32, Option<String>)> {
-    let entries = collect_codex_process_entries_from_powershell();
+    let launch_path = match resolve_codex_launch_path() {
+        Ok(path) => path,
+        Err(err) => {
+            crate::modules::logger::log_warn(&format!(
+                "[Codex Probe] 启动路径未配置或无效，跳过 PID 匹配: {}",
+                err
+            ));
+            return Vec::new();
+        }
+    };
+    let expected = launch_path.to_string_lossy().to_string();
+    let entries = collect_codex_process_entries_from_powershell(&expected);
     if !entries.is_empty() {
         return entries;
     }
-    collect_codex_process_entries_from_sysinfo_fallback()
+    collect_codex_process_entries_from_sysinfo_fallback(&expected)
 }
 
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
@@ -6668,10 +6826,73 @@ pub fn start_codex_with_args(codex_home: &str, extra_args: &[String]) -> Result<
         return Ok(open_pid);
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+
+        let codex_home_trimmed = codex_home.trim();
+        if codex_home_trimmed.is_empty() {
+            return Err("实例目录为空，无法启动".to_string());
+        }
+
+        let launch_path = resolve_codex_launch_path()?;
+        let app_user_data_dir = crate::modules::codex_instance::get_windows_app_user_data_dir(
+            Path::new(codex_home_trimmed),
+        )?;
+        std::fs::create_dir_all(&app_user_data_dir).map_err(|e| {
+            format!(
+                "创建 Codex Windows 实例运行目录失败 ({}): {}",
+                app_user_data_dir.to_string_lossy(),
+                e
+            )
+        })?;
+
+        let mut cmd = Command::new(&launch_path);
+        apply_managed_proxy_env_to_command(&mut cmd);
+        cmd.env("CODEX_HOME", codex_home_trimmed);
+        cmd.env("CODEX_ELECTRON_USER_DATA_PATH", &app_user_data_dir);
+        if should_detach_child() {
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
+            cmd.stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+        }
+        for arg in extra_args {
+            let trimmed = arg.trim();
+            if !trimmed.is_empty() {
+                cmd.arg(trimmed);
+            }
+        }
+
+        let child =
+            spawn_command_with_trace(&mut cmd).map_err(|e| format!("启动 Codex 失败: {}", e))?;
+        crate::modules::logger::log_info(&format!(
+            "[Codex Start] Windows 实例启动命令已发送 launch_path={} codex_home={} app_user_data_dir={} pid={}",
+            launch_path.to_string_lossy(),
+            summarize_text_for_process_log(codex_home_trimmed, 96),
+            app_user_data_dir.to_string_lossy(),
+            child.id()
+        ));
+
+        let probe_started = Instant::now();
+        let timeout = Duration::from_secs(15);
+        while probe_started.elapsed() < timeout {
+            if let Some(resolved_pid) = resolve_codex_pid(None, Some(codex_home_trimmed)) {
+                return Ok(resolved_pid);
+            }
+            thread::sleep(Duration::from_millis(250));
+        }
+        crate::modules::logger::log_warn(&format!(
+            "[Codex Start] Windows 实例启动后 15s 内未匹配到实例 PID，回退 spawn pid={}",
+            child.id()
+        ));
+        Ok(child.id())
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
         let _ = (codex_home, extra_args);
-        Err("Codex 多开实例仅支持 macOS".to_string())
+        Err("Codex 多开实例仅支持 macOS 和 Windows".to_string())
     }
 }
 
@@ -6890,10 +7111,90 @@ pub fn close_codex_instances(codex_homes: &[String], timeout_secs: u64) -> Resul
         return Ok(());
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    {
+        crate::modules::logger::log_info("正在关闭受管 Codex 实例...");
+
+        let default_home = normalize_path_for_compare(
+            &crate::modules::codex_account::get_codex_home()
+                .to_string_lossy()
+                .to_string(),
+        );
+        let mut target_app_dirs: HashSet<String> = HashSet::new();
+        let mut includes_default = false;
+
+        for home in codex_homes {
+            let normalized_home = normalize_path_for_compare(home);
+            if normalized_home.is_empty() {
+                continue;
+            }
+            if normalized_home == default_home {
+                includes_default = true;
+                continue;
+            }
+            if let Some(app_dir) = get_managed_codex_windows_app_user_data_dir(home) {
+                let normalized_app_dir = normalize_path_for_compare(&app_dir);
+                if !normalized_app_dir.is_empty() {
+                    target_app_dirs.insert(normalized_app_dir);
+                }
+            }
+        }
+
+        let default_app_dir = get_default_codex_windows_app_user_data_dir()
+            .map(|value| normalize_path_for_compare(&value))
+            .filter(|value| !value.is_empty());
+
+        if target_app_dirs.is_empty() && !includes_default {
+            crate::modules::logger::log_info("未提供可关闭的 Codex 实例目录");
+            return Ok(());
+        }
+
+        let matches_target =
+            |dir: Option<&String>, target_app_dirs: &HashSet<String>, includes_default: bool| {
+                match dir {
+                    Some(value) => {
+                        let normalized = normalize_path_for_compare(value);
+                        (!normalized.is_empty() && target_app_dirs.contains(&normalized))
+                            || (includes_default
+                                && default_app_dir.as_deref() == Some(normalized.as_str()))
+                    }
+                    None => includes_default,
+                }
+            };
+
+        let entries = collect_codex_process_entries();
+        let mut pids: Vec<u32> = entries
+            .iter()
+            .filter_map(|(pid, dir)| {
+                matches_target(dir.as_ref(), &target_app_dirs, includes_default).then_some(*pid)
+            })
+            .collect();
+        pids.sort();
+        pids.dedup();
+        if pids.is_empty() {
+            crate::modules::logger::log_info("受管 Codex 实例未在运行，无需关闭");
+            return Ok(());
+        }
+
+        crate::modules::logger::log_info(&format!(
+            "准备关闭 {} 个受管 Codex 主进程...",
+            pids.len()
+        ));
+        let _ = close_pids(&pids, timeout_secs);
+
+        let still_running = collect_codex_process_entries()
+            .into_iter()
+            .any(|(_, dir)| matches_target(dir.as_ref(), &target_app_dirs, includes_default));
+        if still_running {
+            return Err("无法关闭受管 Codex 实例进程，请手动关闭后重试".to_string());
+        }
+        Ok(())
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
         let _ = (codex_homes, timeout_secs);
-        Err("Codex 多开实例仅支持 macOS".to_string())
+        Err("Codex 多开实例仅支持 macOS 和 Windows".to_string())
     }
 }
 

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1667,7 +1667,7 @@
       "comingSoon": "Multi-Instance Coming Soon",
       "comingSoonDesc": "Run multiple Codex.app instances with different accounts simultaneously, stay tuned.",
       "unsupported": {
-        "desc": "Codex multi-instance is currently available only on macOS."
+        "desc": "Codex multi-instance is available only on macOS and Windows."
       },
       "quota": {
         "hourly": "5h",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1667,7 +1667,7 @@
       "comingSoon": "多开实例功能即将上线",
       "comingSoonDesc": "支持以不同账号同时运行多个 Codex.app 实例，敬请期待。",
       "unsupported": {
-        "desc": "Codex 多开实例仅支持 macOS，请在 macOS 上使用。"
+        "desc": "Codex 多开实例仅支持 macOS 和 Windows。"
       },
       "quota": {
         "hourly": "5小时",

--- a/src/pages/CodexInstancesPage.tsx
+++ b/src/pages/CodexInstancesPage.tsx
@@ -58,7 +58,9 @@ export function CodexInstancesContent({
   const instanceStore = useCodexInstanceStore();
   const { accounts: storeAccounts, fetchAccounts } = useCodexAccountStore();
   const accounts = accountsForSelect ?? storeAccounts;
-  const isSupportedPlatform = usePlatformRuntimeSupport("macos-only");
+  const isMacOS = usePlatformRuntimeSupport("macos-only");
+  const isWindows = usePlatformRuntimeSupport("windows-only");
+  const isSupportedPlatform = isMacOS || isWindows;
   const [showCodeReviewQuota, setShowCodeReviewQuota] = useState<boolean>(
     isCodexCodeReviewQuotaVisibleByDefault,
   );
@@ -304,7 +306,7 @@ export function CodexInstancesContent({
           unsupportedTitleKey="common.shared.instances.unsupported.title"
           unsupportedTitleDefault="暂不支持当前系统"
           unsupportedDescKey="codex.instances.unsupported.desc"
-          unsupportedDescDefault="Codex 多开实例仅支持 macOS。"
+          unsupportedDescDefault="Codex 多开实例仅支持 macOS 和 Windows。"
           onInstanceStarted={handleInstanceStarted}
           resolveStartSuccessMessage={(instance) =>
             (instance.launchMode ?? "app") === "cli"


### PR DESCRIPTION
## 变更内容

- 让 Codex 多开实例页面在 Windows 上可用，并更新平台不支持提示。
- Windows 下自动探测 Store/MSIX 版 Codex 的 `Codex.exe`，没有手动配置路径时也能启动。
- 启动受管 Codex 实例时同时设置 `CODEX_HOME` 和 `CODEX_ELECTRON_USER_DATA_PATH`，让每个实例拥有独立的 Codex 配置目录与 Electron 用户数据目录，从而支持多个账号窗口并行运行。
- Windows 进程探测会读取 Electron helper 的 `--user-data-dir`，再回溯到主进程 PID，用于正确识别、聚焦和关闭对应实例。
- 为 Codex CLI 模式补齐 Windows 终端启动命令生成和执行逻辑。
- 同步 `cockpit-core` 中的 Codex 实例逻辑，并补齐 Windows 编译需要的依赖与缺失字段初始化。

## 背景

之前 Codex 多开实例只在 macOS 上可用。Windows 版 Codex 桌面应用是 Electron/MSIX 应用，仅设置 `CODEX_HOME` 不能完整隔离窗口会话；这次实现为每个受管实例额外分配独立的 Electron user-data 目录，使不同账号可以稳定地同时打开。

## 验证

- `npm run build`
- `npm run typecheck`
- `cargo check -p cockpit-core --lib`
- `cargo check -p cockpit-tools --lib`
- `cargo check -p cockpit-cli`
- `cargo test -p cockpit-core --lib --no-run`
- `cargo test -p cockpit-tools --lib --no-run`
- `git diff --check`
- Windows 运行时 smoke：使用临时 `CODEX_HOME` 和 `CODEX_ELECTRON_USER_DATA_PATH` 启动两个独立 Codex 桌面实例，确认得到两个不同主进程 PID，每个实例有独立 helper 进程，清理后没有残留临时 Codex 进程。
