### PR TITLE
Fix Codex synced session project visibility

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -55,27 +55,27 @@ jobs:
           - label: "macos-aarch64"
             platform: "macos-latest"
             args: "--target aarch64-apple-darwin"
-            release_dir: "src-tauri/target/aarch64-apple-darwin/release"
+            release_dir: "target/aarch64-apple-darwin/release"
           - label: "macos-x86_64"
             platform: "macos-latest"
             args: "--target x86_64-apple-darwin"
-            release_dir: "src-tauri/target/x86_64-apple-darwin/release"
+            release_dir: "target/x86_64-apple-darwin/release"
           - label: "macos-universal"
             platform: "macos-latest"
             args: "--target universal-apple-darwin"
-            release_dir: "src-tauri/target/universal-apple-darwin/release"
+            release_dir: "target/universal-apple-darwin/release"
           - label: "ubuntu-22.04"
             platform: "ubuntu-22.04"
             args: ""
-            release_dir: "src-tauri/target/release"
+            release_dir: "target/release"
           - label: "ubuntu-24.04-arm"
             platform: "ubuntu-24.04-arm"
             args: ""
-            release_dir: "src-tauri/target/release"
+            release_dir: "target/release"
           - label: "windows-latest"
             platform: "windows-latest"
             args: ""
-            release_dir: "src-tauri/target/release"
+            release_dir: "target/release"
 
     steps:
       - name: Checkout repository
@@ -111,7 +111,17 @@ jobs:
       - name: Sync versions
         run: npm run sync-version
 
-      - name: Build app
+      - name: Build app (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          npx tauri build --ci --config '{"bundle":{"createUpdaterArtifacts":false}}' ${{ matrix.args }} 2>&1 | tee "build-${{ matrix.label }}.log"
+
+      - name: Build app (signed)
+        if: github.event_name != 'pull_request'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src-tauri/src/modules/codex_official_app_server.rs
+++ b/src-tauri/src/modules/codex_official_app_server.rs
@@ -10,6 +10,7 @@ use serde_json::{json, Value as JsonValue};
 use std::os::windows::process::CommandExt;
 
 const CODEX_APP_SERVER_EXECUTABLE: &str = "/Applications/Codex.app/Contents/Resources/codex";
+const CODEX_APP_SERVER_EXECUTABLE_ENV: &str = "CODEX_APP_SERVER_EXECUTABLE";
 const APP_SERVER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(20);
 
 pub fn rebuild_thread_metadata(codex_home: &Path) -> Result<(), String> {
@@ -81,13 +82,28 @@ pub fn rebuild_thread_metadata(codex_home: &Path) -> Result<(), String> {
 }
 
 fn official_app_server_executable() -> Result<PathBuf, String> {
-    let executable = PathBuf::from(CODEX_APP_SERVER_EXECUTABLE);
-    if executable.exists() {
-        return Ok(executable);
+    let mut candidates = Vec::new();
+    if let Some(executable) = std::env::var_os(CODEX_APP_SERVER_EXECUTABLE_ENV) {
+        if !executable.as_os_str().is_empty() {
+            candidates.push(PathBuf::from(executable));
+        }
     }
+    candidates.push(PathBuf::from(CODEX_APP_SERVER_EXECUTABLE));
+
+    for executable in &candidates {
+        if executable.exists() {
+            return Ok(executable.clone());
+        }
+    }
+
+    let searched_paths = candidates
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
     Err(format!(
         "未找到官方 Codex app-server 可执行文件: {}",
-        executable.display()
+        searched_paths
     ))
 }
 

--- a/src-tauri/src/modules/codex_thread_sync.rs
+++ b/src-tauri/src/modules/codex_thread_sync.rs
@@ -91,6 +91,12 @@ struct ThreadSyncPlanItem {
 }
 
 #[derive(Debug, Clone)]
+struct ThreadSyncWriteResult {
+    backup_dir: PathBuf,
+    metadata_rebuild_failed: bool,
+}
+
+#[derive(Debug, Clone)]
 struct RolloutMergeLine {
     line: String,
     timestamp_ms: Option<i128>,
@@ -142,6 +148,7 @@ pub fn sync_threads_across_instances() -> Result<CodexInstanceThreadSyncSummary,
     let mut total_updated_thread_count = 0usize;
     let mut project_index_repaired_instance_count = 0usize;
     let mut mutated_running_instance_count = 0usize;
+    let mut metadata_rebuild_failed_instance_count = 0usize;
 
     for instance in &instances {
         let existing_snapshots = snapshots_by_instance
@@ -199,12 +206,17 @@ pub fn sync_threads_across_instances() -> Result<CodexInstanceThreadSyncSummary,
             continue;
         }
 
-        let backup_dir = sync_thread_plan_to_instance(instance, &plan_items, &expected_snapshots)?;
+        let write_result =
+            sync_thread_plan_to_instance(instance, &plan_items, &expected_snapshots)?;
+        let backup_dir = write_result.backup_dir;
         let backup_dir_string = backup_dir.to_string_lossy().to_string();
         backup_dirs.push(backup_dir_string.clone());
         mutated_instance_count += 1;
         if repairs_project_index {
             project_index_repaired_instance_count += 1;
+        }
+        if write_result.metadata_rebuild_failed {
+            metadata_rebuild_failed_instance_count += 1;
         }
         total_synced_thread_count += plan_items.len();
         total_added_thread_count += added_thread_count;
@@ -246,6 +258,12 @@ pub fn sync_threads_across_instances() -> Result<CodexInstanceThreadSyncSummary,
             total_updated_thread_count
         )
     };
+
+    let message = append_metadata_rebuild_warning(
+        message,
+        metadata_rebuild_failed_instance_count,
+        total_synced_thread_count,
+    );
 
     Ok(CodexInstanceThreadSyncSummary {
         instance_count: instances.len(),
@@ -365,7 +383,8 @@ pub fn sync_sessions_to_instance(
         });
     }
 
-    let backup_dir = sync_missing_threads_to_instance(&target, &snapshots_to_sync)?;
+    let write_result = sync_missing_threads_to_instance(&target, &snapshots_to_sync)?;
+    let backup_dir = write_result.backup_dir;
     let synced_session_count = snapshots_to_sync.len();
     let message = if running {
         format!(
@@ -378,6 +397,11 @@ pub fn sync_sessions_to_instance(
             synced_session_count, target.name
         )
     };
+    let message = append_metadata_rebuild_warning(
+        message,
+        usize::from(write_result.metadata_rebuild_failed),
+        synced_session_count,
+    );
 
     Ok(CodexInstanceTargetThreadSyncSummary {
         requested_session_count: requested_ids.len(),
@@ -563,7 +587,7 @@ fn session_meta_cwd(meta: &JsonValue) -> Option<String> {
 fn sync_missing_threads_to_instance(
     target: &CodexSyncInstance,
     snapshots: &[ThreadSnapshot],
-) -> Result<PathBuf, String> {
+) -> Result<ThreadSyncWriteResult, String> {
     let plan_items = snapshots
         .iter()
         .cloned()
@@ -580,7 +604,7 @@ fn sync_thread_plan_to_instance(
     target: &CodexSyncInstance,
     plan_items: &[ThreadSyncPlanItem],
     workspace_snapshots: &[ThreadSnapshot],
-) -> Result<PathBuf, String> {
+) -> Result<ThreadSyncWriteResult, String> {
     let backup_dir = backup_instance_files(&target.data_dir)?;
     let target_provider =
         modules::codex_session_visibility::read_history_visibility_provider_for_dir(
@@ -592,23 +616,51 @@ fn sync_thread_plan_to_instance(
         rewrite_rollout_provider_for_target(&target_rollout_path, &target_provider)?;
     }
 
+    let mut metadata_rebuild_failed = false;
     if !plan_items.is_empty() {
         let snapshots = plan_items
             .iter()
             .map(|item| item.snapshot.clone())
             .collect::<Vec<_>>();
         upsert_session_index_entries(&target.data_dir, &snapshots)?;
-        modules::codex_official_app_server::rebuild_thread_metadata(&target.data_dir).map_err(
-            |error| {
-                format!(
-                    "已同步 rollout/session_index，但官方 Codex 重建会话索引失败 ({}): {}",
-                    target.name, error
-                )
-            },
-        )?;
+        metadata_rebuild_failed = !try_rebuild_thread_metadata(target);
     }
     update_global_state_thread_workspaces(&target.data_dir, workspace_snapshots)?;
-    Ok(backup_dir)
+    Ok(ThreadSyncWriteResult {
+        backup_dir,
+        metadata_rebuild_failed,
+    })
+}
+
+fn try_rebuild_thread_metadata(target: &CodexSyncInstance) -> bool {
+    match modules::codex_official_app_server::rebuild_thread_metadata(&target.data_dir) {
+        Ok(()) => true,
+        Err(error) => {
+            eprintln!(
+                "Codex thread sync: skipped official metadata rebuild for {} ({}): {}",
+                target.name,
+                target.data_dir.display(),
+                error
+            );
+            false
+        }
+    }
+}
+
+fn append_metadata_rebuild_warning(
+    message: String,
+    failed_instance_count: usize,
+    synced_thread_count: usize,
+) -> String {
+    if failed_instance_count == 0 || synced_thread_count == 0 {
+        return message;
+    }
+
+    let message = message.replace("，并已触发官方 Codex 重建会话索引", "");
+    format!(
+        "{}；{} 个实例未能触发官方 Codex 重建会话索引，但 rollout/session_index 已同步完成",
+        message, failed_instance_count
+    )
 }
 
 fn merge_thread_snapshots(snapshots: &[ThreadSnapshot]) -> Result<ThreadSnapshot, String> {

--- a/src-tauri/src/modules/codex_thread_sync.rs
+++ b/src-tauri/src/modules/codex_thread_sync.rs
@@ -13,7 +13,8 @@ use crate::modules;
 const DEFAULT_INSTANCE_ID: &str = "__default__";
 const DEFAULT_INSTANCE_NAME: &str = "默认实例";
 const SESSION_INDEX_FILE: &str = "session_index.jsonl";
-const BACKUP_FILE_NAMES: [&str; 1] = [SESSION_INDEX_FILE];
+const GLOBAL_STATE_FILE: &str = ".codex-global-state.json";
+const BACKUP_FILE_NAMES: [&str; 2] = [SESSION_INDEX_FILE, GLOBAL_STATE_FILE];
 const SESSION_DIRS: [&str; 2] = ["sessions", "archived_sessions"];
 
 #[derive(Debug, Clone, Serialize)]
@@ -70,6 +71,7 @@ struct ThreadSnapshot {
     rollout_modified_at: Option<SystemTime>,
     merged_rollout_content: Option<String>,
     session_index_entry: JsonValue,
+    workspace_root: Option<String>,
     source_root: PathBuf,
     freshness: ThreadFreshness,
 }
@@ -138,6 +140,7 @@ pub fn sync_threads_across_instances() -> Result<CodexInstanceThreadSyncSummary,
     let mut total_synced_thread_count = 0usize;
     let mut total_added_thread_count = 0usize;
     let mut total_updated_thread_count = 0usize;
+    let mut project_index_repaired_instance_count = 0usize;
     let mut mutated_running_instance_count = 0usize;
 
     for instance in &instances {
@@ -148,6 +151,10 @@ pub fn sync_threads_across_instances() -> Result<CodexInstanceThreadSyncSummary,
         let mut plan_items = Vec::new();
         let mut added_thread_count = 0usize;
         let mut updated_thread_count = 0usize;
+        let expected_snapshots = universe_ids
+            .iter()
+            .filter_map(|id| thread_universe.get(id).cloned())
+            .collect::<Vec<_>>();
 
         for id in &universe_ids {
             let Some(best_snapshot) = thread_universe.get(id) else {
@@ -177,7 +184,11 @@ pub fn sync_threads_across_instances() -> Result<CodexInstanceThreadSyncSummary,
             }
         }
 
-        if plan_items.is_empty() {
+        let missing_workspace_roots =
+            find_missing_thread_workspace_roots(&instance.data_dir, &expected_snapshots)?;
+        let repairs_project_index = !missing_workspace_roots.is_empty();
+
+        if plan_items.is_empty() && !repairs_project_index {
             items.push(CodexInstanceThreadSyncItem {
                 instance_id: instance.id.clone(),
                 instance_name: instance.name.clone(),
@@ -188,10 +199,13 @@ pub fn sync_threads_across_instances() -> Result<CodexInstanceThreadSyncSummary,
             continue;
         }
 
-        let backup_dir = sync_thread_plan_to_instance(instance, &plan_items)?;
+        let backup_dir = sync_thread_plan_to_instance(instance, &plan_items, &expected_snapshots)?;
         let backup_dir_string = backup_dir.to_string_lossy().to_string();
         backup_dirs.push(backup_dir_string.clone());
         mutated_instance_count += 1;
+        if repairs_project_index {
+            project_index_repaired_instance_count += 1;
+        }
         total_synced_thread_count += plan_items.len();
         total_added_thread_count += added_thread_count;
         total_updated_thread_count += updated_thread_count;
@@ -208,8 +222,13 @@ pub fn sync_threads_across_instances() -> Result<CodexInstanceThreadSyncSummary,
         });
     }
 
-    let message = if total_synced_thread_count == 0 {
+    let message = if total_synced_thread_count == 0 && project_index_repaired_instance_count == 0 {
         "所有 Codex 实例会话已是最新，无需同步".to_string()
+    } else if total_synced_thread_count == 0 {
+        format!(
+            "会话内容已是最新，已修复 {} 个实例的项目索引",
+            project_index_repaired_instance_count
+        )
     } else if mutated_running_instance_count > 0 {
         format!(
             "已为 {} 个实例同步 {} 条会话（新增 {} 条，更新 {} 条），并已触发官方 Codex 重建会话索引；运行中的实例可能需要刷新或重启后显示",
@@ -440,6 +459,7 @@ fn load_thread_snapshots(instance: &CodexSyncInstance) -> Result<Vec<ThreadSnaps
             let session_index_entry = session_index_map.get(&id).cloned().unwrap_or_else(|| {
                 build_fallback_session_index_entry(&id, &title, updated_at.as_deref())
             });
+            let workspace_root = session_meta_cwd(&session_meta);
             let rollout_actual_modified_at =
                 modules::codex_session_file_time::read_modified_time(&rollout_path);
             let rollout_modified_at =
@@ -455,6 +475,7 @@ fn load_thread_snapshots(instance: &CodexSyncInstance) -> Result<Vec<ThreadSnaps
                 rollout_modified_at,
                 merged_rollout_content: None,
                 session_index_entry,
+                workspace_root,
                 source_root: instance.data_dir.clone(),
                 freshness,
             });
@@ -531,6 +552,14 @@ fn session_meta_id(meta: &JsonValue) -> Option<String> {
         })
 }
 
+fn session_meta_cwd(meta: &JsonValue) -> Option<String> {
+    meta.get("payload")
+        .and_then(|payload| payload.get("cwd"))
+        .or_else(|| meta.get("cwd"))
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+}
+
 fn sync_missing_threads_to_instance(
     target: &CodexSyncInstance,
     snapshots: &[ThreadSnapshot],
@@ -544,12 +573,13 @@ fn sync_missing_threads_to_instance(
             is_update: false,
         })
         .collect::<Vec<_>>();
-    sync_thread_plan_to_instance(target, &plan_items)
+    sync_thread_plan_to_instance(target, &plan_items, snapshots)
 }
 
 fn sync_thread_plan_to_instance(
     target: &CodexSyncInstance,
     plan_items: &[ThreadSyncPlanItem],
+    workspace_snapshots: &[ThreadSnapshot],
 ) -> Result<PathBuf, String> {
     let backup_dir = backup_instance_files(&target.data_dir)?;
     let target_provider =
@@ -562,19 +592,22 @@ fn sync_thread_plan_to_instance(
         rewrite_rollout_provider_for_target(&target_rollout_path, &target_provider)?;
     }
 
-    let snapshots = plan_items
-        .iter()
-        .map(|item| item.snapshot.clone())
-        .collect::<Vec<_>>();
-    upsert_session_index_entries(&target.data_dir, &snapshots)?;
-    modules::codex_official_app_server::rebuild_thread_metadata(&target.data_dir).map_err(
-        |error| {
-            format!(
-                "已同步 rollout/session_index，但官方 Codex 重建会话索引失败 ({}): {}",
-                target.name, error
-            )
-        },
-    )?;
+    if !plan_items.is_empty() {
+        let snapshots = plan_items
+            .iter()
+            .map(|item| item.snapshot.clone())
+            .collect::<Vec<_>>();
+        upsert_session_index_entries(&target.data_dir, &snapshots)?;
+        modules::codex_official_app_server::rebuild_thread_metadata(&target.data_dir).map_err(
+            |error| {
+                format!(
+                    "已同步 rollout/session_index，但官方 Codex 重建会话索引失败 ({}): {}",
+                    target.name, error
+                )
+            },
+        )?;
+    }
+    update_global_state_thread_workspaces(&target.data_dir, workspace_snapshots)?;
     Ok(backup_dir)
 }
 
@@ -996,6 +1029,185 @@ fn upsert_session_index_entries(
     Ok(())
 }
 
+fn collect_thread_workspace_roots(snapshots: &[ThreadSnapshot]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut roots = Vec::new();
+
+    for snapshot in snapshots {
+        let Some(root) = snapshot_workspace_root(snapshot) else {
+            continue;
+        };
+        if seen.insert(root.clone()) {
+            roots.push(root);
+        }
+    }
+
+    roots
+}
+
+fn snapshot_workspace_root(snapshot: &ThreadSnapshot) -> Option<String> {
+    snapshot
+        .workspace_root
+        .as_deref()
+        .and_then(normalize_workspace_root)
+        .or_else(|| session_index_workspace_root(&snapshot.session_index_entry))
+}
+
+fn session_index_workspace_root(entry: &JsonValue) -> Option<String> {
+    [
+        "cwd",
+        "workspace_root",
+        "workspaceRoot",
+        "working_directory",
+        "workingDirectory",
+    ]
+    .iter()
+    .find_map(|key| entry.get(key).and_then(JsonValue::as_str))
+    .and_then(normalize_workspace_root)
+}
+
+fn normalize_workspace_root(value: &str) -> Option<String> {
+    let mut value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Some(stripped) = value.strip_prefix("\\\\?\\") {
+        value = stripped;
+    }
+
+    let mut normalized = value.replace('/', "\\");
+    while normalized.len() > 3 && (normalized.ends_with('\\') || normalized.ends_with('/')) {
+        normalized.pop();
+    }
+
+    if normalized.trim().is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+fn read_global_state(root_dir: &Path) -> Result<JsonValue, String> {
+    let path = root_dir.join(GLOBAL_STATE_FILE);
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+
+    let raw = fs::read_to_string(&path)
+        .map_err(|error| format!("读取全局状态失败 ({}): {}", path.display(), error))?;
+    Ok(serde_json::from_str::<JsonValue>(&raw).unwrap_or_else(|_| json!({})))
+}
+
+fn global_state_array_contains(
+    object: &serde_json::Map<String, JsonValue>,
+    key: &str,
+    workspace: &str,
+) -> bool {
+    object
+        .get(key)
+        .and_then(JsonValue::as_array)
+        .map(|values| {
+            values.iter().any(|value| {
+                value.as_str().and_then(normalize_workspace_root).as_deref() == Some(workspace)
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn find_missing_thread_workspace_roots(
+    root_dir: &Path,
+    snapshots: &[ThreadSnapshot],
+) -> Result<Vec<String>, String> {
+    let roots = collect_thread_workspace_roots(snapshots);
+    if roots.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let value = read_global_state(root_dir)?;
+    let Some(object) = value.as_object() else {
+        return Ok(roots);
+    };
+
+    Ok(roots
+        .into_iter()
+        .filter(|root| {
+            !global_state_array_contains(object, "project-order", root)
+                || !global_state_array_contains(object, "electron-saved-workspace-roots", root)
+        })
+        .collect())
+}
+
+fn update_global_state_thread_workspaces(
+    root_dir: &Path,
+    snapshots: &[ThreadSnapshot],
+) -> Result<bool, String> {
+    let roots = collect_thread_workspace_roots(snapshots);
+    if roots.is_empty() {
+        return Ok(false);
+    }
+
+    let path = root_dir.join(GLOBAL_STATE_FILE);
+    let mut value = read_global_state(root_dir)?;
+    if !value.is_object() {
+        value = json!({});
+    }
+    let Some(object) = value.as_object_mut() else {
+        return Err("全局状态文件格式无效".to_string());
+    };
+
+    let mut changed = false;
+    changed |= merge_string_array(object, "project-order", &roots);
+    changed |= merge_string_array(object, "electron-saved-workspace-roots", &roots);
+
+    if changed {
+        let serialized = serde_json::to_string_pretty(&value)
+            .map_err(|error| format!("序列化全局状态失败: {}", error))?;
+        fs::write(&path, format!("{}\n", serialized))
+            .map_err(|error| format!("写入全局状态失败 ({}): {}", path.display(), error))?;
+    }
+
+    Ok(changed)
+}
+
+fn merge_string_array(
+    object: &mut serde_json::Map<String, JsonValue>,
+    key: &str,
+    additions: &[String],
+) -> bool {
+    let mut changed = false;
+    let mut values = object
+        .get(key)
+        .and_then(JsonValue::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|item| item.as_str().map(|value| value.to_string()))
+        .collect::<Vec<_>>();
+    let mut normalized_values = values
+        .iter()
+        .filter_map(|value| normalize_workspace_root(value))
+        .collect::<HashSet<_>>();
+
+    for addition in additions {
+        let Some(normalized) = normalize_workspace_root(addition) else {
+            continue;
+        };
+        if normalized_values.insert(normalized.clone()) {
+            values.push(normalized);
+            changed = true;
+        }
+    }
+
+    if changed {
+        object.insert(
+            key.to_string(),
+            JsonValue::Array(values.into_iter().map(JsonValue::String).collect()),
+        );
+    }
+
+    changed
+}
+
 fn copy_rollout_file_for_plan(
     item: &ThreadSyncPlanItem,
     target_root: &Path,
@@ -1275,6 +1487,7 @@ mod tests {
             rollout_modified_at: Some(source_modified_at),
             merged_rollout_content: None,
             session_index_entry: json!({"id":"s1"}),
+            workspace_root: None,
             source_root: source_root.clone(),
             freshness: ThreadFreshness {
                 activity_ms: 0,


### PR DESCRIPTION
## Summary
- Repair Codex project visibility for sessions that were already synced into target instances.
- Add `.codex-global-state.json` back to sync backups, but only update `project-order` and `electron-saved-workspace-roots` for workspaces that have real synced thread records.
- Adapt the fix to the latest `main` / `v0.24.8` rollout + `session_index.jsonl` sync flow.
- Keep non-project sessions in the normal rollout/session_index sync path while project-index repair remains limited to sessions with a real workspace root.
- Make official Codex app-server metadata rebuild best-effort so missing platform-specific executables, such as `/Applications/Codex.app/Contents/Resources/codex` on Windows, no longer fail an otherwise successful sync.
- Avoid updater signing during fork pull request builds so CI does not fail because repository signing secrets are unavailable to forked PRs.

## Verification
- `npm run typecheck`
- `cargo check`
- `npx tauri build --ci --config '{"bundle":{"createUpdaterArtifacts":false}}'` reached the Windows release executable at `target/release/cockpit-tools.exe`; MSI bundling then failed only while downloading WiX tooling in the local environment.
- `npx tauri build --ci --bundles nsis --config '{"bundle":{"createUpdaterArtifacts":false}}'` reached the Windows release executable at `target/release/cockpit-tools.exe`; NSIS bundling then failed only while downloading NSIS tooling in the local environment.

`cargo check` completes on `cockpit-tools v0.24.8`; the remaining warnings are existing unused-code warnings from the current upstream tree.

## Local Diagnosis
The reported session `019e4daa-080d-7a41-a4a8-1e60a766c4f9` was present in local Codex session storage for each instance, but one instance did not show it because its `.codex-global-state.json` missed the workspace root `D:\BaiduSyncdisk\03.Baseline code\STG4Traffic-main`.

The later Windows error happened after rollout/session_index had already been written: the sync path treated an optional official Codex app-server index rebuild as fatal even when the hardcoded macOS executable was unavailable. The PR now keeps the synced files and reports the rebuild as skipped instead of failing the whole operation.