### PR TITLE
[codex] Fix reverse-proxy session visibility repair

### DIFF
--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -37,14 +37,28 @@ fn repair_codex_session_visibility_after_provider_change(
     context: &str,
     before_provider: Option<String>,
     after_provider: Option<String>,
+    force_repair: bool,
 ) -> Result<(), String> {
     let (Some(before), Some(after)) = (before_provider, after_provider) else {
+        if force_repair {
+            let started = Instant::now();
+            let summary = codex_session_visibility::repair_session_visibility_across_instances()?;
+            logger::log_info(&format!(
+                "[Codex Session Visibility] {}: forced repair, mutated_instances={}, rollout_files={}, sqlite_rows={}, elapsed_ms={}",
+                context,
+                summary.mutated_instance_count,
+                summary.changed_rollout_file_count,
+                summary.updated_sqlite_row_count,
+                started.elapsed().as_millis()
+            ));
+        }
         return Ok(());
     };
-    if before == after {
+    if !force_repair && before == after {
         return Ok(());
     }
-    if codex_launch_credential_kind_for_provider(&before)
+    if !force_repair
+        && codex_launch_credential_kind_for_provider(&before)
         == codex_launch_credential_kind_for_provider(&after)
     {
         return Ok(());
@@ -213,6 +227,7 @@ pub async fn switch_codex_account(
         "switch-codex-account",
         previous_provider,
         codex_session_visibility::read_history_visibility_provider_for_dir(&codex_home).ok(),
+        false,
     )?;
     let account_speed = account.app_speed.clone();
     codex_speed::write_official_app_speed(account_speed.clone())?;
@@ -1824,6 +1839,12 @@ pub async fn codex_local_access_set_enabled(
 pub async fn codex_local_access_activate(app: AppHandle) -> Result<CodexLocalAccessState, String> {
     let codex_home = codex_account::get_codex_home();
     let state = codex_local_access::activate_local_access_for_dir(&codex_home).await?;
+    repair_codex_session_visibility_after_provider_change(
+        "activate-api-service",
+        codex_session_visibility::read_history_visibility_provider_for_dir(&codex_home).ok(),
+        Some("codex_local_access".to_string()),
+        true,
+    )?;
     let api_service_speed = codex_speed::get_api_service_app_speed_config()?.speed;
     codex_speed::write_official_app_speed(api_service_speed.clone())?;
 

--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::process::Command;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use tauri::AppHandle;
@@ -262,24 +262,63 @@ fn sync_codex_threads_across_idle_instances(context: &str) {
 fn repair_session_visibility_before_launch(
     context: &str,
     launch_provider_change: &Option<CodexLaunchProviderChange>,
+    force_repair: bool,
 ) -> Result<(), String> {
-    let Some(change) = launch_provider_change else {
+    if launch_provider_change.is_none() && !force_repair {
         return Ok(());
     };
 
     let started = Instant::now();
     let summary = modules::codex_session_visibility::repair_session_visibility_across_instances()?;
-    modules::logger::log_info(&format!(
-        "[Codex Session Visibility] {}: repaired before launch, from_provider={}, to_provider={}, mutated_instances={}, rollout_files={}, sqlite_rows={}, elapsed_ms={}",
-        context,
-        change.from_provider,
-        change.to_provider,
-        summary.mutated_instance_count,
-        summary.changed_rollout_file_count,
-        summary.updated_sqlite_row_count,
-        started.elapsed().as_millis()
-    ));
+    if let Some(change) = launch_provider_change {
+        modules::logger::log_info(&format!(
+            "[Codex Session Visibility] {}: repaired before launch, from_provider={}, to_provider={}, mutated_instances={}, rollout_files={}, sqlite_rows={}, elapsed_ms={}",
+            context,
+            change.from_provider,
+            change.to_provider,
+            summary.mutated_instance_count,
+            summary.changed_rollout_file_count,
+            summary.updated_sqlite_row_count,
+            started.elapsed().as_millis()
+        ));
+    } else {
+        modules::logger::log_info(&format!(
+            "[Codex Session Visibility] {}: forced repair before launch, mutated_instances={}, rollout_files={}, sqlite_rows={}, elapsed_ms={}",
+            context,
+            summary.mutated_instance_count,
+            summary.changed_rollout_file_count,
+            summary.updated_sqlite_row_count,
+            started.elapsed().as_millis()
+        ));
+    }
     Ok(())
+}
+
+fn schedule_session_visibility_repair_after_launch(context: &'static str) {
+    tokio::spawn(async move {
+        for delay in [Duration::from_secs(2), Duration::from_secs(8)] {
+            tokio::time::sleep(delay).await;
+            let started = Instant::now();
+            match modules::codex_session_visibility::repair_session_visibility_across_instances() {
+                Ok(summary) => {
+                    modules::logger::log_info(&format!(
+                        "[Codex Session Visibility] {}: delayed repair, mutated_instances={}, rollout_files={}, sqlite_rows={}, elapsed_ms={}",
+                        context,
+                        summary.mutated_instance_count,
+                        summary.changed_rollout_file_count,
+                        summary.updated_sqlite_row_count,
+                        started.elapsed().as_millis()
+                    ));
+                }
+                Err(error) => {
+                    modules::logger::log_warn(&format!(
+                        "[Codex Session Visibility] {}: delayed repair skipped: {}",
+                        context, error
+                    ));
+                }
+            }
+        }
+    });
 }
 
 async fn apply_bound_account_to_initialized_profile(
@@ -299,7 +338,9 @@ async fn apply_bound_account_to_initialized_profile(
     }
     let launch_provider_change =
         build_launch_credential_change(previous_provider, read_launch_provider_for_dir(profile_dir));
-    repair_session_visibility_before_launch(context, &launch_provider_change)?;
+    let force_repair =
+        bind_account_id.is_some_and(modules::codex_instance::is_api_service_bind_account_id);
+    repair_session_visibility_before_launch(context, &launch_provider_change, force_repair)?;
     Ok(launch_provider_change.and_then(|change| change.credential_change))
 }
 
@@ -813,6 +854,30 @@ async fn codex_start_instance_internal(
         if default_settings.launch_mode != InstanceLaunchMode::Cli {
             modules::process::ensure_codex_launch_path_configured()?;
         }
+        if skip_default_bind_account_injection {
+            if let Some(pid) = modules::process::resolve_codex_pid(
+                default_settings.last_pid,
+                Some(default_dir.to_string_lossy().as_ref()),
+            ) {
+                modules::logger::log_info(&format!(
+                    "[Codex Start] default instance already running, reusing managed pid={} instead of launching another process",
+                    pid
+                ));
+                let updated = modules::codex_instance::update_default_pid(Some(pid))?;
+                let _ = modules::process::focus_codex_instance(
+                    Some(pid),
+                    Some(default_dir.to_string_lossy().as_ref()),
+                );
+                schedule_session_visibility_repair_after_launch("after-reuse-default");
+                return Ok(default_instance_view(
+                    &default_dir,
+                    &updated,
+                    default_bind_account_id,
+                    true,
+                    Some(pid),
+                ));
+            }
+        }
         let close_started = Instant::now();
         let fast_closed = if skip_default_bind_account_injection {
             modules::process::close_codex_default_fast_by_pid(default_settings.last_pid, 20)?
@@ -854,7 +919,14 @@ async fn codex_start_instance_internal(
             previous_provider,
             read_launch_provider_for_dir(&default_dir),
         );
-        repair_session_visibility_before_launch("before-start-default", &launch_provider_change)?;
+        let force_visibility_repair = default_bind_account_id
+            .as_deref()
+            .is_some_and(modules::codex_instance::is_api_service_bind_account_id);
+        repair_session_visibility_before_launch(
+            "before-start-default",
+            &launch_provider_change,
+            force_visibility_repair,
+        )?;
         let launch_credential_change = launch_provider_change
             .as_ref()
             .and_then(|change| change.credential_change.clone());
@@ -895,6 +967,9 @@ async fn codex_start_instance_internal(
             flow_started.elapsed().as_millis()
         ));
         modules::codex_model_injector::inject_for_codex_home_later(default_dir.clone());
+        if force_visibility_repair {
+            schedule_session_visibility_repair_after_launch("after-start-default");
+        }
         let updated = modules::codex_instance::update_default_pid(Some(pid))?;
         let running = modules::process::is_pid_running(pid);
         return Ok(default_instance_view(
@@ -937,7 +1012,15 @@ async fn codex_start_instance_internal(
         read_launch_provider_for_dir(instance_dir),
     );
     modules::codex_speed::write_app_speed_for_dir(instance_dir, instance.app_speed.clone())?;
-    repair_session_visibility_before_launch("before-start-instance", &launch_provider_change)?;
+    let force_visibility_repair = instance
+        .bind_account_id
+        .as_deref()
+        .is_some_and(modules::codex_instance::is_api_service_bind_account_id);
+    repair_session_visibility_before_launch(
+        "before-start-instance",
+        &launch_provider_change,
+        force_visibility_repair,
+    )?;
     let launch_credential_change = launch_provider_change
         .as_ref()
         .and_then(|change| change.credential_change.clone());
@@ -961,6 +1044,9 @@ async fn codex_start_instance_internal(
     modules::codex_model_injector::inject_for_codex_home_later(PathBuf::from(
         &instance.user_data_dir,
     ));
+    if force_visibility_repair {
+        schedule_session_visibility_repair_after_launch("after-start-instance");
+    }
     let updated = modules::codex_instance::update_instance_after_start(&instance.id, pid)?;
     let running = modules::process::is_pid_running(pid);
     let initialized = is_profile_initialized(&updated.user_data_dir);

--- a/src-tauri/src/modules/codex_protocol.rs
+++ b/src-tauri/src/modules/codex_protocol.rs
@@ -398,11 +398,21 @@ fn remove_unsupported_responses_fields(obj: &mut Map<String, Value>) -> bool {
         changed |= obj.remove(key).is_some();
     }
 
-    if obj.get("service_tier").is_some()
-        && obj.get("service_tier").and_then(Value::as_str) != Some("priority")
-    {
-        obj.remove("service_tier");
-        changed = true;
+    if let Some(service_tier) = obj.get("service_tier").and_then(Value::as_str) {
+        match service_tier {
+            "priority" => {}
+            "fast" | "flex" => {
+                obj.insert(
+                    "service_tier".to_string(),
+                    Value::String("priority".to_string()),
+                );
+                changed = true;
+            }
+            _ => {
+                obj.remove("service_tier");
+                changed = true;
+            }
+        }
     }
 
     changed
@@ -511,5 +521,20 @@ mod tests {
             .pointer("/models/0/input_modalities")
             .and_then(Value::as_array)
             .is_some());
+    }
+
+    #[test]
+    fn maps_fast_service_tier_to_priority() {
+        let mut body = json!({
+            "model": "gpt-5.4",
+            "input": "hello",
+            "service_tier": "fast"
+        });
+
+        normalize_responses_body_for_codex(&mut body);
+        assert_eq!(
+            body.get("service_tier").and_then(Value::as_str),
+            Some("priority")
+        );
     }
 }

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -980,6 +980,13 @@ fn should_detach_child() -> bool {
     true
 }
 
+fn spawn_managed_codex_child(cmd: &mut Command) -> Result<Child, String> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    spawn_command_with_trace(cmd).map_err(|e| format!("启动 Codex 失败: {}", e))
+}
+
 #[cfg(target_os = "macos")]
 fn sanitize_macos_gui_launch_env(cmd: &mut Command) {
     // Avoid inheriting Cockpit bundle identity into child GUI apps.
@@ -7664,8 +7671,7 @@ pub fn start_codex_with_args(codex_home: &str, extra_args: &[String]) -> Result<
                     "--user-data-dir={}",
                     app_user_data_dir.to_string_lossy()
                 ));
-                let child =
-                    spawn_detached_unix(&mut cmd).map_err(|e| format!("启动 Codex 失败: {}", e))?;
+                let child = spawn_managed_codex_child(&mut cmd)?;
                 crate::modules::logger::log_info(&format!(
                     "[Codex Start] macOS managed instance using --user-data-dir and CODEX_ELECTRON_USER_DATA_PATH; codex_home={} electron_user_data={} launch_path={}",
                     summarize_text_for_process_log(codex_home_trimmed, 96),
@@ -7730,12 +7736,9 @@ pub fn start_codex_with_args(codex_home: &str, extra_args: &[String]) -> Result<
         apply_managed_proxy_env_to_command(&mut cmd);
         cmd.env("CODEX_HOME", codex_home_trimmed);
         cmd.env("CODEX_ELECTRON_USER_DATA_PATH", &app_user_data_dir);
-        if should_detach_child() {
-            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
-            cmd.stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null());
-        }
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
         for arg in extra_args {
             let trimmed = arg.trim();
             if !trimmed.is_empty() {


### PR DESCRIPTION
﻿## Summary
- force Codex session visibility repair when API service / reverse-proxy mode is activated, even if the visible provider already reads as `codex_local_access`
- add delayed post-launch repairs for API-service-bound Codex instances to cover async session writes after startup
- preserve default speed handling by mapping `fast` / `flex` service tiers to `priority`

## Root Cause
Switching from a subscription account back to API service could leave rollout/session metadata on `openai` because the repair only ran when the provider appeared to change. With repeated injection or overlapping instances, later writes could reintroduce stale subscription-provider metadata after the one-shot repair.

## Validation
- `npm run typecheck`
- `git diff --check`

Rust validation was not run locally because `cargo` is not installed on this machine.
