### PR TITLE
fix(codex): allow port changes after local access bind failures

### DIFF
--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -4779,7 +4779,7 @@ pub async fn kill_local_access_port_processes() -> Result<CodexLocalAccessPortCl
 }
 
 pub async fn update_local_access_port(port: u16) -> Result<CodexLocalAccessState, String> {
-    ensure_runtime_loaded().await?;
+    ensure_runtime_loaded_without_start().await?;
 
     let maybe_collection = {
         let runtime = gateway_runtime().lock().await;


### PR DESCRIPTION
## Summary
- Load the saved Codex local access config without starting the existing gateway before applying a port change.
- Keep candidate-port validation and restart the gateway after the new port is saved.

## Problem
On Windows, a saved local access port can become unavailable because it is reserved or excluded by the OS. In that state, binding the existing port fails with `os error 10013`. The port update command currently loads runtime state through the path that may start the existing gateway first, so the command can fail before the replacement port is validated and persisted. That leaves the UI stuck on the bad saved port.

## Test Plan
- `npm run typecheck`
- `cargo test --lib extracts_usage_from_codex_response_completed_payload`
- `git diff --check`