### PR TITLE
feat: add account-level refresh interval overrides

### DIFF
--- a/src/hooks/useAutoRefresh.ts
+++ b/src/hooks/useAutoRefresh.ts
@@ -13,8 +13,19 @@ import { useWorkbuddyAccountStore } from '../stores/useWorkbuddyAccountStore';
 import { useQoderAccountStore } from '../stores/useQoderAccountStore';
 import { useTraeAccountStore } from '../stores/useTraeAccountStore';
 import { useZedAccountStore } from '../stores/useZedAccountStore';
+import { getGitHubCopilotAccountDisplayEmail } from '../types/githubCopilot';
+import { getWindsurfAccountDisplayEmail } from '../types/windsurf';
+import { getKiroAccountDisplayEmail } from '../types/kiro';
+import { getCursorAccountDisplayEmail } from '../types/cursor';
+import { getGeminiAccountDisplayEmail } from '../types/gemini';
+import { getCodebuddyAccountDisplayEmail } from '../types/codebuddy';
+import { getWorkbuddyAccountDisplayEmail } from '../types/workbuddy';
+import { getQoderAccountDisplayEmail } from '../types/qoder';
+import { getTraeAccountDisplayEmail } from '../types/trae';
+import { getZedAccountDisplayEmail } from '../types/zed';
 import {
   loadCurrentAccountRefreshMinutesMap,
+  getAccountRefreshMinutes,
   type CurrentAccountRefreshPlatform,
 } from '../utils/currentAccountRefresh';
 import {
@@ -101,6 +112,44 @@ function buildEnabledPlatformsSummary(
   return parts.join(', ');
 }
 
+function resolveCurrentMinutes(
+  platform: CurrentAccountRefreshPlatform,
+  email: string | null,
+  defaultMap: Record<CurrentAccountRefreshPlatform, number>,
+): number {
+  return email
+    ? getAccountRefreshMinutes(platform, email, defaultMap[platform])
+    : defaultMap[platform];
+}
+
+function getCurrentAccountEmails(): Record<CurrentAccountRefreshPlatform, string | null> {
+  const getProviderEmail = <T extends { id: string; email?: string | null }>(
+    store: { getState: () => { currentAccountId: string | null; accounts: T[] } },
+    getDisplayEmail: (account: T) => string,
+  ): string | null => {
+    const state = store.getState();
+    const account = state.accounts.find((a) => a.id === state.currentAccountId);
+    if (!account) return null;
+    return account.email ?? getDisplayEmail(account);
+  };
+
+  return {
+    antigravity: useAccountStore.getState().currentAccount?.email ?? null,
+    codex: useCodexAccountStore.getState().currentAccount?.email ?? null,
+    ghcp: getProviderEmail(useGitHubCopilotAccountStore, getGitHubCopilotAccountDisplayEmail),
+    windsurf: getProviderEmail(useWindsurfAccountStore, getWindsurfAccountDisplayEmail),
+    kiro: getProviderEmail(useKiroAccountStore, getKiroAccountDisplayEmail),
+    cursor: getProviderEmail(useCursorAccountStore, getCursorAccountDisplayEmail),
+    gemini: getProviderEmail(useGeminiAccountStore, getGeminiAccountDisplayEmail),
+    codebuddy: getProviderEmail(useCodebuddyAccountStore, getCodebuddyAccountDisplayEmail),
+    codebuddy_cn: getProviderEmail(useCodebuddyCnAccountStore, getCodebuddyAccountDisplayEmail),
+    workbuddy: getProviderEmail(useWorkbuddyAccountStore, getWorkbuddyAccountDisplayEmail),
+    qoder: getProviderEmail(useQoderAccountStore, getQoderAccountDisplayEmail),
+    trae: getProviderEmail(useTraeAccountStore, getTraeAccountDisplayEmail),
+    zed: getProviderEmail(useZedAccountStore, getZedAccountDisplayEmail),
+  };
+}
+
 export function useAutoRefresh() {
   const refreshAllQuotas = useAccountStore((state) => state.refreshAllQuotas);
   const fetchAccounts = useAccountStore((state) => state.fetchAccounts);
@@ -143,8 +192,8 @@ export function useAutoRefresh() {
   const fetchCurrentZedAccountId = useZedAccountStore((state) => state.fetchCurrentAccountId);
   const refreshZedToken = useZedAccountStore((state) => state.refreshToken);
 
-  const agRefreshingRef = useRef(false);
-  const agCurrentRefreshingRef = useRef(false);
+  const antigravityRefreshingRef = useRef(false);
+  const antigravityCurrentRefreshingRef = useRef(false);
   const codexRefreshingRef = useRef(false);
   const codexCurrentRefreshingRef = useRef(false);
   const ghcpRefreshingRef = useRef(false);
@@ -322,6 +371,7 @@ export function useAutoRefresh() {
           stopScheduler();
 
           const currentRefreshMinutesMap = loadCurrentAccountRefreshMinutesMap();
+          const currentAccountEmails = getCurrentAccountEmails();
           const runProviderCurrentRefresh = async (
             fetchCurrentProviderAccountId: () => Promise<string | null>,
             refreshProviderToken: (accountId: string) => Promise<void>,
@@ -338,9 +388,9 @@ export function useAutoRefresh() {
               key: 'antigravity',
               label: 'Antigravity IDE',
               intervalMinutes: config.auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.antigravity,
-              fullRefreshingRef: agRefreshingRef,
-              currentRefreshingRef: agCurrentRefreshingRef,
+              currentMinutes: resolveCurrentMinutes('antigravity', currentAccountEmails.antigravity, currentRefreshMinutesMap),
+              fullRefreshingRef: antigravityRefreshingRef,
+              currentRefreshingRef: antigravityCurrentRefreshingRef,
               runFullRefresh: async () => {
                 await refreshAllQuotas();
               },
@@ -360,7 +410,7 @@ export function useAutoRefresh() {
               key: 'codex',
               label: 'Codex',
               intervalMinutes: config.codex_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.codex,
+              currentMinutes: resolveCurrentMinutes('codex', currentAccountEmails.codex, currentRefreshMinutesMap),
               fullRefreshingRef: codexRefreshingRef,
               currentRefreshingRef: codexCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -382,7 +432,7 @@ export function useAutoRefresh() {
               key: 'ghcp',
               label: 'GitHub Copilot',
               intervalMinutes: config.ghcp_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.ghcp,
+              currentMinutes: resolveCurrentMinutes('ghcp', currentAccountEmails.ghcp, currentRefreshMinutesMap),
               fullRefreshingRef: ghcpRefreshingRef,
               currentRefreshingRef: ghcpCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -396,7 +446,7 @@ export function useAutoRefresh() {
               key: 'windsurf',
               label: 'Windsurf',
               intervalMinutes: config.windsurf_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.windsurf,
+              currentMinutes: resolveCurrentMinutes('windsurf', currentAccountEmails.windsurf, currentRefreshMinutesMap),
               fullRefreshingRef: windsurfRefreshingRef,
               currentRefreshingRef: windsurfCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -413,7 +463,7 @@ export function useAutoRefresh() {
               key: 'kiro',
               label: 'Kiro',
               intervalMinutes: config.kiro_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.kiro,
+              currentMinutes: resolveCurrentMinutes('kiro', currentAccountEmails.kiro, currentRefreshMinutesMap),
               fullRefreshingRef: kiroRefreshingRef,
               currentRefreshingRef: kiroCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -427,7 +477,7 @@ export function useAutoRefresh() {
               key: 'cursor',
               label: 'Cursor',
               intervalMinutes: config.cursor_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.cursor,
+              currentMinutes: resolveCurrentMinutes('cursor', currentAccountEmails.cursor, currentRefreshMinutesMap),
               fullRefreshingRef: cursorRefreshingRef,
               currentRefreshingRef: cursorCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -441,7 +491,7 @@ export function useAutoRefresh() {
               key: 'gemini',
               label: 'Gemini',
               intervalMinutes: config.gemini_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.gemini,
+              currentMinutes: resolveCurrentMinutes('gemini', currentAccountEmails.gemini, currentRefreshMinutesMap),
               fullRefreshingRef: geminiRefreshingRef,
               currentRefreshingRef: geminiCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -455,7 +505,7 @@ export function useAutoRefresh() {
               key: 'codebuddy',
               label: 'CodeBuddy',
               intervalMinutes: config.codebuddy_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.codebuddy,
+              currentMinutes: resolveCurrentMinutes('codebuddy', currentAccountEmails.codebuddy, currentRefreshMinutesMap),
               fullRefreshingRef: codebuddyRefreshingRef,
               currentRefreshingRef: codebuddyCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -472,7 +522,7 @@ export function useAutoRefresh() {
               key: 'codebuddy_cn',
               label: 'CodeBuddy CN',
               intervalMinutes: config.codebuddy_cn_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.codebuddy_cn,
+              currentMinutes: resolveCurrentMinutes('codebuddy_cn', currentAccountEmails.codebuddy_cn, currentRefreshMinutesMap),
               fullRefreshingRef: codebuddyCnRefreshingRef,
               currentRefreshingRef: codebuddyCnCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -489,7 +539,7 @@ export function useAutoRefresh() {
               key: 'workbuddy',
               label: 'WorkBuddy',
               intervalMinutes: config.workbuddy_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.workbuddy,
+              currentMinutes: resolveCurrentMinutes('workbuddy', currentAccountEmails.workbuddy, currentRefreshMinutesMap),
               fullRefreshingRef: workbuddyRefreshingRef,
               currentRefreshingRef: workbuddyCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -506,7 +556,7 @@ export function useAutoRefresh() {
               key: 'qoder',
               label: 'Qoder',
               intervalMinutes: config.qoder_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.qoder,
+              currentMinutes: resolveCurrentMinutes('qoder', currentAccountEmails.qoder, currentRefreshMinutesMap),
               fullRefreshingRef: qoderRefreshingRef,
               currentRefreshingRef: qoderCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -520,7 +570,7 @@ export function useAutoRefresh() {
               key: 'trae',
               label: 'Trae',
               intervalMinutes: config.trae_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.trae,
+              currentMinutes: resolveCurrentMinutes('trae', currentAccountEmails.trae, currentRefreshMinutesMap),
               fullRefreshingRef: traeRefreshingRef,
               currentRefreshingRef: traeCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -534,7 +584,7 @@ export function useAutoRefresh() {
               key: 'zed',
               label: 'Zed',
               intervalMinutes: config.zed_auto_refresh_minutes,
-              currentMinutes: currentRefreshMinutesMap.zed,
+              currentMinutes: resolveCurrentMinutes('zed', currentAccountEmails.zed, currentRefreshMinutesMap),
               fullRefreshingRef: zedRefreshingRef,
               currentRefreshingRef: zedCurrentRefreshingRef,
               runFullRefresh: async () => {
@@ -566,7 +616,7 @@ export function useAutoRefresh() {
               console.log(`[AutoRefresh] ${descriptor.label} 已禁用`);
             }
 
-            if (descriptor.intervalMinutes > 0) {
+            if (descriptor.intervalMinutes > 0 && descriptor.currentMinutes > 0) {
               console.log(`[AutoRefresh] ${descriptor.label} 当前账号刷新: 每 ${descriptor.currentMinutes} 分钟`);
               tasks.push({
                 key: `current:${descriptor.key}`,
@@ -582,7 +632,7 @@ export function useAutoRefresh() {
                   ),
               });
             } else {
-              console.log(`[AutoRefresh] ${descriptor.label} 当前账号刷新已禁用（配额自动刷新未开启）`);
+              console.log(`[AutoRefresh] ${descriptor.label} 当前账号刷新已禁用${descriptor.currentMinutes === -1 ? '（账号级覆盖禁用）' : '（配额自动刷新未开启）'}`);
             }
           }
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -44,7 +44,32 @@ import {
   type CurrentAccountRefreshPlatform,
   loadCurrentAccountRefreshMinutesMap,
   saveCurrentAccountRefreshMinutesMap,
+  loadAccountRefreshOverrides,
+  setAccountRefreshMinutes,
+  removeAccountRefreshOverride,
+  type AccountRefreshOverrides,
 } from '../utils/currentAccountRefresh';
+import { useGitHubCopilotAccountStore } from '../stores/useGitHubCopilotAccountStore';
+import { useWindsurfAccountStore } from '../stores/useWindsurfAccountStore';
+import { useKiroAccountStore } from '../stores/useKiroAccountStore';
+import { useCursorAccountStore } from '../stores/useCursorAccountStore';
+import { useGeminiAccountStore } from '../stores/useGeminiAccountStore';
+import { useCodebuddyAccountStore } from '../stores/useCodebuddyAccountStore';
+import { useCodebuddyCnAccountStore } from '../stores/useCodebuddyCnAccountStore';
+import { useWorkbuddyAccountStore } from '../stores/useWorkbuddyAccountStore';
+import { useQoderAccountStore } from '../stores/useQoderAccountStore';
+import { useTraeAccountStore } from '../stores/useTraeAccountStore';
+import { useZedAccountStore } from '../stores/useZedAccountStore';
+import { getGitHubCopilotAccountDisplayEmail } from '../types/githubCopilot';
+import { getWindsurfAccountDisplayEmail } from '../types/windsurf';
+import { getKiroAccountDisplayEmail } from '../types/kiro';
+import { getCursorAccountDisplayEmail } from '../types/cursor';
+import { getGeminiAccountDisplayEmail } from '../types/gemini';
+import { getCodebuddyAccountDisplayEmail } from '../types/codebuddy';
+import { getWorkbuddyAccountDisplayEmail } from '../types/workbuddy';
+import { getQoderAccountDisplayEmail } from '../types/qoder';
+import { getTraeAccountDisplayEmail } from '../types/trae';
+import { getZedAccountDisplayEmail } from '../types/zed';
 import { ALL_PLATFORM_IDS, PlatformId } from '../types/platform';
 import { SettingsAccountTransferSection } from '../components/SettingsAccountTransferSection';
 import { useEscClose } from '../hooks/useEscClose';
@@ -377,6 +402,9 @@ export function SettingsPage() {
   const [currentAccountRefreshCustomMode, setCurrentAccountRefreshCustomMode] = useState<
     Record<CurrentAccountRefreshPlatform, boolean>
   >(() => buildDefaultCurrentAccountRefreshCustomModeMap());
+  const [accountOverrides, setAccountOverrides] = useState<AccountRefreshOverrides>(
+    loadAccountRefreshOverrides(),
+  );
   const [codebuddyQuotaAlertEnabled, setCodebuddyQuotaAlertEnabled] = useState(false);
   const [codebuddyQuotaAlertThreshold, setCodebuddyQuotaAlertThreshold] = useState('20');
   const [codebuddyCnQuotaAlertEnabled, setCodebuddyCnQuotaAlertEnabled] = useState(false);
@@ -1652,6 +1680,147 @@ export function SettingsPage() {
     );
   };
 
+  const getAccountsForPlatform = (
+    platform: CurrentAccountRefreshPlatform,
+  ): Array<{ id: string; email: string }> => {
+    const getProviderAccounts = <T extends { id: string; email?: string | null }>(
+      store: { getState: () => { accounts: T[] } },
+      getDisplayEmail: (account: T) => string,
+    ): Array<{ id: string; email: string }> =>
+      store.getState().accounts.map((a) => ({
+        id: a.id,
+        email: a.email ?? getDisplayEmail(a),
+      }));
+
+    switch (platform) {
+      case 'antigravity':
+        return antigravityAccounts.map((a) => ({ id: a.id, email: a.email }));
+      case 'codex':
+        return codexAccounts.map((a) => ({ id: a.id, email: a.email }));
+      case 'ghcp':
+        return getProviderAccounts(useGitHubCopilotAccountStore, getGitHubCopilotAccountDisplayEmail);
+      case 'windsurf':
+        return getProviderAccounts(useWindsurfAccountStore, getWindsurfAccountDisplayEmail);
+      case 'kiro':
+        return getProviderAccounts(useKiroAccountStore, getKiroAccountDisplayEmail);
+      case 'cursor':
+        return getProviderAccounts(useCursorAccountStore, getCursorAccountDisplayEmail);
+      case 'gemini':
+        return getProviderAccounts(useGeminiAccountStore, getGeminiAccountDisplayEmail);
+      case 'codebuddy':
+        return getProviderAccounts(useCodebuddyAccountStore, getCodebuddyAccountDisplayEmail);
+      case 'codebuddy_cn':
+        return getProviderAccounts(useCodebuddyCnAccountStore, getCodebuddyAccountDisplayEmail);
+      case 'workbuddy':
+        return getProviderAccounts(useWorkbuddyAccountStore, getWorkbuddyAccountDisplayEmail);
+      case 'qoder':
+        return getProviderAccounts(useQoderAccountStore, getQoderAccountDisplayEmail);
+      case 'trae':
+        return getProviderAccounts(useTraeAccountStore, getTraeAccountDisplayEmail);
+      case 'zed':
+        return getProviderAccounts(useZedAccountStore, getZedAccountDisplayEmail);
+      default:
+        return [];
+    }
+  };
+
+  const handleAccountOverrideChange = (
+    platform: CurrentAccountRefreshPlatform,
+    email: string,
+    value: string,
+  ) => {
+    if (value === 'inherit') {
+      removeAccountRefreshOverride(platform, email);
+    } else {
+      setAccountRefreshMinutes(platform, email, Number(value));
+    }
+    setAccountOverrides(loadAccountRefreshOverrides());
+  };
+
+  const renderAccountLevelRefreshConfig = (platform: CurrentAccountRefreshPlatform) => {
+    const accounts = getAccountsForPlatform(platform);
+    if (accounts.length === 0) {
+      return null;
+    }
+
+    const platformOverrides = accountOverrides[platform] ?? {};
+    const hasAnyOverride = Object.keys(platformOverrides).length > 0;
+
+    return (
+      <div className="settings-row">
+        <div className="row-label">
+          <div className="row-title">
+            {t('settings.general.accountLevelRefreshTitle', '账号级刷新配置')}
+          </div>
+          <div className="row-desc">
+            {t(
+              'settings.general.accountLevelRefreshDesc',
+              '为不同账号设置不同的自动刷新间隔，覆盖平台级默认值。',
+            )}
+          </div>
+        </div>
+        <div className="row-control">
+          <details>
+            <summary style={{ cursor: 'pointer', fontSize: '13px', color: 'var(--text-secondary)' }}>
+              {hasAnyOverride
+                ? t('settings.general.accountLevelRefreshSummaryActive', '已配置 {{count}} 个账号', {
+                    count: Object.keys(platformOverrides).length,
+                  })
+                : t('settings.general.accountLevelRefreshSummary', '展开配置')}
+            </summary>
+            <div style={{ marginTop: '8px', display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              {accounts.map((account) => {
+                const overrideValue = platformOverrides[account.email];
+                const selectValue = overrideValue !== undefined ? String(overrideValue) : 'inherit';
+                return (
+                  <div
+                    key={account.id}
+                    style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
+                  >
+                    <span
+                      style={{
+                        flex: 1,
+                        fontSize: '13px',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                      title={account.email}
+                    >
+                      {account.email}
+                    </span>
+                    <select
+                      className="settings-select"
+                      style={{ minWidth: '100px', width: 'auto', fontSize: '12px' }}
+                      value={selectValue}
+                      onChange={(e) =>
+                        handleAccountOverrideChange(platform, account.email, e.target.value)
+                      }
+                    >
+                      <option value="inherit">
+                        {t('settings.general.accountLevelRefreshInherit', '继承平台设置')}
+                      </option>
+                      <option value="-1">
+                        {t('settings.general.accountLevelRefreshDisabled', '禁用')}
+                      </option>
+                      <option value="1">1 {t('settings.general.minutes')}</option>
+                      <option value="2">2 {t('settings.general.minutes')}</option>
+                      <option value="5">5 {t('settings.general.minutes')}</option>
+                      <option value="10">10 {t('settings.general.minutes')}</option>
+                      <option value="15">15 {t('settings.general.minutes')}</option>
+                      <option value="30">30 {t('settings.general.minutes')}</option>
+                      <option value="60">60 {t('settings.general.minutes')}</option>
+                    </select>
+                  </div>
+                );
+              })}
+            </div>
+          </details>
+        </div>
+      </div>
+    );
+  };
+
   const autoRefreshIsPreset = REFRESH_PRESET_VALUES.includes(autoRefresh);
   const codexAutoRefreshIsPreset = REFRESH_PRESET_VALUES.includes(codexAutoRefresh);
   const ghcpAutoRefreshIsPreset = REFRESH_PRESET_VALUES.includes(ghcpAutoRefresh);
@@ -2211,6 +2380,7 @@ export function SettingsPage() {
               </div>
 
               {renderCurrentAccountRefreshRow('antigravity')}
+              {renderAccountLevelRefreshConfig('antigravity')}
 
               <div className="settings-row">
                 <div className="row-label">
@@ -2643,6 +2813,7 @@ export function SettingsPage() {
               </div>
 
               {renderCurrentAccountRefreshRow('codex')}
+              {renderAccountLevelRefreshConfig('codex')}
 
               <div className="settings-row">
                 <div className="row-label">
@@ -3033,6 +3204,7 @@ export function SettingsPage() {
               </div>
 
               {renderCurrentAccountRefreshRow('ghcp')}
+              {renderAccountLevelRefreshConfig('ghcp')}
 
               <div className="settings-row">
                 <div className="row-label">
@@ -3220,6 +3392,7 @@ export function SettingsPage() {
               </div>
 
               {renderCurrentAccountRefreshRow('windsurf')}
+              {renderAccountLevelRefreshConfig('windsurf')}
 
               <div className="settings-row">
                 <div className="row-label">
@@ -3407,6 +3580,7 @@ export function SettingsPage() {
               </div>
 
               {renderCurrentAccountRefreshRow('kiro')}
+              {renderAccountLevelRefreshConfig('kiro')}
 
               <div className="settings-row">
                 <div className="row-label">
@@ -3595,6 +3769,7 @@ export function SettingsPage() {
               </div>
 
               {renderCurrentAccountRefreshRow('codebuddy')}
+              {renderAccountLevelRefreshConfig('codebuddy')}
 
               <div className="settings-row">
                 <div className="row-label">
@@ -3785,6 +3960,7 @@ export function SettingsPage() {
                   </div>
 
                   {renderCurrentAccountRefreshRow('codebuddy_cn')}
+                  {renderAccountLevelRefreshConfig('codebuddy_cn')}
 
                   <div className="settings-row">
                     <div className="row-label">
@@ -3975,6 +4151,7 @@ export function SettingsPage() {
                   </div>
 
                   {renderCurrentAccountRefreshRow('qoder')}
+                  {renderAccountLevelRefreshConfig('qoder')}
 
                   <div className="settings-row">
                     <div className="row-label">
@@ -4165,6 +4342,7 @@ export function SettingsPage() {
                   </div>
 
                   {renderCurrentAccountRefreshRow('trae')}
+                  {renderAccountLevelRefreshConfig('trae')}
 
                   <div className="settings-row">
                     <div className="row-label">
@@ -4355,6 +4533,7 @@ export function SettingsPage() {
                   </div>
 
                   {renderCurrentAccountRefreshRow('workbuddy')}
+                  {renderAccountLevelRefreshConfig('workbuddy')}
 
                   <div className="settings-row">
                     <div className="row-label">
@@ -4543,6 +4722,7 @@ export function SettingsPage() {
                   </div>
 
                   {renderCurrentAccountRefreshRow('zed')}
+                  {renderAccountLevelRefreshConfig('zed')}
 
                   <div className="settings-row">
                     <div className="row-label">
@@ -4729,6 +4909,7 @@ export function SettingsPage() {
               </div>
 
               {renderCurrentAccountRefreshRow('cursor')}
+              {renderAccountLevelRefreshConfig('cursor')}
 
               <div className="settings-row">
                 <div className="row-label">
@@ -4934,6 +5115,7 @@ export function SettingsPage() {
                   )}
 
                   {renderCurrentAccountRefreshRow('gemini')}
+                  {renderAccountLevelRefreshConfig('gemini')}
 
                   <div className="settings-row">
                     <div className="row-label">

--- a/src/utils/currentAccountRefresh.ts
+++ b/src/utils/currentAccountRefresh.ts
@@ -108,3 +108,75 @@ export function saveCurrentAccountRefreshMinutesMap(
   }
   return normalized;
 }
+
+export const ACCOUNT_REFRESH_OVERRIDES_KEY = 'agtools.account_refresh_overrides.v1';
+
+export type AccountRefreshOverrides = Partial<Record<CurrentAccountRefreshPlatform, Record<string, number>>>;
+
+export function loadAccountRefreshOverrides(): AccountRefreshOverrides {
+  try {
+    const raw = localStorage.getItem(ACCOUNT_REFRESH_OVERRIDES_KEY);
+    if (!raw) {
+      return {};
+    }
+    return JSON.parse(raw) as AccountRefreshOverrides;
+  } catch {
+    return {};
+  }
+}
+
+export function saveAccountRefreshOverrides(overrides: AccountRefreshOverrides): void {
+  try {
+    localStorage.setItem(ACCOUNT_REFRESH_OVERRIDES_KEY, JSON.stringify(overrides));
+  } catch {
+    // 忽略持久化失败
+  }
+}
+
+export function getAccountRefreshMinutes(
+  platform: CurrentAccountRefreshPlatform,
+  email: string,
+  platformDefault: number,
+): number {
+  const overrides = loadAccountRefreshOverrides();
+  const platformOverrides = overrides[platform];
+  if (platformOverrides && email in platformOverrides) {
+    const value = platformOverrides[email];
+    if (value === -1) return -1;
+    return sanitizeCurrentAccountRefreshMinutes(value);
+  }
+  return platformDefault;
+}
+
+export function setAccountRefreshMinutes(
+  platform: CurrentAccountRefreshPlatform,
+  email: string,
+  minutes: number,
+): void {
+  // 验证输入：-1 表示禁用，其他值需要在有效范围内
+  if (minutes !== -1) {
+    if (!Number.isFinite(minutes) || minutes < MIN_CURRENT_ACCOUNT_REFRESH_MINUTES || minutes > MAX_CURRENT_ACCOUNT_REFRESH_MINUTES) {
+      return;
+    }
+  }
+  const overrides = loadAccountRefreshOverrides();
+  if (!overrides[platform]) {
+    overrides[platform] = {};
+  }
+  overrides[platform][email] = minutes;
+  saveAccountRefreshOverrides(overrides);
+}
+
+export function removeAccountRefreshOverride(
+  platform: CurrentAccountRefreshPlatform,
+  email: string,
+): void {
+  const overrides = loadAccountRefreshOverrides();
+  if (overrides[platform] && email in overrides[platform]) {
+    delete overrides[platform][email];
+    if (Object.keys(overrides[platform]).length === 0) {
+      delete overrides[platform];
+    }
+    saveAccountRefreshOverrides(overrides);
+  }
+}


### PR DESCRIPTION
## Summary

Allow per-account refresh interval configuration that overrides the platform-level default. Each account can now have its own refresh interval or be disabled independently.

### Changes

- **AccountRefreshOverrides type** (`src/utils/currentAccountRefresh.ts`): Added localStorage-backed per-account refresh configuration with `-1` to disable
- **useAutoRefresh hook** (`src/hooks/useAutoRefresh.ts`): Added `resolveCurrentMinutes` helper to eliminate repeated ternary patterns; fixed guard to handle disabled accounts
- **Settings UI** (`src/pages/SettingsPage.tsx`): Added collapsible account-level config section for all 13 platforms

### Behavior

- Account override > Platform default > Global default (1 minute)
- `-1` disables auto-refresh for that specific account
- Inherits platform setting when no override is set

### Test plan

- [ ] Verify account-level overrides persist in localStorage
- [ ] Verify `-1` correctly disables current-account refresh
- [ ] Verify settings UI shows correct inheritance state