### PR TITLE
fix(local-access): 让 collection 模式 /v1/models 包含 API-key 账号的模型目录

### DIFF
--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -1117,16 +1117,61 @@ fn selected_accounts_have_image_generation_capacity(
     })
 }
 
+fn selected_api_key_model_catalogs(
+    accounts: &[CodexAccount],
+    collection: &CodexLocalAccessCollection,
+) -> Vec<String> {
+    if collection.account_ids.is_empty() {
+        return Vec::new();
+    }
+    let selected: HashSet<&str> = collection.account_ids.iter().map(String::as_str).collect();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut values: Vec<String> = Vec::new();
+    for account in accounts
+        .iter()
+        .filter(|account| selected.contains(account.id.as_str()) && account.is_api_key_auth())
+    {
+        for model in normalize_provider_gateway_models(
+            account
+                .api_model_catalog
+                .iter()
+                .map(String::as_str)
+                .collect(),
+        ) {
+            let key = model.to_ascii_lowercase();
+            if seen.insert(key) {
+                values.push(model);
+            }
+        }
+    }
+    values
+}
+
 fn base_codex_model_ids_for_collection(
     collection: &CodexLocalAccessCollection,
     health_by_account_id: Option<&HashMap<String, RuntimeAccountHealth>>,
 ) -> Vec<String> {
     let image_allowed =
         selected_accounts_have_image_generation_capacity(collection, health_by_account_id);
-    supported_codex_model_ids()
+    let accounts = codex_account::list_accounts_checked().unwrap_or_default();
+    let mut seen: HashSet<String> = supported_codex_model_ids()
         .into_iter()
-        .filter(|model| model != CODEX_IMAGE_MODEL_ID || image_allowed)
-        .collect()
+        .map(|model| model.trim().to_ascii_lowercase())
+        .collect();
+    let mut models: Vec<String> = supported_codex_model_ids()
+        .into_iter()
+        .filter(|model| image_allowed || model != CODEX_IMAGE_MODEL_ID)
+        .collect();
+    for model in selected_api_key_model_catalogs(&accounts, collection) {
+        let key = model.trim().to_ascii_lowercase();
+        if key.is_empty() {
+            continue;
+        }
+        if seen.insert(key) {
+            models.push(model);
+        }
+    }
+    models
 }
 
 fn normalize_model_rule_value(value: &str) -> String {
@@ -16650,15 +16695,15 @@ mod tests {
         provider_gateway_default_model_for_account, provider_gateway_models_for_account,
         recover_invalid_stats_file, remove_codex_local_access_config, resolve_plan_rank,
         resolve_supported_model_alias, resolve_upstream_target,
-        restore_config_toml_from_takeover_backup, should_retry_single_account_upstream_status,
-        should_treat_response_as_stream, should_try_next_account, sidecar_codex_api_key_auth_id,
-        sidecar_stable_id, validate_client_model_visible, visible_codex_model_ids_for_api_key,
-        websocket_accept_value, websocket_connect_error_from_http_response,
-        write_local_access_profile_model_override, write_provider_gateway_model_catalog,
-        write_string_atomic, CodexLocalAccessCollection, CodexLocalAccessGatewayMode,
-        CodexLocalAccessScope, GatewayResponseAdapter, ParsedRequest, ResolvedLocalApiKey,
-        ResponseUsageCollector, RoutingCandidate, SidecarUsageDetails, SidecarUsageEvent,
-        UsageCapture, CODEX_AUTO_REVIEW_MODEL_ID, CODEX_PROFILE_AUTH_FILE,
+        restore_config_toml_from_takeover_backup, selected_api_key_model_catalogs,
+        should_retry_single_account_upstream_status, should_treat_response_as_stream,
+        should_try_next_account, sidecar_codex_api_key_auth_id, sidecar_stable_id,
+        validate_client_model_visible, visible_codex_model_ids_for_api_key, websocket_accept_value,
+        websocket_connect_error_from_http_response, write_local_access_profile_model_override,
+        write_provider_gateway_model_catalog, write_string_atomic, CodexLocalAccessCollection,
+        CodexLocalAccessGatewayMode, CodexLocalAccessScope, GatewayResponseAdapter, ParsedRequest,
+        ResolvedLocalApiKey, ResponseUsageCollector, RoutingCandidate, SidecarUsageDetails,
+        SidecarUsageEvent, UsageCapture, CODEX_AUTO_REVIEW_MODEL_ID, CODEX_PROFILE_AUTH_FILE,
         CODEX_PROFILE_CONFIG_FILE, CODEX_PROVIDER_MODEL_BACKUP_FILE,
         CODEX_PROVIDER_MODEL_CATALOG_FILE, DEFAULT_MAX_RETRY_INTERVAL_MS,
         DEFAULT_SESSION_AFFINITY_TTL_MS,
@@ -16771,6 +16816,108 @@ mod tests {
                 "deepseek-v4-flash".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn selected_api_key_model_catalogs_merges_api_key_accounts() {
+        let collection =
+            test_local_access_collection(vec!["apikey-1".to_string(), "apikey-2".to_string()]);
+        let mut first = CodexAccount::new_api_key(
+            "apikey-1".to_string(),
+            "minimax@example.com".to_string(),
+            "sk-test".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.minimaxi.com/v1".to_string()),
+            Some("minimax".to_string()),
+            Some("MiniMax".to_string()),
+            vec![
+                "MiniMax-M3".to_string(),
+                "MiniMax-M3".to_string(),
+                " ".to_string(),
+            ],
+        );
+        first.api_model_catalog.push("MiniMax-M3-Plus".to_string());
+        let second = CodexAccount::new_api_key(
+            "apikey-2".to_string(),
+            "kimi@example.com".to_string(),
+            "sk-test-2".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.moonshot.cn/v1".to_string()),
+            Some("moonshot".to_string()),
+            Some("Moonshot".to_string()),
+            vec!["kimi-k2.6".to_string()],
+        );
+
+        let catalogs = selected_api_key_model_catalogs(&[first, second], &collection);
+        assert_eq!(
+            catalogs,
+            vec![
+                "MiniMax-M3".to_string(),
+                "MiniMax-M3-Plus".to_string(),
+                "kimi-k2.6".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn selected_api_key_model_catalogs_ignores_unselected_and_non_api_key_accounts() {
+        let collection = test_local_access_collection(vec!["apikey-1".to_string()]);
+        let mut selected = CodexAccount::new_api_key(
+            "apikey-1".to_string(),
+            "minimax@example.com".to_string(),
+            "sk-test".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.minimaxi.com/v1".to_string()),
+            Some("minimax".to_string()),
+            Some("MiniMax".to_string()),
+            vec!["MiniMax-M3".to_string()],
+        );
+        let unselected = CodexAccount::new_api_key(
+            "apikey-other".to_string(),
+            "deepseek@example.com".to_string(),
+            "sk-other".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.deepseek.com/v1".to_string()),
+            Some("deepseek".to_string()),
+            Some("DeepSeek".to_string()),
+            vec!["deepseek-v4-pro".to_string()],
+        );
+        let mut oauth = CodexAccount::new_api_key(
+            "oauth-1".to_string(),
+            "oauth@example.com".to_string(),
+            "sk-oauth".to_string(),
+            CodexApiProviderMode::Custom,
+            None,
+            None,
+            None,
+            vec!["MiniMax-M3".to_string()],
+        );
+        // OAuth 账号不算 api key auth
+        oauth.auth_mode = crate::models::codex::CodexAuthMode::OAuth;
+        let _ = &mut selected;
+        let _ = &mut oauth;
+
+        assert_eq!(
+            selected_api_key_model_catalogs(&[selected, unselected, oauth], &collection),
+            vec!["MiniMax-M3".to_string()]
+        );
+    }
+
+    #[test]
+    fn selected_api_key_model_catalogs_returns_empty_when_no_selected_ids() {
+        let collection = test_local_access_collection(Vec::new());
+        let account = CodexAccount::new_api_key(
+            "apikey-1".to_string(),
+            "minimax@example.com".to_string(),
+            "sk-test".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.minimaxi.com/v1".to_string()),
+            Some("minimax".to_string()),
+            Some("MiniMax".to_string()),
+            vec!["MiniMax-M3".to_string()],
+        );
+
+        assert!(selected_api_key_model_catalogs(&[account], &collection).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## 背景

从「账号总览」的「API 服务-新」卡片启动 codex 后，`GET /v1/models` 只返回 gpt-5-codex
等内置白名单模型，供应商里配的自定义模型目录（如 MiniMax-M3）拿不到；从
「模型供应商」卡片 ▶ 启动则正常。

## 根因

两条启动路径走两套模型列表组装函数：

- 供应商卡片 → provider gateway 路径 → `provider_gateway_models_for_account` 会读
  `CodexAccount.api_model_catalog`
- 账号总览 → 普通 `CodexLocalAccessCollection` 路径 → `base_codex_model_ids_for_collection`
  只拼 `supported_codex_model_ids()` + `codex_wakeup` model presets，完全不消费
  `api_model_catalog`

## 改动

- 新增 `selected_api_key_model_catalogs(accounts, collection)` helper：按
  `collection.account_ids` 取交集并过滤 `is_api_key_auth()`，把命中的账号的
  `api_model_catalog` 合并去重 + trim。
- `base_codex_model_ids_for_collection` 在 `supported_codex_model_ids()` 之后用同一份
  去重集合拼接 helper 结果，并继续走现有 `apply_model_aliases_to_ids` /
  `apply_model_filters` 管道，让 `excluded_models` 仍能按 collection 规则屏蔽某个模型。
- 兼容 OAuth 账号：helper 用 `is_api_key_auth()` 判定，OAuth 账号的
  `api_model_catalog` 不会被错误暴露。

## 测试

`src-tauri/src/modules/codex_local_access.rs` 新增 3 个单元测试：

1. `selected_api_key_model_catalogs_merges_api_key_accounts`：多账号去重 + 空白过滤。
2. `selected_api_key_model_catalogs_ignores_unselected_and_non_api_key_accounts`：
   未选中账号 / OAuth 账号的 catalog 不被合并。
3. `selected_api_key_model_catalogs_returns_empty_when_no_selected_ids`：
   空 collection 直接返回空。

## 验证

- `cargo test --lib`：206 passed / 0 failed
- `cargo fmt --check`：干净

## 影响面

- 仅修改 `codex_local_access.rs` 中 collection 模式下的模型列表组装函数；provider
  gateway 路径、`/v1/chat/completions` 路由逻辑不变。
- `excluded_models` / `forced_alias` 仍按 collection 规则生效，无旁路风险。
