### PR TITLE
fix(codex): reconcile session_index.jsonl during visibility repair

### DIFF
--- a/src-tauri/src/modules/codex_session_visibility.rs
+++ b/src-tauri/src/modules/codex_session_visibility.rs
@@ -4,7 +4,7 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-use chrono::Utc;
+use chrono::{TimeZone, Utc};
 use rusqlite::Connection;
 use serde::Serialize;
 use serde_json::{json, Value as JsonValue};
@@ -31,6 +31,7 @@ pub struct CodexSessionVisibilityRepairItem {
     pub target_provider: String,
     pub changed_rollout_file_count: usize,
     pub updated_sqlite_row_count: usize,
+    pub added_session_index_entry_count: usize,
     pub skipped_sqlite_file: bool,
     pub backup_dir: Option<String>,
     pub running: bool,
@@ -43,6 +44,7 @@ pub struct CodexSessionVisibilityRepairSummary {
     pub mutated_instance_count: usize,
     pub changed_rollout_file_count: usize,
     pub updated_sqlite_row_count: usize,
+    pub added_session_index_entry_count: usize,
     pub skipped_sqlite_file_count: usize,
     pub items: Vec<CodexSessionVisibilityRepairItem>,
     pub backup_dirs: Vec<String>,
@@ -79,6 +81,13 @@ struct ThreadsTableColumns {
     thread_source: bool,
 }
 
+#[derive(Debug, Clone)]
+struct SqliteThreadIndexRow {
+    id: String,
+    title: String,
+    updated_at: Option<i64>,
+}
+
 pub fn repair_session_visibility_across_instances(
 ) -> Result<CodexSessionVisibilityRepairSummary, String> {
     let instances = collect_instances()?;
@@ -88,6 +97,7 @@ pub fn repair_session_visibility_across_instances(
     let mut mutated_instance_count = 0usize;
     let mut changed_rollout_file_count = 0usize;
     let mut updated_sqlite_row_count = 0usize;
+    let mut added_session_index_entry_count = 0usize;
     let mut skipped_sqlite_file_count = 0usize;
     let mut mutated_running_instance_count = 0usize;
 
@@ -98,17 +108,23 @@ pub fn repair_session_visibility_across_instances(
             collect_rollout_provider_changes(&instance.data_dir, &target_provider)?;
         let sqlite_scan = count_sqlite_rows_to_update(&instance.data_dir, &target_provider)?;
         let sqlite_rows_to_update = sqlite_scan.rows_to_update;
+        let missing_session_index_entries =
+            count_missing_session_index_entries(&instance.data_dir)?;
         if sqlite_scan.skipped_unusable_database {
             skipped_sqlite_file_count += 1;
         }
 
-        if rollout_changes.is_empty() && sqlite_rows_to_update == 0 {
+        if rollout_changes.is_empty()
+            && sqlite_rows_to_update == 0
+            && missing_session_index_entries == 0
+        {
             items.push(CodexSessionVisibilityRepairItem {
                 instance_id: instance.id.clone(),
                 instance_name: instance.name.clone(),
                 target_provider,
                 changed_rollout_file_count: 0,
                 updated_sqlite_row_count: 0,
+                added_session_index_entry_count: 0,
                 skipped_sqlite_file: sqlite_scan.skipped_unusable_database,
                 backup_dir: None,
                 running,
@@ -120,6 +136,7 @@ pub fn repair_session_visibility_across_instances(
             &instance.data_dir,
             &rollout_changes,
             sqlite_rows_to_update > 0,
+            missing_session_index_entries > 0,
             &instance.id,
             &target_provider,
         )?;
@@ -130,8 +147,9 @@ pub fn repair_session_visibility_across_instances(
             &target_provider,
             &rollout_changes,
             sqlite_rows_to_update > 0,
+            missing_session_index_entries > 0,
         );
-        let sqlite_rows_updated = match repaired {
+        let (sqlite_rows_updated, session_index_entries_added) = match repaired {
             Ok(value) => value,
             Err(error) => {
                 let restore_result = restore_instance_files_from_backup(
@@ -160,6 +178,7 @@ pub fn repair_session_visibility_across_instances(
         mutated_instance_count += 1;
         changed_rollout_file_count += rollout_changes.len();
         updated_sqlite_row_count += sqlite_rows_updated;
+        added_session_index_entry_count += session_index_entries_added;
         if running {
             mutated_running_instance_count += 1;
         }
@@ -170,6 +189,7 @@ pub fn repair_session_visibility_across_instances(
             target_provider,
             changed_rollout_file_count: rollout_changes.len(),
             updated_sqlite_row_count: sqlite_rows_updated,
+            added_session_index_entry_count: session_index_entries_added,
             skipped_sqlite_file: sqlite_scan.skipped_unusable_database,
             backup_dir: Some(backup_dir_string),
             running,
@@ -182,6 +202,7 @@ pub fn repair_session_visibility_across_instances(
         mutated_instance_count,
         changed_rollout_file_count,
         updated_sqlite_row_count,
+        added_session_index_entry_count,
         mutated_running_instance_count,
         skipped_sqlite_file_count,
     );
@@ -191,6 +212,7 @@ pub fn repair_session_visibility_across_instances(
         mutated_instance_count,
         changed_rollout_file_count,
         updated_sqlite_row_count,
+        added_session_index_entry_count,
         skipped_sqlite_file_count,
         items,
         backup_dirs,
@@ -207,7 +229,8 @@ fn repair_single_instance(
     target_provider: &str,
     rollout_changes: &[RolloutProviderChange],
     update_sqlite: bool,
-) -> Result<usize, String> {
+    reconcile_session_index: bool,
+) -> Result<(usize, usize), String> {
     let sqlite_rows_updated = if update_sqlite {
         update_sqlite_provider(data_dir, target_provider)?
     } else {
@@ -216,31 +239,49 @@ fn repair_single_instance(
     for change in rollout_changes {
         rewrite_rollout_provider(change)?;
     }
-    Ok(sqlite_rows_updated)
+    let session_index_entries_added = if reconcile_session_index {
+        reconcile_session_index_from_sqlite(data_dir)?
+    } else {
+        0
+    };
+    Ok((sqlite_rows_updated, session_index_entries_added))
 }
 
 fn build_summary_message(
     mutated_instance_count: usize,
     changed_rollout_file_count: usize,
     updated_sqlite_row_count: usize,
+    added_session_index_entry_count: usize,
     mutated_running_instance_count: usize,
     _skipped_sqlite_file_count: usize,
 ) -> String {
     if mutated_instance_count == 0 {
-        return "所有 Codex 实例的历史会话 provider 元数据已与当前 provider 一致，无需修复"
+        return "所有 Codex 实例的历史会话 provider 元数据与 session_index 已与当前 provider 一致，无需修复"
             .to_string();
     }
 
+    let index_suffix = if added_session_index_entry_count > 0 {
+        format!("，补写 {} 条 session_index 记录", added_session_index_entry_count)
+    } else {
+        String::new()
+    };
+
     if mutated_running_instance_count > 0 {
         return format!(
-            "已为 {} 个实例修复历史会话可见性：改写 {} 个 rollout 文件，更新 {} 条 SQLite 记录。运行中的实例可能需要重启后显示",
-            mutated_instance_count, changed_rollout_file_count, updated_sqlite_row_count
+            "已为 {} 个实例修复历史会话可见性：改写 {} 个 rollout 文件，更新 {} 条 SQLite 记录{}。运行中的实例可能需要重启后显示",
+            mutated_instance_count,
+            changed_rollout_file_count,
+            updated_sqlite_row_count,
+            index_suffix
         );
     }
 
     format!(
-        "已为 {} 个实例修复历史会话可见性：改写 {} 个 rollout 文件，更新 {} 条 SQLite 记录",
-        mutated_instance_count, changed_rollout_file_count, updated_sqlite_row_count
+        "已为 {} 个实例修复历史会话可见性：改写 {} 个 rollout 文件，更新 {} 条 SQLite 记录{}",
+        mutated_instance_count,
+        changed_rollout_file_count,
+        updated_sqlite_row_count,
+        index_suffix
     )
 }
 
@@ -519,6 +560,181 @@ fn read_session_index_map(root_dir: &Path) -> Result<HashMap<String, JsonValue>,
         entries.insert(id.to_string(), entry);
     }
     Ok(entries)
+}
+
+fn count_missing_session_index_entries(data_dir: &Path) -> Result<usize, String> {
+    let session_index_map = read_session_index_map(data_dir)?;
+    let rows = load_sqlite_thread_index_rows(data_dir)?;
+    Ok(rows
+        .iter()
+        .filter(|row| !session_index_map.contains_key(&row.id))
+        .count())
+}
+
+fn load_sqlite_thread_index_rows(data_dir: &Path) -> Result<Vec<SqliteThreadIndexRow>, String> {
+    let db_path = data_dir.join(STATE_DB_FILE);
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let connection = match Connection::open(&db_path) {
+        Ok(connection) => connection,
+        Err(error) if modules::db::is_unusable_sqlite_database_error(&error) => {
+            log_skipped_sqlite_database(&db_path, &error.to_string());
+            return Ok(Vec::new());
+        }
+        Err(error) => {
+            return Err(format!(
+                "打开实例数据库失败 ({}): {}",
+                db_path.display(),
+                error
+            ));
+        }
+    };
+
+    let mut statement = match connection.prepare("PRAGMA table_info(threads)") {
+        Ok(statement) => statement,
+        Err(error) if is_missing_threads_table_error(&error) => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(format_sqlite_read_error(
+                &db_path,
+                "读取 SQLite threads 表结构失败",
+                &error,
+            ));
+        }
+    };
+    let rows = statement
+        .query_map([], |row| row.get::<usize, String>(1))
+        .map_err(|error| {
+            format_sqlite_read_error(&db_path, "读取 SQLite threads 表结构失败", &error)
+        })?;
+    let mut names = HashSet::new();
+    for row in rows {
+        names.insert(row.map_err(|error| {
+            format_sqlite_read_error(&db_path, "读取 SQLite threads 表结构失败", &error)
+        })?);
+    }
+    if !names.contains("id") {
+        return Ok(Vec::new());
+    }
+
+    let title_expr = if names.contains("title") {
+        "COALESCE(title, '')"
+    } else {
+        "''"
+    };
+    let updated_at_expr = if names.contains("updated_at") {
+        "updated_at"
+    } else {
+        "NULL"
+    };
+    let sql = format!(
+        "SELECT id, {title_expr}, {updated_at_expr} FROM threads ORDER BY updated_at DESC"
+    );
+    let mut statement = connection.prepare(sql.as_str()).map_err(|error| {
+        format!(
+            "准备 SQLite 会话索引查询失败 ({}): {}",
+            db_path.display(),
+            error
+        )
+    })?;
+    let mapped = statement
+        .query_map([], |row| {
+            Ok(SqliteThreadIndexRow {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                updated_at: row.get(2)?,
+            })
+        })
+        .map_err(|error| {
+            format!(
+                "查询 SQLite 会话索引行失败 ({}): {}",
+                db_path.display(),
+                error
+            )
+        })?;
+    let mut result = Vec::new();
+    for row in mapped {
+        result.push(row.map_err(|error| {
+            format!(
+                "读取 SQLite 会话索引行失败 ({}): {}",
+                db_path.display(),
+                error
+            )
+        })?);
+    }
+    Ok(result)
+}
+
+fn format_thread_updated_at_iso(updated_at: Option<i64>) -> String {
+    let seconds = updated_at.unwrap_or_else(|| Utc::now().timestamp());
+    Utc.timestamp_opt(seconds, 0)
+        .single()
+        .unwrap_or_else(Utc::now)
+        .to_rfc3339_opts(chrono::SecondsFormat::Micros, true)
+}
+
+fn build_session_index_entry_from_thread(row: &SqliteThreadIndexRow) -> JsonValue {
+    json!({
+        "id": row.id,
+        "thread_name": if row.title.trim().is_empty() {
+            "Untitled"
+        } else {
+            row.title.as_str()
+        },
+        "updated_at": format_thread_updated_at_iso(row.updated_at),
+    })
+}
+
+fn reconcile_session_index_from_sqlite(data_dir: &Path) -> Result<usize, String> {
+    let session_index_map = read_session_index_map(data_dir)?;
+    let rows = load_sqlite_thread_index_rows(data_dir)?;
+    let missing_rows: Vec<&SqliteThreadIndexRow> = rows
+        .iter()
+        .filter(|row| !session_index_map.contains_key(&row.id))
+        .collect();
+    if missing_rows.is_empty() {
+        return Ok(0);
+    }
+
+    let path = data_dir.join(SESSION_INDEX_FILE);
+    let mut lines = if path.exists() {
+        fs::read_to_string(&path)
+            .map_err(|error| {
+                format!(
+                    "读取 session_index.jsonl 失败 ({}): {}",
+                    path.display(),
+                    error
+                )
+            })?
+            .lines()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    while lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.pop();
+    }
+
+    for row in &missing_rows {
+        let entry = build_session_index_entry_from_thread(row);
+        let line = serde_json::to_string(&entry)
+            .map_err(|error| format!("序列化 session_index 条目失败: {}", error))?;
+        lines.push(line);
+    }
+
+    let mut output = lines.join("\n");
+    output.push('\n');
+    modules::atomic_write::write_string_atomic(&path, &output).map_err(|error| {
+        format!(
+            "写入 session_index.jsonl 失败 ({}): {}",
+            path.display(),
+            error
+        )
+    })?;
+    Ok(missing_rows.len())
 }
 
 fn normalize_codex_timestamp_ms(timestamp: i64) -> i128 {
@@ -1018,6 +1234,7 @@ fn backup_instance_files(
     data_dir: &Path,
     rollout_changes: &[RolloutProviderChange],
     include_sqlite: bool,
+    include_session_index: bool,
     instance_id: &str,
     target_provider: &str,
 ) -> Result<PathBuf, String> {
@@ -1063,12 +1280,39 @@ fn backup_instance_files(
         sqlite_backup_created = backup_sqlite_database(data_dir, &backup_dir)?;
     }
 
+    let mut session_index_backup_created = false;
+    if include_session_index {
+        let source = data_dir.join(SESSION_INDEX_FILE);
+        if source.exists() {
+            let target = backup_dir.join("files").join(SESSION_INDEX_FILE);
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent).map_err(|error| {
+                    format!(
+                        "创建 session_index 备份目录失败 ({}): {}",
+                        parent.display(),
+                        error
+                    )
+                })?;
+            }
+            fs::copy(&source, &target).map_err(|error| {
+                format!(
+                    "备份 session_index.jsonl 失败 ({} -> {}): {}",
+                    source.display(),
+                    target.display(),
+                    error
+                )
+            })?;
+            session_index_backup_created = true;
+        }
+    }
+
     let manifest = json!({
         "instanceId": instance_id,
         "instanceRoot": data_dir,
         "targetProvider": target_provider,
         "createdAt": Utc::now().to_rfc3339(),
         "hasSqliteBackup": sqlite_backup_created,
+        "hasSessionIndexBackup": session_index_backup_created,
         "rolloutFiles": backed_up_files,
     });
     fs::write(
@@ -1285,7 +1529,8 @@ mod tests {
             collect_rollout_provider_changes(&data_dir, "relay").expect("collect rollout changes");
         assert_eq!(changes.len(), 1);
 
-        repair_single_instance(&data_dir, "relay", &changes, false).expect("repair rollout");
+        repair_single_instance(&data_dir, "relay", &changes, false, false)
+            .expect("repair rollout");
 
         let content = fs::read_to_string(&rollout_path).expect("read repaired rollout");
         assert!(content.contains("\"model_provider\":\"relay\""));
@@ -1319,7 +1564,8 @@ mod tests {
         assert_eq!(changes.len(), 1);
         assert!(changes[0].updated_first_line.is_none());
 
-        repair_single_instance(&data_dir, "relay", &changes, false).expect("repair rollout time");
+        repair_single_instance(&data_dir, "relay", &changes, false, false)
+            .expect("repair rollout time");
 
         assert_eq!(
             fs::read_to_string(&rollout_path).expect("read repaired rollout"),
@@ -1474,8 +1720,8 @@ mod tests {
             .expect("insert old row");
         drop(connection);
 
-        let backup_dir =
-            backup_instance_files(&data_dir, &[], true, "default", "relay").expect("backup db");
+        let backup_dir = backup_instance_files(&data_dir, &[], true, false, "default", "relay")
+            .expect("backup db");
 
         let connection = Connection::open(&db_path).expect("reopen sqlite");
         connection
@@ -1507,6 +1753,61 @@ mod tests {
             )
             .expect("read restored provider");
         assert_eq!(provider, "old");
+
+        fs::remove_dir_all(&data_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn session_index_repair_appends_missing_sqlite_threads() {
+        let data_dir = make_temp_dir("codex-session-visibility-index-test");
+        let db_path = data_dir.join(STATE_DB_FILE);
+        let connection = Connection::open(&db_path).expect("open sqlite");
+        connection
+            .execute(
+                "CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    updated_at INTEGER
+                )",
+                [],
+            )
+            .expect("create threads table");
+        connection
+            .execute(
+                "INSERT INTO threads (id, title, updated_at) VALUES
+                 ('indexed-thread', 'Indexed', 1_700_000_000),
+                 ('missing-thread', 'Missing chat', 1_800_000_000)",
+                [],
+            )
+            .expect("insert rows");
+        drop(connection);
+
+        fs::write(
+            data_dir.join(SESSION_INDEX_FILE),
+            "{\"id\":\"indexed-thread\",\"thread_name\":\"Indexed\",\"updated_at\":\"2024-01-01T00:00:00.0000000Z\"}\n",
+        )
+        .expect("write session index");
+
+        let missing =
+            count_missing_session_index_entries(&data_dir).expect("count missing index entries");
+        assert_eq!(missing, 1);
+
+        let added = reconcile_session_index_from_sqlite(&data_dir).expect("reconcile index");
+        assert_eq!(added, 1);
+
+        let index_map = read_session_index_map(&data_dir).expect("read session index");
+        assert!(index_map.contains_key("missing-thread"));
+        assert_eq!(
+            index_map
+                .get("missing-thread")
+                .and_then(|entry| entry.get("thread_name"))
+                .and_then(JsonValue::as_str),
+            Some("Missing chat")
+        );
+        assert_eq!(
+            count_missing_session_index_entries(&data_dir).expect("recount missing index entries"),
+            0
+        );
 
         fs::remove_dir_all(&data_dir).expect("cleanup temp dir");
     }

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -154,6 +154,7 @@ export interface CodexSessionVisibilityRepairItem {
   targetProvider: string;
   changedRolloutFileCount: number;
   updatedSqliteRowCount: number;
+  addedSessionIndexEntryCount: number;
   skippedSqliteFile: boolean;
   backupDir?: string | null;
   running: boolean;
@@ -164,6 +165,7 @@ export interface CodexSessionVisibilityRepairSummary {
   mutatedInstanceCount: number;
   changedRolloutFileCount: number;
   updatedSqliteRowCount: number;
+  addedSessionIndexEntryCount: number;
   skippedSqliteFileCount: number;
   items: CodexSessionVisibilityRepairItem[];
   backupDirs: string[];


### PR DESCRIPTION
## Summary / 摘要

**EN:** After switching Codex provider/account (OAuth / API key / local relay), Cockpit session visibility repair rewrote rollout and sqlite provider metadata but did not rebuild missing session_index.jsonl entries, which can hide valid local chats in Codex Desktop (openai/codex#22452).

**ZH:** Codex 账号切换后，可见性修复会改 rollout 与 sqlite 的 provider，但不会补全缺失的 session_index.jsonl，导致侧边栏隐藏仍存在于本地的聊天（openai/codex#22452）。

## What changed / 改动

**EN:** Append missing session_index rows from state_5.sqlite during visibility repair; trigger when index drift exists alone; backup session_index.jsonl; report addedSessionIndexEntryCount; add unit test.

**ZH:** 修复时从 sqlite 补写缺失 index；仅 index 漂移也触发；写入前备份；摘要报告 addedSessionIndexEntryCount；新增单测。

## Test plan / 测试

- [x] cargo test session_index_repair_appends_missing_sqlite_threads
- [ ] Cockpit account switch + visibility repair on drifted profile
- [ ] Restart Codex Desktop and verify sidebar history
