### PR TITLE
fix(dashboard): prioritize displayGroups over rawDisplayModels

### DIFF
--- a/src/presentation/platformAccountPresentation.ts
+++ b/src/presentation/platformAccountPresentation.ts
@@ -499,39 +499,32 @@ export function getAntigravityQuotaDisplayItems(
   account: Account,
   displayGroups: DisplayGroup[],
 ): AgQuotaDisplayItem[] {
+  if (displayGroups.length > 0) {
+    const quotas = getAgAccountQuotas(account);
+    const settings = buildAgDisplayGroupSettings(displayGroups);
+    const groupedItems: AgQuotaDisplayItem[] = [];
+
+    for (const group of displayGroups) {
+      const percentage = calculateGroupQuota(group.id, quotas, settings);
+      if (percentage === null) continue;
+
+      const resetTimestamp = getAntigravityGroupResetTimestamp(account, group);
+      groupedItems.push({
+        key: `group:${group.id}`,
+        label: group.name,
+        percentage,
+        resetTime: resetTimestamp ? new Date(resetTimestamp).toISOString() : "",
+      });
+    }
+
+    if (groupedItems.length > 0) {
+      return groupedItems;
+    }
+  }
+
   const rawDisplayModels = getDisplayModels(account.quota);
   if (rawDisplayModels.length === 0) {
     return [];
-  }
-
-  if (displayGroups.length === 0) {
-    return rawDisplayModels.map((model) => ({
-      key: model.name,
-      label: getModelShortName(model.name),
-      percentage: model.percentage,
-      resetTime: model.reset_time,
-    }));
-  }
-
-  const quotas = getAgAccountQuotas(account);
-  const settings = buildAgDisplayGroupSettings(displayGroups);
-  const groupedItems: AgQuotaDisplayItem[] = [];
-
-  for (const group of displayGroups) {
-    const percentage = calculateGroupQuota(group.id, quotas, settings);
-    if (percentage === null) continue;
-
-    const resetTimestamp = getAntigravityGroupResetTimestamp(account, group);
-    groupedItems.push({
-      key: `group:${group.id}`,
-      label: group.name,
-      percentage,
-      resetTime: resetTimestamp ? new Date(resetTimestamp).toISOString() : "",
-    });
-  }
-
-  if (groupedItems.length > 0) {
-    return groupedItems;
   }
 
   return rawDisplayModels.map((model) => ({


### PR DESCRIPTION
fix issue https://github.com/jlcodes99/cockpit-tools/issues/865


 

### 描述

**问题背景 (Context)**
在 Dashboard 界面的 AntiGravity 区块中，当账号的容量配额信息（Quota）只包含“非规范化模型”（Non-Canonical Models，例如底层的 `MODEL_PLACEHOLDER_M29`）时，会出现界面渲染为“暂无数据”的 Bug。但实际上该账号是正常的，且拥有有效配额。

**问题根因 (Root Cause)**
在 `src/presentation/platformAccountPresentation.ts` 文件中的 `getAntigravityQuotaDisplayItems` 函数中，存在逻辑执行优先级的缺陷。
原有的代码在最开始执行了以下拦截逻辑：
```typescript
const rawDisplayModels = getDisplayModels(account.quota);
if (rawDisplayModels.length === 0) {
  return []; // 提前退出了函数
}
```
由于 `getDisplayModels` 内部会严格过滤掉不在 `CANONICAL_MODELS` 列表中的模型，当账号只有非规范模型时，`rawDisplayModels` 为空数组。这就导致了代码直接返回 `[]`，从而完全跳过了下方原本可以正确识别并展示非规范模型的 `displayGroups`（如 Gemini Pro、Claude 分组）映射逻辑。

**修复方案 (Proposed Changes)**
- 调整了 `getAntigravityQuotaDisplayItems` 函数的执行顺序：
  - **优先执行分组逻辑**：现在代码会优先检查传入的 `displayGroups`，并基于 `group.models` 映射表计算 `percentage`，如果计算出 `groupedItems` 不为空，则直接返回。这完美兼容了非规范模型（因为分组配置的白名单原生支持非规范 ID）。
  - **后置兜底逻辑**：将 `rawDisplayModels.length === 0` 的判断和返回作为兜底逻辑移到了函数末尾，避免了早期的“误杀”。

 