### PR TITLE
fix: 保留 sidecar Codex Responses 思考强度

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	internalregistry "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	responsesconverter "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
 	sdkopenai "github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
@@ -2026,26 +2027,68 @@ func manifestRegistryModels(m *manifest) []*cliproxy.ModelInfo {
 	if m == nil {
 		return nil
 	}
-	ids := make([]string, 0, len(m.ModelIDs)+len(m.ModelAliases)*2)
-	ids = append(ids, m.ModelIDs...)
-	for _, alias := range m.ModelAliases {
-		ids = append(ids, alias.SourceModel, alias.Alias)
+	entries := make([]manifestRegistryModelEntry, 0, len(m.ModelIDs)+len(m.ModelAliases)*2)
+	seen := make(map[string]struct{}, cap(entries))
+	for _, id := range m.ModelIDs {
+		entries = appendManifestRegistryModelEntry(entries, seen, id, "")
 	}
-	ids = appendCodexInternalModels(ids)
-	ids = normalizeStringList(ids)
-	models := make([]*cliproxy.ModelInfo, 0, len(ids))
+	for _, alias := range m.ModelAliases {
+		entries = appendManifestRegistryModelEntry(entries, seen, alias.SourceModel, "")
+		entries = appendManifestRegistryModelEntry(entries, seen, alias.Alias, alias.SourceModel)
+	}
+	for _, id := range appendCodexInternalModels(nil) {
+		entries = appendManifestRegistryModelEntry(entries, seen, id, "")
+	}
+	models := make([]*cliproxy.ModelInfo, 0, len(entries))
 	now := time.Now().Unix()
-	for _, id := range ids {
-		models = append(models, &cliproxy.ModelInfo{
-			ID:          id,
-			Object:      "model",
-			Created:     now,
-			OwnedBy:     "openai",
-			Type:        "openai",
-			DisplayName: displayNameForModel(id),
-		})
+	for _, entry := range entries {
+		models = append(models, manifestRegistryModelInfo(entry.id, entry.source, now))
 	}
 	return models
+}
+
+type manifestRegistryModelEntry struct {
+	id     string
+	source string
+}
+
+func appendManifestRegistryModelEntry(entries []manifestRegistryModelEntry, seen map[string]struct{}, id string, source string) []manifestRegistryModelEntry {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return entries
+	}
+	key := strings.ToLower(id)
+	if _, exists := seen[key]; exists {
+		return entries
+	}
+	seen[key] = struct{}{}
+	return append(entries, manifestRegistryModelEntry{
+		id:     id,
+		source: strings.TrimSpace(source),
+	})
+}
+
+func manifestRegistryModelInfo(id string, source string, created int64) *cliproxy.ModelInfo {
+	info := &cliproxy.ModelInfo{
+		ID:          id,
+		Object:      "model",
+		Created:     created,
+		OwnedBy:     "openai",
+		Type:        "openai",
+		DisplayName: displayNameForModel(id),
+	}
+	lookupID := id
+	if source != "" {
+		lookupID = source
+	}
+	if staticInfo := internalregistry.LookupStaticModelInfo(lookupID); staticInfo != nil {
+		if staticInfo.Thinking != nil {
+			info.Thinking = staticInfo.Thinking
+		}
+		return info
+	}
+	info.UserDefined = true
+	return info
 }
 
 type sidecarRoundTripperProvider struct {

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -14,6 +14,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
@@ -187,6 +190,131 @@ func TestSidecarRuntimeRegistersConfigCodexAPIKeyAuths(t *testing.T) {
 	if got := m.accountByAuthID[strings.ToLower(codexAPIKeyAuth.ID)]; got == nil || got.ID != "api-account" {
 		t.Fatalf("expected auth to be linked to manifest account, got %#v", got)
 	}
+}
+
+func TestManifestRegistryModelsPreservesStaticThinkingSupport(t *testing.T) {
+	models := manifestRegistryModels(&manifest{
+		ModelIDs: []string{"gpt-5.2"},
+	})
+
+	info := findModelInfoForTest(models, "gpt-5.2")
+	if info == nil {
+		t.Fatalf("expected gpt-5.2 in manifest registry models: %#v", models)
+	}
+	if info.Thinking == nil {
+		t.Fatalf("expected gpt-5.2 to preserve static thinking support: %#v", info)
+	}
+	if !stringSliceContains(info.Thinking.Levels, "high") {
+		t.Fatalf("expected gpt-5.2 thinking levels to include high: %#v", info.Thinking.Levels)
+	}
+	if info.UserDefined {
+		t.Fatalf("static model should not be marked user-defined: %#v", info)
+	}
+}
+
+func TestManifestRegistryModelsCopiesSourceThinkingToAliases(t *testing.T) {
+	models := manifestRegistryModels(&manifest{
+		ModelAliases: []modelAliasSpec{{
+			SourceModel: "gpt-5.2",
+			Alias:       "gpt-5.2-codex",
+			Fork:        true,
+		}},
+	})
+
+	alias := findModelInfoForTest(models, "gpt-5.2-codex")
+	if alias == nil {
+		t.Fatalf("expected alias in manifest registry models: %#v", models)
+	}
+	if alias.Thinking == nil {
+		t.Fatalf("expected alias to inherit source thinking support: %#v", alias)
+	}
+	if !stringSliceContains(alias.Thinking.Levels, "high") {
+		t.Fatalf("expected alias thinking levels to include high: %#v", alias.Thinking.Levels)
+	}
+	if alias.UserDefined {
+		t.Fatalf("alias backed by static source should not be marked user-defined: %#v", alias)
+	}
+}
+
+func TestManifestRegistryModelsTreatsUnknownModelsAsUserDefined(t *testing.T) {
+	models := manifestRegistryModels(&manifest{
+		ModelIDs: []string{"custom-codex-model"},
+	})
+
+	info := findModelInfoForTest(models, "custom-codex-model")
+	if info == nil {
+		t.Fatalf("expected custom model in manifest registry models: %#v", models)
+	}
+	if !info.UserDefined {
+		t.Fatalf("unknown manifest model should be user-defined so thinking passes upstream: %#v", info)
+	}
+	if info.Thinking != nil {
+		t.Fatalf("unknown manifest model should not invent thinking support: %#v", info)
+	}
+}
+
+func TestManifestRegisteredModelsPreserveReasoningEffortThroughThinkingPipeline(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "test-codex-auth",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+	}
+	manager := buildCoreAuthManager(&config.Config{}, &cockpitSelector{}, nil)
+	registered, err := manager.Register(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	auth = registered
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	registerManifestModelsForAuth(manager, &manifest{
+		ModelIDs: []string{"gpt-5.2"},
+		ModelAliases: []modelAliasSpec{{
+			SourceModel: "gpt-5.2",
+			Alias:       "gpt-5.2-codex",
+		}},
+	}, auth)
+
+	for _, model := range []string{"gpt-5.2", "gpt-5.2-codex"} {
+		out, err := thinking.ApplyThinking(
+			[]byte(`{"model":"`+model+`","reasoning":{"effort":"high"}}`),
+			model,
+			"openai-response",
+			"codex",
+			"codex",
+		)
+		if err != nil {
+			t.Fatalf("ApplyThinking(%s): %v", model, err)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(out, &payload); err != nil {
+			t.Fatalf("translated payload for %s should be JSON: %v", model, err)
+		}
+		reasoning, _ := payload["reasoning"].(map[string]any)
+		if reasoning["effort"] != "high" {
+			t.Fatalf("reasoning effort should survive manifest registry for %s: %s", model, out)
+		}
+	}
+}
+
+func findModelInfoForTest(models []*cliproxy.ModelInfo, id string) *cliproxy.ModelInfo {
+	for _, model := range models {
+		if model != nil && strings.EqualFold(model.ID, id) {
+			return model
+		}
+	}
+	return nil
+}
+
+func stringSliceContains(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, target) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuiltinTranslatorNormalizesOpenAIResponsesForCodex(t *testing.T) {


### PR DESCRIPTION
﻿## 问题

新 sidecar API 服务在 Codex `/v1/responses` 请求链路中会经过 `thinking.ApplyThinking`。manifest 注册模型时原先只写入基础 `ModelInfo` 字段，覆盖了静态模型表中 provider=codex 的 thinking 能力元数据，导致 `reasoning.effort` 被误判为不支持并从请求体中移除。

旧 Rust gateway 没有这段 manifest -> registry -> thinking 能力覆盖链路，因此同样的 Responses 请求可以保留思考强度。

## 修复

- manifest 注册模型时复用静态模型表中的 `Thinking` 能力元数据。
- alias 模型从 source model 继承 thinking 能力，例如 `gpt-5.2-codex` 继承 `gpt-5.2`。
- 未知自定义模型标记为 `UserDefined`，不硬编码、不凭空生成 thinking level。
- 增加回归测试覆盖 registry、alias、thinking pipeline，以及真实 HTTP handler -> sidecar runtime -> Codex executor -> mock upstream 的 `/v1/responses` 链路。

## 验证

- `go test . -run "TestHTTPResponsesPreservesReasoningEffortThroughCodexRuntime|TestManifestRegistryModels|TestManifestRegisteredModels" -v`
- `go test ./...`
- `go build -o $env:TEMP\cockpit-cliproxy-reasoning-fix.exe .`

本地端到端 HTTP 验证已实际发请求：测试通过 `/v1/responses` handler 发送 `{"model":"gpt-5.2-codex","reasoning":{"effort":"high"}}`，mock Codex upstream 捕获到的 `/responses` 请求体包含 `"model":"gpt-5.2"` 和 `"reasoning":{"effort":"high"}`。

额外用两个真实测试站点做了正反对照：`/v1/models` 均返回 200 且列出 `gpt-5.2`；但直接请求 `/v1/responses` 时，无论是否携带 `reasoning.effort`，两个站点均返回 502。因此该对照不能证明 reasoning 字段被拒绝，只能说明这些真实站点当前直连 Responses 链路不可用或上游异常。

Closes #1115
