### PR TITLE
[codex] fix local access probe URL

### DIFF
--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -8745,7 +8745,7 @@ async fn probe_local_access_gateway(
     api_key: &str,
     model_id: &str,
 ) -> LocalAccessGatewayProbeResult {
-    let url = format!("{}/v1/responses", base_url.trim_end_matches('/'));
+    let url = probe_local_access_gateway_url(base_url);
     let client = match build_localhost_http_client(Duration::from_secs(90), "本地网关诊断") {
         Ok(client) => client,
         Err(error) => {
@@ -8807,6 +8807,15 @@ async fn probe_local_access_gateway(
         detail: clean_diagnostic_text(body_text.clone()),
         gateway_output: clean_diagnostic_text(format!("HTTP {}\n{}", status.as_u16(), body_text)),
     })
+}
+
+fn probe_local_access_gateway_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        format!("{}/responses", trimmed)
+    } else {
+        format!("{}{}", trimmed, RESPONSES_PATH)
+    }
 }
 
 fn format_cli_failure_output(
@@ -14204,10 +14213,11 @@ mod tests {
         is_local_access_eligible_account, is_responses_completion_event, model_pricing,
         normalize_custom_routing_rules, parse_codex_retry_after,
         parse_responses_payload_from_upstream, parse_websocket_upstream_error,
-        prepare_gateway_request, profile_base_url_matches, recover_invalid_stats_file,
-        remove_codex_local_access_config, resolve_plan_rank, resolve_supported_model_alias,
-        resolve_upstream_target, should_retry_single_account_upstream_status,
-        should_treat_response_as_stream, should_try_next_account, validate_client_model_visible,
+        prepare_gateway_request, probe_local_access_gateway_url, profile_base_url_matches,
+        recover_invalid_stats_file, remove_codex_local_access_config, resolve_plan_rank,
+        resolve_supported_model_alias, resolve_upstream_target,
+        should_retry_single_account_upstream_status, should_treat_response_as_stream,
+        should_try_next_account, validate_client_model_visible,
         visible_codex_model_ids_for_api_key, websocket_accept_value,
         websocket_connect_error_from_http_response, CodexLocalAccessCollection,
         CodexLocalAccessGatewayMode, CodexLocalAccessScope, GatewayResponseAdapter, ParsedRequest,
@@ -14732,6 +14742,18 @@ supports_websockets = false
             Some("http://127.0.0.1:14998/v1"),
             "http://localhost:14998/v1"
         ));
+    }
+
+    #[test]
+    fn probe_local_access_gateway_url_preserves_existing_v1_prefix() {
+        assert_eq!(
+            probe_local_access_gateway_url("http://localhost:11892/v1"),
+            "http://localhost:11892/v1/responses"
+        );
+        assert_eq!(
+            probe_local_access_gateway_url("http://localhost:11892/v1/"),
+            "http://localhost:11892/v1/responses"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix Codex local API service fallback gateway probe URL construction when the service Base URL already includes `/v1`.
- Add a regression test covering `http://localhost:<port>/v1` and trailing-slash variants so the probe no longer calls `/v1/v1/responses`.

## Root Cause
The GUI health check first runs a Codex CLI request. If that CLI path fails, the fallback gateway probe builds its URL by appending `/v1/responses` to `state.base_url`. The displayed and stored local access Base URL already includes `/v1`, so the fallback probe can hit `/v1/v1/responses` and report `endpoint not supported` even though the actual gateway endpoint is healthy.

## Validation
- `git diff --check HEAD~1..HEAD`
- Manual local reproduction before fix: `/v1/responses` returned 200, `/v1/v1/responses` returned 404 `endpoint not supported`.
- Manual GUI verification after local runtime config correction: Cockpit Tools service panel test returned `pong` and displayed service check success for `gpt-5.5`.

Not run locally:
- `cargo test probe_local_access_gateway_url_preserves_existing_v1_prefix` because `cargo` is not installed or available in this Windows PATH.