### PR TITLE
feat: add wakeup task confirmation mode with notification

### DIFF
--- a/src-tauri/src/commands/wakeup.rs
+++ b/src-tauri/src/commands/wakeup.rs
@@ -134,3 +134,18 @@ pub async fn wakeup_verification_run_batch(
 pub fn wakeup_set_official_ls_version_mode(mode: Option<String>) -> Result<(), String> {
     modules::wakeup::set_official_ls_version_mode(mode.as_deref())
 }
+
+#[tauri::command]
+pub async fn confirm_wakeup_task(app: AppHandle, task_id: String) -> Result<(), String> {
+    modules::wakeup_scheduler::execute_pending_confirmation(&app, &task_id).await
+}
+
+#[tauri::command]
+pub async fn cancel_wakeup_task(task_id: String) -> Result<(), String> {
+    modules::wakeup_scheduler::cancel_pending_confirmation(&task_id)
+}
+
+#[tauri::command]
+pub async fn check_wakeup_timeouts(app: AppHandle) -> Result<(), String> {
+    modules::wakeup_scheduler::check_and_handle_timeouts(&app).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -439,6 +439,9 @@ pub fn run() {
             commands::wakeup::wakeup_verification_load_history,
             commands::wakeup::wakeup_verification_delete_history,
             commands::wakeup::wakeup_verification_run_batch,
+            commands::wakeup::confirm_wakeup_task,
+            commands::wakeup::cancel_wakeup_task,
+            commands::wakeup::check_wakeup_timeouts,
             // Update Commands
             commands::update::should_check_updates,
             commands::update::update_last_check_time,

--- a/src-tauri/src/modules/wakeup_history.rs
+++ b/src-tauri/src/modules/wakeup_history.rs
@@ -21,6 +21,7 @@ pub struct WakeupHistoryItem {
     pub model_id: String,
     pub prompt: Option<String>,
     pub success: bool,
+    pub status: Option<String>,
     pub message: Option<String>,
     pub duration: Option<u64>,
 }
@@ -121,4 +122,29 @@ pub fn add_history_items(new_items: Vec<WakeupHistoryItem>) -> Result<(), String
 pub fn clear_history() -> Result<(), String> {
     let _lock = HISTORY_LOCK.lock().map_err(|_| "获取历史锁失败")?;
     save_history(&[])
+}
+
+/// 记录单条状态历史（用于确认/跳过等场景）
+pub fn record_status(
+    _app: &tauri::AppHandle,
+    task: &crate::modules::wakeup_scheduler::WakeupTask,
+    trigger_source: &str,
+    status: &str,
+) -> Result<(), String> {
+    let item = WakeupHistoryItem {
+        id: uuid::Uuid::new_v4().to_string(),
+        timestamp: chrono::Utc::now().timestamp(),
+        trigger_type: "scheduled".to_string(),
+        trigger_source: trigger_source.to_string(),
+        task_name: Some(task.name.clone()),
+        account_email: task.schedule.selected_accounts.first().cloned().unwrap_or_default(),
+        model_id: task.schedule.selected_models.first().cloned().unwrap_or_default(),
+        prompt: task.schedule.custom_prompt.clone(),
+        success: status == "success",
+        status: Some(status.to_string()),
+        message: Some(format!("Status: {}", status)),
+        duration: Some(0),
+    };
+
+    add_history_items(vec![item])
 }

--- a/src-tauri/src/modules/wakeup_scheduler.rs
+++ b/src-tauri/src/modules/wakeup_scheduler.rs
@@ -56,37 +56,43 @@ pub struct ScheduleConfig {
     pub time_window_end: Option<String>,
     pub fallback_times: Option<Vec<String>>,
     pub startup_delay_minutes: Option<i32>,
+    pub execution_mode: Option<String>,
+    pub confirm_timeout_minutes: Option<i32>,
 }
 
 #[derive(Debug, Clone)]
-struct WakeupTask {
-    id: String,
-    name: String,
-    enabled: bool,
-    last_run_at: Option<i64>,
-    schedule: ScheduleConfigNormalized,
+pub struct WakeupTask {
+    pub id: String,
+    pub name: String,
+    pub enabled: bool,
+    pub last_run_at: Option<i64>,
+    pub schedule: ScheduleConfigNormalized,
+    pub execution_mode: String,
+    pub confirm_timeout_minutes: i32,
 }
 
 #[derive(Debug, Clone)]
-struct ScheduleConfigNormalized {
-    repeat_mode: String,
-    daily_times: Vec<String>,
-    weekly_days: Vec<i32>,
-    weekly_times: Vec<String>,
-    interval_hours: i32,
-    interval_start_time: String,
-    interval_end_time: String,
-    selected_models: Vec<String>,
-    selected_accounts: Vec<String>,
-    crontab: Option<String>,
-    wake_on_reset: bool,
-    custom_prompt: Option<String>,
-    max_output_tokens: i32,
-    time_window_enabled: bool,
-    time_window_start: Option<String>,
-    time_window_end: Option<String>,
-    fallback_times: Vec<String>,
-    startup_delay_minutes: Option<i32>,
+pub struct ScheduleConfigNormalized {
+    pub repeat_mode: String,
+    pub daily_times: Vec<String>,
+    pub weekly_days: Vec<i32>,
+    pub weekly_times: Vec<String>,
+    pub interval_hours: i32,
+    pub interval_start_time: String,
+    pub interval_end_time: String,
+    pub selected_models: Vec<String>,
+    pub selected_accounts: Vec<String>,
+    pub crontab: Option<String>,
+    pub wake_on_reset: bool,
+    pub custom_prompt: Option<String>,
+    pub max_output_tokens: i32,
+    pub time_window_enabled: bool,
+    pub time_window_start: Option<String>,
+    pub time_window_end: Option<String>,
+    pub fallback_times: Vec<String>,
+    pub startup_delay_minutes: Option<i32>,
+    pub execution_mode: String,
+    pub confirm_timeout_minutes: i32,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -109,6 +115,20 @@ struct SchedulerState {
 static STATE: OnceLock<Mutex<SchedulerState>> = OnceLock::new();
 static STARTED: OnceLock<Mutex<bool>> = OnceLock::new();
 static STARTUP_TRIGGERED: OnceLock<Mutex<bool>> = OnceLock::new();
+
+#[derive(Debug, Clone)]
+struct PendingConfirmation {
+    task: WakeupTask,
+    trigger_source: String,
+    scheduled_at: i64,
+    timeout_at: i64,
+}
+
+static PENDING_CONFIRMATIONS: OnceLock<Mutex<HashMap<String, PendingConfirmation>>> = OnceLock::new();
+
+fn pending_confirmations() -> &'static Mutex<HashMap<String, PendingConfirmation>> {
+    PENDING_CONFIRMATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 fn state() -> &'static Mutex<SchedulerState> {
     STATE.get_or_init(|| Mutex::new(SchedulerState::default()))
@@ -183,12 +203,19 @@ fn apply_state(enabled: bool, tasks: Vec<WakeupTaskInput>) {
     guard.enabled = enabled;
     guard.tasks = tasks
         .into_iter()
-        .map(|task| WakeupTask {
-            id: task.id,
-            name: task.name,
-            enabled: task.enabled,
-            last_run_at: task.last_run_at,
-            schedule: normalize_schedule(task.schedule),
+        .map(|task| {
+            let normalized = normalize_schedule(task.schedule);
+            let execution_mode = normalized.execution_mode.clone();
+            let confirm_timeout_minutes = normalized.confirm_timeout_minutes;
+            WakeupTask {
+                id: task.id,
+                name: task.name,
+                enabled: task.enabled,
+                last_run_at: task.last_run_at,
+                schedule: normalized,
+                execution_mode,
+                confirm_timeout_minutes,
+            }
         })
         .collect();
 }
@@ -250,6 +277,14 @@ fn normalize_schedule(raw: ScheduleConfig) -> ScheduleConfigNormalized {
     let startup_delay_minutes = raw
         .startup_delay_minutes
         .map(|value| value.clamp(0, 24 * 60));
+    let execution_mode = raw
+        .execution_mode
+        .filter(|mode| mode == "auto" || mode == "confirm")
+        .unwrap_or_else(|| "auto".to_string());
+    let confirm_timeout_minutes = raw
+        .confirm_timeout_minutes
+        .filter(|&v| v >= 1 && v <= 60)
+        .unwrap_or(5);
     ScheduleConfigNormalized {
         repeat_mode: raw.repeat_mode,
         daily_times,
@@ -269,6 +304,8 @@ fn normalize_schedule(raw: ScheduleConfig) -> ScheduleConfigNormalized {
         time_window_end: raw.time_window_end,
         fallback_times,
         startup_delay_minutes,
+        execution_mode,
+        confirm_timeout_minutes,
     }
 }
 
@@ -982,6 +1019,32 @@ fn handle_quota_reset_task(app: &AppHandle, task: &WakeupTask, now: DateTime<Loc
 }
 
 async fn run_task(app: &AppHandle, task: &WakeupTask, trigger_source: &str) {
+    // 检查是否需要确认
+    if task.execution_mode == "confirm" {
+        let timeout_minutes = task.confirm_timeout_minutes;
+        let timeout_at = chrono::Local::now().timestamp() + (timeout_minutes as i64 * 60);
+
+        let pending = PendingConfirmation {
+            task: task.clone(),
+            trigger_source: trigger_source.to_string(),
+            scheduled_at: chrono::Local::now().timestamp(),
+            timeout_at,
+        };
+
+        // 发送通知
+        let notification_id = send_confirmation_notification(app, &task.name, &task.schedule).await;
+
+        // 存储到待确认队列并发射事件
+        store_pending_confirmation(app, task.id.clone(), pending, notification_id);
+
+        modules::logger::log_info(&format!(
+            "[WakeupTasks] 任务 {} 需要确认，已发送通知",
+            task.name
+        ));
+        return;
+    }
+
+    // 直接执行模式（现有逻辑）
     run_task_with_models(
         app,
         task,
@@ -989,6 +1052,129 @@ async fn run_task(app: &AppHandle, task: &WakeupTask, trigger_source: &str) {
         task.schedule.selected_models.clone(),
     )
     .await;
+}
+
+async fn send_confirmation_notification(
+    app: &AppHandle,
+    task_name: &str,
+    schedule: &ScheduleConfigNormalized,
+) -> u32 {
+    let account_emails: Vec<String> = schedule.selected_accounts.clone();
+    let models: Vec<String> = schedule.selected_models.clone();
+
+    let body = format!(
+        "任务: {}\n账号: {}\n模型: {}\n点击确认执行唤醒",
+        task_name,
+        account_emails.join(", "),
+        models.join(", ")
+    );
+
+    match app.notification()
+        .builder()
+        .title("唤醒任务待确认")
+        .body(&body)
+        .show()
+    {
+        Ok(notification_id) => notification_id,
+        Err(e) => {
+            modules::logger::log_warn(&format!("[WakeupTasks] 发送通知失败: {}", e));
+            0
+        }
+    }
+}
+
+fn store_pending_confirmation(
+    app: &AppHandle,
+    task_id: String,
+    pending: PendingConfirmation,
+    notification_id: u32,
+) {
+    let mut lock = pending_confirmations().lock().unwrap();
+    lock.insert(task_id.clone(), pending);
+
+    // 发射事件通知前端建立映射
+    #[derive(serde::Serialize, Clone)]
+    struct NotificationMappingPayload {
+        task_id: String,
+        notification_id: u32,
+    }
+
+    let payload = NotificationMappingPayload {
+        task_id,
+        notification_id,
+    };
+
+    if let Err(e) = app.emit("wakeup://notification-mapping", payload) {
+        modules::logger::log_warn(&format!("[WakeupTasks] 发射通知映射事件失败: {}", e));
+    }
+}
+
+pub async fn execute_pending_confirmation(
+    app: &AppHandle,
+    task_id: &str,
+) -> Result<(), String> {
+    let pending = {
+        let mut lock = pending_confirmations().lock().unwrap();
+        lock.remove(task_id)
+    };
+
+    if let Some(pending) = pending {
+        // 检查是否超时
+        if chrono::Local::now().timestamp() > pending.timeout_at {
+            record_task_history(app, &pending.task, &pending.trigger_source, "skipped_timeout").await;
+            return Ok(());
+        }
+
+        // 执行唤醒
+        run_task_with_models(
+            app,
+            &pending.task,
+            &pending.trigger_source,
+            pending.task.schedule.selected_models.clone(),
+        ).await;
+    }
+
+    Ok(())
+}
+
+pub fn cancel_pending_confirmation(task_id: &str) -> Result<(), String> {
+    let mut lock = pending_confirmations().lock().unwrap();
+    lock.remove(task_id);
+    Ok(())
+}
+
+pub async fn check_and_handle_timeouts(app: &AppHandle) -> Result<(), String> {
+    let timed_out_tasks: Vec<(String, PendingConfirmation)> = {
+        let mut lock = pending_confirmations().lock().unwrap();
+        let now = chrono::Local::now().timestamp();
+        let expired_ids: Vec<String> = lock
+            .iter()
+            .filter(|(_, pending)| now > pending.timeout_at)
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        expired_ids
+            .into_iter()
+            .filter_map(|id| lock.remove(&id).map(|pending| (id, pending)))
+            .collect()
+    };
+
+    for (_task_id, pending) in timed_out_tasks {
+        record_task_history(app, &pending.task, &pending.trigger_source, "skipped_timeout").await;
+    }
+
+    Ok(())
+}
+
+async fn record_task_history(
+    app: &AppHandle,
+    task: &WakeupTask,
+    trigger_source: &str,
+    status: &str,
+) {
+    if let Err(e) = modules::wakeup_history::record_status(app, task, trigger_source, status) {
+        modules::logger::log_warn(&format!("[WakeupTasks] 记录历史失败: {}", e));
+    }
 }
 
 async fn run_task_with_models(
@@ -1083,6 +1269,7 @@ async fn run_task_with_models(
                 model_id: model.clone(),
                 prompt: Some(prompt.clone()),
                 success,
+                status: if success { Some("success".to_string()) } else { Some("failed".to_string()) },
                 message,
                 duration: Some(duration),
             });

--- a/src-tauri/src/modules/wakeup_scheduler.rs
+++ b/src-tauri/src/modules/wakeup_scheduler.rs
@@ -364,6 +364,13 @@ pub fn ensure_started(app: AppHandle) {
     tauri::async_runtime::spawn(async move {
         loop {
             run_scheduler_once(&app).await;
+            // 检查确认超时，避免因前端未调用导致确认任务堆积
+            if let Err(e) = check_and_handle_timeouts(&app).await {
+                modules::logger::log_warn(&format!(
+                    "[WakeupTasks] 超时检查失败: {}",
+                    e
+                ));
+            }
             sleep(Duration::from_secs(30)).await;
         }
     });
@@ -1089,7 +1096,7 @@ fn store_pending_confirmation(
     pending: PendingConfirmation,
     notification_id: u32,
 ) {
-    let mut lock = pending_confirmations().lock().unwrap();
+    let mut lock = lock_or_recover(pending_confirmations(), "pending confirmations lock");
     lock.insert(task_id.clone(), pending);
 
     // 发射事件通知前端建立映射
@@ -1114,7 +1121,7 @@ pub async fn execute_pending_confirmation(
     task_id: &str,
 ) -> Result<(), String> {
     let pending = {
-        let mut lock = pending_confirmations().lock().unwrap();
+        let mut lock = lock_or_recover(pending_confirmations(), "pending confirmations lock");
         lock.remove(task_id)
     };
 
@@ -1138,14 +1145,14 @@ pub async fn execute_pending_confirmation(
 }
 
 pub fn cancel_pending_confirmation(task_id: &str) -> Result<(), String> {
-    let mut lock = pending_confirmations().lock().unwrap();
+    let mut lock = lock_or_recover(pending_confirmations(), "pending confirmations lock");
     lock.remove(task_id);
     Ok(())
 }
 
 pub async fn check_and_handle_timeouts(app: &AppHandle) -> Result<(), String> {
     let timed_out_tasks: Vec<(String, PendingConfirmation)> = {
-        let mut lock = pending_confirmations().lock().unwrap();
+        let mut lock = lock_or_recover(pending_confirmations(), "pending confirmations lock");
         let now = chrono::Local::now().timestamp();
         let expired_ids: Vec<String> = lock
             .iter()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -88,6 +88,9 @@
         ]
       }
     },
+    "notification": {
+      "enabled": true
+    },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEMxRkU1RTdBRDdCRUUzM0QKUldROTQ3N1hlbDcrd1ZVQ2E3b1ZoVUdXL3BWQmpjdzNnWllNUW1LNHVwcE9wdGI1Q1UxQmdnQ0oK",
       "endpoints": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import type { UpdateCheckResult, UpdateInfo } from './components/UpdateNotificat
 import type { Update as UpdaterUpdate } from '@tauri-apps/plugin-updater';
 import { parseUpdaterReleaseNotes, resolveUpdaterDownloadUrl } from './utils/updaterReleaseNotes';
 import { FloatingCardWindow } from './pages/FloatingCardWindow';
+import { initWakeupNotificationListener } from './utils/wakeupNotificationListener';
 import {
   createUpdaterCanceledError,
   isRetryableUpdaterError,
@@ -677,6 +678,11 @@ function MainApp() {
   
   // 启用自动刷新 hook
   useAutoRefresh();
+
+  // 初始化唤醒通知监听器
+  useEffect(() => {
+    initWakeupNotificationListener();
+  }, []);
 
   useEffect(() => {
     const handleRefreshShortcut = (event: KeyboardEvent) => {

--- a/src/pages/WakeupTasksPage.tsx
+++ b/src/pages/WakeupTasksPage.tsx
@@ -115,6 +115,8 @@ interface WakeupTask {
   createdAt: number;
   lastRunAt?: number;
   schedule: ScheduleConfig;
+  execution_mode?: 'auto' | 'confirm';
+  confirm_timeout_minutes?: number;
 }
 
 interface WakeupGeneralConfig {
@@ -711,6 +713,8 @@ export function WakeupTasksPage({ onNavigate }: WakeupPageProps) {
     'immediate',
   );
   const [formStartupDelayMinutes, setFormStartupDelayMinutes] = useState('1');
+  const [formExecutionMode, setFormExecutionMode] = useState<'auto' | 'confirm'>('auto');
+  const [formConfirmTimeoutMinutes, setFormConfirmTimeoutMinutes] = useState(5);
   const {
     message: formError,
     scrollKey: formErrorScrollKey,
@@ -1638,6 +1642,8 @@ export function WakeupTasksPage({ onNavigate }: WakeupPageProps) {
     setFormCrontabError('');
     setFormStartupDelayMode('immediate');
     setFormStartupDelayMinutes('1');
+    setFormExecutionMode('auto');
+    setFormConfirmTimeoutMinutes(5);
     setFormTimeWindowEnabled(false);
     setFormTimeWindowStart('09:00');
     setFormTimeWindowEnd('18:00');
@@ -1685,6 +1691,8 @@ export function WakeupTasksPage({ onNavigate }: WakeupPageProps) {
     setFormTimeWindowStart(schedule.timeWindowStart || '09:00');
     setFormTimeWindowEnd(schedule.timeWindowEnd || '18:00');
     setFormFallbackTimes(schedule.fallbackTimes?.length ? [...schedule.fallbackTimes] : ['07:00']);
+    setFormExecutionMode(task.execution_mode || 'auto');
+    setFormConfirmTimeoutMinutes(task.confirm_timeout_minutes || 5);
     setCustomDailyTime('');
     setCustomWeeklyTime('');
     setCustomFallbackTime('');
@@ -2111,6 +2119,8 @@ export function WakeupTasksPage({ onNavigate }: WakeupPageProps) {
         ? tasksRef.current.find((task) => task.id === editingTaskId)?.lastRunAt
         : undefined,
       schedule,
+      execution_mode: formExecutionMode,
+      confirm_timeout_minutes: formExecutionMode === 'confirm' ? formConfirmTimeoutMinutes : 5,
     };
 
     setTasks((prev) => {
@@ -3245,6 +3255,40 @@ export function WakeupTasksPage({ onNavigate }: WakeupPageProps) {
                       </div>
                     </div>
                   )}
+                </div>
+              )}
+
+              <div className="wakeup-form-group">
+                <label>{t('wakeup.form.executionMode', '执行模式')}</label>
+                <select
+                  className="wakeup-select"
+                  value={formExecutionMode}
+                  onChange={(event) =>
+                    setFormExecutionMode(event.target.value as 'auto' | 'confirm')
+                  }
+                >
+                  <option value="auto">{t('wakeup.form.executionModeAuto', '直接执行')}</option>
+                  <option value="confirm">{t('wakeup.form.executionModeConfirm', '需要确认')}</option>
+                </select>
+              </div>
+
+              {formExecutionMode === 'confirm' && (
+                <div className="wakeup-form-group">
+                  <label>{t('wakeup.form.confirmTimeout', '确认超时（分钟）')}</label>
+                  <div className="wakeup-input-with-unit">
+                    <input
+                      className="wakeup-input"
+                      type="number"
+                      min={1}
+                      max={60}
+                      value={formConfirmTimeoutMinutes}
+                      onChange={(event) => {
+                        const value = Math.min(60, Math.max(1, Number(event.target.value)));
+                        setFormConfirmTimeoutMinutes(value);
+                      }}
+                    />
+                    <span>{t('settings.general.minutes')}</span>
+                  </div>
                 </div>
               )}
 

--- a/src/types/codexWakeup.ts
+++ b/src/types/codexWakeup.ts
@@ -19,6 +19,13 @@ export interface CodexCliStatus {
 export type CodexWakeupScheduleKind = 'daily' | 'weekly' | 'interval' | 'quota_reset' | 'startup';
 export type CodexWakeupQuotaResetWindow = 'either' | 'primary_window' | 'secondary_window';
 export type CodexWakeupReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export type WakeupTaskExecutionMode = 'auto' | 'confirm';
+export type WakeupTaskHistoryStatus =
+  | 'success'
+  | 'failed'
+  | 'skipped_timeout'
+  | 'skipped_app_closed'
+  | 'skipped_manual';
 
 export interface CodexWakeupSchedule {
   kind: CodexWakeupScheduleKind;
@@ -40,6 +47,8 @@ export interface CodexWakeupTask {
   model_display_name?: string;
   model_reasoning_effort?: CodexWakeupReasoningEffort;
   schedule: CodexWakeupSchedule;
+  execution_mode?: WakeupTaskExecutionMode;
+  confirm_timeout_minutes?: number;
   created_at: number;
   updated_at: number;
   last_run_at?: number;
@@ -84,6 +93,7 @@ export interface CodexWakeupHistoryItem {
   account_email: string;
   account_context_text?: string;
   success: boolean;
+  status?: WakeupTaskHistoryStatus;
   prompt?: string;
   model?: string;
   model_display_name?: string;

--- a/src/utils/wakeupNotificationListener.ts
+++ b/src/utils/wakeupNotificationListener.ts
@@ -1,0 +1,66 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+interface NotificationAction {
+  actionId: string;
+  notificationId: number;
+}
+
+interface TaskNotificationMapping {
+  taskId: string;
+  notificationId: number;
+}
+
+// 存储通知 ID 到任务 ID 的映射
+const notificationTaskMap = new Map<number, string>();
+
+export function mapNotificationToTask(notificationId: number, taskId: string): void {
+  notificationTaskMap.set(notificationId, taskId);
+}
+
+export function initWakeupNotificationListener(): void {
+  // 监听通知动作事件
+  listen<NotificationAction>('notification://action', async (event) => {
+    const { actionId, notificationId } = event.payload;
+
+    const taskId = notificationTaskMap.get(notificationId);
+    if (!taskId) {
+      console.warn(`No task found for notification ${notificationId}`);
+      return;
+    }
+
+    // 清理映射
+    notificationTaskMap.delete(notificationId);
+
+    if (actionId === 'confirm') {
+      try {
+        await invoke('confirm_wakeup_task', { taskId });
+        console.log(`Wakeup task ${taskId} confirmed and executed`);
+      } catch (error) {
+        console.error(`Failed to confirm wakeup task: ${error}`);
+      }
+    } else if (actionId === 'cancel') {
+      try {
+        await invoke('cancel_wakeup_task', { taskId });
+        console.log(`Wakeup task ${taskId} cancelled`);
+      } catch (error) {
+        console.error(`Failed to cancel wakeup task: ${error}`);
+      }
+    }
+  });
+
+  // 监听后端发送的通知映射事件
+  listen<TaskNotificationMapping>('wakeup://notification-mapping', (event) => {
+    const { taskId, notificationId } = event.payload;
+    mapNotificationToTask(notificationId, taskId);
+  });
+
+  // 定期检查超时
+  setInterval(async () => {
+    try {
+      await invoke('check_wakeup_timeouts');
+    } catch (error) {
+      console.error('Failed to check timeouts:', error);
+    }
+  }, 30000); // 每 30 秒检查一次
+}


### PR DESCRIPTION
## Summary

- Add optional `confirm` execution mode for wakeup tasks, so tasks send a system notification instead of executing immediately
- Users can verify VPN/proxy configuration before triggering wakeup, preventing accidental risk-control triggers
- Tasks that are not confirmed within the configured timeout are automatically skipped and recorded in history

## Changes

- **Types**: Add `WakeupTaskExecutionMode`, `WakeupTaskHistoryStatus` and optional fields on `CodexWakeupTask` / `CodexWakeupHistoryItem`
- **Rust backend**: Add `PendingConfirmation` state, confirmation/cancel/timeout commands, and notification dispatch via Tauri notification plugin
- **Frontend**: Add execution mode and timeout configuration in wakeup task form; initialize notification listener in App

## Test plan

- [ ] Create a wakeup task with `confirm` mode and a short timeout
- [ ] Verify notification appears at scheduled time
- [ ] Confirm via notification action and verify task executes
- [ ] Cancel via notification action and verify task is skipped
- [ ] Verify timeout skip is recorded in history with `skipped_timeout` status
- [ ] Verify existing `auto` mode tasks continue to work unchanged