### PR TITLE
fix: 解决切换至 Antigravity 平台 Tab 时意外拉起新版客户端的 Bug

### DIFF
--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -1704,7 +1704,7 @@ pub fn detect_antigravity_legacy_exec_path() -> Option<std::path::PathBuf> {
         if let Some(path) = detect_windows_exec_path_by_signatures(
             "antigravity",
             &["Antigravity.exe", "antigravity.exe", "Electron.exe"],
-            &["antigravity"],
+            &[],
             &["antigravity"],
             &["antigravity"],
         ) {


### PR DESCRIPTION
#### 问题背景 (Bug Description)
在 Cockpit Tools 软件中，当用户切换左侧 Tab 至新版 `Antigravity` 平台时，如果本地未运行该客户端，系统在某些 Windows 环境下会自动且意外地在后台拉起 `Antigravity` 软件。

**原因分析**：
* 切换到新版 `Antigravity` 平台时，前端的版本检测徽章（`AntigravityInstalledVersionBadge`）会触发深度版本扫描，调用后端的 `detect_antigravity_legacy_exec_path`。
* 在原逻辑中，如果常规安装路径下检测不到客户端，会通过 PowerShell 脚本（在 `detect_windows_exec_path_by_signatures` 中）检索系统命令行中名为 `antigravity` 的全局指令（执行了 `Get-Command antigravity`）。
* 在部分 Windows 系统上（例如通过全局 npm、scoop 等配置了全局 wrapper 或别名），PowerShell 的 `Get-Command` 在解析此类包装别名时，会由于系统特性意外触发该包装程序的执行，进而导致新版客户端被意外启动。

#### 修复方案 (Solution)
对新版 `Antigravity` 的版本检测机制进行了净化：
* 在 `detect_antigravity_legacy_exec_path` 调用 `detect_windows_exec_path_by_signatures` 进行特征扫描时，将第三个参数（命令检索数组 `command_names`）设为空 `&[]`。
* **效果**：这使得扫描新版客户端时彻底跳过了会引发程序执行的 `Get-Command` 别名检测，从根本上杜绝了切换 Tab 导致软件意外启动的 Bug。
* **兼容性**：在此修改下，系统依然能完整通过 `App Paths`（注册表直接读取）、`Uninstall`（控制面板卸载列表检索）以及 `Shortcuts`（桌面与开始菜单快捷方式解析）等其他无任何拉起副作用的深度扫描方式，安全地获取并在界面上显示新版 `Antigravity` 的版本号。
* **隔离影响**：该修改仅应用于新版 `Antigravity` 的检测，旧版本 `Antigravity IDE`（后端对应 `detect_antigravity_exec_path`）的原有检索逻辑完全未做任何改动。