### PR TITLE
支持 Antigravity 配置项备份恢复与优化免费账号重置时间

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -509,7 +509,23 @@ function MainApp() {
   const sideNavClassicFirstSyncDone = useSideNavLayoutStore((state) => state.classicFirstSyncDone);
   const markSideNavClassicFirstSyncDone = useSideNavLayoutStore((state) => state.markClassicFirstSyncDone);
   const syncSidebarEntriesFromDashboard = usePlatformLayoutStore((state) => state.syncSidebarEntriesFromDashboard);
-  const [page, setPage] = useState<Page>('dashboard');
+  const [page, setPage] = useState<Page>(() => {
+    try {
+      const saved = localStorage.getItem('agtools.active_page');
+      if (saved) {
+        return saved as Page;
+      }
+    } catch {}
+    return 'dashboard';
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('agtools.active_page', page);
+    } catch (e) {
+      console.warn('Failed to save active page to localStorage:', e);
+    }
+  }, [page]);
   const [showUpdateNotification, setShowUpdateNotification] = useState(false);
   const [updateNotificationKey, setUpdateNotificationKey] = useState(0);
   const [showCloseDialog, setShowCloseDialog] = useState(false);

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -93,7 +93,8 @@ import { QuickSettingsPopover } from '../components/QuickSettingsPopover'
 import {
   isPrivacyModeEnabledByDefault,
   maskSensitiveValue,
-  persistPrivacyModeEnabled
+  persistPrivacyModeEnabled,
+  PRIVACY_MODE_CHANGED_EVENT
 } from '../utils/privacy'
 import { useExportJsonModal } from '../hooks/useExportJsonModal'
 import { MultiSelectFilterDropdown, type MultiSelectFilterOption } from '../components/MultiSelectFilterDropdown'
@@ -129,13 +130,9 @@ import {
   normalizeAntigravityExternalImportToken,
 } from '../utils/externalProviderImport'
 import {
-  ACCOUNTS_OVERVIEW_FILTER_PERSISTENCE_CHANGED_EVENT,
-  type AccountsOverviewFilterPersistenceChangedDetail,
   normalizeAccountsOverviewScope,
   readAccountsOverviewFilterField,
-  readAccountsOverviewFilterPersistenceEnabled,
   readAccountsOverviewFilterStringArray,
-  removeAccountsOverviewFilterField,
   writeAccountsOverviewFilterField,
 } from '../utils/accountsOverviewFilterPersistence'
 import { useAntigravityRuntimeTarget } from '../hooks/useAntigravityRuntimeTarget'
@@ -288,18 +285,10 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     }
   }, [storeError])
 
-  const initialFilterPersistenceEnabled = readAccountsOverviewFilterPersistenceEnabled(
-    ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-  )
-  const [filterPersistenceEnabled, setFilterPersistenceEnabled] = useState<boolean>(
-    initialFilterPersistenceEnabled,
-  )
+
 
   // View mode
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    if (!initialFilterPersistenceEnabled) {
-      return 'grid'
-    }
     const saved = readAccountsOverviewFilterField<unknown>(
       ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
       ANTIGRAVITY_FILTER_FIELD_VIEW_MODE,
@@ -333,31 +322,25 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
   // 筛选
   const [searchQuery, setSearchQuery] = useState('')
   const [filterTypes, setFilterTypes] = useState<AccountsFilterType[]>(() =>
-    initialFilterPersistenceEnabled
-      ? (readAccountsOverviewFilterStringArray(
-          ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-          ANTIGRAVITY_FILTER_FIELD_FILTER_TYPES,
-        ) as AccountsFilterType[])
-      : [],
+    (readAccountsOverviewFilterStringArray(
+      ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+      ANTIGRAVITY_FILTER_FIELD_FILTER_TYPES,
+    ) as AccountsFilterType[])
   )
   const [tagFilter, setTagFilter] = useState<string[]>(() =>
-    initialFilterPersistenceEnabled
-      ? readAccountsOverviewFilterStringArray(
-          ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-          ANTIGRAVITY_FILTER_FIELD_TAG_FILTER,
-        )
-      : [],
+    readAccountsOverviewFilterStringArray(
+      ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+      ANTIGRAVITY_FILTER_FIELD_TAG_FILTER,
+    )
   )
   const [groupByTag, setGroupByTag] = useState<boolean>(() =>
-    initialFilterPersistenceEnabled
-      ? Boolean(
-          readAccountsOverviewFilterField<unknown>(
-            ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-            ANTIGRAVITY_FILTER_FIELD_GROUP_BY_TAG,
-            false,
-          ),
-        )
-      : false,
+    Boolean(
+      readAccountsOverviewFilterField<unknown>(
+        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+        ANTIGRAVITY_FILTER_FIELD_GROUP_BY_TAG,
+        false,
+      ),
+    )
   )
 
   const toggleFilterTypeValue = useCallback((value: AccountsFilterType) => {
@@ -463,9 +446,6 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
   // ─── 账号分组（文件夹）────────────────────────────────────
   const [accountGroups, setAccountGroups] = useState<AccountGroup[]>([])
   const [activeGroupId, setActiveGroupId] = useState<string | null>(() => {
-    if (!initialFilterPersistenceEnabled) {
-      return null
-    }
     const saved = readAccountsOverviewFilterField<string | null>(
       ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
       ANTIGRAVITY_FILTER_FIELD_ACTIVE_GROUP_ID,
@@ -514,9 +494,6 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     }
   }, [accountGroups, groupQuickAddGroupId])
   const [sortBy, setSortBy] = useState<string>(() => {
-    if (!initialFilterPersistenceEnabled) {
-      return DEFAULT_ANTIGRAVITY_SORT_BY
-    }
     return normalizeAntigravitySortBy(
       readAccountsOverviewFilterField<unknown>(
         ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
@@ -526,9 +503,6 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     )
   })
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>(() => {
-    if (!initialFilterPersistenceEnabled) {
-      return 'desc'
-    }
     return normalizeAntigravitySortDirection(
       readAccountsOverviewFilterField<unknown>(
         ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
@@ -640,130 +614,142 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     return total.toFixed(2).replace(/\.?0+$/, '')
   }
 
+
+
   useEffect(() => {
-    const handleFilterPersistenceChanged = (event: Event) => {
-      const detail = (event as CustomEvent<AccountsOverviewFilterPersistenceChangedDetail>).detail
-      if (!detail || detail.scope !== ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE) {
-        return
-      }
-      setFilterPersistenceEnabled(Boolean(detail.enabled))
-    }
-    window.addEventListener(
-      ACCOUNTS_OVERVIEW_FILTER_PERSISTENCE_CHANGED_EVENT,
-      handleFilterPersistenceChanged as EventListener,
-    )
-    return () => {
-      window.removeEventListener(
-        ACCOUNTS_OVERVIEW_FILTER_PERSISTENCE_CHANGED_EVENT,
-        handleFilterPersistenceChanged as EventListener,
+    const handleConfigUpdated = () => {
+      const savedViewMode = readAccountsOverviewFilterField<unknown>(
+        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+        ANTIGRAVITY_FILTER_FIELD_VIEW_MODE,
+        'grid',
       )
+      if (savedViewMode === 'grid' || savedViewMode === 'list' || savedViewMode === 'compact') {
+        setViewMode(savedViewMode)
+      }
+
+      setFilterTypes(
+        readAccountsOverviewFilterStringArray(
+          ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+          ANTIGRAVITY_FILTER_FIELD_FILTER_TYPES,
+        ) as AccountsFilterType[]
+      )
+
+      setTagFilter(
+        readAccountsOverviewFilterStringArray(
+          ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+          ANTIGRAVITY_FILTER_FIELD_TAG_FILTER,
+        )
+      )
+
+      setGroupByTag(
+        Boolean(
+          readAccountsOverviewFilterField<unknown>(
+            ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+            ANTIGRAVITY_FILTER_FIELD_GROUP_BY_TAG,
+            false,
+          ),
+        )
+      )
+
+      const savedActiveGroupId = readAccountsOverviewFilterField<string | null>(
+        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+        ANTIGRAVITY_FILTER_FIELD_ACTIVE_GROUP_ID,
+        null,
+      )
+      setActiveGroupId(typeof savedActiveGroupId === 'string' && savedActiveGroupId.trim() ? savedActiveGroupId : null)
+
+      setSortBy(
+        normalizeAntigravitySortBy(
+          readAccountsOverviewFilterField<unknown>(
+            ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+            ANTIGRAVITY_FILTER_FIELD_SORT_BY,
+            DEFAULT_ANTIGRAVITY_SORT_BY,
+          ) as string,
+        )
+      )
+
+      setSortDirection(
+        normalizeAntigravitySortDirection(
+          readAccountsOverviewFilterField<unknown>(
+            ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
+            ANTIGRAVITY_FILTER_FIELD_SORT_DIRECTION,
+            'desc',
+          ) as string | null,
+        )
+      )
+
+      setPrivacyModeEnabled(isPrivacyModeEnabledByDefault())
+    }
+
+    const handlePrivacyModeChanged = (event: Event) => {
+      const isEnabled = (event as CustomEvent<boolean>).detail
+      setPrivacyModeEnabled(isEnabled)
+    }
+
+    window.addEventListener('config-updated', handleConfigUpdated)
+    window.addEventListener(PRIVACY_MODE_CHANGED_EVENT, handlePrivacyModeChanged as EventListener)
+
+    return () => {
+      window.removeEventListener('config-updated', handleConfigUpdated)
+      window.removeEventListener(PRIVACY_MODE_CHANGED_EVENT, handlePrivacyModeChanged as EventListener)
     }
   }, [])
 
   useEffect(() => {
-    if (!filterPersistenceEnabled) {
-      removeAccountsOverviewFilterField(
-        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-        ANTIGRAVITY_FILTER_FIELD_VIEW_MODE,
-      )
-      return
-    }
     writeAccountsOverviewFilterField(
       ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
       ANTIGRAVITY_FILTER_FIELD_VIEW_MODE,
       viewMode,
     )
-  }, [filterPersistenceEnabled, viewMode])
+  }, [viewMode])
 
   useEffect(() => {
-    if (!filterPersistenceEnabled) {
-      removeAccountsOverviewFilterField(
-        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-        ANTIGRAVITY_FILTER_FIELD_SORT_BY,
-      )
-      return
-    }
     writeAccountsOverviewFilterField(
       ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
       ANTIGRAVITY_FILTER_FIELD_SORT_BY,
       sortBy,
     )
-  }, [filterPersistenceEnabled, sortBy])
+  }, [sortBy])
 
   useEffect(() => {
-    if (!filterPersistenceEnabled) {
-      removeAccountsOverviewFilterField(
-        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-        ANTIGRAVITY_FILTER_FIELD_SORT_DIRECTION,
-      )
-      return
-    }
     writeAccountsOverviewFilterField(
       ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
       ANTIGRAVITY_FILTER_FIELD_SORT_DIRECTION,
       sortDirection,
     )
-  }, [filterPersistenceEnabled, sortDirection])
+  }, [sortDirection])
 
   useEffect(() => {
-    if (!filterPersistenceEnabled) {
-      removeAccountsOverviewFilterField(
-        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-        ANTIGRAVITY_FILTER_FIELD_FILTER_TYPES,
-      )
-      return
-    }
     writeAccountsOverviewFilterField(
       ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
       ANTIGRAVITY_FILTER_FIELD_FILTER_TYPES,
       filterTypes,
     )
-  }, [filterPersistenceEnabled, filterTypes])
+  }, [filterTypes])
 
   useEffect(() => {
-    if (!filterPersistenceEnabled) {
-      removeAccountsOverviewFilterField(
-        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-        ANTIGRAVITY_FILTER_FIELD_TAG_FILTER,
-      )
-      return
-    }
     writeAccountsOverviewFilterField(
       ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
       ANTIGRAVITY_FILTER_FIELD_TAG_FILTER,
       tagFilter,
     )
-  }, [filterPersistenceEnabled, tagFilter])
+  }, [tagFilter])
 
   useEffect(() => {
-    if (!filterPersistenceEnabled) {
-      removeAccountsOverviewFilterField(
-        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-        ANTIGRAVITY_FILTER_FIELD_GROUP_BY_TAG,
-      )
-      return
-    }
     writeAccountsOverviewFilterField(
       ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
       ANTIGRAVITY_FILTER_FIELD_GROUP_BY_TAG,
       groupByTag,
     )
-  }, [filterPersistenceEnabled, groupByTag])
+  }, [groupByTag])
 
   useEffect(() => {
-    if (!filterPersistenceEnabled) {
-      removeAccountsOverviewFilterField(
-        ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
-        ANTIGRAVITY_FILTER_FIELD_ACTIVE_GROUP_ID,
-      )
-      return
-    }
     writeAccountsOverviewFilterField(
       ANTIGRAVITY_FILTER_PERSISTENCE_SCOPE,
       ANTIGRAVITY_FILTER_FIELD_ACTIVE_GROUP_ID,
       activeGroupId,
     )
-  }, [activeGroupId, filterPersistenceEnabled])
+  }, [activeGroupId])
 
   useEffect(() => {
     if (!displayGroupsLoaded) {

--- a/src/presentation/platformAccountPresentation.ts
+++ b/src/presentation/platformAccountPresentation.ts
@@ -22,6 +22,7 @@ import {
   getAntigravityTierBadge,
   getQuotaClass as getAntigravityQuotaClass,
   matchModelName,
+  getSubscriptionTier,
 } from "../utils/account";
 import {
   CB_PACKAGE_CODE,
@@ -544,12 +545,18 @@ export function getAntigravityQuotaDisplayItems(
     });
   }
 
+  const isFree = getSubscriptionTier(account.quota) === 'FREE';
+
   if (claude5h) {
+    let resetTime = claude5h.reset_time;
+    if (isFree) {
+      resetTime = claude5h.reset_time || claudeWeekly?.reset_time || '';
+    }
     result.push({
       key: 'claude:5h',
       label: 'Claude (5h)',
       percentage: claude5h.percentage,
-      resetTime: claude5h.reset_time,
+      resetTime: resetTime,
     });
   }
   if (claudeWeekly) {
@@ -564,16 +571,20 @@ export function getAntigravityQuotaDisplayItems(
     let percentage = gemini5h.percentage;
     let resetTime = gemini5h.reset_time;
 
-    if (resetTime) {
-      const resetTs = new Date(resetTime).getTime();
-      if (!isNaN(resetTs)) {
-        const diffHours = (resetTs - Date.now()) / (1000 * 60 * 60);
-        // If the reset time is > 5 hours in the future (e.g. weekly reset),
-        // it means the weekly limit is active and capping the 5h limit.
-        // We override the 5h display remaining to 100% and clear the reset time.
-        if (diffHours > 5) {
-          percentage = 100;
-          resetTime = '';
+    if (isFree) {
+      resetTime = gemini5h.reset_time || geminiWeekly?.reset_time || '';
+    } else {
+      if (resetTime) {
+        const resetTs = new Date(resetTime).getTime();
+        if (!isNaN(resetTs)) {
+          const diffHours = (resetTs - Date.now()) / (1000 * 60 * 60);
+          // If the reset time is > 5 hours in the future (e.g. weekly reset),
+          // it means the weekly limit is active and capping the 5h limit.
+          // We override the 5h display remaining to 100% and clear the reset time.
+          if (diffHours > 5) {
+            percentage = 100;
+            resetTime = '';
+          }
         }
       }
     }

--- a/src/services/dataTransferService.ts
+++ b/src/services/dataTransferService.ts
@@ -220,6 +220,13 @@ export interface DataTransferConfigBundle {
   compact_group_colors?: unknown;
   compact_hidden_groups?: unknown;
   app_language?: string;
+  antigravity_view_mode?: unknown;
+  antigravity_sort_by?: unknown;
+  antigravity_sort_direction?: unknown;
+  antigravity_filter_types?: unknown;
+  antigravity_group_by_tag?: unknown;
+  antigravity_active_group_id?: unknown;
+  privacy_mode_enabled?: unknown;
 }
 
 export interface DataTransferBundle {
@@ -1012,6 +1019,13 @@ async function exportConfigBundle(registry: AccountRegistry): Promise<DataTransf
     compact_group_colors: safeGetLocalStorageItem('compactGroupColors'),
     compact_hidden_groups: safeGetLocalStorageItem('compactHiddenGroups'),
     app_language: localStorage.getItem('app-language') ?? undefined,
+    antigravity_view_mode: safeGetLocalStorageItem('agtools.antigravity.accounts_overview_filters.view_mode'),
+    antigravity_sort_by: safeGetLocalStorageItem('agtools.antigravity.accounts_overview_filters.sort_by'),
+    antigravity_sort_direction: safeGetLocalStorageItem('agtools.antigravity.accounts_overview_filters.sort_direction'),
+    antigravity_filter_types: safeGetLocalStorageItem('agtools.antigravity.accounts_overview_filters.filter_types'),
+    antigravity_group_by_tag: safeGetLocalStorageItem('agtools.antigravity.accounts_overview_filters.group_by_tag'),
+    antigravity_active_group_id: safeGetLocalStorageItem('agtools.antigravity.accounts_overview_filters.active_group_id'),
+    privacy_mode_enabled: safeGetLocalStorageItem('agtools.privacy_mode_enabled'),
   };
 }
 
@@ -1109,6 +1123,31 @@ async function importConfigBundle(bundle: DataTransferConfigBundle): Promise<Dat
   if (bundle.compact_hidden_groups !== undefined) safeSetLocalStorageItem('compactHiddenGroups', bundle.compact_hidden_groups);
   if (bundle.app_language !== undefined) {
     localStorage.setItem('app-language', bundle.app_language);
+  }
+  if (bundle.antigravity_view_mode !== undefined) {
+    safeSetLocalStorageItem('agtools.antigravity.accounts_overview_filters.view_mode', bundle.antigravity_view_mode);
+  }
+  if (bundle.antigravity_sort_by !== undefined) {
+    safeSetLocalStorageItem('agtools.antigravity.accounts_overview_filters.sort_by', bundle.antigravity_sort_by);
+  }
+  if (bundle.antigravity_sort_direction !== undefined) {
+    safeSetLocalStorageItem('agtools.antigravity.accounts_overview_filters.sort_direction', bundle.antigravity_sort_direction);
+  }
+  if (bundle.antigravity_filter_types !== undefined) {
+    safeSetLocalStorageItem('agtools.antigravity.accounts_overview_filters.filter_types', bundle.antigravity_filter_types);
+  }
+  if (bundle.antigravity_group_by_tag !== undefined) {
+    safeSetLocalStorageItem('agtools.antigravity.accounts_overview_filters.group_by_tag', bundle.antigravity_group_by_tag);
+  }
+  if (bundle.antigravity_active_group_id !== undefined) {
+    safeSetLocalStorageItem('agtools.antigravity.accounts_overview_filters.active_group_id', bundle.antigravity_active_group_id);
+  }
+  if (bundle.privacy_mode_enabled !== undefined) {
+    safeSetLocalStorageItem('agtools.privacy_mode_enabled', bundle.privacy_mode_enabled);
+    if (typeof window !== 'undefined') {
+      const isEnabled = bundle.privacy_mode_enabled === true || bundle.privacy_mode_enabled === 'true' || bundle.privacy_mode_enabled === 1 || bundle.privacy_mode_enabled === '1';
+      window.dispatchEvent(new CustomEvent('agtools:privacy-mode-changed', { detail: isEnabled }));
+    }
   }
 
   saveCurrentAccountRefreshMinutesMap(bundle.current_account_refresh_minutes);


### PR DESCRIPTION
#### 1. 背景与问题 (Background & Issue)
* **配置持久化与备份需求**：当前 Antigravity 账号管理页面的筛选条件（账号类型过滤）、排序指标、排序方向、排版视图模式以及邮箱显示/隐藏等配置在用户切换页面或重启应用时有时会重置。并且这些配置不支持通过 Cockpit 配置导出/导入进行备份与恢复。
* **免费账号 5 小时配额重置时间显示异常**：在免费账号卡片中，当 5 小时配额重置时间因超出 5 小时被前端逻辑清空时，卡片下方的重置时间将显示为空。我们需要在此处为 5 小时配额的重置时间提供合理兜底（如果为空，则回退显示周配额重置时间）。

---

#### 2. 修改内容 (Changes Made)

##### **配置项始终持久化与备份恢复支持**
* **`src/services/dataTransferService.ts`**：
  * 在配置导入/导出实体 `DataTransferConfigBundle` 中，引入了 Antigravity 页面的筛选配置、视图模式、排序指标、排序方向、分组文件夹 ID 以及全局邮箱隐藏/显示等选项。
  * **按需求排除了标签过滤选项 (`tag_filter`)**，使其不包含在备份恢复数据中。
  * 在导入恢复时，自动将这些配置写回 `localStorage`，并针对邮箱隐私模式派发对应的更新事件。
* **`src/pages/AccountsPage.tsx`**：
  * 将 Antigravity 管理页面各选项（`viewMode`, `filterTypes`, `tagFilter`, `groupByTag`, `activeGroupId`, `sortBy`, `sortDirection`）的读取与持久化逻辑调整为**始终保存与自动读取**，不再受制于全局“筛选条件记忆”开关。
  * 注册了对 `config-updated` 和 `agtools:privacy-mode-changed` 事件的监听，当用户恢复备份配置时，能**实时刷新**当前界面的各项配置选择。
  * 清理了冗余及未使用的导入项与状态。

##### **免费账号 5 小时配额重置时间显示修正**
* **`src/presentation/platformAccountPresentation.ts`**：
  * 在处理 Antigravity 配额展示的方法 `getAntigravityQuotaDisplayItems` 中引入了 `getSubscriptionTier`。
  * 针对免费账号（`FREE` 级别），为 `Claude (5h)` 和 `Gemini (5h)` 的重置时间设置了如下兜底逻辑：**优先使用 5 小时原本的重置时间；如果 5 小时重置时间为空，则使用周重置时间 (`weekly.reset_time`) 进行兜底显示**。

---

#### 3. 验证与测试 (Verification & Testing)
* **编译/类型检查**：本地执行 `npm run typecheck` (`tsc --noEmit`) 检查通过，无任何编译或 TypeScript 报错。
* **功能验证**：
  * **持久化**：在 Antigravity 界面调整排序、排版和类型筛选后，刷新应用配置能被完整保留。
  * **备份恢复**：导出备份后可在导出的 JSON 中正确看到除 `tag_filter` 以外的所有相关配置键值，导入此备份后页面能即时刷新应用新配置。
  * **重置时间**：在免费账号卡片下，若 5 小时配额重置时间为 `""`，卡片对应 5 小时行下方能正常兜底显示周配额重置时间。