### PR TITLE
fix(codex): repair session timestamps after visibility auto-fix

### DIFF
--- a/src-tauri/src/modules/codex_session_visibility.rs
+++ b/src-tauri/src/modules/codex_session_visibility.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use chrono::{TimeZone, Utc};
 use rusqlite::Connection;
@@ -22,6 +22,7 @@ const SESSION_DIRS: [&str; 2] = ["sessions", "archived_sessions"];
 const SESSION_VISIBILITY_REPAIR_BACKUP_PREFIX: &str = "backup-";
 const SESSION_VISIBILITY_REPAIR_BACKUP_SUFFIX: &str = "-session-visibility-repair";
 const MAX_SESSION_VISIBILITY_REPAIR_BACKUPS: usize = 1;
+const SESSION_INDEX_ACTIVITY_DRIFT_MS: i128 = 3_600_000;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -86,6 +87,7 @@ struct SqliteThreadIndexRow {
     id: String,
     title: String,
     updated_at: Option<i64>,
+    rollout_path: Option<String>,
 }
 
 pub fn repair_session_visibility_across_instances(
@@ -239,6 +241,7 @@ fn repair_single_instance(
     for change in rollout_changes {
         rewrite_rollout_provider(change)?;
     }
+    repair_sqlite_thread_timestamps(data_dir)?;
     let session_index_entries_added = if reconcile_session_index {
         reconcile_session_index_from_sqlite(data_dir)?
     } else {
@@ -384,12 +387,18 @@ fn collect_rollout_provider_changes(
                 continue;
             };
             let session_id = session_meta_id(&parsed);
-            let target_modified_at = session_id
-                .as_deref()
-                .and_then(|id| session_index_map.get(id))
-                .and_then(parse_session_index_updated_at_ms)
-                .or_else(|| rollout_file_activity_ms(&rollout_path))
-                .and_then(modules::codex_session_file_time::system_time_from_unix_millis);
+            let fallback_modified_ms = modules::codex_session_file_time::read_modified_time(
+                &rollout_path,
+            )
+            .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+            .map(|value| value.as_millis() as i128);
+            let target_modified_at = resolve_target_modified_at_ms(
+                session_id.as_deref(),
+                &session_index_map,
+                &rollout_path,
+                fallback_modified_ms,
+            )
+            .and_then(modules::codex_session_file_time::system_time_from_unix_millis);
             let current_modified_at =
                 modules::codex_session_file_time::read_modified_time(&rollout_path);
             let current_provider = parsed["payload"]
@@ -624,8 +633,14 @@ fn load_sqlite_thread_index_rows(data_dir: &Path) -> Result<Vec<SqliteThreadInde
     } else {
         "NULL"
     };
-    let sql =
-        format!("SELECT id, {title_expr}, {updated_at_expr} FROM threads ORDER BY updated_at DESC");
+    let rollout_path_expr = if names.contains("rollout_path") {
+        "rollout_path"
+    } else {
+        "NULL"
+    };
+    let sql = format!(
+        "SELECT id, {title_expr}, {updated_at_expr}, {rollout_path_expr} FROM threads ORDER BY updated_at DESC"
+    );
     let mut statement = connection.prepare(sql.as_str()).map_err(|error| {
         format!(
             "准备 SQLite 会话索引查询失败 ({}): {}",
@@ -639,6 +654,7 @@ fn load_sqlite_thread_index_rows(data_dir: &Path) -> Result<Vec<SqliteThreadInde
                 id: row.get(0)?,
                 title: row.get(1)?,
                 updated_at: row.get(2)?,
+                rollout_path: row.get(3)?,
             })
         })
         .map_err(|error| {
@@ -669,7 +685,27 @@ fn format_thread_updated_at_iso(updated_at: Option<i64>) -> String {
         .to_rfc3339_opts(chrono::SecondsFormat::Micros, true)
 }
 
-fn build_session_index_entry_from_thread(row: &SqliteThreadIndexRow) -> JsonValue {
+fn resolve_thread_updated_at_seconds(data_dir: &Path, row: &SqliteThreadIndexRow) -> Option<i64> {
+    let rollout_activity_seconds = row
+        .rollout_path
+        .as_deref()
+        .map(|path| resolve_rollout_path(data_dir, path))
+        .filter(|path| path.exists())
+        .and_then(|path| rollout_file_activity_ms(&path))
+        .map(|value| (value / 1000) as i64);
+    match (row.updated_at, rollout_activity_seconds) {
+        (Some(sqlite_seconds), Some(activity_seconds))
+            if i64::abs(sqlite_seconds - activity_seconds) > 3600 =>
+        {
+            Some(activity_seconds)
+        }
+        (Some(sqlite_seconds), _) => Some(sqlite_seconds),
+        (None, Some(activity_seconds)) => Some(activity_seconds),
+        (None, None) => None,
+    }
+}
+
+fn build_session_index_entry_from_thread(data_dir: &Path, row: &SqliteThreadIndexRow) -> JsonValue {
     json!({
         "id": row.id,
         "thread_name": if row.title.trim().is_empty() {
@@ -677,7 +713,7 @@ fn build_session_index_entry_from_thread(row: &SqliteThreadIndexRow) -> JsonValu
         } else {
             row.title.as_str()
         },
-        "updated_at": format_thread_updated_at_iso(row.updated_at),
+        "updated_at": format_thread_updated_at_iso(resolve_thread_updated_at_seconds(data_dir, row)),
     })
 }
 
@@ -714,7 +750,7 @@ fn reconcile_session_index_from_sqlite(data_dir: &Path) -> Result<usize, String>
     }
 
     for row in &missing_rows {
-        let entry = build_session_index_entry_from_thread(row);
+        let entry = build_session_index_entry_from_thread(data_dir, row);
         let line = serde_json::to_string(&entry)
             .map_err(|error| format!("序列化 session_index 条目失败: {}", error))?;
         lines.push(line);
@@ -794,6 +830,128 @@ fn rollout_file_activity_ms(path: &Path) -> Option<i128> {
         .filter_map(|line| serde_json::from_str::<JsonValue>(line.trim()).ok())
         .filter_map(|value| parse_rollout_line_timestamp_ms(&value))
         .max()
+}
+
+fn resolve_target_modified_at_ms(
+    session_id: Option<&str>,
+    session_index_map: &HashMap<String, JsonValue>,
+    rollout_path: &Path,
+    fallback_ms: Option<i128>,
+) -> Option<i128> {
+    let indexed = session_id
+        .and_then(|id| session_index_map.get(id))
+        .and_then(parse_session_index_updated_at_ms);
+    let activity = rollout_file_activity_ms(rollout_path);
+    match (indexed, activity) {
+        (Some(indexed), Some(activity))
+            if (indexed - activity).abs() > SESSION_INDEX_ACTIVITY_DRIFT_MS =>
+        {
+            Some(activity)
+        }
+        (Some(indexed), _) => Some(indexed),
+        (None, Some(activity)) => Some(activity),
+        (None, None) => fallback_ms,
+    }
+}
+
+fn resolve_rollout_path(data_dir: &Path, rollout_path: &str) -> PathBuf {
+    let trimmed = rollout_path.trim();
+    let stripped = trimmed.strip_prefix(r"\\?\").unwrap_or(trimmed);
+    let path = Path::new(stripped);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        data_dir.join(path)
+    }
+}
+
+fn repair_sqlite_thread_timestamps(data_dir: &Path) -> Result<usize, String> {
+    let db_path = data_dir.join(STATE_DB_FILE);
+    if !db_path.exists() {
+        return Ok(0);
+    }
+
+    let mut connection = match Connection::open(&db_path) {
+        Ok(connection) => connection,
+        Err(error) if modules::db::is_unusable_sqlite_database_error(&error) => {
+            log_skipped_sqlite_database(&db_path, &error.to_string());
+            return Ok(0);
+        }
+        Err(error) => {
+            return Err(format!(
+                "打开实例数据库失败 ({}): {}",
+                db_path.display(),
+                error
+            ));
+        }
+    };
+
+    let mut statement = match connection.prepare(
+        "SELECT id, rollout_path, updated_at FROM threads WHERE rollout_path IS NOT NULL AND rollout_path <> ''",
+    ) {
+        Ok(statement) => statement,
+        Err(error) if is_missing_threads_table_error(&error) => return Ok(0),
+        Err(error) => {
+            return Err(format_sqlite_read_error(
+                &db_path,
+                "准备 SQLite 会话时间修复查询失败",
+                &error,
+            ));
+        }
+    };
+
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+            ))
+        })
+        .map_err(|error| {
+            format_sqlite_read_error(&db_path, "查询 SQLite 会话时间失败", &error)
+        })?;
+
+    let mut updates = Vec::new();
+    for row in rows {
+        let (thread_id, rollout_path, updated_at) = row.map_err(|error| {
+            format_sqlite_read_error(&db_path, "读取 SQLite 会话时间失败", &error)
+        })?;
+        let rollout = resolve_rollout_path(data_dir, &rollout_path);
+        if !rollout.exists() {
+            continue;
+        }
+        let Some(activity_ms) = rollout_file_activity_ms(&rollout) else {
+            continue;
+        };
+        let activity_seconds = (activity_ms / 1000) as i64;
+        let current = updated_at.unwrap_or(0);
+        if i64::abs(current - activity_seconds) <= 1 {
+            continue;
+        }
+        updates.push((activity_seconds, thread_id));
+    }
+    drop(statement);
+
+    if updates.is_empty() {
+        return Ok(0);
+    }
+
+    let transaction = connection
+        .transaction()
+        .map_err(|error| format_sqlite_write_error(&db_path, &error))?;
+    for (activity_seconds, thread_id) in &updates {
+        transaction
+            .execute(
+                "UPDATE threads SET updated_at = ?1, updated_at_ms = ?2 WHERE id = ?3",
+                (*activity_seconds, *activity_seconds * 1000, thread_id.as_str()),
+            )
+            .map_err(|error| format_sqlite_write_error(&db_path, &error))?;
+    }
+    transaction
+        .commit()
+        .map_err(|error| format_sqlite_write_error(&db_path, &error))?;
+    Ok(updates.len())
 }
 
 fn is_missing_threads_table_error(error: &rusqlite::Error) -> bool {
@@ -1747,6 +1905,88 @@ mod tests {
             )
             .expect("read restored provider");
         assert_eq!(provider, "old");
+
+        fs::remove_dir_all(&data_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn resolve_target_modified_prefers_rollout_activity_when_index_drifts() {
+        let data_dir = make_temp_dir("codex-session-visibility-index-drift-test");
+        let rollout_dir = data_dir.join("sessions").join("2026").join("06").join("08");
+        fs::create_dir_all(&rollout_dir).expect("create rollout dir");
+        let rollout_path = rollout_dir.join("rollout-test.jsonl");
+        fs::write(
+            &rollout_path,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\",\"model_provider\":\"relay\"}}\n{\"type\":\"event\",\"timestamp\":\"2024-01-01T00:00:00Z\"}\n",
+        )
+        .expect("write rollout");
+        fs::write(
+            data_dir.join(SESSION_INDEX_FILE),
+            "{\"id\":\"s1\",\"thread_name\":\"Test\",\"updated_at\":\"2026-03-16T23:36:58.7406859Z\"}\n",
+        )
+        .expect("write session index");
+
+        let session_index_map = read_session_index_map(&data_dir).expect("read session index");
+        let target = resolve_target_modified_at_ms(
+            Some("s1"),
+            &session_index_map,
+            &rollout_path,
+            None,
+        )
+        .expect("resolve target modified");
+
+        assert_eq!(target, 1_704_067_200_000);
+        fs::remove_dir_all(&data_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn sqlite_timestamp_repair_syncs_from_rollout_activity() {
+        let data_dir = make_temp_dir("codex-session-visibility-sqlite-time-test");
+        let rollout_dir = data_dir.join("sessions").join("2026").join("06").join("08");
+        fs::create_dir_all(&rollout_dir).expect("create rollout dir");
+        let rollout_path = rollout_dir.join("rollout-test.jsonl");
+        fs::write(
+            &rollout_path,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread-1\",\"model_provider\":\"relay\"}}\n{\"type\":\"event\",\"timestamp\":\"2024-02-03T04:05:06Z\"}\n",
+        )
+        .expect("write rollout");
+        let rollout_path_string = rollout_path.to_string_lossy().to_string();
+
+        let db_path = data_dir.join(STATE_DB_FILE);
+        let connection = Connection::open(&db_path).expect("open sqlite");
+        connection
+            .execute(
+                "CREATE TABLE threads (
+                    id TEXT PRIMARY KEY,
+                    rollout_path TEXT,
+                    updated_at INTEGER,
+                    updated_at_ms INTEGER
+                )",
+                [],
+            )
+            .expect("create threads table");
+        connection
+            .execute(
+                "INSERT INTO threads (id, rollout_path, updated_at, updated_at_ms) VALUES
+                 ('thread-1', ?1, 1_800_000_000, 1_800_000_000_000)",
+                [rollout_path_string.as_str()],
+            )
+            .expect("insert row");
+        drop(connection);
+
+        let updated = repair_sqlite_thread_timestamps(&data_dir).expect("repair sqlite timestamps");
+        assert_eq!(updated, 1);
+
+        let connection = Connection::open(&db_path).expect("reopen sqlite");
+        let (updated_at, updated_at_ms) = connection
+            .query_row(
+                "SELECT updated_at, updated_at_ms FROM threads WHERE id = 'thread-1'",
+                [],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .expect("read repaired timestamps");
+        assert_eq!(updated_at, 1_706_933_106);
+        assert_eq!(updated_at_ms, 1_706_933_106_000);
 
         fs::remove_dir_all(&data_dir).expect("cleanup temp dir");
     }


### PR DESCRIPTION
## Summary

- After API/account switches, Cockpit auto-runs session visibility repair so chats stay visible, but session dates could still show as "just now" or wrong historical times.
- Root cause: rollout rewrites refresh file mtime; repair trusted stale `session_index.jsonl` timestamps over rollout event activity; sqlite `updated_at` was never resynced.
- Align timestamp repair with codex-switcher: when session_index and rollout activity drift by >1 hour, prefer rollout events; sync sqlite `updated_at` / `updated_at_ms` from rollout activity after repair; use rollout activity when appending missing session_index rows.

## Test plan

- [x] `cargo test codex_session_visibility::tests::resolve_target_modified_prefers_rollout_activity_when_index_drifts`
- [ ] Switch Codex account via Cockpit API combination and confirm auto visibility repair keeps correct sidebar dates
- [ ] Restart Codex Desktop and verify historical session ordering
