### PR TITLE
feat(codex): 支持查询和执行 ChatGPT reset credit

### DIFF
--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -665,6 +665,32 @@ pub async fn refresh_codex_subscription_info(
 }
 
 #[tauri::command]
+pub async fn query_codex_reset_credits(
+    account_id: String,
+) -> Result<codex_quota::CodexResetCreditUsage, String> {
+    codex_quota::query_reset_credits(&account_id).await
+}
+
+#[tauri::command]
+pub async fn consume_codex_reset_credit(
+    app: AppHandle,
+    account_id: String,
+) -> Result<codex_quota::CodexResetCreditResult, String> {
+    let mut result = codex_quota::consume_reset_credit(&account_id).await?;
+    if let Err(error) = codex_quota::refresh_account_quota(&account_id).await {
+        logger::log_warn(&format!(
+            "ChatGPT reset credit 已执行，但刷新 Codex 配额失败: {}",
+            error
+        ));
+        result.quota_refresh_error = Some(error);
+    } else {
+        run_codex_post_refresh_checks(&app).await;
+        let _ = crate::modules::tray::update_tray_menu(&app);
+    }
+    Ok(result)
+}
+
+#[tauri::command]
 pub async fn refresh_current_codex_quota(app: AppHandle) -> Result<(), String> {
     let Some(account) = codex_account::get_current_account() else {
         return Err("未找到当前 Codex 账号".to_string());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -569,6 +569,8 @@ pub fn run() {
             commands::codex::confirm_codex_batch_import,
             commands::codex::refresh_codex_quota,
             commands::codex::refresh_codex_subscription_info,
+            commands::codex::query_codex_reset_credits,
+            commands::codex::consume_codex_reset_credit,
             commands::codex::refresh_all_codex_quotas,
             commands::codex::refresh_current_codex_quota,
             commands::codex::codex_oauth_login_start,

--- a/src-tauri/src/modules/codex_quota.rs
+++ b/src-tauri/src/modules/codex_quota.rs
@@ -1,11 +1,15 @@
 use crate::models::codex::{CodexAccount, CodexQuota, CodexQuotaErrorInfo};
 use crate::modules::{codex_account, logger};
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, REFERER, USER_AGENT};
+use reqwest::header::{
+    HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, REFERER, USER_AGENT,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 // 使用 wham/usage 端点（Quotio 使用的）
 const USAGE_URL: &str = "https://chatgpt.com/backend-api/wham/usage";
+const RESET_CREDIT_CONSUME_URL: &str =
+    "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume";
 const SUBSCRIPTION_ACCOUNTS_CHECK_URL: &str =
     "https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27";
 const SUBSCRIPTIONS_URL: &str = "https://chatgpt.com/backend-api/subscriptions";
@@ -137,15 +141,72 @@ struct RateLimitInfo {
     secondary_window: Option<WindowInfo>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexRateLimitResetCredits {
+    #[serde(default)]
+    pub available_count: i32,
+}
+
 /// 使用率响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct UsageResponse {
+    #[serde(rename = "user_id")]
+    user_id: Option<String>,
+    #[serde(rename = "account_id")]
+    account_id: Option<String>,
+    email: Option<String>,
     #[serde(rename = "plan_type")]
     plan_type: Option<String>,
     #[serde(rename = "rate_limit")]
     rate_limit: Option<RateLimitInfo>,
     #[serde(rename = "code_review_rate_limit")]
     code_review_rate_limit: Option<RateLimitInfo>,
+    #[serde(rename = "rate_limit_reset_credits")]
+    rate_limit_reset_credits: Option<CodexRateLimitResetCredits>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexResetCreditUsage {
+    pub available_count: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_type: Option<String>,
+    pub fetched_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexResetCredit {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub granted_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redeem_started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redeemed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexResetCreditResult {
+    #[serde(default)]
+    pub code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credit: Option<CodexResetCredit>,
+    #[serde(default)]
+    pub windows_reset: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quota_refresh_error: Option<String>,
 }
 
 fn normalize_remaining_percentage(window: &WindowInfo) -> i32 {
@@ -218,6 +279,63 @@ fn normalize_optional_ref(raw: Option<&str>) -> Option<String> {
     } else {
         Some(trimmed.to_string())
     }
+}
+
+fn resolve_chatgpt_account_id(account: &CodexAccount) -> Option<String> {
+    normalize_optional_ref(account.account_id.as_deref())
+        .or_else(|| normalize_optional_ref(account.organization_id.as_deref()))
+        .or_else(|| {
+            codex_account::extract_chatgpt_account_id_from_access_token(
+                &account.tokens.access_token,
+            )
+        })
+}
+
+fn build_chatgpt_json_headers(
+    account: &CodexAccount,
+    chatgpt_account_id: Option<&str>,
+) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {}", account.tokens.access_token))
+            .map_err(|e| format!("构建 Authorization 头失败: {}", e))?,
+    );
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+    headers.insert(REFERER, HeaderValue::from_static(CHATGPT_WEB_REFERER));
+    headers.insert(USER_AGENT, HeaderValue::from_static(CHATGPT_WEB_USER_AGENT));
+    headers.insert("oai-language", HeaderValue::from_static("zh-CN"));
+    headers.insert("originator", HeaderValue::from_static("Codex Desktop"));
+    headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+    headers.insert("sec-fetch-mode", HeaderValue::from_static("no-cors"));
+    headers.insert("sec-fetch-dest", HeaderValue::from_static("empty"));
+    headers.insert("priority", HeaderValue::from_static("u=4, i"));
+
+    if let Some(account_id) = normalize_optional_ref(chatgpt_account_id) {
+        headers.insert(
+            "ChatGPT-Account-Id",
+            HeaderValue::from_str(&account_id)
+                .map_err(|e| format!("构建 ChatGPT-Account-Id 头失败: {}", e))?,
+        );
+    }
+
+    Ok(headers)
+}
+
+fn build_upstream_error_message(
+    context: &str,
+    status: reqwest::StatusCode,
+    headers: &HeaderMap,
+    body: &str,
+) -> String {
+    let detail_code = extract_detail_code_from_body(body);
+    let mut error_message = format!("{}接口返回错误 {}", context, status);
+    if let Some(code) = detail_code {
+        error_message.push_str(&format!(" [error_code:{}]", code));
+    }
+    error_message.push_str(&format!(" [body_len:{}]", body.len()));
+    append_http_error_diagnostics(&mut error_message, headers, body);
+    error_message
 }
 
 fn normalize_optional_json_scalar(value: Option<&serde_json::Value>) -> Option<String> {
@@ -676,28 +794,8 @@ async fn refresh_account_tokens(account: &mut CodexAccount, reason: &str) -> Res
 pub async fn fetch_quota(account: &CodexAccount) -> Result<FetchQuotaResult, String> {
     let client = reqwest::Client::new();
 
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        AUTHORIZATION,
-        HeaderValue::from_str(&format!("Bearer {}", account.tokens.access_token))
-            .map_err(|e| format!("构建 Authorization 头失败: {}", e))?,
-    );
-    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
-
-    // 添加 ChatGPT-Account-Id 头（关键！）
-    let account_id = account.account_id.clone().or_else(|| {
-        codex_account::extract_chatgpt_account_id_from_access_token(&account.tokens.access_token)
-    });
-
-    if let Some(ref acc_id) = account_id {
-        if !acc_id.is_empty() {
-            headers.insert(
-                "ChatGPT-Account-Id",
-                HeaderValue::from_str(acc_id)
-                    .map_err(|e| format!("构建 Account-Id 头失败: {}", e))?,
-            );
-        }
-    }
+    let account_id = resolve_chatgpt_account_id(account);
+    let headers = build_chatgpt_json_headers(account, account_id.as_deref())?;
 
     logger::log_info(&format!(
         "Codex 配额请求: {} (account_id: {:?})",
@@ -760,6 +858,139 @@ pub async fn fetch_quota(account: &CodexAccount) -> Result<FetchQuotaResult, Str
     let plan_type = usage.plan_type.clone();
 
     Ok(FetchQuotaResult { quota, plan_type })
+}
+
+fn parse_reset_credit_usage_from_body(body: &str) -> Result<CodexResetCreditUsage, String> {
+    let usage: UsageResponse = serde_json::from_str(body)
+        .map_err(|e| format!("解析 ChatGPT reset credit JSON 失败: {}", e))?;
+    let available_count = usage
+        .rate_limit_reset_credits
+        .as_ref()
+        .map(|credits| credits.available_count)
+        .unwrap_or(0)
+        .max(0);
+
+    Ok(CodexResetCreditUsage {
+        available_count,
+        user_id: usage.user_id,
+        account_id: usage.account_id,
+        email: usage.email,
+        plan_type: usage.plan_type,
+        fetched_at: now_timestamp(),
+    })
+}
+
+fn parse_reset_credit_result_from_body(body: &str) -> Result<CodexResetCreditResult, String> {
+    serde_json::from_str(body)
+        .map_err(|e| format!("解析 ChatGPT reset credit 重置 JSON 失败: {}", e))
+}
+
+pub async fn query_reset_credits(account_id: &str) -> Result<CodexResetCreditUsage, String> {
+    let account = codex_account::prepare_account_for_injection(account_id).await?;
+    if account.is_api_key_auth() {
+        return Err("API Key 账号不支持查询 ChatGPT reset credit。".to_string());
+    }
+
+    let chatgpt_account_id = resolve_chatgpt_account_id(&account)
+        .ok_or_else(|| "未获取到 ChatGPT Account ID，请重新授权该账号。".to_string())?;
+    let headers = build_chatgpt_json_headers(&account, Some(&chatgpt_account_id))?;
+    let client = reqwest::Client::new();
+
+    logger::log_info(&format!(
+        "Codex reset credit 查询请求: {} (account_id: {})",
+        USAGE_URL, chatgpt_account_id
+    ));
+
+    let response = client
+        .get(USAGE_URL)
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|e| format!("请求 ChatGPT reset credit 失败: {}", e))?;
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("读取 ChatGPT reset credit 响应失败: {}", e))?;
+
+    logger::log_info(&format!(
+        "Codex reset credit 查询响应: url={}, status={}, request-id={}, x-request-id={}, cf-ray={}, body_len={}",
+        USAGE_URL,
+        status,
+        get_header_value(&headers, "request-id"),
+        get_header_value(&headers, "x-request-id"),
+        get_header_value(&headers, "cf-ray"),
+        body.len()
+    ));
+
+    if !status.is_success() {
+        return Err(build_upstream_error_message(
+            "ChatGPT reset credit 查询",
+            status,
+            &headers,
+            &body,
+        ));
+    }
+
+    parse_reset_credit_usage_from_body(&body)
+}
+
+pub async fn consume_reset_credit(account_id: &str) -> Result<CodexResetCreditResult, String> {
+    let account = codex_account::prepare_account_for_injection(account_id).await?;
+    if account.is_api_key_auth() {
+        return Err("API Key 账号不支持执行 ChatGPT reset credit 重置。".to_string());
+    }
+
+    let chatgpt_account_id = resolve_chatgpt_account_id(&account)
+        .ok_or_else(|| "未获取到 ChatGPT Account ID，请重新授权该账号。".to_string())?;
+    let mut headers = build_chatgpt_json_headers(&account, Some(&chatgpt_account_id))?;
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+    let redeem_request_id = uuid::Uuid::new_v4().to_string();
+    let client = reqwest::Client::new();
+
+    logger::log_info(&format!(
+        "Codex reset credit 执行请求: {} (account_id: {})",
+        RESET_CREDIT_CONSUME_URL, chatgpt_account_id
+    ));
+
+    let response = client
+        .post(RESET_CREDIT_CONSUME_URL)
+        .headers(headers)
+        .json(&json!({ "redeem_request_id": redeem_request_id }))
+        .send()
+        .await
+        .map_err(|e| format!("执行 ChatGPT reset credit 重置失败: {}", e))?;
+
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("读取 ChatGPT reset credit 重置响应失败: {}", e))?;
+
+    logger::log_info(&format!(
+        "Codex reset credit 执行响应: url={}, status={}, request-id={}, x-request-id={}, cf-ray={}, body_len={}",
+        RESET_CREDIT_CONSUME_URL,
+        status,
+        get_header_value(&headers, "request-id"),
+        get_header_value(&headers, "x-request-id"),
+        get_header_value(&headers, "cf-ray"),
+        body.len()
+    ));
+
+    if !status.is_success() {
+        return Err(build_upstream_error_message(
+            "ChatGPT reset credit 重置",
+            status,
+            &headers,
+            &body,
+        ));
+    }
+
+    parse_reset_credit_result_from_body(&body)
 }
 
 /// 从使用率响应中解析配额信息
@@ -1225,7 +1456,10 @@ pub async fn refresh_all_quotas() -> Result<Vec<(String, Result<CodexQuota, Stri
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_http_error_body_for_display, HTTP_ERROR_BODY_DISPLAY_MAX_CHARS};
+    use super::{
+        normalize_http_error_body_for_display, parse_reset_credit_result_from_body,
+        parse_reset_credit_usage_from_body, HTTP_ERROR_BODY_DISPLAY_MAX_CHARS,
+    };
 
     #[test]
     fn displays_empty_http_error_body_explicitly() {
@@ -1243,5 +1477,74 @@ mod tests {
         assert!(display.starts_with("first second "));
         assert!(display.ends_with("...(truncated)"));
         assert!(display.chars().count() <= HTTP_ERROR_BODY_DISPLAY_MAX_CHARS + 14);
+    }
+
+    #[test]
+    fn parses_reset_credit_count_from_usage_response() {
+        let usage = parse_reset_credit_usage_from_body(
+            r#"{
+                "user_id": "user-1",
+                "account_id": "account-1",
+                "email": "user@example.com",
+                "plan_type": "plus",
+                "rate_limit_reset_credits": {
+                    "available_count": 2
+                }
+            }"#,
+        )
+        .expect("usage response should deserialize");
+
+        assert_eq!(usage.available_count, 2);
+        assert_eq!(usage.user_id.as_deref(), Some("user-1"));
+        assert_eq!(usage.account_id.as_deref(), Some("account-1"));
+        assert_eq!(usage.email.as_deref(), Some("user@example.com"));
+        assert_eq!(usage.plan_type.as_deref(), Some("plus"));
+        assert!(usage.fetched_at > 0);
+    }
+
+    #[test]
+    fn treats_missing_reset_credit_count_as_zero() {
+        let usage = parse_reset_credit_usage_from_body(r#"{"plan_type":"free"}"#)
+            .expect("usage response should deserialize");
+
+        assert_eq!(usage.available_count, 0);
+    }
+
+    #[test]
+    fn clamps_negative_reset_credit_count_to_zero() {
+        let usage = parse_reset_credit_usage_from_body(
+            r#"{"rate_limit_reset_credits":{"available_count":-3}}"#,
+        )
+        .expect("usage response should deserialize");
+
+        assert_eq!(usage.available_count, 0);
+    }
+
+    #[test]
+    fn parses_reset_credit_consume_response() {
+        let result = parse_reset_credit_result_from_body(
+            r#"{
+                "code": "success",
+                "windows_reset": 2,
+                "credit": {
+                    "id": "credit-1",
+                    "reset_type": "rate_limit_reset_credit",
+                    "status": "redeemed",
+                    "redeemed_at": "2026-06-18T08:00:00Z"
+                }
+            }"#,
+        )
+        .expect("reset response should deserialize");
+
+        assert_eq!(result.code, "success");
+        assert_eq!(result.windows_reset, 2);
+        let credit = result.credit.expect("credit should be present");
+        assert_eq!(credit.id.as_deref(), Some("credit-1"));
+        assert_eq!(credit.status.as_deref(), Some("redeemed"));
+        assert_eq!(
+            credit.reset_type.as_deref(),
+            Some("rate_limit_reset_credit")
+        );
+        assert_eq!(credit.redeemed_at.as_deref(), Some("2026-06-18T08:00:00Z"));
     }
 }

--- a/src/components/codex/CodexResetCreditControl.tsx
+++ b/src/components/codex/CodexResetCreditControl.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useState } from "react";
+import { RefreshCw, RotateCcw } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { confirm } from "@tauri-apps/plugin-dialog";
+import * as codexService from "../../services/codexService";
+import type { CodexResetCreditUsage } from "../../types/codex";
+
+type CodexResetCreditControlProps = {
+  accountId: string;
+  usage: CodexResetCreditUsage | null;
+  variant?: "card" | "table";
+  onUsageChange: (accountId: string, usage: CodexResetCreditUsage) => void;
+  onChanged?: () => void | Promise<void>;
+};
+
+function normalizeError(error: unknown): string {
+  return String(error).replace(/^Error:\s*/, "");
+}
+
+export function CodexResetCreditControl({
+  accountId,
+  usage,
+  variant = "card",
+  onUsageChange,
+  onChanged,
+}: CodexResetCreditControlProps) {
+  const { t } = useTranslation();
+  const [querying, setQuerying] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [notice, setNotice] = useState<{
+    tone: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  const availableCount = usage?.available_count ?? null;
+  const hasCredits = (availableCount ?? 0) > 0;
+  const busy = querying || resetting;
+
+  const queryCredits = useCallback(async () => {
+    setQuerying(true);
+    setNotice(null);
+    try {
+      const nextUsage = await codexService.queryCodexResetCredits(accountId);
+      onUsageChange(accountId, nextUsage);
+    } catch (error) {
+      setNotice({
+        tone: "error",
+        text: t("codex.resetCredits.queryFailed", {
+          defaultValue: "查询失败：{{error}}",
+          error: normalizeError(error),
+        }),
+      });
+    } finally {
+      setQuerying(false);
+    }
+  }, [accountId, onUsageChange, t]);
+
+  const resetCredit = useCallback(async () => {
+    const confirmed = await confirm(
+      t(
+        "codex.resetCredits.confirm",
+        "将消耗 1 次 ChatGPT reset credit 执行重置，是否继续？",
+      ),
+      {
+        title: t("codex.resetCredits.confirmTitle", "执行重置"),
+        kind: "warning",
+      },
+    );
+    if (!confirmed) return;
+
+    setResetting(true);
+    setNotice(null);
+    try {
+      const result = await codexService.consumeCodexResetCredit(accountId);
+      const nextUsage = await codexService.queryCodexResetCredits(accountId);
+      onUsageChange(accountId, nextUsage);
+      await onChanged?.();
+      setNotice({
+        tone: result.quota_refresh_error ? "error" : "success",
+        text: result.quota_refresh_error
+          ? t("codex.resetCredits.resetRefreshFailed", {
+              defaultValue: "已重置，配额刷新失败：{{error}}",
+              error: result.quota_refresh_error,
+            })
+          : t("codex.resetCredits.resetSuccess", "已执行重置"),
+      });
+    } catch (error) {
+      setNotice({
+        tone: "error",
+        text: t("codex.resetCredits.resetFailed", {
+          defaultValue: "重置失败：{{error}}",
+          error: normalizeError(error),
+        }),
+      });
+    } finally {
+      setResetting(false);
+    }
+  }, [accountId, onChanged, onUsageChange, t]);
+
+  return (
+    <div className={`codex-reset-credit-control ${variant}`}>
+      <div className="codex-reset-credit-main">
+        <span className="codex-reset-credit-label">
+          {t("codex.resetCredits.label", "Reset Credit")}
+        </span>
+        <strong className={hasCredits ? "available" : ""}>
+          {availableCount == null ? "--" : availableCount}
+        </strong>
+      </div>
+      <div className="codex-reset-credit-actions">
+        <button
+          type="button"
+          className="codex-reset-credit-btn"
+          onClick={() => void queryCredits()}
+          disabled={busy}
+          title={t("codex.resetCredits.query", "查询次数")}
+          aria-label={t("codex.resetCredits.query", "查询次数")}
+        >
+          <RefreshCw size={13} className={querying ? "loading-spinner" : ""} />
+        </button>
+        <button
+          type="button"
+          className="codex-reset-credit-btn primary"
+          onClick={() => void resetCredit()}
+          disabled={busy || !hasCredits}
+          title={t("codex.resetCredits.reset", "执行重置")}
+        >
+          <RotateCcw size={13} className={resetting ? "loading-spinner" : ""} />
+          <span>{t("codex.resetCredits.resetShort", "重置")}</span>
+        </button>
+      </div>
+      {notice && (
+        <span className={`codex-reset-credit-notice ${notice.tone}`}>
+          {notice.text}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -122,6 +122,7 @@ import {
 import { CodexWakeupContent } from "../components/codex/CodexWakeupContent";
 import { CodexModelProviderManager } from "../components/codex/CodexModelProviderManager";
 import { CodexSpeedSelect } from "../components/codex/CodexSpeedSelect";
+import { CodexResetCreditControl } from "../components/codex/CodexResetCreditControl";
 import { QuickSettingsPopover } from "../components/QuickSettingsPopover";
 import { useProviderAccountsPage } from "../hooks/useProviderAccountsPage";
 import {
@@ -137,6 +138,7 @@ import { SingleSelectDropdown } from "../components/SingleSelectDropdown";
 import type {
   CodexAccount,
   CodexAppSpeed,
+  CodexResetCreditUsage,
   CodexSessionVisibilityRepairProgress,
 } from "../types/codex";
 import type {
@@ -881,6 +883,9 @@ export function CodexAccountsPage() {
   );
   const [refreshingSubscriptionAccountId, setRefreshingSubscriptionAccountId] =
     useState<string | null>(null);
+  const [resetCreditUsageMap, setResetCreditUsageMap] = useState<
+    Record<string, CodexResetCreditUsage>
+  >({});
   const [removingGroupAccountIds, setRemovingGroupAccountIds] = useState<
     Set<string>
   >(new Set());
@@ -7581,6 +7586,21 @@ export function CodexAccountsPage() {
     [fetchAccounts, fetchCurrentAccount, resolveGroupAccounts, setMessage, t],
   );
 
+  const handleResetCreditChanged = useCallback(async () => {
+    await fetchAccounts();
+    await fetchCurrentAccount();
+  }, [fetchAccounts, fetchCurrentAccount]);
+
+  const handleResetCreditUsageChange = useCallback(
+    (accountId: string, usage: CodexResetCreditUsage) => {
+      setResetCreditUsageMap((prev) => ({
+        ...prev,
+        [accountId]: usage,
+      }));
+    },
+    [],
+  );
+
   useEffect(() => {
     const teamAccountIds = paginatedAccounts
       .filter(
@@ -7987,81 +8007,92 @@ export function CodexAccountsPage() {
               {showApiKeyUsagePanel ? (
                 renderApiKeyUsagePanel(account, apiKeyUsageProvider)
               ) : (
-              <>
-                {hasQuotaError && (
-                  <div
-                    className={`quota-error-inline ${isQuotaRefreshNotice ? "quota-refresh-notice" : ""}`}
-                    title={accountIssueMeta.rawMessage}
-                  >
-                    {isQuotaRefreshNotice ? (
-                      <Info size={14} />
-                    ) : (
-                      <CircleAlert size={14} />
-                    )}
-                    <span>{accountIssueMeta.displayText}</span>
-                    {showReauthorizeAction && (
-                      <button
-                        className="btn btn-sm btn-outline"
-                        onClick={() => openCodexAddModal("oauth", account)}
-                        title={t("common.shared.addModal.oauth", "OAuth 授权")}
-                      >
-                        {t("common.shared.addModal.oauth", "OAuth 授权")}
-                      </button>
-                    )}
-                  </div>
-                )}
-                {cockpitApiAccountBalanceText && (
-                  <div className="codex-account-balance-line">
-                    <span>
-                      {t(
-                        "codex.modelProviders.usage.accountBalance",
-                        "账户余额",
-                      )}
-                      ：
-                    </span>
-                    <strong>{cockpitApiAccountBalanceText}</strong>
-                  </div>
-                )}
-                {quotaItems.map((item) => {
-                  const QuotaIcon =
-                    item.key === "secondary"
-                      ? Calendar
-                      : item.key === "code_review"
-                        ? BookOpen
-                        : item.key === "new_api_quota"
-                          ? Database
-                          : Clock;
-                  return (
+                <>
+                  {hasQuotaError && (
                     <div
-                      key={item.key}
-                      className="quota-item"
-                      title={item.hintText}
+                      className={`quota-error-inline ${isQuotaRefreshNotice ? "quota-refresh-notice" : ""}`}
+                      title={accountIssueMeta.rawMessage}
                     >
-                      <div className="quota-header">
-                        <QuotaIcon size={14} />
-                        <span className="quota-label">{item.label}</span>
-                        <span className={`quota-pct ${item.quotaClass}`}>
-                          {item.valueText}
-                        </span>
-                      </div>
-                      <div className="quota-bar-track">
-                        <div
-                          className={`quota-bar ${item.quotaClass}`}
-                          style={{ width: `${item.percentage}%` }}
-                        />
-                      </div>
-                      {item.resetText && (
-                        <span className="quota-reset">{item.resetText}</span>
+                      {isQuotaRefreshNotice ? (
+                        <Info size={14} />
+                      ) : (
+                        <CircleAlert size={14} />
+                      )}
+                      <span>{accountIssueMeta.displayText}</span>
+                      {showReauthorizeAction && (
+                        <button
+                          className="btn btn-sm btn-outline"
+                          onClick={() => openCodexAddModal("oauth", account)}
+                          title={t(
+                            "common.shared.addModal.oauth",
+                            "OAuth 授权",
+                          )}
+                        >
+                          {t("common.shared.addModal.oauth", "OAuth 授权")}
+                        </button>
                       )}
                     </div>
-                  );
-                })}
-                {quotaItems.length === 0 && !cockpitApiAccountBalanceText && (
-                  <div className="quota-empty">
-                    {t("common.shared.quota.noData", "暂无配额数据")}
-                  </div>
-                )}
-              </>
+                  )}
+                  {cockpitApiAccountBalanceText && (
+                    <div className="codex-account-balance-line">
+                      <span>
+                        {t(
+                          "codex.modelProviders.usage.accountBalance",
+                          "账户余额",
+                        )}
+                        ：
+                      </span>
+                      <strong>{cockpitApiAccountBalanceText}</strong>
+                    </div>
+                  )}
+                  {quotaItems.map((item) => {
+                    const QuotaIcon =
+                      item.key === "secondary"
+                        ? Calendar
+                        : item.key === "code_review"
+                          ? BookOpen
+                          : item.key === "new_api_quota"
+                            ? Database
+                            : Clock;
+                    return (
+                      <div
+                        key={item.key}
+                        className="quota-item"
+                        title={item.hintText}
+                      >
+                        <div className="quota-header">
+                          <QuotaIcon size={14} />
+                          <span className="quota-label">{item.label}</span>
+                          <span className={`quota-pct ${item.quotaClass}`}>
+                            {item.valueText}
+                          </span>
+                        </div>
+                        <div className="quota-bar-track">
+                          <div
+                            className={`quota-bar ${item.quotaClass}`}
+                            style={{ width: `${item.percentage}%` }}
+                          />
+                        </div>
+                        {item.resetText && (
+                          <span className="quota-reset">{item.resetText}</span>
+                        )}
+                      </div>
+                    );
+                  })}
+                  {quotaItems.length === 0 && !cockpitApiAccountBalanceText && (
+                    <div className="quota-empty">
+                      {t("common.shared.quota.noData", "暂无配额数据")}
+                    </div>
+                  )}
+                  {!isApiKeyAccount && (
+                    <CodexResetCreditControl
+                      accountId={account.id}
+                      usage={resetCreditUsageMap[account.id] ?? null}
+                      onUsageChange={handleResetCreditUsageChange}
+                      onChanged={handleResetCreditChanged}
+                    />
+                  )}
+                </>
               )}
             </div>
           )}
@@ -9395,6 +9426,15 @@ export function CodexAccountsPage() {
                     </span>
                   )}
                 </div>
+                {!isApiKeyAccount && (
+                  <CodexResetCreditControl
+                    accountId={account.id}
+                    variant="table"
+                    usage={resetCreditUsageMap[account.id] ?? null}
+                    onUsageChange={handleResetCreditUsageChange}
+                    onChanged={handleResetCreditChanged}
+                  />
+                )}
                 {hasQuotaError && (
                   <div
                     className={`quota-error-inline table ${isQuotaRefreshNotice ? "quota-refresh-notice" : ""}`}

--- a/src/services/codexService.ts
+++ b/src/services/codexService.ts
@@ -7,6 +7,8 @@ import {
   CodexProviderWireApi,
   CodexQuickConfig,
   CodexQuota,
+  CodexResetCreditResult,
+  CodexResetCreditUsage,
 } from '../types/codex';
 
 export interface CodexOAuthLoginStartResponse {
@@ -219,6 +221,16 @@ export async function refreshCodexQuota(accountId: string): Promise<CodexQuota> 
 /** 强制刷新单个账号的订阅信息 */
 export async function refreshCodexSubscriptionInfo(accountId: string): Promise<CodexAccount> {
   return await invoke('refresh_codex_subscription_info', { accountId });
+}
+
+/** 查询 ChatGPT reset credit 剩余次数 */
+export async function queryCodexResetCredits(accountId: string): Promise<CodexResetCreditUsage> {
+  return await invoke('query_codex_reset_credits', { accountId });
+}
+
+/** 消耗一次 ChatGPT reset credit 执行重置 */
+export async function consumeCodexResetCredit(accountId: string): Promise<CodexResetCreditResult> {
+  return await invoke('consume_codex_reset_credit', { accountId });
 }
 
 /** 刷新所有账号配额 */

--- a/src/styles/pages/codex.css
+++ b/src/styles/pages/codex.css
@@ -2127,6 +2127,111 @@
   border-radius: var(--radius-sm);
 }
 
+.codex-reset-credit-control {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 32px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+}
+
+.codex-reset-credit-control.table {
+  width: max-content;
+  max-width: 100%;
+  margin-top: 8px;
+  padding: 6px 8px;
+}
+
+.codex-reset-credit-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.codex-reset-credit-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.codex-reset-credit-main strong {
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1;
+}
+
+.codex-reset-credit-main strong.available {
+  color: var(--success);
+}
+
+.codex-reset-credit-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.codex-reset-credit-control.table .codex-reset-credit-actions {
+  margin-left: 0;
+}
+
+.codex-reset-credit-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 24px;
+  min-width: 24px;
+  padding: 0 7px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.codex-reset-credit-btn:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: var(--primary);
+  background: var(--bg-secondary);
+}
+
+.codex-reset-credit-btn.primary {
+  color: var(--primary);
+}
+
+.codex-reset-credit-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.codex-reset-credit-notice {
+  flex-basis: 100%;
+  min-width: 0;
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.codex-reset-credit-notice.success {
+  color: var(--success);
+}
+
+.codex-reset-credit-notice.error {
+  color: var(--danger);
+}
+
 .codex-api-key-usage-panel {
   display: flex;
   flex-direction: column;

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -89,6 +89,32 @@ export interface CodexQuota {
   raw_data?: unknown;
 }
 
+export interface CodexResetCreditUsage {
+  available_count: number;
+  user_id?: string;
+  account_id?: string;
+  email?: string;
+  plan_type?: string;
+  fetched_at: number;
+}
+
+export interface CodexResetCredit {
+  id?: string;
+  reset_type?: string;
+  status?: string;
+  granted_at?: string;
+  expires_at?: string;
+  redeem_started_at?: string;
+  redeemed_at?: string;
+}
+
+export interface CodexResetCreditResult {
+  code: string;
+  credit?: CodexResetCredit;
+  windows_reset: number;
+  quota_refresh_error?: string;
+}
+
 const COCKPIT_API_BASE_URL = "https://chongcodex.cn/v1";
 
 function normalizeCodexApiBaseUrlForMatch(rawValue?: string | null): string {


### PR DESCRIPTION
## Summary

为 Codex 账号增加 ChatGPT reset credit 支持。

- 查询可用的 ChatGPT reset credit 次数
- 支持消耗 1 次 reset credit 执行重置
- 重置成功后刷新账号 quota
- 在 Codex 账号卡片和表格视图中展示紧凑的 Reset Credit 控件
- 切换卡片/表格视图时保留已查询的 Reset Credit 结果
- 为 usage / consume 响应解析补充单元测试

## Screenshots

<img width="1280" height="754" alt="reset1 2" src="https://github.com/user-attachments/assets/1ee73c22-8585-4f13-9594-a0159e0a781d" />
<img width="1280" height="754" alt="reset1" src="https://github.com/user-attachments/assets/2385bf82-9c68-4d41-b91a-fee902b35e8d" />
<img width="1265" height="794" alt="reset2" src="https://github.com/user-attachments/assets/444a8cc8-1695-42a7-8921-00acb479905f" />


## Testing

- `npm run typecheck`
- `cargo test --manifest-path src-tauri\Cargo.toml codex_quota::tests --lib`

手动验证：

- 使用真实 ChatGPT 账号验证 reset credit 查询链路，当前可用次数为 `0`
- 验证 UI 正确显示 `0`
- 验证可用次数为 `0` 时，执行重置按钮不可点击
- 验证卡片视图和表格视图切换后，已查询的 Reset Credit 结果不会丢失

## Notes

目前没有可用 reset credit 次数大于 0 的账号，因此真实 consume 流程还需要后续使用正数账号验证。当前 PR 已通过单元测试覆盖响应解析、缺失字段、负数兜底和 consume 响应解析。