### PR TITLE
fix(codex): 允许 sidecar 保存纯 API Key 集合

### DIFF
--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -5406,7 +5406,6 @@ async fn prepare_sidecar_launch_config(
 
     let mut manifest_accounts = Vec::new();
     let mut codex_keys = Vec::new();
-    let mut oauth_account_count = 0usize;
     for account_id in &collection.account_ids {
         let Some(account) = load_sidecar_account(account_id).await else {
             logger::log_codex_api_warn(&format!(
@@ -5436,14 +5435,6 @@ async fn prepare_sidecar_launch_config(
             .map_err(|e| format!("序列化 sidecar Codex OAuth 认证失败: {}", e))?;
         write_string_atomic(&auth_path, &auth_content)?;
         manifest_accounts.push(sidecar_account_manifest_value(&account, Some(&file_name)));
-        oauth_account_count += 1;
-    }
-
-    if oauth_account_count == 0 && !codex_keys.is_empty() {
-        return Err(
-            "当前 API 服务 sidecar 暂不支持纯 API Key 账号池；请至少加入一个 Codex OAuth 账号，或继续改为主网关直连 API Key 路径。"
-                .to_string(),
-        );
     }
 
     let health_snapshot = {


### PR DESCRIPTION
## 摘要
- 允许 Codex 本地接入 sidecar 在集合只包含 API Key 账号时继续生成配置。
- 保持现有 `codex-api-key` sidecar 配置路径不变，API Key 账号仍交给 sidecar 处理。

## 问题
只包含 Codex API Key 账号的 API 服务集合在 sidecar 配置写入前就会保存失败。`prepare_sidecar_launch_config` 已经会把 API Key 账号收集到 `codex_keys`，后续也会写入 `codex-api-key`，但它又在 sidecar auth manifest 没有 OAuth 账号时直接拒绝集合。这样会让纯 API Key 路径不可达，即使 sidecar 已经支持 `codex-api-key` 配置项。

## 测试计划
- `cargo test --lib api_key_accounts_are_eligible_with_upstream_key`
- 确认旧的纯 API Key 报错文案和 `oauth_account_count` 拦截已移除。
- 确认存在 API Key 条目时仍会写入 `codex-api-key`。

Fixes #930.