### PR TITLE
Fix Windows Codex account switch leaving default app on old login

### DIFF
--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -4664,6 +4664,24 @@ fn get_managed_codex_windows_app_user_data_dir(codex_home: &str) -> Option<Strin
 }
 
 #[cfg(target_os = "windows")]
+fn get_default_codex_windows_app_user_data_dirs(default_codex_home: &str) -> HashSet<String> {
+    let mut dirs = HashSet::new();
+    if let Some(app_dir) = get_default_codex_windows_app_user_data_dir() {
+        let normalized = normalize_path_for_compare(&app_dir);
+        if !normalized.is_empty() {
+            dirs.insert(normalized);
+        }
+    }
+    if let Some(app_dir) = get_managed_codex_windows_app_user_data_dir(default_codex_home) {
+        let normalized = normalize_path_for_compare(&app_dir);
+        if !normalized.is_empty() {
+            dirs.insert(normalized);
+        }
+    }
+    dirs
+}
+
+#[cfg(target_os = "windows")]
 fn is_codex_windows_main_process_command_line(cmdline: &str) -> bool {
     let lower = cmdline.to_ascii_lowercase();
     !lower.is_empty() && !is_helper_command_line(&lower) && !lower.contains("crashpad_handler")
@@ -8488,16 +8506,14 @@ pub fn close_codex_instances(codex_homes: &[String], timeout_secs: u64) -> Resul
             return Ok(());
         }
 
-        let current_default_app_dir = if includes_default {
-            get_managed_codex_windows_app_user_data_dir(
+        let current_default_app_dirs = if includes_default {
+            get_default_codex_windows_app_user_data_dirs(
                 crate::modules::codex_account::get_codex_home()
                     .to_string_lossy()
                     .as_ref(),
             )
-            .map(|value| normalize_path_for_compare(&value))
-            .filter(|value| !value.is_empty())
         } else {
-            None
+            HashSet::new()
         };
 
         let matches_target = |dir: Option<&String>,
@@ -8509,7 +8525,7 @@ pub fn close_codex_instances(codex_homes: &[String], timeout_secs: u64) -> Resul
                     !normalized.is_empty()
                         && (target_app_dirs.contains(&normalized)
                             || (includes_default
-                                && current_default_app_dir.as_deref() == Some(normalized.as_str())))
+                                && current_default_app_dirs.contains(&normalized)))
                 }
                 None => includes_default,
             }


### PR DESCRIPTION
## Problem
Switching Codex accounts on Windows can report success while the running Codex App remains on the previous login.

## Root Cause
The switch flow writes the new auth state, but the default Codex close path only matched the managed app-data directory derived from CODEX_HOME. A Store/default-launched Codex App can use the official default app-data directory instead, so the old process may stay alive and keep its in-memory login state.

## Fix
When closing the default Codex instance on Windows, match both:
- the official default Codex app user-data directory
- the managed app user-data directory derived from the default CODEX_HOME

## Verification
- `git diff --check`
- `npm run build`

## Maintainer Interest
I’m interested in helping maintain this project long-term, especially around Windows/Tauri/Codex account switching flows. I’m happy to keep submitting focused fixes and respond to review quickly.