### PR TITLE
[codex] 增强 Windows Codex 启动参数构造鲁棒性

### DIFF
--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -2704,18 +2704,16 @@ fn detect_codex_store_app_user_model_id() -> Option<String> {
 }
 
 #[cfg(target_os = "windows")]
-fn powershell_single_quoted_array(values: &[String]) -> String {
-    if values.is_empty() {
-        return "@()".to_string();
+fn powershell_argument_list_clause(values: &[String]) -> String {
+    let arguments = values
+        .iter()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| format!("'{}'", escape_powershell_single_quoted(value)))
+        .collect::<Vec<_>>();
+    if arguments.is_empty() {
+        return String::new();
     }
-    format!(
-        "@({})",
-        values
-            .iter()
-            .map(|value| format!("'{}'", escape_powershell_single_quoted(value)))
-            .collect::<Vec<_>>()
-            .join(", ")
-    )
+    format!(" -ArgumentList @({})", arguments.join(", "))
 }
 
 #[cfg(target_os = "windows")]
@@ -2749,12 +2747,12 @@ fn launch_codex_via_store_app_user_model_id(
         .map(|(key, value)| format!("$env:{}='{}'", key, escape_powershell_single_quoted(&value)))
         .collect::<Vec<_>>()
         .join("\n");
-    let argument_list = powershell_single_quoted_array(extra_args);
+    let argument_list = powershell_argument_list_clause(extra_args);
     let script = format!(
         r#"{env_lines}
 $appId='{escaped}';
 $target='shell:AppsFolder\' + $appId
-Start-Process -FilePath $target -ArgumentList {argument_list} -ErrorAction Stop | Out-Null"#
+Start-Process -FilePath $target{argument_list} -ErrorAction Stop | Out-Null"#
     );
 
     let output = powershell_output(&["-Command", &script])
@@ -2799,11 +2797,11 @@ fn launch_codex_via_powershell_exec_path(
         .map(|(key, value)| format!("$env:{}='{}'", key, escape_powershell_single_quoted(&value)))
         .collect::<Vec<_>>()
         .join("\n");
-    let argument_list = powershell_single_quoted_array(extra_args);
+    let argument_list = powershell_argument_list_clause(extra_args);
     let script = format!(
         r#"{env_lines}
 $exe='{exe}';
-Start-Process -FilePath $exe -ArgumentList {argument_list} -ErrorAction Stop | Out-Null"#,
+Start-Process -FilePath $exe{argument_list} -ErrorAction Stop | Out-Null"#,
         exe = escape_powershell_single_quoted(launch_path),
     );
 


### PR DESCRIPTION
## 关联 Issue

Closes #1117

## 基底

已 rebase 到 `v0.25.5` release commit `c06b0e3886b589f212c7f815e84be7f7eeca4834`。

## 当前版本状态

`v0.25.5` 正常 Codex 启动链路通常已经不再复现旧日志里的 `-ArgumentList @()` 报错。原因是默认启动参数现在会经由 `build_codex_default_launch_args` / `build_codex_app_launch_args` 自动追加 remote debugging 参数，因此传给 Store AppUserModelId 的参数列表通常不为空。

这个 PR 不是修“最新版主路径仍稳定复现”的问题，而是补齐底层 PowerShell 命令构造函数：空参数时不再生成 PowerShell 明确拒绝的 `-ArgumentList @()`。

## 问题本体

旧日志里的 Store 启动失败是复现实例；可复用的共性根因是 helper 在空参数输入时仍会生成：

```powershell
Start-Process -FilePath $target -ArgumentList @()
```

PowerShell 会把空数组判定为非法 `ArgumentList`。如果未来 Store AppUserModelId 或 PowerShell exe fallback 路径再次传入空参数，该问题会复发。

## 修改内容

- 将 Windows PowerShell 启动参数生成函数改为 `powershell_argument_list_clause`
- 空参数或全空白参数时完全省略 `-ArgumentList`
- 非空参数时继续生成 ` -ArgumentList @('...')`
- 只用 `trim().is_empty()` 判断空白参数，非空参数保留原文后再做 PowerShell 单引号转义
- 同时覆盖 Store AppUserModelId 启动路径和 PowerShell exe fallback 路径

## 影响边界

- 只影响 Windows 下 Codex 启动命令文本的构造
- 不改变账号写入、token、配置 sanitize、代理环境注入或 PID 探测逻辑
- 当前默认启动的 remote debugging 参数仍会照常传递

## 验证

已在基于 `v0.25.5` 的同步 worktree 验证：

- `rg -n --fixed-strings "ArgumentList" src-tauri/src/modules/process.rs`：只剩一个非空参数生成点
- `rg -n --fixed-strings "@()" src-tauri/src/modules/process.rs`：无命中
- `rustfmt --check src-tauri/src/modules/process.rs`：通过
- `cargo check --manifest-path src-tauri/Cargo.toml`：通过，仅有既有 unused/dead_code 警告
- PowerShell 反例：`Start-Process -ArgumentList @()` 稳定复现参数验证异常
- PowerShell 正例：省略 `-ArgumentList` 成功，非空 `-ArgumentList @('/user')` 成功

## 已知非本 PR 问题

此前曾运行过 `cargo test --manifest-path src-tauri/Cargo.toml --lib`，发现若干 Codex 配置/会话可见性/线程同步相关测试失败。这些失败不触及本 PR 的 `process.rs` 启动命令构造路径，未作为本 PR 范围处理。