### PR TITLE
Fix Windows Antigravity version detection

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -461,7 +461,8 @@ fn find_antigravity_windows_exe(root: &Path) -> Option<PathBuf> {
 fn read_antigravity_windows_exe_metadata(root: &Path) -> Option<AntigravityInstalledVersionInfo> {
     let exe_path = find_antigravity_windows_exe(root)?;
     let script = r#"
-$p = $args[0]
+& {
+param([string]$p)
 if (-not (Test-Path -LiteralPath $p)) { exit 2 }
 $v = (Get-Item -LiteralPath $p).VersionInfo
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
@@ -470,6 +471,7 @@ $v = (Get-Item -LiteralPath $p).VersionInfo
   ProductVersion = $v.ProductVersion
   FileVersion = $v.FileVersion
 } | ConvertTo-Json -Compress
+}
 "#;
     let mut command = std::process::Command::new("powershell");
     {


### PR DESCRIPTION
## Summary

This PR fixes Windows Antigravity Desktop version detection for the 2.0+ switch path.

On Windows, `read_antigravity_windows_exe_metadata()` invokes PowerShell with an inline `-Command` script and appends the executable path afterward. The old script read the path from `$args[0]`, but with this invocation form the path can be appended to the final pipeline command instead of being exposed as `$args[0]`. As a result, `$p` becomes null/empty, VersionInfo detection returns `None`, and account switching can fail before reaching the existing Antigravity 2.0 system-credential injection path.

This addresses the user-facing failure:

```text
无法确认 Antigravity 安装版本，请确认已安装 Antigravity.app，或在设置中选择正确的 Antigravity 启动路径
```

## Changes

- Wrap the PowerShell snippet in an invocation block.
- Bind the executable path through `param([string]$p)` instead of reading `$args[0]`.
- Keep the fix scoped to the Windows VersionInfo detection code only.

## Validation

Verified on Windows with Antigravity Desktop 2.0.6 installed at:

```text
C:\Users\<user>\AppData\Local\Programs\Antigravity\Antigravity.exe
```

Before the fix, the old script leaves `$p` null/empty and `Test-Path -LiteralPath $p` fails.

After the fix, the same invocation pattern successfully reads VersionInfo:

```json
{"ProductName":"Antigravity","ProductVersion":"2.0.6.0","FileVersion":"2.0.6"}
```

Also ran:

```text
npm run typecheck
```

Result: passed.
