### PR TITLE
fix: improve PowerShell argument binding in Antigravity version detection

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -460,17 +460,19 @@ fn find_antigravity_windows_exe(root: &Path) -> Option<PathBuf> {
 #[cfg(target_os = "windows")]
 fn read_antigravity_windows_exe_metadata(root: &Path) -> Option<AntigravityInstalledVersionInfo> {
     let exe_path = find_antigravity_windows_exe(root)?;
-    let script = r#"
-$p = $args[0]
-if (-not (Test-Path -LiteralPath $p)) { exit 2 }
+    let exe_path_escaped = exe_path.to_string_lossy().replace('\'', "''");
+    let script = format!(
+        r#"$p = '{exe_path_escaped}'
+if (-not (Test-Path -LiteralPath $p)) {{ exit 2 }}
 $v = (Get-Item -LiteralPath $p).VersionInfo
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-[pscustomobject]@{
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[pscustomobject]@{{
   ProductName = $v.ProductName
   ProductVersion = $v.ProductVersion
   FileVersion = $v.FileVersion
-} | ConvertTo-Json -Compress
-"#;
+}} | ConvertTo-Json -Compress"#,
+    );
     let mut command = std::process::Command::new("powershell");
     {
         use std::os::windows::process::CommandExt;
@@ -483,9 +485,8 @@ $v = (Get-Item -LiteralPath $p).VersionInfo
             "-ExecutionPolicy",
             "Bypass",
             "-Command",
-            script,
+            &script,
         ])
-        .arg(&exe_path)
         .output()
         .ok()?;
     if !output.status.success() {


### PR DESCRIPTION
## Summary

- Fix PowerShell argument binding in `read_antigravity_windows_exe_metadata` (issue #1011)
- Paths with spaces or special characters could silently fail because PowerShell `-Command` mode does not reliably bind trailing arguments to `$args`

## Changes

- Embed the exe path directly into the script via string interpolation, eliminating the `$args[0]` binding ambiguity
- Escape single quotes in the path for safety
- Add `$OutputEncoding = UTF8` alongside `[Console]::OutputEncoding`, consistent with `build_powershell_command` in `process.rs`

## Root cause

The previous code used `$args[0]` inside a `-Command` script and passed the exe path as a trailing `.arg()`. In PowerShell `-Command` mode, trailing arguments are not always bound to `$args` as expected — they may be treated as string concatenation to the script text. This is especially problematic when the path contains spaces.

Fixes #1011