### PR TITLE
fix(codex): make OAuth authorization button clickable in list view

### DIFF
--- a/src/styles/pages/codex.css
+++ b/src/styles/pages/codex.css
@@ -1479,6 +1479,15 @@
   margin-top: 8px;
 }
 
+.codex-accounts-page .sticky-action-cell {
+  pointer-events: none;
+}
+
+.codex-accounts-page .sticky-action-cell .action-btn,
+.codex-accounts-page .sticky-action-cell button {
+  pointer-events: auto;
+}
+
 /* 卡片底部 */
 .codex-account-card .codex-card-bottom {
   margin-top: auto;


### PR DESCRIPTION
修复 Codex 列表页中授权失效提示里的 “OAuth 授权” 按钮无法点击的问题。

原因是右侧固定的“操作”列覆盖到配额状态区域，空白区域拦截了点击。现在只让操作列里的按钮接收点击，空白区域不再挡住下面的 OAuth 授权按钮。

已在本地 `tauri dev` 中验证按钮可以点击。

Closes #757
