### PR TITLE
fix: remove third-party ad, add CSP, harden release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify release is from main branch
+        shell: bash
+        run: |
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "ERROR: Release tags must be on the main branch."
+            echo "This tag is not on main. Releases from integration/feature branches are blocked."
+            exit 1
+          fi
+          echo "Branch check passed - tag is on main branch."
 
       - name: Install dependencies (Linux)
         if: startsWith(matrix.platform, 'ubuntu')

--- a/announcements.json
+++ b/announcements.json
@@ -1,27 +1,7 @@
 {
   "version": "1.0",
   "topRightAd_backup": null,
-  "topRightAd": {
-    "id": "top-right-ad-2026-04-shop",
-    "priority": 100,
-    "text": "少量Codex plus成品号和Kiro成品号。需要的可以选购，感谢",
-    "badge": "推广",
-    "ctaLabel": "选购",
-    "ctaUrl": "https://xiangzili.xyz",
-    "targetVersions": "*",
-    "targetLanguages": [
-      "*"
-    ],
-    "createdAt": "2026-04-07T12:00:00Z",  
-    "expiresAt": null,
-    "locales": {
-      "zh-CN": {
-        "text": "少量Codex plus成品号和Kiro成品号。需要的可以选购，感谢",
-        "badge": "推广",
-        "ctaLabel": "选购"
-      }
-    }
-  },
+  "topRightAd": null,
   "announcements": [
     {
       "id": "ann-2026-05-12-v0230-withdrawn-manual-update",

--- a/src-tauri/src/modules/announcement.rs
+++ b/src-tauri/src/modules/announcement.rs
@@ -8,7 +8,7 @@ use super::config;
 use super::logger;
 
 const ANNOUNCEMENT_URL: &str =
-    "https://raw.githubusercontent.com/jlcodes99/cockpit-tools/main/announcements.json";
+    "https://raw.githubusercontent.com/TurnX-alt/cockpit-tools/main/announcements.json";
 const ANNOUNCEMENT_CACHE_FILE: &str = "announcement_cache.json";
 const ANNOUNCEMENT_READ_IDS_FILE: &str = "announcement_read_ids.json";
 const ANNOUNCEMENT_LOCAL_OVERRIDE_FILE: &str = "announcements.local.json";

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,7 +43,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; img-src 'self' asset: https: data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://localhost:* ws://localhost:* https://localhost:* tauri://localhost"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

Security hardening for Cockpit Tools Tauri application. Addresses critical supply-chain and runtime security issues identified in a comprehensive security audit.

## Changes

### 1. Remove Third-Party Advertisement (CRITICAL)
- **File**: `announcements.json`
- **Before**: `topRightAd` contained a promotion linking to `https://xiangzili.xyz` (a third-party shop selling AI IDE accounts)
- **After**: `topRightAd` set to `null`
- **Why**: The ad is delivered via a remote-controlled JSON file fetched at runtime from GitHub Raw. Any compromise of the repository or GitHub account could push malicious links to all active users. The promoted third-party site has no security vetting and could be used for phishing or malware distribution.

### 2. Content Security Policy (HIGH)
- **File**: `src-tauri/tauri.conf.json`
- **Before**: `"csp": null` — WebView has no content security restrictions
- **After**: Restrictive CSP policy
- **Why**: Prevents XSS-based exploitation of Tauri IPC capabilities in WebView context.

### 3. Release Workflow Branch Guard (HIGH)
- **File**: `.github/workflows/release.yml`
- **Before**: No branch verification — any tag could trigger a release
- **After**: Added `git merge-base --is-ancestor` check to ensure tags are on the `main` branch
- **Why**: The v0.23.0 incident was caused by a release from an integration branch containing unreviewed PR changes with a potentially wrong update channel. This guard prevents future integration-branch releases.

### 4. Announcement Fetch URL (user fork)
- **File**: `src-tauri/src/modules/announcement.rs`
- **Changed**: `ANNOUNCEMENT_URL` to point to the fork
- **Note**: This change is fork-specific. Upstream may choose to keep the original URL or make it configurable.

## Test Plan
- [ ] Verify app starts without third-party ad in the top-right corner
- [ ] Verify CSP does not break WebView rendering or Tauri IPC communication
- [ ] Verify all windows (main, floating-card) render correctly
- [ ] Manually test the release workflow by pushing a test tag on main
- [ ] Verify the branch guard blocks tags on non-main branches