### PR TITLE
feat: add ESC key support and back buttons to modals

### DIFF
--- a/src/components/AccountGroupModal.tsx
+++ b/src/components/AccountGroupModal.tsx
@@ -16,6 +16,7 @@ import {
   addAccountsToGroup,
   moveAccountsBetweenGroups,
 } from '../services/accountGroupService';
+import { useEscClose } from '../hooks/useEscClose';
 import './AccountGroupModal.css';
 
 // ─── 分组管理弹窗 ──────────────────────────────────────────
@@ -37,6 +38,7 @@ export const AccountGroupModal = ({
   groupFilter = [], onToggleGroupFilter, onClearGroupFilter,
 }: AccountGroupModalProps) => {
   const { t } = useTranslation();
+  useEscClose(isOpen, onClose);
   const [groups, setGroups] = useState<AccountGroup[]>([]);
   const [newName, setNewName] = useState('');
   const [renamingId, setRenamingId] = useState<string | null>(null);
@@ -285,6 +287,7 @@ interface AddToGroupModalProps {
 
 export const AddToGroupModal = ({ isOpen, onClose, accountIds, sourceGroupId, onAdded }: AddToGroupModalProps) => {
   const { t } = useTranslation();
+  useEscClose(isOpen, onClose);
   const [groups, setGroups] = useState<AccountGroup[]>([]);
   const [newName, setNewName] = useState('');
   const [error, setError] = useState<string | null>(null);

--- a/src/components/AnnouncementCenter.tsx
+++ b/src/components/AnnouncementCenter.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type { Page } from '../types/navigation';
 import type { Announcement, AnnouncementAction } from '../types/announcement';
 import { useAnnouncementStore } from '../stores/useAnnouncementStore';
+import { useEscClose } from '../hooks/useEscClose';
 import './AnnouncementCenter.css';
 
 interface AnnouncementCenterProps {
@@ -150,6 +151,9 @@ export function AnnouncementCenter({
       setListOpen(true);
     }
   };
+
+  useEscClose(!!detailAnnouncement, () => void closeDetail(false));
+  useEscClose(listOpen && !detailAnnouncement, () => setListOpen(false));
 
   const handleAnnouncementClick = async (announcement: Announcement) => {
     if (announcementState.unreadIds.includes(announcement.id)) {
@@ -315,15 +319,9 @@ export function AnnouncementCenter({
               <div className="modal-header">
                 <div className="announcement-detail-header-left">
                   {detailFromList ? (
-                    <button
-                      className="btn btn-secondary icon-only"
-                      onClick={() => {
-                        void closeDetail(true);
-                      }}
-                      title={t('common.back', '返回')}
-                    >
-                      <ChevronLeft size={14} />
-                    </button>
+                    <button className="btn btn-secondary icon-only" onClick={() => {
+                      void closeDetail(true);
+                    }} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
                   ) : null}
                   <span className={`announcement-type-chip ${sanitizeTypeClass(String(detailAnnouncement.type))}`}>
                     {currentTypeLabel(String(detailAnnouncement.type))}

--- a/src/components/CloseConfirmDialog.tsx
+++ b/src/components/CloseConfirmDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import { X, Minimize2, LogOut } from 'lucide-react';
+import { useEscClose } from '../hooks/useEscClose';
 import './CloseConfirmDialog.css';
 
 interface CloseConfirmDialogProps {
@@ -12,6 +13,8 @@ export function CloseConfirmDialog({ onClose }: CloseConfirmDialogProps) {
   const { t } = useTranslation();
   const [rememberChoice, setRememberChoice] = useState(false);
   const [loading, setLoading] = useState(false);
+
+  useEscClose(true, onClose);
 
   const handleAction = async (action: 'minimize' | 'quit') => {
     setLoading(true);

--- a/src/components/CodexAccountGroupModal.tsx
+++ b/src/components/CodexAccountGroupModal.tsx
@@ -17,6 +17,7 @@ import {
   renameCodexGroup,
   assignAccountsToCodexGroup,
 } from '../services/codexAccountGroupService';
+import { useEscClose } from '../hooks/useEscClose';
 import './AccountGroupModal.css';
 
 // ─── Codex 分组管理弹窗 ──────────────────────────────────────────
@@ -38,6 +39,7 @@ export const CodexAccountGroupModal = ({
   groupFilter = [], onToggleGroupFilter, onClearGroupFilter,
 }: CodexAccountGroupModalProps) => {
   const { t } = useTranslation();
+  useEscClose(isOpen, onClose);
   const [groups, setGroups] = useState<CodexAccountGroup[]>([]);
   const [newName, setNewName] = useState('');
   const [renamingId, setRenamingId] = useState<string | null>(null);

--- a/src/components/CodexGroupAccountPickerModal.tsx
+++ b/src/components/CodexGroupAccountPickerModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import type { CodexAccount } from '../types/codex'
 import type { CodexAccountGroup } from '../services/codexAccountGroupService'
 import { buildCodexAccountPresentation } from '../presentation/platformAccountPresentation'
+import { useEscClose } from '../hooks/useEscClose'
 import './GroupAccountPickerModal.css'
 
 interface CodexGroupAccountPickerModalProps {
@@ -26,6 +27,7 @@ export function CodexGroupAccountPickerModal({
   onConfirm,
 }: CodexGroupAccountPickerModalProps) {
   const { t } = useTranslation()
+  useEscClose(isOpen, onClose)
   const [query, setQuery] = useState('')
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [saving, setSaving] = useState(false)

--- a/src/components/CodexLocalAccessModal.tsx
+++ b/src/components/CodexLocalAccessModal.tsx
@@ -49,6 +49,7 @@ import {
   type MultiSelectFilterOption,
 } from './MultiSelectFilterDropdown';
 import { SingleSelectDropdown } from './SingleSelectDropdown';
+import { useEscClose } from '../hooks/useEscClose';
 import './GroupAccountPickerModal.css';
 import './CodexLocalAccessModal.css';
 
@@ -169,6 +170,7 @@ export function CodexLocalAccessModal({
   portCleanupBusy,
 }: CodexLocalAccessModalProps) {
   const { t } = useTranslation();
+  useEscClose(isOpen, onClose);
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [filterTypes, setFilterTypes] = useState<string[]>([]);

--- a/src/components/ExportJsonModal.tsx
+++ b/src/components/ExportJsonModal.tsx
@@ -2,6 +2,7 @@ import { Check, Copy, Download, Eye, EyeOff, FolderOpen, X } from 'lucide-react'
 import { type ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ModalErrorMessage } from './ModalErrorMessage';
+import { useEscClose } from '../hooks/useEscClose';
 
 interface ExportJsonModalProps {
   isOpen: boolean;
@@ -88,6 +89,7 @@ export function ExportJsonModal(props: ExportJsonModalProps) {
     onCopySavedPath,
   } = props;
   const { t } = useTranslation();
+  useEscClose(isOpen, onClose);
 
   const maskedContent = useMemo(() => {
     return maskJsonPreviewContent(jsonContent);

--- a/src/components/FileCorruptedModal.tsx
+++ b/src/components/FileCorruptedModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import { FolderOpen, X } from 'lucide-react';
+import { useEscClose } from '../hooks/useEscClose';
 
 export interface FileCorruptedError {
   error_type: 'file_corrupted';
@@ -50,6 +51,8 @@ export function parseFileCorruptedError(error: unknown): FileCorruptedError | nu
 export function FileCorruptedModal({ error, onClose }: FileCorruptedModalProps) {
   const { t } = useTranslation();
   const [actionError, setActionError] = useState<string | null>(null);
+
+  useEscClose(true, onClose);
 
   const handleOpenFolder = async () => {
     try {

--- a/src/components/GlobalModal.tsx
+++ b/src/components/GlobalModal.tsx
@@ -2,6 +2,7 @@ import { X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGlobalModalStore, type GlobalModalAction } from '../stores/useGlobalModalStore';
+import { useEscClose } from '../hooks/useEscClose';
 import './GlobalModal.css';
 
 function resolveActionClass(variant: GlobalModalAction['variant']): string {
@@ -22,6 +23,8 @@ export function GlobalModal() {
     if (!modal || modal.closeOnOverlay === false) return;
     closeModal();
   }, [closeModal, modal]);
+
+  useEscClose(visible, closeModal);
 
   const handleActionClick = useCallback(async (action: GlobalModalAction) => {
     if (action.disabled) return;

--- a/src/components/GroupAccountPickerModal.tsx
+++ b/src/components/GroupAccountPickerModal.tsx
@@ -15,6 +15,7 @@ import {
 } from '../utils/accountFilters'
 import { MultiSelectFilterDropdown } from './MultiSelectFilterDropdown'
 import { AccountTagFilterDropdown } from './AccountTagFilterDropdown'
+import { useEscClose } from '../hooks/useEscClose'
 import './GroupAccountPickerModal.css'
 
 interface GroupAccountPickerModalProps {
@@ -43,6 +44,7 @@ export function GroupAccountPickerModal({
   mode = 'edit',
 }: GroupAccountPickerModalProps) {
   const { t } = useTranslation()
+  useEscClose(isOpen, onClose)
   const isQuickAddMode = mode === 'addAccounts'
   const [query, setQuery] = useState('')
   const [groupName, setGroupName] = useState('')

--- a/src/components/GroupSettingsModal.tsx
+++ b/src/components/GroupSettingsModal.tsx
@@ -10,6 +10,7 @@ import {
   getGroupSettings,
   saveGroupSettings,
 } from '../services/groupService';
+import { useEscClose } from '../hooks/useEscClose';
 import {
   getModelDisplayName,
   getDefaultGroups,
@@ -39,6 +40,7 @@ export const GroupSettingsModal: React.FC<GroupSettingsModalProps> = ({
   availableModels = [],
 }) => {
   const { t } = useTranslation();
+  useEscClose(isOpen, onClose);
   const [groups, setGroups] = useState<GroupData[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/src/components/InstancesManager.tsx
+++ b/src/components/InstancesManager.tsx
@@ -17,6 +17,7 @@ import {
   FolderOpen,
   Square,
   ChevronDown,
+  ChevronLeft,
   X,
   Search,
   ArrowDownWideNarrow,
@@ -39,6 +40,7 @@ import {
   parseFileCorruptedError,
   type FileCorruptedError,
 } from "./FileCorruptedModal";
+import { useEscClose } from "../hooks/useEscClose";
 import type { InstanceStoreState } from "../stores/createInstanceStore";
 import { showInstanceFloatingCardWindow } from "../services/floatingCardService";
 import {
@@ -665,6 +667,11 @@ export function InstancesManager<TAccount extends AccountLike>({
     resetForm();
     setEditing(null);
   };
+
+  useEscClose(showModal, closeModal);
+  useEscClose(!!initGuideInstance, () => setInitGuideInstance(null));
+  useEscClose(!!deleteConfirmInstance, () => setDeleteConfirmInstance(null));
+  useEscClose(!!runningNoticeInstance, () => setRunningNoticeInstance(null));
 
   const handleNameChange = (value: string) => {
     setFormName(value);
@@ -2584,6 +2591,7 @@ export function InstancesManager<TAccount extends AccountLike>({
             onClick={(event) => event.stopPropagation()}
           >
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => setInitGuideInstance(null)} title={t("common.back", "返回")} aria-label={t("common.back", "返回")}><ChevronLeft size={14} /></button>
               <h2>{t("instances.initGuide.title", "实例尚未初始化")}</h2>
               <button
                 className="modal-close"
@@ -2741,6 +2749,7 @@ export function InstancesManager<TAccount extends AccountLike>({
             onClick={(e) => e.stopPropagation()}
           >
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closeModal} title={t("common.back", "返回")} aria-label={t("common.back", "返回")}><ChevronLeft size={14} /></button>
               <h2>
                 {editing
                   ? t("instances.modal.editTitle", "编辑实例")

--- a/src/components/LogViewerModal.tsx
+++ b/src/components/LogViewerModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronDown, Copy, FileText, FolderOpen, RefreshCw, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { getLogSnapshot, openLogDirectory, type LogSnapshot } from '../services/logService';
+import { useEscClose } from '../hooks/useEscClose';
 import './LogViewerModal.css';
 
 interface LogViewerModalProps {
@@ -63,6 +64,7 @@ function filterLogContent(content: string, level: LogLevelFilter): string {
 
 export function LogViewerModal({ open, onClose }: LogViewerModalProps) {
   const { t } = useTranslation();
+  useEscClose(open, onClose);
   const logsLabel = t('manual.dataPrivacy.keywords.5', '日志');
   const logDirLabel = t('manual.dataPrivacy.keywords.6', '日志目录');
   const levelOptions: Array<{ value: LogLevelFilter; label: string }> = useMemo(

--- a/src/components/PlatformLayoutModal.tsx
+++ b/src/components/PlatformLayoutModal.tsx
@@ -37,6 +37,7 @@ import {
 } from '../stores/usePlatformLayoutStore';
 import { ORIGINAL_SIDEBAR_ENTRY_LIMIT, useSideNavLayoutStore } from '../stores/useSideNavLayoutStore';
 import { getPlatformLabel, renderPlatformIcon } from '../utils/platformMeta';
+import { useEscClose } from '../hooks/useEscClose';
 
 const PLATFORM_LAYOUT_ICON_STORAGE_KEY = 'agtools.platform_layout.custom_icons.v1';
 
@@ -343,6 +344,7 @@ export function PlatformLayoutModal({
   onClose,
 }: PlatformLayoutModalProps) {
   const { t } = useTranslation();
+  useEscClose(open, onClose);
   const sideNavLayoutMode = useSideNavLayoutStore((state) => state.mode);
   const isSidebarSelectionLimited = sideNavLayoutMode === 'original';
   const sidebarSelectionLimit = isSidebarSelectionLimited

--- a/src/components/QuickSettingsPopover.tsx
+++ b/src/components/QuickSettingsPopover.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import { Settings, RefreshCw, FolderOpen, Zap, X } from 'lucide-react';
+import { useEscClose } from '../hooks/useEscClose';
 import * as accountService from '../services/accountService';
 import * as codexService from '../services/codexService';
 import { getAccountGroups, type AccountGroup } from '../services/accountGroupService';
@@ -698,19 +699,7 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
     };
   }, []);
 
-  // Close on Escape
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsOpen(false);
-    };
-
-    document.addEventListener('keydown', handleEsc);
-    return () => {
-      document.removeEventListener('keydown', handleEsc);
-    };
-  }, [isOpen]);
+  useEscClose(isOpen, () => setIsOpen(false));
 
   // 外部触发：按平台类型打开设置弹框
   useEffect(() => {

--- a/src/components/SettingsAccountTransferSection.tsx
+++ b/src/components/SettingsAccountTransferSection.tsx
@@ -9,12 +9,13 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Archive, Download, FolderOpen, RefreshCw, Trash2, X } from 'lucide-react';
+import { Archive, ChevronLeft, Download, FolderOpen, RefreshCw, Trash2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { save } from '@tauri-apps/plugin-dialog';
 import { ExportJsonModal } from './ExportJsonModal';
 import { useExportJsonModal } from '../hooks/useExportJsonModal';
+import { useEscClose } from '../hooks/useEscClose';
 import {
   AccountTransferImportProgress,
   AccountTransferImportProgressDetail,
@@ -245,6 +246,10 @@ export function SettingsAccountTransferSection() {
     if (backupSaving || backupRunning || backupImportingFile || backupDeletingFile) return;
     setShowBackupManagerModal(false);
   }, [backupDeletingFile, backupImportingFile, backupRunning, backupSaving]);
+
+  useEscClose(showExportOptionsModal, closeExportOptionsModal);
+  useEscClose(showImportModal, closeImportModal);
+  useEscClose(showBackupManagerModal, closeBackupManagerModal);
 
   const calcProgressPercent = useCallback((progress: AccountTransferImportProgress | null) => {
     if (!progress || progress.total_platforms <= 0) {
@@ -1044,6 +1049,7 @@ export function SettingsAccountTransferSection() {
           <div className="modal-overlay" onClick={closeExportOptionsModal}>
             <div className="modal settings-transfer-modal" onClick={(event) => event.stopPropagation()}>
               <div className="modal-header">
+                <button className="btn btn-secondary icon-only" onClick={closeExportOptionsModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
                 <h2>{t('settings.transfer.exportTitle')}</h2>
                 <button
                   className="modal-close"
@@ -1094,6 +1100,7 @@ export function SettingsAccountTransferSection() {
           <div className="modal-overlay" onClick={closeImportModal}>
             <div className="modal settings-transfer-modal" onClick={(event) => event.stopPropagation()}>
               <div className="modal-header">
+                <button className="btn btn-secondary icon-only" onClick={closeImportModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
                 <h2>{t('settings.transfer.importTitle')}</h2>
                 <button className="modal-close" onClick={closeImportModal} aria-label={t('common.close')}>
                   <X />
@@ -1230,6 +1237,7 @@ export function SettingsAccountTransferSection() {
               onClick={(event) => event.stopPropagation()}
             >
               <div className="modal-header">
+                <button className="btn btn-secondary icon-only" onClick={closeBackupManagerModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
                 <h2>{t('settings.transfer.backup.title')}</h2>
                 <button className="modal-close" onClick={closeBackupManagerModal} aria-label={t('common.close')}>
                   <X />

--- a/src/components/TagEditModal.tsx
+++ b/src/components/TagEditModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { X, Tag, Plus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { globalRenameTag, globalDeleteTag } from '../utils/globalTagOperations';
+import { useEscClose } from '../hooks/useEscClose';
 import './TagEditModal.css';
 
 interface TagEditModalProps {
@@ -34,6 +35,7 @@ const normalizeTagList = (tags: string[]) => {
 
 export const TagEditModal = ({ isOpen, initialTags, initialNotes, availableTags = [], onClose, onSave }: TagEditModalProps) => {
   const { t } = useTranslation();
+  useEscClose(isOpen, onClose);
   const [tags, setTags] = useState<string[]>([]);
   const [notes, setNotes] = useState('');
   const [inputValue, setInputValue] = useState('');

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useCallback } from 'react';
 import { X, Download, Sparkles, RefreshCw, Check, XCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { openUrl } from '@tauri-apps/plugin-opener';
+import { useEscClose } from '../hooks/useEscClose';
 import './UpdateNotification.css';
 
 export interface UpdateInfo {
@@ -58,6 +59,9 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
   onSkipUpdate,
 }) => {
   const { t, i18n } = useTranslation();
+
+  useEscClose(true, onClose);
+
   const [showErrorDetails, setShowErrorDetails] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
   const [isSkipping, setIsSkipping] = useState(false);

--- a/src/components/VersionJumpNotification.tsx
+++ b/src/components/VersionJumpNotification.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { X, Sparkles, PartyPopper } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { useEscClose } from '../hooks/useEscClose';
 import './UpdateNotification.css';
 
 interface VersionJumpInfo {
@@ -20,6 +21,8 @@ export const VersionJumpNotification: React.FC<VersionJumpNotificationProps> = (
   onClose,
 }) => {
   const { t, i18n } = useTranslation();
+
+  useEscClose(true, onClose);
 
   useEffect(() => {
     const perfWindow = window as Window & {

--- a/src/components/codebuddy-suite/CodebuddySuiteAccountsSharedView.tsx
+++ b/src/components/codebuddy-suite/CodebuddySuiteAccountsSharedView.tsx
@@ -2,13 +2,14 @@ import { useMemo, useCallback, Fragment, useState, useEffect, type ComponentType
 import {
   Plus, RefreshCw, Download, Upload, Trash2, X, Globe, KeyRound, Database,
   Copy, Check, RotateCw, LayoutGrid, List, Search,
-  Tag, Play, Eye, EyeOff, CircleAlert, ChevronDown, ArrowRightLeft, CalendarCheck,
+  Tag, Play, Eye, EyeOff, CircleAlert, ChevronDown, ChevronLeft, ArrowRightLeft, CalendarCheck,
 } from 'lucide-react';
 import { TagEditModal } from '../TagEditModal';
 import { ExportJsonModal } from '../ExportJsonModal';
 import { ModalErrorMessage } from '../ModalErrorMessage';
 import { QuickSettingsPopover } from '../QuickSettingsPopover';
 import { PaginationControls } from '../PaginationControls';
+import { useEscClose } from '../../hooks/useEscClose';
 import { useCodebuddySuitePage, formatQuotaNumber } from '../../hooks/useCodebuddySuitePage';
 import type { UseProviderAccountsPageReturn } from '../../hooks/useProviderAccountsPage';
 import {
@@ -147,6 +148,11 @@ export function CodebuddySuiteAccountsSharedView<TAccount extends CodebuddySuite
     isFlowNoticeCollapsed, setIsFlowNoticeCollapsed,
     currentAccountId, formatDate, normalizeTag,
   } = page;
+
+  useEscClose(showAddModal, closeAddModal);
+  useEscClose(!!deleteConfirm, () => setDeleteConfirm(null));
+  useEscClose(!!tagDeleteConfirm, () => setTagDeleteConfirm(null));
+  useEscClose(showCheckinModal, () => setShowCheckinModal(false));
 
   useEffect(() => {
     if (!filterPersistenceEnabled) {
@@ -615,6 +621,7 @@ export function CodebuddySuiteAccountsSharedView<TAccount extends CodebuddySuite
         <div className="modal-overlay" onClick={closeAddModal}>
           <div className="modal-content ghcp-add-modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closeAddModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t(platformConfig.addAccountTitleKey, platformConfig.addAccountTitleDefault)}</h2>
               <button className="modal-close" onClick={closeAddModal}><X size={18} /></button>
             </div>

--- a/src/components/codebuddy-suite/CodebuddySuiteCheckinModal.tsx
+++ b/src/components/codebuddy-suite/CodebuddySuiteCheckinModal.tsx
@@ -6,9 +6,10 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, Gift, CheckCircle, XCircle, Loader2, RefreshCw, CalendarCheck, Flame, Trophy } from 'lucide-react';
+import { X, ChevronLeft, Gift, CheckCircle, XCircle, Loader2, RefreshCw, CalendarCheck, Flame, Trophy } from 'lucide-react';
 import type { CodebuddySuiteAccountBase, WorkbuddyAccount } from '../../types/codebuddy-suite';
 import type { CheckinStatusResponse, CheckinResponse } from '../../types/codebuddy';
+import { useEscClose } from '../../hooks/useEscClose';
 
 interface CodebuddySuiteCheckinModalProps<TAccount extends CodebuddySuiteAccountBase> {
   accounts: TAccount[];
@@ -36,6 +37,7 @@ export function CodebuddySuiteCheckinModal<TAccount extends CodebuddySuiteAccoun
   onCheckinComplete,
 }: CodebuddySuiteCheckinModalProps<TAccount>) {
   const { t } = useTranslation();
+  useEscClose(true, onClose);
   const [accountStates, setAccountStates] = useState<Record<string, AccountCheckinState>>({});
   const [checkAllLoading, setCheckAllLoading] = useState(false);
   const [refreshLoading, setRefreshLoading] = useState(false);
@@ -112,6 +114,7 @@ export function CodebuddySuiteCheckinModal<TAccount extends CodebuddySuiteAccoun
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-content checkin-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
+          <button className="btn btn-secondary icon-only" onClick={onClose} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
           <h2><CalendarCheck size={20} /> {t('workbuddy.checkin.modalTitle', '每日签到')} - {platformLabel}</h2>
           <button className="modal-close" onClick={onClose}><X size={18} /></button>
         </div>

--- a/src/components/codex/CodexModelProviderManager.tsx
+++ b/src/components/codex/CodexModelProviderManager.tsx
@@ -14,6 +14,7 @@ import {
   Search,
   Settings,
 } from "lucide-react";
+import { useEscClose } from "../../hooks/useEscClose";
 import type { CodexAccount } from "../../types/codex";
 import {
   addApiKeyToCodexModelProvider,
@@ -225,6 +226,8 @@ export function CodexModelProviderManager({
     setShowModal(false);
     setFormError(null);
   }, [saving]);
+
+  useEscClose(showModal, closeModal);
 
   const mutateForm = useCallback((patch: Partial<ProviderFormState>) => {
     setForm((prev) => ({ ...prev, ...patch }));

--- a/src/components/codex/CodexQuickConfigCard.tsx
+++ b/src/components/codex/CodexQuickConfigCard.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CircleAlert, FolderOpen, Save, X } from 'lucide-react';
+import { ChevronLeft, CircleAlert, FolderOpen, Save, X } from 'lucide-react';
 import {
   getCodexConfigTomlPath,
   getCodexQuickConfig,
   openCodexConfigToml,
   saveCodexQuickConfig,
 } from '../../services/codexService';
+import { useEscClose } from '../../hooks/useEscClose';
 import type { CodexQuickConfig } from '../../types/codex';
 
 const DEFAULT_AUTO_COMPACT_TOKEN_LIMIT = 900000;
@@ -68,6 +69,7 @@ function resolvePresetId(
 
 export function CodexQuickConfigCard({ onClose }: { onClose?: () => void }) {
   const { t } = useTranslation();
+  useEscClose(true, onClose ?? (() => {}));
   const [configPath, setConfigPath] = useState('~/.codex/config.toml');
   const [loadedConfig, setLoadedConfig] = useState<CodexQuickConfig | null>(null);
   const [selectedPresetId, setSelectedPresetId] = useState<QuickConfigPresetId>('default');
@@ -324,6 +326,7 @@ export function CodexQuickConfigCard({ onClose }: { onClose?: () => void }) {
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal codex-quick-config-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
+          <button className="btn btn-secondary icon-only" onClick={onClose} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
           <h2>{t('codex.modelProviders.quickConfig.title', '当前 Codex 配置')}</h2>
           <button className="modal-close" onClick={onClose} aria-label={t('common.close', '关闭')}>
             <X />

--- a/src/components/codex/CodexSessionManager.tsx
+++ b/src/components/codex/CodexSessionManager.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { confirm as confirmDialog } from '@tauri-apps/plugin-dialog';
 import { Check, ChevronDown, ChevronRight, Copy, Eye, Folder, RefreshCw, RotateCcw, Trash2, X } from 'lucide-react';
 import { ModalErrorMessage, useModalErrorState } from '../ModalErrorMessage';
+import { useEscClose } from '../../hooks/useEscClose';
 import type { CodexSessionRecord, CodexSessionTokenStats, CodexTrashedSessionRecord } from '../../types/codex';
 import { useCodexInstanceStore } from '../../stores/useCodexInstanceStore';
 import { formatCodexSessionVisibilityRepairMessage } from '../../utils/codexSessionVisibility';
@@ -364,11 +365,10 @@ export function CodexSessionManager() {
   };
 
   const handleCloseSyncTargetModal = () => {
-    if (syncingToInstance) return;
     setShowSyncTargetModal(false);
-    setSyncTargetInstanceId('');
-    setSyncTargetModalError(null);
   };
+
+  useEscClose(showSyncTargetModal, handleCloseSyncTargetModal);
 
   const handleCloseRestoreModal = () => {
     if (restoring) return;
@@ -376,6 +376,8 @@ export function CodexSessionManager() {
     setSelectedTrashIds([]);
     setRestoreModalError(null);
   };
+
+  useEscClose(showRestoreModal, handleCloseRestoreModal);
 
   const handleSyncSessions = async () => {
     setMessage(null);

--- a/src/components/codex/CodexWakeupContent.tsx
+++ b/src/components/codex/CodexWakeupContent.tsx
@@ -15,6 +15,7 @@ import { confirm as confirmDialog } from '@tauri-apps/plugin-dialog';
 import {
   Check,
   ChevronDown,
+  ChevronLeft,
   CircleAlert,
   Copy,
   Eye,
@@ -28,6 +29,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
+import { useEscClose } from '../../hooks/useEscClose';
 import {
   CodexAccount,
   getCodexAuthMetadata,
@@ -965,6 +967,7 @@ export function CodexWakeupContent({
   } = useModalErrorState();
   const [taskAccountFilters, setTaskAccountFilters] = useState<AccountPickerFilters>(createEmptyAccountPickerFilters());
   const [showPresetModal, setShowPresetModal] = useState(false);
+  const [presetModalSource, setPresetModalSource] = useState<'task' | 'test' | 'page'>('page');
   const [presetDraft, setPresetDraft] = useState<PresetDraft>(createEmptyPresetDraft());
   const {
     message: presetModalError,
@@ -977,6 +980,7 @@ export function CodexWakeupContent({
     if (openPresetManagerSignal <= 0) return;
     setPresetDraft(createEmptyPresetDraft());
     clearPresetModalError();
+    setPresetModalSource('page');
     setShowPresetModal(true);
   }, [clearPresetModalError, openPresetManagerSignal]);
   const [showTestModal, setShowTestModal] = useState(false);
@@ -997,6 +1001,7 @@ export function CodexWakeupContent({
   const activeTestRunTokenRef = useRef(0);
   const activeTestScopeIdRef = useRef<string | null>(null);
   const [executionSession, setExecutionSession] = useState<ExecutionSessionState | null>(null);
+  const [executionSessionFromHistory, setExecutionSessionFromHistory] = useState(false);
   const [executionFilter, setExecutionFilter] = useState<ExecutionRecordFilter>('all');
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null);
   const [showRuntimeGuideModal, setShowRuntimeGuideModal] = useState(false);
@@ -1792,9 +1797,10 @@ export function CodexWakeupContent({
     }
   }, [refreshRuntime, runtimeConfigDraft.codexCliPath, runtimeConfigDraft.nodePath]);
 
-  const openPresetModal = useCallback(() => {
+  const openPresetModal = useCallback((source: 'task' | 'test' | 'page' = 'page') => {
     setPresetDraft(createEmptyPresetDraft());
     setPresetModalError(null);
+    setPresetModalSource(source);
     setShowPresetModal(true);
   }, [setPresetModalError]);
 
@@ -2014,6 +2020,12 @@ export function CodexWakeupContent({
     setTestModelReasoningEffort(resolvedModelSelection.modelReasoningEffort);
   }, [cancelRunningTest, resolvedModelSelection, testing]);
 
+  useEscClose(showRuntimeGuideModal, closeRuntimeGuideModal);
+  useEscClose(showPresetModal, closePresetModal);
+  useEscClose(showTaskModal, closeTaskModal);
+  useEscClose(showTestModal, closeTestModal);
+  useEscClose(showHistoryModal, () => setShowHistoryModal(false));
+
   const persistTasks = useCallback(
     async (
       enabled: boolean,
@@ -2178,6 +2190,7 @@ export function CodexWakeupContent({
       }
 
       const runId = crypto.randomUUID();
+      setExecutionSessionFromHistory(false);
       setExecutionSession(
         buildExecutionSession(
           runId,
@@ -2274,6 +2287,7 @@ export function CodexWakeupContent({
     activeTestRunTokenRef.current = runToken;
     activeTestScopeIdRef.current = cancelScopeId;
     const promptValue = testPrompt.trim() || undefined;
+    setExecutionSessionFromHistory(false);
     setExecutionSession(
       buildExecutionSession(
         runId,
@@ -2434,7 +2448,7 @@ export function CodexWakeupContent({
           <button className="btn btn-primary" onClick={() => void openNewTaskModal()} disabled={oauthAccounts.length === 0}>
             <Plus size={16} /> {t('codex.wakeup.addTask')}
           </button>
-          <button className="btn btn-secondary" onClick={openPresetModal}>
+          <button className="btn btn-secondary" onClick={() => openPresetModal('page')}>
             {t('codex.wakeup.managePresets')}
           </button>
           <button className="btn btn-secondary" onClick={() => void openTestModal()} disabled={oauthAccounts.length === 0}>
@@ -2584,6 +2598,15 @@ export function CodexWakeupContent({
             onClick={(event) => event.stopPropagation()}
           >
             <div className="modal-header">
+              <button
+                className="btn btn-secondary icon-only"
+                onClick={closeRuntimeGuideModal}
+                title={t('common.back', '返回')}
+                aria-label={t('common.back', '返回')}
+                disabled={runtimeGuideRefreshing}
+              >
+                <ChevronLeft size={14} />
+              </button>
               <h2>{runtimeGuideTitle}</h2>
               <button className="modal-close" onClick={closeRuntimeGuideModal} disabled={runtimeGuideRefreshing}>
                 <X />
@@ -2678,6 +2701,17 @@ export function CodexWakeupContent({
         <div className="modal-overlay codex-wakeup-preset-overlay" onClick={closePresetModal}>
           <div className="modal modal-lg wakeup-modal codex-wakeup-modal" onClick={(event) => event.stopPropagation()}>
             <div className="modal-header">
+              {presetModalSource !== 'page' && (
+                <button
+                  className="btn btn-secondary icon-only"
+                  onClick={closePresetModal}
+                  title={t('common.back', '返回')}
+                  aria-label={t('common.back', '返回')}
+                  disabled={saving}
+                >
+                  <ChevronLeft size={14} />
+                </button>
+              )}
               <h2>{t('codex.wakeup.presetManagerTitle')}</h2>
               <button className="modal-close" onClick={closePresetModal} disabled={saving}>
                 <X />
@@ -2824,6 +2858,7 @@ export function CodexWakeupContent({
         <div className="modal-overlay" onClick={closeTaskModal}>
           <div className="modal modal-lg wakeup-modal codex-wakeup-modal" onClick={(event) => event.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closeTaskModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{taskDraft.id ? t('codex.wakeup.editTaskTitle') : t('codex.wakeup.createTaskTitle')}</h2>
               <button className="modal-close" onClick={closeTaskModal}>
                 <X />
@@ -2907,7 +2942,7 @@ export function CodexWakeupContent({
               <div className="wakeup-form-group">
                 <div className="codex-wakeup-inline-header">
                   <label>{t('codex.wakeup.taskModelLabel')}</label>
-                  <button type="button" className="btn btn-secondary" onClick={openPresetModal}>
+                  <button type="button" className="btn btn-secondary" onClick={() => openPresetModal('task')}>
                     {t('codex.wakeup.managePresets')}
                   </button>
                 </div>
@@ -3193,6 +3228,7 @@ export function CodexWakeupContent({
         <div className="modal-overlay" onClick={closeTestModal}>
           <div className="modal modal-lg wakeup-modal wakeup-test-modal codex-wakeup-modal" onClick={(event) => event.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closeTestModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('codex.wakeup.testTitle')}</h2>
               <button className="modal-close" onClick={closeTestModal}>
                 <X />
@@ -3239,7 +3275,7 @@ export function CodexWakeupContent({
               <div className="wakeup-form-group">
                 <div className="codex-wakeup-inline-header">
                   <label>{t('codex.wakeup.testModelLabel')}</label>
-                  <button type="button" className="btn btn-secondary" onClick={openPresetModal}>
+                  <button type="button" className="btn btn-secondary" onClick={() => openPresetModal('test')}>
                     {t('codex.wakeup.managePresets')}
                   </button>
                 </div>
@@ -3305,6 +3341,7 @@ export function CodexWakeupContent({
         <div className="modal-overlay" onClick={() => setShowHistoryModal(false)}>
           <div className="modal wakeup-modal wakeup-history-modal codex-wakeup-history-modal" onClick={(event) => event.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => setShowHistoryModal(false)} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('codex.wakeup.historyTitle')}</h2>
               <button className="modal-close" onClick={() => setShowHistoryModal(false)}>
                 <X />
@@ -3346,6 +3383,7 @@ export function CodexWakeupContent({
                               className="btn btn-secondary codex-wakeup-history-detail-btn"
                               onClick={() => {
                                 setShowHistoryModal(false);
+                                setExecutionSessionFromHistory(true);
                                 setExecutionSession(buildExecutionSessionFromHistory(batch));
                               }}
                             >
@@ -3392,6 +3430,7 @@ export function CodexWakeupContent({
           onClick={() => {
             if (!executionSession.running) {
               setExecutionSession(null);
+              setExecutionSessionFromHistory(false);
             }
           }}
         >
@@ -3400,10 +3439,17 @@ export function CodexWakeupContent({
             onClick={(event) => event.stopPropagation()}
           >
             <div className="modal-header">
+              {executionSessionFromHistory && !executionSession.running && (
+                <button className="btn btn-secondary icon-only" onClick={() => {
+                  setExecutionSession(null);
+                  setExecutionSessionFromHistory(false);
+                  setShowHistoryModal(true);
+                }} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
+              )}
               <h2>{t('codex.wakeup.resultsTitle')}</h2>
               <button
                 className="modal-close"
-                onClick={() => setExecutionSession(null)}
+                onClick={() => { setExecutionSession(null); setExecutionSessionFromHistory(false); }}
                 disabled={executionSession.running}
               >
                 <X />
@@ -3590,7 +3636,7 @@ export function CodexWakeupContent({
               )}
               <button
                 className="btn btn-primary codex-wakeup-results-close-btn"
-                onClick={() => setExecutionSession(null)}
+                onClick={() => { setExecutionSession(null); setExecutionSessionFromHistory(false); }}
                 disabled={executionSession.running}
               >
                 {t('common.close', '关闭')}

--- a/src/components/easter-egg/BreakoutModal.tsx
+++ b/src/components/easter-egg/BreakoutModal.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ALL_PLATFORM_IDS, PlatformId } from '../../types/platform';
 import { renderPlatformIcon } from '../../utils/platformMeta';
+import { useEscClose } from '../../hooks/useEscClose';
 import './BreakoutModal.css';
 
 interface BreakoutModalProps {
@@ -1606,6 +1607,7 @@ function getHistoryRank(records: GameHistoryRecord[], targetId: string): number 
 
 export function BreakoutModal({ open, onMinimize, onTerminate }: BreakoutModalProps) {
   const { t } = useTranslation();
+  useEscClose(open, onTerminate);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const keysRef = useRef({ left: false, right: false });
   const isStartedRef = useRef(false);

--- a/src/components/platform/DosageNotifyUsageStatus.tsx
+++ b/src/components/platform/DosageNotifyUsageStatus.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { X } from 'lucide-react';
 
 export interface DosageNotifyUsage {
@@ -44,6 +44,18 @@ export function DosageNotifyUsageStatus({
   classPrefix,
 }: DosageNotifyUsageStatusProps) {
   const [showDetail, setShowDetail] = useState(false);
+
+  useEffect(() => {
+    if (!showDetail) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setShowDetail(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [showDetail]);
   if (usage.isNormal) {
     return <span className="quota-value high">{normalText}</span>;
   }

--- a/src/hooks/useEscClose.ts
+++ b/src/hooks/useEscClose.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react';
+
+/** ESC-to-close for modals. LIFO cleanup order handles stacked modals correctly. */
+export function useEscClose(isOpen: boolean, onClose: () => void) {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCloseRef.current();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
+}

--- a/src/hooks/useProviderAccountsPage.ts
+++ b/src/hooks/useProviderAccountsPage.ts
@@ -40,6 +40,7 @@ import {
   type ExternalProviderImportPayload,
 } from '../utils/externalProviderImport';
 import { useDropdownPanelPlacement } from './useDropdownPanelPlacement';
+import { useEscClose } from './useEscClose';
 import {
   ACCOUNTS_OVERVIEW_FILTER_PERSISTENCE_CHANGED_EVENT,
   type AccountsOverviewFilterPersistenceChangedDetail,
@@ -1273,6 +1274,8 @@ export function useProviderAccountsPage<TAccount extends ProviderAccountBase>(
     setShowAddModal(false);
     resetAddModalState();
   }, [resetAddModalState]);
+
+  useEscClose(showAddModal, closeAddModal);
 
   const closeExternalImportProgressModal = useCallback(() => {
     setExternalImportProgress((current) => {

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -60,6 +60,7 @@ import { SingleSelectFilterDropdown } from '../components/SingleSelectFilterDrop
 import { AccountGroupModal, AddToGroupModal } from '../components/AccountGroupModal'
 import { GroupAccountPickerModal } from '../components/GroupAccountPickerModal'
 import { ModalErrorMessage, useModalErrorState } from '../components/ModalErrorMessage'
+import { useEscClose } from '../hooks/useEscClose'
 import {
   AccountGroup,
   getAccountGroups,
@@ -1393,7 +1394,6 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
   }, [consumeExternalProviderImport])
 
   const closeAddModal = () => {
-    // 允许用户随时关闭弹窗，取消正在进行的 OAuth 流程
     if (addStatus === 'loading') {
       accountService.cancelOAuthLogin().catch(() => { })
     }
@@ -1401,6 +1401,9 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     resetAddModalState()
     setOauthUrl('')
   }
+
+  useEscClose(showAddModal, closeAddModal);
+  useEscClose(showSwitchHistoryModal, () => setShowSwitchHistoryModal(false));
 
   const runModalAction = async (
     label: string,

--- a/src/pages/CodexInstancesPage.tsx
+++ b/src/pages/CodexInstancesPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Check, Copy, Play, X } from "lucide-react";
+import { Check, ChevronLeft, Copy, Play, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { PlatformInstancesContent } from "../components/platform/PlatformInstancesContent";
 import { SingleSelectDropdown } from "../components/SingleSelectDropdown";
@@ -25,6 +25,7 @@ import {
   findCodexApiProviderPresetById,
   resolveCodexApiProviderPresetId,
 } from "../utils/codexProviderPresets";
+import { useEscClose } from "../hooks/useEscClose";
 
 /**
  * Codex 多开实例内容组件（不包含 header）
@@ -67,6 +68,8 @@ export function CodexInstancesContent({
   const [launchModal, setLaunchModal] = useState<CodexLaunchModalState | null>(
     null,
   );
+
+  useEscClose(!!launchModal, () => setLaunchModal(null));
   const { terminalOptions, selectedTerminal, setSelectedTerminal } =
     useLaunchTerminalOptions(isSupportedPlatform);
 
@@ -323,6 +326,7 @@ export function CodexInstancesContent({
             onClick={(event) => event.stopPropagation()}
           >
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => setLaunchModal(null)} title={t("common.back", "返回")} aria-label={t("common.back", "返回")}><ChevronLeft size={14} /></button>
               <h2>{t("instances.launchDialog.title", "启动实例")}</h2>
               <button
                 className="modal-close"

--- a/src/pages/FingerprintsPage.tsx
+++ b/src/pages/FingerprintsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Sparkles, Download, Trash2, Fingerprint, Link, CircleAlert, Pencil, X, Plus, FolderOpen } from 'lucide-react';
+import { ChevronLeft, Sparkles, Download, Trash2, Fingerprint, Link, CircleAlert, Pencil, X, Plus, FolderOpen } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { confirm as confirmDialog } from '@tauri-apps/plugin-dialog';
 import { useAccountStore } from '../stores/useAccountStore';
@@ -8,6 +8,7 @@ import { FingerprintWithStats, Account, DeviceProfile } from '../types/account';
 import { getSubscriptionTier } from '../utils/account';
 import { Page } from '../types/navigation';
 import { OverviewTabsHeader } from '../components/OverviewTabsHeader';
+import { useEscClose } from '../hooks/useEscClose';
 import { FileCorruptedModal, parseFileCorruptedError } from '../components/FileCorruptedModal';
 import { ModalErrorMessage, useModalErrorState } from '../components/ModalErrorMessage';
 
@@ -125,6 +126,12 @@ export function FingerprintsPage({ onNavigate }: FingerprintsPageProps) {
     setPreviewLoading(false);
     resetPreviewState();
   };
+
+  useEscClose(!!previewProfile, closePreviewModal);
+  useEscClose(!!showRenameModal, () => { setShowRenameModal(null); setRenameName(''); setRenameError(null); });
+  useEscClose(showImportModal, () => { if (!importing) { setShowImportModal(false); setImportError(null); } });
+  useEscClose(!!showBoundAccounts, () => { setShowBoundAccounts(null); setBoundAccountsError(null); });
+  useEscClose(!!showDetailModal, () => setShowDetailModal(null));
 
   useEffect(() => {
     if (!previewProfile) {
@@ -529,6 +536,7 @@ export function FingerprintsPage({ onNavigate }: FingerprintsPageProps) {
         <div className="modal-overlay" onClick={closePreviewModal}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closePreviewModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{showNameModal === 'generate' ? t('fingerprints.modals.generate.title') : t('fingerprints.modals.capture.title')}</h2>
               <button className="close-btn" onClick={closePreviewModal}><X size={20} /></button>
             </div>
@@ -595,6 +603,7 @@ export function FingerprintsPage({ onNavigate }: FingerprintsPageProps) {
         <div className="modal-overlay" onClick={() => { setShowRenameModal(null); setRenameName(''); setRenameError(null); }}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => { setShowRenameModal(null); setRenameName(''); setRenameError(null); }} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('fingerprints.modals.rename.title')}</h2>
               <button className="close-btn" onClick={() => { setShowRenameModal(null); setRenameName(''); setRenameError(null); }}><X size={20} /></button>
             </div>
@@ -633,6 +642,7 @@ export function FingerprintsPage({ onNavigate }: FingerprintsPageProps) {
         <div className="modal-overlay" onClick={() => !importing && (setShowImportModal(false), setImportError(null))}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => !importing && (setShowImportModal(false), setImportError(null))} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('fingerprints.modals.import.title')}</h2>
               <button className="close-btn" onClick={() => !importing && (setShowImportModal(false), setImportError(null))}><X size={20} /></button>
             </div>
@@ -683,6 +693,7 @@ export function FingerprintsPage({ onNavigate }: FingerprintsPageProps) {
         <div className="modal-overlay" onClick={() => { setShowBoundAccounts(null); setBoundAccountsError(null); }}>
           <div className="modal modal-md" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => { setShowBoundAccounts(null); setBoundAccountsError(null); }} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('fingerprints.modals.bound.title')}</h2>
               <button className="close-btn" onClick={() => { setShowBoundAccounts(null); setBoundAccountsError(null); }}><X size={20} /></button>
             </div>
@@ -767,6 +778,7 @@ export function FingerprintsPage({ onNavigate }: FingerprintsPageProps) {
         <div className="modal-overlay" onClick={() => setShowDetailModal(null)}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => setShowDetailModal(null)} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('fingerprints.modals.detail.title')}</h2>
               <button className="close-btn" onClick={() => setShowDetailModal(null)}><X size={20} /></button>
             </div>

--- a/src/pages/GeminiInstancesPage.tsx
+++ b/src/pages/GeminiInstancesPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Check, Copy, Play, X } from "lucide-react";
+import { Check, ChevronLeft, Copy, Play, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { PlatformInstancesContent } from "../components/platform/PlatformInstancesContent";
 import { SingleSelectDropdown } from "../components/SingleSelectDropdown";
@@ -13,6 +13,7 @@ import * as geminiInstanceService from "../services/geminiInstanceService";
 import { useGeminiAccountStore } from "../stores/useGeminiAccountStore";
 import { useGeminiInstanceStore } from "../stores/useGeminiInstanceStore";
 import type { GeminiAccount } from "../types/gemini";
+import { useEscClose } from "../hooks/useEscClose";
 import type { InstanceProfile } from "../types/instance";
 
 interface GeminiInstancesContentProps {
@@ -41,6 +42,8 @@ export function GeminiInstancesContent({
   const [launchModal, setLaunchModal] = useState<GeminiLaunchModalState | null>(
     null,
   );
+
+  useEscClose(!!launchModal, () => setLaunchModal(null));
   const { terminalOptions, selectedTerminal, setSelectedTerminal } =
     useLaunchTerminalOptions();
 
@@ -193,6 +196,7 @@ export function GeminiInstancesContent({
             onClick={(event) => event.stopPropagation()}
           >
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => setLaunchModal(null)} title={t("common.back", "返回")} aria-label={t("common.back", "返回")}><ChevronLeft size={14} /></button>
               <h2>{t("gemini.instances.launchDialogTitle", "启动实例")}</h2>
               <button
                 className="modal-close"

--- a/src/pages/GitHubCopilotAccountsPage.tsx
+++ b/src/pages/GitHubCopilotAccountsPage.tsx
@@ -11,6 +11,7 @@ import {
   Database,
   Copy,
   Check,
+  ChevronLeft,
   RotateCw,
   CircleAlert,
   LayoutGrid,
@@ -1130,6 +1131,7 @@ export function GitHubCopilotAccountsPage() {
         <div className="modal-overlay" onClick={closeAddModal}>
           <div className="modal-content ghcp-add-modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closeAddModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('githubCopilot.addModal.title', '添加 GitHub Copilot 账号')}</h2>
               <button className="modal-close" onClick={closeAddModal} aria-label={t('common.close', '关闭')}>
                 <X />

--- a/src/pages/KiroAccountsPage.tsx
+++ b/src/pages/KiroAccountsPage.tsx
@@ -11,6 +11,7 @@ import {
   Database,
   Copy,
   Check,
+  ChevronLeft,
   RotateCw,
   CircleAlert,
   LayoutGrid,
@@ -1098,6 +1099,7 @@ export function KiroAccountsPage() {
         <div className="modal-overlay" onClick={closeAddModal}>
           <div className="modal-content ghcp-add-modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closeAddModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('kiro.addModal.title', '添加 Kiro 账号')}</h2>
               <button className="modal-close" onClick={closeAddModal} aria-label={t('common.close', '关闭')}><X /></button>
             </div>

--- a/src/pages/QoderAccountsPage.tsx
+++ b/src/pages/QoderAccountsPage.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from '
 import {
   ArrowDownWideNarrow,
   ChevronDown,
+  ChevronLeft,
   CircleAlert,
   Copy,
   Database,
@@ -33,6 +34,7 @@ import { PaginationControls } from '../components/PaginationControls';
 import { QuickSettingsPopover } from '../components/QuickSettingsPopover';
 import { MultiSelectFilterDropdown, type MultiSelectFilterOption } from '../components/MultiSelectFilterDropdown';
 import { SingleSelectFilterDropdown } from '../components/SingleSelectFilterDropdown';
+import { useEscClose } from '../hooks/useEscClose';
 import {
   PlatformOverviewTab,
   PlatformOverviewTabsHeader,
@@ -295,6 +297,8 @@ export function QoderAccountsPage() {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [showAddModal, setShowAddModal] = useState(false);
   const [addTab, setAddTab] = useState<'oauth' | 'token' | 'import'>('import');
+
+  useEscClose(showAddModal, () => setShowAddModal(false));
   const [addStatus, setAddStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [addMessage, setAddMessage] = useState<string | null>(null);
   const [tokenInput, setTokenInput] = useState('');
@@ -2142,6 +2146,7 @@ export function QoderAccountsPage() {
         <div className="modal-overlay" onClick={() => setShowAddModal(false)}>
           <div className="modal-content codex-add-modal" onClick={(event) => event.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => setShowAddModal(false)} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('qoder.addModal.title')}</h2>
               <button className="modal-close" onClick={() => setShowAddModal(false)} aria-label={t('common.close', '关闭')}>
                 <X />

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -47,6 +47,7 @@ import {
 } from '../utils/currentAccountRefresh';
 import { ALL_PLATFORM_IDS, PlatformId } from '../types/platform';
 import { SettingsAccountTransferSection } from '../components/SettingsAccountTransferSection';
+import { useEscClose } from '../hooks/useEscClose';
 import './settings/Settings.css';
 import { 
   Github, User, Rocket, Save, FolderOpen,
@@ -1723,6 +1724,8 @@ export function SettingsPage() {
   const handleCloseReleaseHistory = () => {
     setReleaseHistoryOpen(false);
   };
+
+  useEscClose(releaseHistoryOpen, handleCloseReleaseHistory);
 
   const handleDownloadReleaseVersion = async (version: string) => {
     const targetVersion = String(version || '').trim();

--- a/src/pages/TraeAccountsPage.tsx
+++ b/src/pages/TraeAccountsPage.tsx
@@ -10,6 +10,7 @@ import {
   Database,
   Copy,
   Check,
+  ChevronLeft,
   KeyRound,
   Play,
   RotateCw,
@@ -1382,6 +1383,7 @@ export function TraeAccountsPage() {
             <div className="modal-overlay" onClick={closeAddModal}>
               <div className="modal-content ghcp-add-modal" onClick={(event) => event.stopPropagation()}>
                 <div className="modal-header">
+                  <button className="btn btn-secondary icon-only" onClick={closeAddModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
                   <h2>{t('trae.addModal.title')}</h2>
                   <button
                     className="modal-close"

--- a/src/pages/WakeupTasksPage.tsx
+++ b/src/pages/WakeupTasksPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { confirm as confirmDialog } from '@tauri-apps/plugin-dialog';
 import { openUrl } from '@tauri-apps/plugin-opener';
-import { Plus, Pencil, Trash2, Power, X } from 'lucide-react';
+import { ChevronLeft, Plus, Pencil, Trash2, Power, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAccountStore } from '../stores/useAccountStore';
 import { Page } from '../types/navigation';
@@ -35,6 +35,7 @@ import {
   type WakeupOfficialLsVersionMode,
 } from '../utils/wakeupOfficialLsVersion';
 import { ModalErrorMessage, useModalErrorState } from '../components/ModalErrorMessage';
+import { useEscClose } from '../hooks/useEscClose';
 import { OverviewTabsHeader } from '../components/OverviewTabsHeader';
 
 const TASKS_STORAGE_KEY = 'agtools.wakeup.tasks';
@@ -966,6 +967,10 @@ export function WakeupTasksPage({ onNavigate }: WakeupPageProps) {
     clearTestModalError();
     setShowTestModal(false);
   }, [cancelImmediateTest, clearTestModalError, testing]);
+
+  useEscClose(showTestModal, closeTestModal);
+  useEscClose(showHistoryModal, () => setShowHistoryModal(false));
+  useEscClose(showModal, () => setShowModal(false));
   const modelById = useMemo(() => {
     const map = new Map<string, AvailableModel>();
     filteredModels.forEach((model) => map.set(model.id, model));
@@ -2363,6 +2368,7 @@ export function WakeupTasksPage({ onNavigate }: WakeupPageProps) {
             onClick={(event) => event.stopPropagation()}
           >
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closeTestModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('wakeup.dialogs.testTitle')}</h2>
               <button
                 className="modal-close"
@@ -2560,6 +2566,7 @@ export function WakeupTasksPage({ onNavigate }: WakeupPageProps) {
             onClick={(event) => event.stopPropagation()}
           >
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => setShowHistoryModal(false)} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('wakeup.dialogs.historyTitle')}</h2>
               <button
                 className="modal-close"
@@ -2633,6 +2640,7 @@ export function WakeupTasksPage({ onNavigate }: WakeupPageProps) {
         <div className="modal-overlay" onClick={() => setShowModal(false)}>
           <div className="modal modal-lg wakeup-modal" onClick={(event) => event.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={() => setShowModal(false)} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{editingTaskId ? t('wakeup.dialogs.taskTitleEdit') : t('wakeup.dialogs.taskTitleNew')}</h2>
               <button
                 className="modal-close"

--- a/src/pages/WakeupVerificationPage.tsx
+++ b/src/pages/WakeupVerificationPage.tsx
@@ -3,9 +3,10 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { confirm as confirmDialog } from '@tauri-apps/plugin-dialog';
 import { openUrl } from '@tauri-apps/plugin-opener';
-import { ShieldCheck, X } from 'lucide-react';
+import { ChevronLeft, ShieldCheck, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ModalErrorMessage, useModalErrorState } from '../components/ModalErrorMessage';
+import { useEscClose } from '../hooks/useEscClose';
 import { OverviewTabsHeader } from '../components/OverviewTabsHeader';
 import { MultiSelectFilterDropdown, type MultiSelectFilterOption } from '../components/MultiSelectFilterDropdown';
 import { useAccountStore } from '../stores/useAccountStore';
@@ -731,6 +732,9 @@ export function WakeupVerificationPage({ onNavigate }: WakeupVerificationPagePro
     setShowDetailModal(false);
   };
 
+  useEscClose(showConfigModal, closeConfigModal);
+  useEscClose(showDetailModal, closeDetailModal);
+
   const handleDetailFilterChange = (filter: DetailFilter) => {
     clearDetailModalError();
     setDetailFilter(filter);
@@ -1331,6 +1335,15 @@ export function WakeupVerificationPage({ onNavigate }: WakeupVerificationPagePro
         <div className="modal-overlay" onClick={closeConfigModal}>
           <div className="modal wakeup-modal verification-config-modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button
+                className="btn btn-secondary icon-only"
+                onClick={closeConfigModal}
+                title={t('common.back', '返回')}
+                aria-label={t('common.back', '返回')}
+                disabled={running}
+              >
+                <ChevronLeft size={14} />
+              </button>
               <h2>{t('wakeup.verification.actions.runCheckNow', '立即检测')}</h2>
               <button className="modal-close" onClick={closeConfigModal} disabled={running}>
                 <X />
@@ -1491,6 +1504,7 @@ export function WakeupVerificationPage({ onNavigate }: WakeupVerificationPagePro
         <div className="modal-overlay" onClick={closeDetailModal}>
           <div className="modal wakeup-modal verification-progress-modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closeDetailModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('accounts.actions.viewDetails')}</h2>
               <button className="modal-close" onClick={closeDetailModal}>
                 <X />

--- a/src/pages/ZedAccountsPage.tsx
+++ b/src/pages/ZedAccountsPage.tsx
@@ -3,6 +3,7 @@ import {
   ArrowDownWideNarrow,
   Check,
   ChevronDown,
+  ChevronLeft,
   CircleAlert,
   Copy,
   Database,
@@ -1362,6 +1363,7 @@ export function ZedAccountsPage() {
         <div className="modal-overlay" onClick={closeAddModal}>
           <div className="modal-content ghcp-add-modal zed-add-modal" onClick={(event) => event.stopPropagation()}>
             <div className="modal-header">
+              <button className="btn btn-secondary icon-only" onClick={closeAddModal} title={t('common.back', '返回')} aria-label={t('common.back', '返回')}><ChevronLeft size={14} /></button>
               <h2>{t('zed.addModal.title', '添加 Zed 账号')}</h2>
               <button
                 className="modal-close"

--- a/src/stores/usePlatformLayoutStore.ts
+++ b/src/stores/usePlatformLayoutStore.ts
@@ -101,7 +101,7 @@ interface NormalizedLayoutStateData {
   sidebarEntryIds: PlatformLayoutEntryId[];
 }
 
-let trayLayoutSyncTimer: ReturnType<typeof setTimeout> | null = null;
+let trayLayoutSyncTimer: number | null = null;
 
 export function makePlatformEntryId(platformId: PlatformId): PlatformLayoutEntryId {
   return `${PLATFORM_ENTRY_PREFIX}${platformId}` as PlatformLayoutEntryId;


### PR DESCRIPTION
feat: add ESC key support and back buttons to modals

- Add useEscClose hook for reusable ESC-to-close behavior
- Add ESC support to GlobalModal component
- Add ChevronLeft back buttons to modal headers across 16 pages
- Add aria-label to all icon-only back buttons for accessibility