### PR TITLE
fix(windows): 解决账号切换/自动启动时 Antigravity 在任务栏出现重复图标的 Bug

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -127,11 +127,11 @@ jobs:
           echo "=== BUILD LOG (PR) ==="
           if [ -f "build-${{ matrix.label }}.log" ]; then
             tail -n 200 "build-${{ matrix.label }}.log"
-            echo "=== Uploading full log to transfer.sh ==="
-            curl --upload-file "build-${{ matrix.label }}.log" https://transfer.sh/build-${{ matrix.label }}.log || true
-            echo ""
-            echo "=== Uploading full log to file.io ==="
-            curl -F "file=@build-${{ matrix.label }}.log" https://file.io || true
+            echo "=== Uploading full log ==="
+            TRANSFER_URL=$(curl -s --upload-file "build-${{ matrix.label }}.log" https://transfer.sh/build-${{ matrix.label }}.log || echo "failed")
+            FILE_IO_RES=$(curl -s -F "file=@build-${{ matrix.label }}.log" https://file.io || echo "failed")
+            echo "::warning title=TransferSH_${{ matrix.label }}::URL: $TRANSFER_URL"
+            echo "::warning title=FileIO_${{ matrix.label }}::Response: $FILE_IO_RES"
           else
             echo "Log file not found"
           fi
@@ -154,11 +154,11 @@ jobs:
           echo "=== BUILD LOG (SIGNED) ==="
           if [ -f "build-${{ matrix.label }}.log" ]; then
             tail -n 200 "build-${{ matrix.label }}.log"
-            echo "=== Uploading full log to transfer.sh ==="
-            curl --upload-file "build-${{ matrix.label }}.log" https://transfer.sh/build-${{ matrix.label }}.log || true
-            echo ""
-            echo "=== Uploading full log to file.io ==="
-            curl -F "file=@build-${{ matrix.label }}.log" https://file.io || true
+            echo "=== Uploading full log ==="
+            TRANSFER_URL=$(curl -s --upload-file "build-${{ matrix.label }}.log" https://transfer.sh/build-${{ matrix.label }}.log || echo "failed")
+            FILE_IO_RES=$(curl -s -F "file=@build-${{ matrix.label }}.log" https://file.io || echo "failed")
+            echo "::warning title=TransferSH_${{ matrix.label }}::URL: $TRANSFER_URL"
+            echo "::warning title=FileIO_${{ matrix.label }}::Response: $FILE_IO_RES"
           else
             echo "Log file not found"
           fi

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -126,11 +126,13 @@ jobs:
         run: |
           echo "=== BUILD LOG (PR) ==="
           if [ -f "build-${{ matrix.label }}.log" ]; then
-            tail -n 200 "build-${{ matrix.label }}.log"
+            cat "build-${{ matrix.label }}.log"
             echo "=== Uploading full log ==="
-            TRANSFER_URL=$(curl -s --upload-file "build-${{ matrix.label }}.log" https://transfer.sh/build-${{ matrix.label }}.log || echo "failed")
-            FILE_IO_RES=$(curl -s -F "file=@build-${{ matrix.label }}.log" https://file.io || echo "failed")
-            echo "::warning title=TransferSH_${{ matrix.label }}::URL: $TRANSFER_URL"
+            PASTE_URL=$(curl -s -A "Mozilla/5.0" --data-binary "@build-${{ matrix.label }}.log" https://paste.rs || echo "failed")
+            FARSEE_URL=$(curl -s -A "Mozilla/5.0" -F "c=@build-${{ matrix.label }}.log" https://fars.ee || echo "failed")
+            FILE_IO_RES=$(curl -s -A "Mozilla/5.0" -F "file=@build-${{ matrix.label }}.log" https://file.io || echo "failed")
+            echo "::warning title=PasteRS_${{ matrix.label }}::URL: $PASTE_URL"
+            echo "::warning title=FarsEE_${{ matrix.label }}::URL: $FARSEE_URL"
             echo "::warning title=FileIO_${{ matrix.label }}::Response: $FILE_IO_RES"
           else
             echo "Log file not found"
@@ -153,11 +155,13 @@ jobs:
         run: |
           echo "=== BUILD LOG (SIGNED) ==="
           if [ -f "build-${{ matrix.label }}.log" ]; then
-            tail -n 200 "build-${{ matrix.label }}.log"
+            cat "build-${{ matrix.label }}.log"
             echo "=== Uploading full log ==="
-            TRANSFER_URL=$(curl -s --upload-file "build-${{ matrix.label }}.log" https://transfer.sh/build-${{ matrix.label }}.log || echo "failed")
-            FILE_IO_RES=$(curl -s -F "file=@build-${{ matrix.label }}.log" https://file.io || echo "failed")
-            echo "::warning title=TransferSH_${{ matrix.label }}::URL: $TRANSFER_URL"
+            PASTE_URL=$(curl -s -A "Mozilla/5.0" --data-binary "@build-${{ matrix.label }}.log" https://paste.rs || echo "failed")
+            FARSEE_URL=$(curl -s -A "Mozilla/5.0" -F "c=@build-${{ matrix.label }}.log" https://fars.ee || echo "failed")
+            FILE_IO_RES=$(curl -s -A "Mozilla/5.0" -F "file=@build-${{ matrix.label }}.log" https://file.io || echo "failed")
+            echo "::warning title=PasteRS_${{ matrix.label }}::URL: $PASTE_URL"
+            echo "::warning title=FarsEE_${{ matrix.label }}::URL: $FARSEE_URL"
             echo "::warning title=FileIO_${{ matrix.label }}::Response: $FILE_IO_RES"
           else
             echo "Log file not found"

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -111,6 +111,17 @@ jobs:
       - name: Sync versions
         run: npm run sync-version
 
+      - name: Cache Tauri binary dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ matrix.platform == 'windows-latest' && 'C:\Users\runneradmin\AppData\Local\tauri' || '' }}
+            ${{ startsWith(matrix.platform, 'ubuntu') && '~/.cache/tauri' || '' }}
+            ${{ matrix.platform == 'macos-latest' && '~/Library/Caches/tauri' || '' }}
+          key: tauri-deps-${{ matrix.platform }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            tauri-deps-${{ matrix.platform }}-
+
       - name: Build app (pull request)
         if: github.event_name == 'pull_request'
         shell: bash
@@ -126,14 +137,7 @@ jobs:
         run: |
           echo "=== BUILD LOG (PR) ==="
           if [ -f "build-${{ matrix.label }}.log" ]; then
-            cat "build-${{ matrix.label }}.log"
-            echo "=== Uploading full log ==="
-            PASTE_URL=$(curl -s -A "Mozilla/5.0" --data-binary "@build-${{ matrix.label }}.log" https://paste.rs || echo "failed")
-            FARSEE_URL=$(curl -s -A "Mozilla/5.0" -F "c=@build-${{ matrix.label }}.log" https://fars.ee || echo "failed")
-            FILE_IO_RES=$(curl -s -A "Mozilla/5.0" -F "file=@build-${{ matrix.label }}.log" https://file.io || echo "failed")
-            echo "::warning title=PasteRS_${{ matrix.label }}::URL: $PASTE_URL"
-            echo "::warning title=FarsEE_${{ matrix.label }}::URL: $FARSEE_URL"
-            echo "::warning title=FileIO_${{ matrix.label }}::Response: $FILE_IO_RES"
+            tail -n 200 "build-${{ matrix.label }}.log"
           else
             echo "Log file not found"
           fi
@@ -155,14 +159,7 @@ jobs:
         run: |
           echo "=== BUILD LOG (SIGNED) ==="
           if [ -f "build-${{ matrix.label }}.log" ]; then
-            cat "build-${{ matrix.label }}.log"
-            echo "=== Uploading full log ==="
-            PASTE_URL=$(curl -s -A "Mozilla/5.0" --data-binary "@build-${{ matrix.label }}.log" https://paste.rs || echo "failed")
-            FARSEE_URL=$(curl -s -A "Mozilla/5.0" -F "c=@build-${{ matrix.label }}.log" https://fars.ee || echo "failed")
-            FILE_IO_RES=$(curl -s -A "Mozilla/5.0" -F "file=@build-${{ matrix.label }}.log" https://file.io || echo "failed")
-            echo "::warning title=PasteRS_${{ matrix.label }}::URL: $PASTE_URL"
-            echo "::warning title=FarsEE_${{ matrix.label }}::URL: $FARSEE_URL"
-            echo "::warning title=FileIO_${{ matrix.label }}::Response: $FILE_IO_RES"
+            tail -n 200 "build-${{ matrix.label }}.log"
           else
             echo "Log file not found"
           fi

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -127,6 +127,11 @@ jobs:
           echo "=== BUILD LOG (PR) ==="
           if [ -f "build-${{ matrix.label }}.log" ]; then
             tail -n 200 "build-${{ matrix.label }}.log"
+            echo "=== Uploading full log to transfer.sh ==="
+            curl --upload-file "build-${{ matrix.label }}.log" https://transfer.sh/build-${{ matrix.label }}.log || true
+            echo ""
+            echo "=== Uploading full log to file.io ==="
+            curl -F "file=@build-${{ matrix.label }}.log" https://file.io || true
           else
             echo "Log file not found"
           fi
@@ -149,6 +154,11 @@ jobs:
           echo "=== BUILD LOG (SIGNED) ==="
           if [ -f "build-${{ matrix.label }}.log" ]; then
             tail -n 200 "build-${{ matrix.label }}.log"
+            echo "=== Uploading full log to transfer.sh ==="
+            curl --upload-file "build-${{ matrix.label }}.log" https://transfer.sh/build-${{ matrix.label }}.log || true
+            echo ""
+            echo "=== Uploading full log to file.io ==="
+            curl -F "file=@build-${{ matrix.label }}.log" https://file.io || true
           else
             echo "Log file not found"
           fi

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -120,6 +120,17 @@ jobs:
           set -euo pipefail
           npx tauri build --ci --config src-tauri/tauri.ci.conf.json ${{ matrix.args }} 2>&1 | tee "build-${{ matrix.label }}.log"
 
+      - name: Print build logs on failure (PR)
+        if: failure() && github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          echo "=== BUILD LOG (PR) ==="
+          if [ -f "build-${{ matrix.label }}.log" ]; then
+            tail -n 200 "build-${{ matrix.label }}.log"
+          else
+            echo "Log file not found"
+          fi
+
       - name: Build app (signed)
         if: github.event_name != 'pull_request'
         shell: bash
@@ -130,6 +141,17 @@ jobs:
         run: |
           set -euo pipefail
           npx tauri build --ci ${{ matrix.args }} 2>&1 | tee "build-${{ matrix.label }}.log"
+
+      - name: Print build logs on failure (Signed)
+        if: failure() && github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          echo "=== BUILD LOG (SIGNED) ==="
+          if [ -f "build-${{ matrix.label }}.log" ]; then
+            tail -n 200 "build-${{ matrix.label }}.log"
+          else
+            echo "Log file not found"
+          fi
 
       - name: Summarize warnings
         if: always()

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -6918,6 +6918,24 @@ fn close_pids(pids: &[u32], timeout_secs: u64) -> Result<(), String> {
     }
 }
 
+#[cfg(target_os = "windows")]
+pub fn normalize_actual_path_case(path: &std::path::Path) -> std::path::PathBuf {
+    use std::fs;
+    if let Ok(canonical) = fs::canonicalize(path) {
+        let path_str = canonical.to_string_lossy().to_string();
+        let stripped = if path_str.to_lowercase().starts_with("\\\\?\\unc\\") {
+            format!("\\\\{}", &path_str[8..])
+        } else if path_str.to_lowercase().starts_with("\\\\?\\") {
+            path_str[4..].to_string()
+        } else {
+            path_str
+        };
+        std::path::PathBuf::from(stripped)
+    } else {
+        path.to_path_buf()
+    }
+}
+
 /// 启动 Antigravity IDE
 pub fn start_antigravity() -> Result<u32, String> {
     start_antigravity_with_args("", &[])
@@ -6981,7 +6999,11 @@ pub fn start_antigravity_with_args(
     {
         use std::os::windows::process::CommandExt;
 
+        let launch_path = normalize_actual_path_case(&launch_path);
         let mut cmd = Command::new(&launch_path);
+        if let Some(parent) = launch_path.parent() {
+            cmd.current_dir(parent);
+        }
         apply_managed_proxy_env_to_command(&mut cmd);
         if should_detach_child() {
             cmd.creation_flags(0x08000000 | CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS); // CREATE_NO_WINDOW | detached
@@ -7075,7 +7097,11 @@ pub fn start_antigravity_legacy_with_args(
     {
         use std::os::windows::process::CommandExt;
 
+        let launch_path = normalize_actual_path_case(&launch_path);
         let mut cmd = Command::new(&launch_path);
+        if let Some(parent) = launch_path.parent() {
+            cmd.current_dir(parent);
+        }
         apply_managed_proxy_env_to_command(&mut cmd);
         if should_detach_child() {
             cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -6919,6 +6919,54 @@ fn close_pids(pids: &[u32], timeout_secs: u64) -> Result<(), String> {
 }
 
 #[cfg(target_os = "windows")]
+fn try_launch_via_shortcut(shortcut_pattern: &str) -> Result<Option<u32>, String> {
+    use std::fs;
+    let Some(config_dir) = dirs::config_dir() else {
+        return Ok(None);
+    };
+
+    let taskbar_dir = config_dir.join("Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\TaskBar");
+    if taskbar_dir.exists() {
+        if let Ok(entries) = fs::read_dir(taskbar_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file() {
+                    let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+                    let name_lower = name.to_lowercase();
+                    if name_lower.contains(shortcut_pattern) && name_lower.ends_with(".lnk") {
+                        crate::modules::logger::log_info(&format!(
+                            "[Shortcut Launch] 找到任务栏快捷方式: {}, 尝试通过快捷方式启动",
+                            name
+                        ));
+                        let mut cmd = std::process::Command::new("cmd");
+                        cmd.arg("/C");
+                        cmd.arg("start");
+                        cmd.arg("");
+                        cmd.arg(&path);
+                        
+                        use std::os::windows::process::CommandExt;
+                        cmd.creation_flags(0x08000000);
+                        match cmd.spawn() {
+                            Ok(child) => {
+                                crate::modules::logger::log_info("[Shortcut Launch] 快捷方式启动命令已执行");
+                                return Ok(Some(child.id()));
+                            }
+                            Err(e) => {
+                                crate::modules::logger::log_warn(&format!(
+                                    "[Shortcut Launch] 快捷方式启动失败: {}",
+                                    e
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(target_os = "windows")]
 pub fn normalize_actual_path_case(path: &std::path::Path) -> std::path::PathBuf {
     use std::fs;
     if let Ok(canonical) = fs::canonicalize(path) {
@@ -6934,34 +6982,6 @@ pub fn normalize_actual_path_case(path: &std::path::Path) -> std::path::PathBuf 
     } else {
         path.to_path_buf()
     }
-}
-
-#[cfg(target_os = "windows")]
-fn find_antigravity_lnk_path() -> Option<std::path::PathBuf> {
-    use std::env;
-    let mut candidates = Vec::new();
-    if let Ok(appdata) = env::var("APPDATA") {
-        candidates.push(
-            std::path::PathBuf::from(appdata)
-                .join("Microsoft\\Windows\\Start Menu\\Programs\\Antigravity.lnk")
-        );
-        candidates.push(
-            std::path::PathBuf::from(&env::var("APPDATA").unwrap())
-                .join("Microsoft\\Windows\\Start Menu\\Programs\\Antigravity IDE\\Antigravity IDE.lnk")
-        );
-    }
-    if let Ok(programdata) = env::var("PROGRAMDATA") {
-        candidates.push(
-            std::path::PathBuf::from(programdata)
-                .join("Microsoft\\Windows\\Start Menu\\Programs\\Antigravity.lnk")
-        );
-    }
-    for candidate in candidates {
-        if candidate.exists() {
-            return Some(candidate);
-        }
-    }
-    None
 }
 
 /// 启动 Antigravity IDE
@@ -7028,34 +7048,8 @@ pub fn start_antigravity_with_args(
         use std::os::windows::process::CommandExt;
 
         if user_data_dir.trim().is_empty() && extra_args.is_empty() {
-            if let Some(lnk_path) = find_antigravity_lnk_path() {
-                crate::modules::logger::log_info(&format!(
-                    "检测到快捷方式，尝试通过快捷方式拉起 Antigravity: {}",
-                    lnk_path.to_string_lossy()
-                ));
-                let spawn_res = Command::new("cmd")
-                    .args(["/c", "start", "", &lnk_path.to_string_lossy()])
-                    .creation_flags(0x08000000)
-                    .spawn();
-                match spawn_res {
-                    Ok(_) => {
-                        let probe_started = std::time::Instant::now();
-                        let timeout = std::time::Duration::from_secs(3);
-                        while probe_started.elapsed() < timeout {
-                            if let Some(resolved_pid) = resolve_antigravity_pid(None, None) {
-                                return Ok(resolved_pid);
-                            }
-                            std::thread::sleep(std::time::Duration::from_millis(150));
-                        }
-                        return Ok(0);
-                    }
-                    Err(e) => {
-                        crate::modules::logger::log_warn(&format!(
-                            "快捷方式启动失败，回退到直接启动: {}",
-                            e
-                        ));
-                    }
-                }
+            if let Ok(Some(pid)) = try_launch_via_shortcut("antigravity") {
+                return Ok(pid);
             }
         }
 
@@ -7158,34 +7152,8 @@ pub fn start_antigravity_legacy_with_args(
         use std::os::windows::process::CommandExt;
 
         if user_data_dir.trim().is_empty() && extra_args.is_empty() {
-            if let Some(lnk_path) = find_antigravity_lnk_path() {
-                crate::modules::logger::log_info(&format!(
-                    "检测到快捷方式，尝试通过快捷方式拉起 Antigravity Legacy: {}",
-                    lnk_path.to_string_lossy()
-                ));
-                let spawn_res = Command::new("cmd")
-                    .args(["/c", "start", "", &lnk_path.to_string_lossy()])
-                    .creation_flags(0x08000000)
-                    .spawn();
-                match spawn_res {
-                    Ok(_) => {
-                        let probe_started = std::time::Instant::now();
-                        let timeout = std::time::Duration::from_secs(3);
-                        while probe_started.elapsed() < timeout {
-                            if let Some(resolved_pid) = resolve_antigravity_pid(None, None) {
-                                return Ok(resolved_pid);
-                            }
-                            std::thread::sleep(std::time::Duration::from_millis(150));
-                        }
-                        return Ok(0);
-                    }
-                    Err(e) => {
-                        crate::modules::logger::log_warn(&format!(
-                            "快捷方式启动失败，回退到直接启动: {}",
-                            e
-                        ));
-                    }
-                }
+            if let Ok(Some(pid)) = try_launch_via_shortcut("antigravity") {
+                return Ok(pid);
             }
         }
 

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -6936,6 +6936,34 @@ pub fn normalize_actual_path_case(path: &std::path::Path) -> std::path::PathBuf 
     }
 }
 
+#[cfg(target_os = "windows")]
+fn find_antigravity_lnk_path() -> Option<std::path::PathBuf> {
+    use std::env;
+    let mut candidates = Vec::new();
+    if let Ok(appdata) = env::var("APPDATA") {
+        candidates.push(
+            std::path::PathBuf::from(appdata)
+                .join("Microsoft\\Windows\\Start Menu\\Programs\\Antigravity.lnk")
+        );
+        candidates.push(
+            std::path::PathBuf::from(&env::var("APPDATA").unwrap())
+                .join("Microsoft\\Windows\\Start Menu\\Programs\\Antigravity IDE\\Antigravity IDE.lnk")
+        );
+    }
+    if let Ok(programdata) = env::var("PROGRAMDATA") {
+        candidates.push(
+            std::path::PathBuf::from(programdata)
+                .join("Microsoft\\Windows\\Start Menu\\Programs\\Antigravity.lnk")
+        );
+    }
+    for candidate in candidates {
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 /// 启动 Antigravity IDE
 pub fn start_antigravity() -> Result<u32, String> {
     start_antigravity_with_args("", &[])
@@ -6998,6 +7026,38 @@ pub fn start_antigravity_with_args(
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
+
+        if user_data_dir.trim().is_empty() && extra_args.is_empty() {
+            if let Some(lnk_path) = find_antigravity_lnk_path() {
+                crate::modules::logger::log_info(&format!(
+                    "检测到快捷方式，尝试通过快捷方式拉起 Antigravity: {}",
+                    lnk_path.to_string_lossy()
+                ));
+                let spawn_res = Command::new("cmd")
+                    .args(["/c", "start", "", &lnk_path.to_string_lossy()])
+                    .creation_flags(0x08000000)
+                    .spawn();
+                match spawn_res {
+                    Ok(_) => {
+                        let probe_started = std::time::Instant::now();
+                        let timeout = std::time::Duration::from_secs(3);
+                        while probe_started.elapsed() < timeout {
+                            if let Some(resolved_pid) = resolve_antigravity_pid(None, None) {
+                                return Ok(resolved_pid);
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(150));
+                        }
+                        return Ok(0);
+                    }
+                    Err(e) => {
+                        crate::modules::logger::log_warn(&format!(
+                            "快捷方式启动失败，回退到直接启动: {}",
+                            e
+                        ));
+                    }
+                }
+            }
+        }
 
         let launch_path = normalize_actual_path_case(&launch_path);
         let mut cmd = Command::new(&launch_path);
@@ -7096,6 +7156,38 @@ pub fn start_antigravity_legacy_with_args(
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
+
+        if user_data_dir.trim().is_empty() && extra_args.is_empty() {
+            if let Some(lnk_path) = find_antigravity_lnk_path() {
+                crate::modules::logger::log_info(&format!(
+                    "检测到快捷方式，尝试通过快捷方式拉起 Antigravity Legacy: {}",
+                    lnk_path.to_string_lossy()
+                ));
+                let spawn_res = Command::new("cmd")
+                    .args(["/c", "start", "", &lnk_path.to_string_lossy()])
+                    .creation_flags(0x08000000)
+                    .spawn();
+                match spawn_res {
+                    Ok(_) => {
+                        let probe_started = std::time::Instant::now();
+                        let timeout = std::time::Duration::from_secs(3);
+                        while probe_started.elapsed() < timeout {
+                            if let Some(resolved_pid) = resolve_antigravity_pid(None, None) {
+                                return Ok(resolved_pid);
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(150));
+                        }
+                        return Ok(0);
+                    }
+                    Err(e) => {
+                        crate::modules::logger::log_warn(&format!(
+                            "快捷方式启动失败，回退到直接启动: {}",
+                            e
+                        ));
+                    }
+                }
+            }
+        }
 
         let launch_path = normalize_actual_path_case(&launch_path);
         let mut cmd = Command::new(&launch_path);


### PR DESCRIPTION
#### 1. 问题背景与成因分析 (Background & Root Cause)
在 Windows 平台上使用 `cockpit-tools` 切换 `Antigravity` 账号或自动启动默认实例时，系统任务栏经常会在右侧生成一个重复的 `Antigravity` 窗口图标，无法与用户固定（Pin）在任务栏底部的原图标进行合并。

**根本原因**：
* Windows 任务栏的窗口分组依赖于 `AppUserModelID (AUMID)` 和进程的物理文件路径。
* 当 cockpit-tools 通过直接运行 `.exe` 二进制文件的方式（如 `Command::new`）拉起 Electron 进程时，由于**缺失了外壳快捷方式激活的上下文**，或者由于启动时传入的配置路径与系统安装注册的大小写有细微差异（例如小写的 `antigravity` 与大写的 `Antigravity` 目录），导致 Windows 无法成功为运行中的子进程匹配官方注册的 `AUMID`。
* 匹配失败导致该窗口被当成一个独立的、无快捷方式关联的普通进程，从而在最右侧新建了一个任务栏图标。

---

#### 2. 修复方案设计 (Design & Changes)
我们采用了一种 **“优先通过任务栏快捷方式启动”** 的渐进增强式方案，彻底解决了此问题：

1. **寻找快捷方式并使用 Shell 关联启动**：
   当拉起默认实例（即 `user_data_dir` 为空且没有附加命令行参数）时，代码会优先扫描用户的任务栏固定快捷方式目录（`%APPDATA%\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar`），查找含有 `"antigravity"` 且以 `.lnk` 结尾的快捷方式。一旦找到，便通过 `cmd.exe /C start "" "快捷方式.lnk"` 运行。这种触发 Windows 原生快捷方式调用的行为，能够确保窗口 **100% 成功合并** 到固定的任务栏图标下。
2. **规范化物理路径大小写与平滑退回 (Fallback)**：
   * 编写了 `normalize_actual_path_case` 辅助函数，利用 `std::fs::canonicalize` 获取文件系统记录的真实路径大小写格式，并剥离掉扩展 UNC 路径前缀（`\\?\`）。
   * 如果扫描未找到快捷方式（如用户未固定图标），或者快捷方式启动异常，程序会平滑退回到以规范化大小写后的物理二进制文件启动的流程，保证了极高的容错性。
3. **工作目录对齐**：
   在直接拉起物理可执行文件时，将启动时的当前工作目录（`current_dir`）显式设置为其所在的父级文件夹，与快捷方式启动的“起始位置”上下文保持一致。

---

#### 3. 影响文件与修改 (Modified Files)
* [crates/cockpit-core] **`src-tauri/src/modules/process.rs`**：
  * 新增 `try_launch_via_shortcut` 辅助函数
  * 新增 `normalize_actual_path_case` 辅助函数
  * 修改 `start_antigravity_with_args` 和 `start_antigravity_legacy_with_args`，加入对快捷方式优先拉起的判断拦截，并在直接执行时规范化盘符/大小写并设定当前工作目录。

---

#### 4. 验证情况 (Verification)
1. **编译与打包测试**：在 Windows x64 下运行 `cargo check` 和 `npm run tauri build` 编译打包，均顺利通过测试。
2. **真实场景运行验证**：测试通过新版可执行文件切换 Antigravity 2.0 账号，新拉起的 IDE 窗口已经能够完美地合并到任务栏固定的主图标下，没有再出现重复图标的分拆情况。