### PR TITLE
fix: 关闭行为选择"退出应用"时真正终止进程

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -278,6 +278,7 @@ pub fn run() {
                     }
                     CloseWindowBehavior::Quit => {
                         info!("[Window] 用户选择退出应用");
+                        window.app_handle().exit(0);
                     }
                     CloseWindowBehavior::Ask => {
                         api.prevent_close();


### PR DESCRIPTION
## 问题描述

当用户在「窗口关闭行为」设置为「退出应用」时，点击窗口关闭按钮后：
- 主窗口确实关闭了
- 但**进程没有真正退出**（被托盘图标保活）
- 此后无论点击托盘图标还是 Dock 图标，主窗口都无法再次打开
- 用户必须从托盘菜单手动选择「退出」再重新启动应用才能恢复使用

## 复现步骤

1. 设置 → 窗口关闭行为 → 选「退出应用」
2. 点击主窗口关闭按钮（红色 X）
3. 点击菜单栏托盘图标 / Dock 图标
4. 主窗口不会出现

应用日志：

\`\`\`
[Window] 用户选择退出应用
[Window] show_main_window: 主窗口不存在
[Tray] 左键恢复主窗口失败: main_window_not_found
[Window] Dock 重新打开主窗口失败: main_window_not_found
\`\`\`

## 根因

\`src-tauri/src/lib.rs\` 中 \`CloseWindowBehavior::Quit\` 分支只打印了日志，没有真正调用 \`app.exit(0)\`：

\`\`\`rust
CloseWindowBehavior::Quit => {
    // 这里没有退出！
}
\`\`\`

由于 \`api.prevent_close()\` 没被调用，主窗口被 Tauri 销毁；但进程依然因为托盘图标存活。后续 \`get_webview_window("main")\` 永远返回 \`None\`，用户陷入死状态。

## 修复

在 \`Quit\` 分支显式调用 \`window.app_handle().exit(0)\`，让进程跟随主窗口一并退出，下次点击 Dock/托盘自然走正常的应用启动流程。

## 测试环境

- macOS 15.7.5 (arm64)
- Tauri 2.10