### PR TITLE
Fix unmatched Codex tool calls in Claude Agent requests

### DIFF
--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_executor.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_executor.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -513,6 +514,88 @@ func insertCodexReasoningReplayItems(body []byte, replayItems [][]byte) ([]byte,
 	return updated, true
 }
 
+func normalizeCodexInputToolCallPairs(body []byte) []byte {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body
+	}
+
+	callIDs := map[string]struct{}{}
+	outputIDs := map[string]struct{}{}
+	input.ForEach(func(_, item gjson.Result) bool {
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		itemType := strings.TrimSpace(item.Get("type").String())
+		switch itemType {
+		case "function_call", "custom_tool_call":
+			if callID != "" {
+				callIDs[itemType+"\x00"+callID] = struct{}{}
+			}
+		case "function_call_output":
+			if callID != "" {
+				outputIDs["function_call\x00"+callID] = struct{}{}
+			}
+		case "custom_tool_call_output":
+			if callID != "" {
+				outputIDs["custom_tool_call\x00"+callID] = struct{}{}
+			}
+		}
+		return true
+	})
+	if len(callIDs) == 0 && len(outputIDs) == 0 {
+		return body
+	}
+
+	changed := false
+	filtered := make([]json.RawMessage, 0, len(input.Array()))
+	input.ForEach(func(_, item gjson.Result) bool {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		switch itemType {
+		case "function_call", "custom_tool_call":
+			if callID == "" {
+				changed = true
+				return true
+			}
+			if _, ok := outputIDs[itemType+"\x00"+callID]; !ok {
+				changed = true
+				return true
+			}
+		case "function_call_output":
+			if callID == "" {
+				changed = true
+				return true
+			}
+			if _, ok := callIDs["function_call\x00"+callID]; !ok {
+				changed = true
+				return true
+			}
+		case "custom_tool_call_output":
+			if callID == "" {
+				changed = true
+				return true
+			}
+			if _, ok := callIDs["custom_tool_call\x00"+callID]; !ok {
+				changed = true
+				return true
+			}
+		}
+		filtered = append(filtered, json.RawMessage(item.Raw))
+		return true
+	})
+	if !changed {
+		return body
+	}
+	inputRaw, err := json.Marshal(filtered)
+	if err != nil {
+		return body
+	}
+	updated, err := sjson.SetRawBytes(body, "input", inputRaw)
+	if err != nil {
+		return body
+	}
+	return updated
+}
+
 func codexReasoningReplayInsertIndex(inputItems []gjson.Result, replayItems [][]byte) int {
 	replayCallIDs := make(map[string]bool)
 	for _, replayItem := range replayItems {
@@ -783,6 +866,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body, replayScope := applyCodexReasoningReplayCache(ctx, from, req, opts, body)
+	body = normalizeCodexInputToolCallPairs(body)
 	reporter.SetTranslatedReasoningEffort(body, to.String())
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
@@ -1058,6 +1142,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body, replayScope := applyCodexReasoningReplayCache(ctx, from, req, opts, body)
+	body = normalizeCodexInputToolCallPairs(body)
 	reporter.SetTranslatedReasoningEffort(body, to.String())
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_executor_reasoning_replay_cache_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_executor_reasoning_replay_cache_test.go
@@ -141,6 +141,77 @@ func TestCodexExecutorReasoningReplayCacheSharesSameSessionAcrossClientKeys(t *t
 	}
 }
 
+func TestCodexExecutorReasoningReplayCacheDropsUnpairedFunctionCallBeforeUpstream(t *testing.T) {
+	internalcache.ClearCodexReasoningReplayCache()
+	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
+
+	if !internalcache.CacheCodexReasoningReplayItems("gpt-5.4", "claude:session-unpaired-tool", [][]byte{
+		[]byte(`{"type":"function_call","call_id":"call_unanswered","name":"Agent","arguments":"{}"}`),
+	}) {
+		t.Fatal("replay function_call was not cached")
+	}
+
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read body: %v", errRead)
+		}
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":0,"status":"completed","model":"gpt-5.4","output":[]}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	_, err := executor.Execute(context.Background(), &cliproxyauth.Auth{
+		ID: "auth-replay-unpaired-tool",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"session-unpaired-tool\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"next"}]}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if got := countCodexInputItemsByType(gotBody, "function_call"); got != 0 {
+		t.Fatalf("function_call item count = %d, want 0; body=%s", got, string(gotBody))
+	}
+	if got := countCodexInputItemsByType(gotBody, "function_call_output"); got != 0 {
+		t.Fatalf("function_call_output item count = %d, want 0; body=%s", got, string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "input.0.role").String(); got != "user" {
+		t.Fatalf("input.0.role = %q, want user; body=%s", got, string(gotBody))
+	}
+}
+
+func TestNormalizeCodexInputToolCallPairsPreservesAnsweredPairs(t *testing.T) {
+	body := []byte(`{
+		"input": [
+			{"type":"function_call","call_id":"call_done","name":"Bash","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_done","output":"ok"},
+			{"type":"custom_tool_call","call_id":"call_custom","name":"custom","input":{}},
+			{"type":"custom_tool_call_output","call_id":"call_custom","output":"ok"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"next"}]}
+		]
+	}`)
+
+	gotBody := normalizeCodexInputToolCallPairs(body)
+
+	for _, itemType := range []string{"function_call", "function_call_output", "custom_tool_call", "custom_tool_call_output"} {
+		if got := countCodexInputItemsByType(gotBody, itemType); got != 1 {
+			t.Fatalf("%s item count = %d, want 1; body=%s", itemType, got, string(gotBody))
+		}
+	}
+}
+
 func TestCodexExecutorReasoningReplaySessionKeyUsesClaudeCodeJSONSessionID(t *testing.T) {
 	from := sdktranslator.FromString("claude")
 	req := cliproxyexecutor.Request{
@@ -270,6 +341,17 @@ func TestCodexExecutorReasoningReplayCacheSharesSameSessionAcrossCodexAuths(t *t
 	if got := gjson.GetBytes(secondBody, "input.0.encrypted_content").String(); got != encryptedContent {
 		t.Fatalf("injected encrypted_content = %q, want cached value", got)
 	}
+}
+
+func countCodexInputItemsByType(body []byte, itemType string) int {
+	count := 0
+	gjson.GetBytes(body, "input").ForEach(func(_, item gjson.Result) bool {
+		if item.Get("type").String() == itemType {
+			count++
+		}
+		return true
+	})
+	return count
 }
 
 func codexReplaySessionOnlyContext(apiKey string) context.Context {

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/translator/codex/claude/codex_claude_request.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/translator/codex/claude/codex_claude_request.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -330,6 +331,7 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 	template, _ = sjson.SetBytes(template, "stream", true)
 	template, _ = sjson.SetBytes(template, "store", false)
 	template, _ = sjson.SetBytes(template, "include", []string{"reasoning.encrypted_content"})
+	template = normalizeCodexToolCallPairs(template)
 
 	return template
 }
@@ -570,4 +572,61 @@ func normalizeToolParameters(raw string) string {
 		schema, _ = sjson.SetRawBytes(schema, "properties", []byte(`{}`))
 	}
 	return string(schema)
+}
+
+func normalizeCodexToolCallPairs(payload []byte) []byte {
+	input := gjson.GetBytes(payload, "input")
+	if !input.IsArray() {
+		return payload
+	}
+
+	hasFunctionCall := false
+	outputIDs := map[string]struct{}{}
+	input.ForEach(func(_, item gjson.Result) bool {
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		switch item.Get("type").String() {
+		case "function_call":
+			hasFunctionCall = true
+		case "function_call_output":
+			if callID != "" {
+				outputIDs[callID] = struct{}{}
+			}
+		}
+		return true
+	})
+	if !hasFunctionCall {
+		return payload
+	}
+
+	changed := false
+	filtered := make([]json.RawMessage, 0, len(input.Array()))
+	input.ForEach(func(_, item gjson.Result) bool {
+		itemType := item.Get("type").String()
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		if itemType == "function_call" {
+			if callID == "" {
+				changed = true
+				return true
+			}
+			if _, ok := outputIDs[callID]; !ok {
+				changed = true
+				return true
+			}
+		}
+		filtered = append(filtered, json.RawMessage(item.Raw))
+		return true
+	})
+	if !changed {
+		return payload
+	}
+
+	inputRaw, err := json.Marshal(filtered)
+	if err != nil {
+		return payload
+	}
+	updated, err := sjson.SetRawBytes(payload, "input", inputRaw)
+	if err != nil {
+		return payload
+	}
+	return updated
 }

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/translator/codex/claude/codex_claude_request_test.go
@@ -198,6 +198,84 @@ func TestConvertClaudeRequestToCodex_ShortenLongToolUseIDs(t *testing.T) {
 	}
 }
 
+func TestConvertClaudeRequestToCodex_DropsUnansweredToolUse(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"messages": [
+			{"role": "user", "content": "run pwd"},
+			{"role": "assistant", "content": [
+				{"type":"tool_use","id":"toolu_unanswered","name":"Bash","input":{"cmd":"pwd"}}
+			]}
+		]
+	}`
+
+	result := ConvertClaudeRequestToCodex("test-model", []byte(inputJSON), false)
+	callIDs, outputIDs := collectRequestToolCallIDs(result)
+
+	assertStringSliceEqual(t, callIDs, nil)
+	assertStringSliceEqual(t, outputIDs, nil)
+}
+
+func TestConvertClaudeRequestToCodex_PreservesAnsweredToolUsePair(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"messages": [
+			{"role": "user", "content": "run pwd"},
+			{"role": "assistant", "content": [
+				{"type":"tool_use","id":"toolu_done","name":"Bash","input":{"cmd":"pwd"}}
+			]},
+			{"role": "user", "content": [
+				{"type":"tool_result","tool_use_id":"toolu_done","content":"ok"}
+			]}
+		]
+	}`
+
+	result := ConvertClaudeRequestToCodex("test-model", []byte(inputJSON), false)
+	callIDs, outputIDs := collectRequestToolCallIDs(result)
+
+	assertStringSliceEqual(t, callIDs, []string{"toolu_done"})
+	assertStringSliceEqual(t, outputIDs, []string{"toolu_done"})
+}
+
+func TestConvertClaudeRequestToCodex_DropsOnlyUnansweredParallelToolUse(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"messages": [
+			{"role": "user", "content": "run two commands"},
+			{"role": "assistant", "content": [
+				{"type":"tool_use","id":"toolu_done","name":"Bash","input":{"cmd":"pwd"}},
+				{"type":"tool_use","id":"toolu_pending","name":"Bash","input":{"cmd":"ls"}}
+			]},
+			{"role": "user", "content": [
+				{"type":"tool_result","tool_use_id":"toolu_done","content":"ok"}
+			]}
+		]
+	}`
+
+	result := ConvertClaudeRequestToCodex("test-model", []byte(inputJSON), false)
+	callIDs, outputIDs := collectRequestToolCallIDs(result)
+
+	assertStringSliceEqual(t, callIDs, []string{"toolu_done"})
+	assertStringSliceEqual(t, outputIDs, []string{"toolu_done"})
+}
+
+func TestConvertClaudeRequestToCodex_PreservesOrphanToolResultForReplayCache(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"messages": [
+			{"role": "user", "content": [
+				{"type":"tool_result","tool_use_id":"toolu_orphan","content":"ok"}
+			]}
+		]
+	}`
+
+	result := ConvertClaudeRequestToCodex("test-model", []byte(inputJSON), false)
+	callIDs, outputIDs := collectRequestToolCallIDs(result)
+
+	assertStringSliceEqual(t, callIDs, nil)
+	assertStringSliceEqual(t, outputIDs, []string{"toolu_orphan"})
+}
+
 func TestConvertClaudeRequestToCodex_ToolChoiceModeMapping(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -464,6 +542,33 @@ func countRequestInputItemsByType(result []byte, itemType string) int {
 		return true
 	})
 	return count
+}
+
+func collectRequestToolCallIDs(result []byte) ([]string, []string) {
+	var callIDs []string
+	var outputIDs []string
+	gjson.GetBytes(result, "input").ForEach(func(_, item gjson.Result) bool {
+		switch item.Get("type").String() {
+		case "function_call":
+			callIDs = append(callIDs, item.Get("call_id").String())
+		case "function_call_output":
+			outputIDs = append(outputIDs, item.Get("call_id").String())
+		}
+		return true
+	})
+	return callIDs, outputIDs
+}
+
+func assertStringSliceEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
 }
 
 func validCodexReasoningSignature() string {


### PR DESCRIPTION
## Summary
- Drop unanswered Codex tool calls before sending the final Responses API request upstream.
- Keep orphan Claude `tool_result` items during translation so they can still pair with replay-cache function calls.
- Add regression coverage for Claude Code Agent/reasoning replay cache requests that previously failed with `No tool output found for function call ...`.

## Why
Claude Code may start an `Agent` sub-agent while the parent request contains an unfinished `Agent` tool call. With Codex/Responses translation and reasoning replay cache, that stale `function_call` can be replayed into a later request without a matching `function_call_output`, and upstream rejects the request with HTTP 400.

## Tests
- `/c/Program Files/Go/bin/go.exe test ./internal/translator/codex/claude`
- `/c/Program Files/Go/bin/go.exe test ./internal/runtime/executor`
- `/c/Program Files/Go/bin/go.exe test ./...` from `sidecars/cockpit-cliproxy`

Fixes #1235