### PR TITLE
fix(wakeup): 注入 StartCascadeRequest.source 修复唤醒失败

### DIFF
--- a/crates/cockpit-core/src/modules/wakeup_gateway.rs
+++ b/crates/cockpit-core/src/modules/wakeup_gateway.rs
@@ -187,12 +187,21 @@ async fn start_official_ls_cascade_session(
     let mut ls = start_official_ls_process(&prepared.account_id, &token).await?;
     let client = build_official_ls_local_client(30)?;
     let base_url = format!("https://127.0.0.1:{}", ls.started.https_port);
+    // 新版官方 LS（≥1.21.6）要求 StartCascadeRequest.source（枚举 CortexTrajectorySource）非空，
+    // 否则返回 "invalid_argument: CortexTrajectorySource is unspecified"。
+    // 唤醒等价于 IDE 前台交互式 cascade，故默认注入 INTERACTIVE_CASCADE；
+    // 若调用方已显式传入 source 则保留，不覆盖。
+    let mut start_body = start_body.clone();
+    if let Some(obj) = start_body.as_object_mut() {
+        obj.entry("source")
+            .or_insert_with(|| json!("CORTEX_TRAJECTORY_SOURCE_INTERACTIVE_CASCADE"));
+    }
     let start_resp = match post_json_to_official_ls(
         &client,
         &base_url,
         &ls.ls_csrf_token,
         START_CASCADE_PATH,
-        start_body,
+        &start_body,
     )
     .await
     {
@@ -1033,6 +1042,14 @@ async fn post_json_to_official_ls(
     if !resp.status().is_success() {
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
+        let preview: String = text.chars().take(512).collect();
+        crate::modules::logger::log_error(&format!(
+            "[WakeupGateway] 官方 LS 返回错误: status={}, path={}, body_len={}, body={}",
+            status,
+            path,
+            text.len(),
+            preview
+        ));
         return Err(format!(
             "官方 LS 返回错误: {} - {} ({})",
             status, text, path

--- a/src-tauri/src/modules/wakeup.rs
+++ b/src-tauri/src/modules/wakeup.rs
@@ -756,11 +756,12 @@ async fn post_gateway_json(
         .unwrap_or_default();
     if !status.is_success() {
         crate::modules::logger::log_error(&format!(
-            "[Wakeup] 网关 {} 返回错误: url={}, status={}, body_len={}",
+            "[Wakeup] 网关 {} 返回错误: url={}, status={}, body_len={}, body={}",
             op_name,
             url,
             status,
-            summarize_body_len(&text)
+            summarize_body_len(&text),
+            truncate_log_text(&text, 512)
         ));
         return Err(format!(
             "网关 {} 返回错误: status={}, body_len={}",

--- a/src-tauri/src/modules/wakeup_gateway.rs
+++ b/src-tauri/src/modules/wakeup_gateway.rs
@@ -187,12 +187,21 @@ async fn start_official_ls_cascade_session(
     let mut ls = start_official_ls_process(&prepared.account_id, &token).await?;
     let client = build_official_ls_local_client(30)?;
     let base_url = format!("https://127.0.0.1:{}", ls.started.https_port);
+    // 新版官方 LS（≥1.21.6）要求 StartCascadeRequest.source（枚举 CortexTrajectorySource）非空，
+    // 否则返回 "invalid_argument: CortexTrajectorySource is unspecified"。
+    // 唤醒等价于 IDE 前台交互式 cascade，故默认注入 INTERACTIVE_CASCADE；
+    // 若调用方已显式传入 source 则保留，不覆盖。
+    let mut start_body = start_body.clone();
+    if let Some(obj) = start_body.as_object_mut() {
+        obj.entry("source")
+            .or_insert_with(|| json!("CORTEX_TRAJECTORY_SOURCE_INTERACTIVE_CASCADE"));
+    }
     let start_resp = match post_json_to_official_ls(
         &client,
         &base_url,
         &ls.ls_csrf_token,
         START_CASCADE_PATH,
-        start_body,
+        &start_body,
     )
     .await
     {
@@ -1033,6 +1042,14 @@ async fn post_json_to_official_ls(
     if !resp.status().is_success() {
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
+        let preview: String = text.chars().take(512).collect();
+        crate::modules::logger::log_error(&format!(
+            "[WakeupGateway] 官方 LS 返回错误: status={}, path={}, body_len={}, body={}",
+            status,
+            path,
+            text.len(),
+            preview
+        ));
         return Err(format!(
             "官方 LS 返回错误: {} - {} ({})",
             status, text, path


### PR DESCRIPTION
## 问题
唤醒经本地网关调用官方 LS（≥1.21.6）的 StartCascade 时缺少必填 `source` 字段（枚举 `CortexTrajectorySource`），官方 LS 返回 `400 invalid_argument: CortexTrajectorySource is unspecified`，被网关统一包成 500，唤醒始终失败。

## 修复
- 网关转发前注入 `source=CORTEX_TRAJECTORY_SOURCE_INTERACTIVE_CASCADE`（不覆盖调用方已传值）
- 错误日志补打真实 body（此前只记 `body_len`，吞掉了原因）

本地已验证唤醒全流程成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)