### PR TITLE
fix(codex): 限制 sidecar 可重试失败的过密节奏

### DIFF
--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/config/sdk_config.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/config/sdk_config.go
@@ -67,6 +67,12 @@ type StreamingConfig struct {
 	// <= 0 disables bootstrap retries. Default is 0.
 	BootstrapRetries int `yaml:"bootstrap-retries,omitempty" json:"bootstrap-retries,omitempty"`
 
+	// BootstrapRetryBaseDelayMS controls the initial wait before a bootstrap retry.
+	BootstrapRetryBaseDelayMS int `yaml:"bootstrap-retry-base-delay-ms,omitempty" json:"bootstrap-retry-base-delay-ms,omitempty"`
+
+	// BootstrapRetryMaxDelayMS caps the bootstrap retry wait.
+	BootstrapRetryMaxDelayMS int `yaml:"bootstrap-retry-max-delay-ms,omitempty" json:"bootstrap-retry-max-delay-ms,omitempty"`
+
 	// StreamOpenTimeoutMS controls how long the sidecar waits for a text stream to open.
 	StreamOpenTimeoutMS int `yaml:"stream-open-timeout-ms,omitempty" json:"stream-open-timeout-ms,omitempty"`
 

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_websockets_executor.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_websockets_executor.go
@@ -88,6 +88,15 @@ func NewCodexWebsocketsExecutor(cfg *config.Config) *CodexWebsocketsExecutor {
 	}
 }
 
+func codexWebsocketRetryDelay(cfg *config.Config, attempt int) time.Duration {
+	if cfg == nil {
+		return 0
+	}
+	base := time.Duration(cfg.Streaming.BootstrapRetryBaseDelayMS) * time.Millisecond
+	max := time.Duration(cfg.Streaming.BootstrapRetryMaxDelayMS) * time.Millisecond
+	return util.BackoffDelay(attempt, base, max)
+}
+
 type codexWebsocketRead struct {
 	conn    *websocket.Conn
 	msgType int
@@ -302,6 +311,9 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			// Retry once with a fresh websocket connection. This is mainly to handle
 			// upstream closing the socket between sequential requests within the same
 			// execution session.
+			if errWait := util.SleepContext(ctx, codexWebsocketRetryDelay(e.cfg, 1)); errWait != nil {
+				return resp, errWait
+			}
 			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
 			if errDialRetry == nil && connRetry != nil {
 				wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
@@ -512,6 +524,11 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
 
 			// Retry once with a new websocket connection for the same execution session.
+			if errWait := util.SleepContext(ctx, codexWebsocketRetryDelay(e.cfg, 1)); errWait != nil {
+				sess.clearActive(readCh)
+				sess.reqMu.Unlock()
+				return nil, errWait
+			}
 			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
 			if errDialRetry != nil || connRetry == nil {
 				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_websockets_executor_test.go
@@ -151,6 +151,24 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) 
 	}
 }
 
+func TestCodexWebsocketRetryDelayUsesStreamingBackoff(t *testing.T) {
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{
+			Streaming: config.StreamingConfig{
+				BootstrapRetryBaseDelayMS: 300,
+				BootstrapRetryMaxDelayMS:  1500,
+			},
+		},
+	}
+
+	if got := codexWebsocketRetryDelay(cfg, 1); got != 300*time.Millisecond {
+		t.Fatalf("attempt 1 delay = %v, want 300ms", got)
+	}
+	if got := codexWebsocketRetryDelay(cfg, 2); got != 600*time.Millisecond {
+		t.Fatalf("attempt 2 delay = %v, want 600ms", got)
+	}
+}
+
 func TestApplyCodexWebsocketHeadersDefaultsToCurrentResponsesBeta(t *testing.T) {
 	headers := applyCodexWebsocketHeaders(context.Background(), http.Header{}, nil, "", nil)
 

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/util/sanitize_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/util/sanitize_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"testing"
+	"time"
 )
 
 func TestSanitizeFunctionName(t *testing.T) {
@@ -126,5 +127,23 @@ func TestRestoreSanitizedToolName(t *testing.T) {
 	}
 	if got := RestoreSanitizedToolName(m, ""); got != "" {
 		t.Errorf("expected empty for empty name, got %q", got)
+	}
+}
+
+func TestBackoffDelay(t *testing.T) {
+	base := 300 * time.Millisecond
+	max := 1500 * time.Millisecond
+
+	if got := BackoffDelay(1, base, max); got != 300*time.Millisecond {
+		t.Fatalf("attempt 1 delay = %v, want 300ms", got)
+	}
+	if got := BackoffDelay(2, base, max); got != 600*time.Millisecond {
+		t.Fatalf("attempt 2 delay = %v, want 600ms", got)
+	}
+	if got := BackoffDelay(3, base, 1000*time.Millisecond); got != 1000*time.Millisecond {
+		t.Fatalf("attempt 3 delay = %v, want 1s", got)
+	}
+	if got := BackoffDelay(0, base, max); got != 0 {
+		t.Fatalf("attempt 0 delay = %v, want 0", got)
 	}
 }

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/util/util.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/util/util.go
@@ -10,12 +10,58 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	log "github.com/sirupsen/logrus"
 )
 
 var functionNameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_.:-]`)
+
+// SleepContext waits for the delay to pass or returns early when ctx is canceled.
+func SleepContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	if ctx == nil {
+		<-timer.C
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// BackoffDelay returns the bounded retry delay for a one-based retry attempt.
+func BackoffDelay(attempt int, base time.Duration, max time.Duration) time.Duration {
+	if attempt <= 0 || base <= 0 {
+		return 0
+	}
+	multiplier := 4
+	switch attempt {
+	case 1:
+		multiplier = 1
+	case 2:
+		multiplier = 2
+	}
+	delay := base
+	if multiplier > 1 {
+		if max > 0 && base > max/time.Duration(multiplier) {
+			delay = max
+		} else {
+			delay = base * time.Duration(multiplier)
+		}
+	}
+	if max > 0 && delay > max {
+		return max
+	}
+	return delay
+}
 
 // SanitizeFunctionName ensures a function name matches the requirements for Gemini/Vertex AI.
 // It replaces invalid characters with underscores, ensures it starts with a letter or underscore,

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/api/handlers/handlers.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/api/handlers/handlers.go
@@ -188,6 +188,15 @@ func StreamingBootstrapRetries(cfg *config.SDKConfig) int {
 	return retries
 }
 
+func streamingBootstrapRetryDelay(cfg *config.SDKConfig, attempt int) time.Duration {
+	if cfg == nil {
+		return 0
+	}
+	base := time.Duration(cfg.Streaming.BootstrapRetryBaseDelayMS) * time.Millisecond
+	max := time.Duration(cfg.Streaming.BootstrapRetryMaxDelayMS) * time.Millisecond
+	return util.BackoffDelay(attempt, base, max)
+}
+
 // PassthroughHeadersEnabled returns whether upstream response headers should be forwarded to clients.
 // Default is false.
 func PassthroughHeadersEnabled(cfg *config.SDKConfig) bool {
@@ -792,7 +801,11 @@ func (h *BaseAPIHandler) executeStreamWithAuthManager(ctx context.Context, handl
 					// retry a few times (to allow auth rotation / transient recovery) and then attempt model fallback.
 					if !sentPayload {
 						if bootstrapRetries < maxBootstrapRetries && bootstrapEligible(streamErr) {
-							bootstrapRetries++
+							nextRetry := bootstrapRetries + 1
+							if errWait := util.SleepContext(ctx, streamingBootstrapRetryDelay(h.Cfg, nextRetry)); errWait != nil {
+								return
+							}
+							bootstrapRetries = nextRetry
 							retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
 							if retryErr == nil {
 								if passthroughHeadersEnabled {

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -370,7 +371,9 @@ func TestExecuteStreamWithAuthManager_HeaderPassthroughDisabledByDefault(t *test
 
 	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{
 		Streaming: sdkconfig.StreamingConfig{
-			BootstrapRetries: 1,
+			BootstrapRetries:          1,
+			BootstrapRetryBaseDelayMS: 300,
+			BootstrapRetryMaxDelayMS:  1500,
 		},
 	}, manager)
 	dataChan, upstreamHeaders, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte(`{"model":"test-model"}`), "")
@@ -430,7 +433,9 @@ func TestExecuteStreamWithAuthManager_DoesNotRetryAfterFirstByte(t *testing.T) {
 
 	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{
 		Streaming: sdkconfig.StreamingConfig{
-			BootstrapRetries: 1,
+			BootstrapRetries:          1,
+			BootstrapRetryBaseDelayMS: 300,
+			BootstrapRetryMaxDelayMS:  1500,
 		},
 	}, manager)
 	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte(`{"model":"test-model"}`), "")
@@ -488,9 +493,12 @@ func TestExecuteStreamWithAuthManager_EnrichesBootstrapRetryAuthUnavailableError
 
 	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{
 		Streaming: sdkconfig.StreamingConfig{
-			BootstrapRetries: 1,
+			BootstrapRetries:          1,
+			BootstrapRetryBaseDelayMS: 300,
+			BootstrapRetryMaxDelayMS:  1500,
 		},
 	}, manager)
+	started := time.Now()
 	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte(`{"model":"test-model"}`), "")
 	if dataChan == nil || errChan == nil {
 		t.Fatalf("expected non-nil channels")
@@ -531,6 +539,10 @@ func TestExecuteStreamWithAuthManager_EnrichesBootstrapRetryAuthUnavailableError
 		t.Fatalf("message missing model context: %q", authErr.Message)
 	}
 
+	wantDelay := 300 * time.Millisecond
+	if elapsed := time.Since(started); elapsed < wantDelay {
+		t.Fatalf("expected bootstrap retry delay >= %v, got %v", wantDelay, elapsed)
+	}
 	if executor.Calls() != 1 {
 		t.Fatalf("expected exactly one upstream call before retry path selection failure, got %d", executor.Calls())
 	}

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/auth/errors.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/auth/errors.go
@@ -1,5 +1,10 @@
 package auth
 
+import (
+	"errors"
+	"net/http"
+)
+
 // Error describes an authentication related failure in a provider agnostic format.
 type Error struct {
 	// Code is a short machine readable identifier.
@@ -28,5 +33,17 @@ func (e *Error) StatusCode() int {
 	if e == nil {
 		return 0
 	}
+	if e.HTTPStatus <= 0 && IsAuthSelectionUnavailable(e) {
+		return http.StatusServiceUnavailable
+	}
 	return e.HTTPStatus
+}
+
+// IsAuthSelectionUnavailable reports local auth selection failures that leave no usable credential.
+func IsAuthSelectionUnavailable(err error) bool {
+	var authErr *Error
+	if !errors.As(err, &authErr) || authErr == nil {
+		return false
+	}
+	return authErr.Code == "auth_not_found" || authErr.Code == "auth_unavailable"
 }

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -30,6 +30,7 @@ import (
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	internalregistry "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	responsesconverter "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
 	sdkopenai "github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
 	sdkauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
@@ -2657,7 +2658,7 @@ func (s *relayServer) handleImagesRelayRequest(c *gin.Context, imageReq imageRel
 	defer cancelStream()
 	result, err := s.executeStreamWithOpenTimeout(c, streamCtx, []string{"codex"}, req, opts, model, startedAt, timeouts.open)
 	if err != nil {
-		writeExecutorError(c, err)
+		s.writeExecutorError(c, err)
 		return
 	}
 	if result == nil || result.Chunks == nil {
@@ -2670,7 +2671,7 @@ func (s *relayServer) handleImagesRelayRequest(c *gin.Context, imageReq imageRel
 	}
 	out, err := collectImagesResponse(streamCtx, result.Chunks, imageReq.responseFormat, timeouts.idle)
 	if err != nil {
-		writeExecutorError(c, err)
+		s.writeExecutorError(c, err)
 		return
 	}
 	writeUpstreamHeaders(c.Writer.Header(), result.Headers)
@@ -3622,7 +3623,7 @@ func (s *relayServer) handleNonStream(c *gin.Context, body []byte, model string,
 	stopWaitLogger()
 	if err != nil {
 		s.emitExecutorDiagnostic(c, "executor_failed", model, "execute", startedAt, err.Error())
-		writeExecutorError(c, err)
+		s.writeExecutorError(c, err)
 		return
 	}
 	s.emitExecutorDiagnostic(c, "executor_completed", model, "execute", startedAt, "")
@@ -3646,7 +3647,7 @@ func (s *relayServer) handleStream(c *gin.Context, body []byte, model string, so
 	stopWaitLogger()
 	if err != nil {
 		s.emitExecutorDiagnostic(c, "executor_failed", model, "execute_stream", startedAt, err.Error())
-		writeExecutorError(c, err)
+		s.writeExecutorError(c, err)
 		return
 	}
 	if result == nil || result.Chunks == nil {
@@ -4378,7 +4379,7 @@ func (s *relayServer) handleOllamaRuntimeNonStream(c *gin.Context, body []byte, 
 	req, opts := buildExecutorRequest(c, body, model, sdktranslator.FormatOpenAI, "", false)
 	resp, err := s.runtime.Execute(relayContext(c), []string{"codex"}, req, opts)
 	if err != nil {
-		writeExecutorError(c, err)
+		s.writeExecutorError(c, err)
 		return
 	}
 	payload := convertOpenAIChatResponseToOllama(resp.Payload, model)
@@ -4394,7 +4395,7 @@ func (s *relayServer) handleOllamaRuntimeStream(c *gin.Context, body []byte, mod
 	defer cancelStream()
 	result, err := s.executeStreamWithOpenTimeout(c, streamCtx, []string{"codex"}, req, opts, model, startedAt, timeouts.open)
 	if err != nil {
-		writeExecutorError(c, err)
+		s.writeExecutorError(c, err)
 		return
 	}
 	if result == nil || result.Chunks == nil {
@@ -5070,7 +5071,7 @@ func writeAPIError(c *gin.Context, status int, message, code string) {
 	})
 }
 
-func writeExecutorError(c *gin.Context, err error) {
+func (s *relayServer) writeExecutorError(c *gin.Context, err error) {
 	status := statusCodeFromError(err)
 	code := "upstream_error"
 	if status == http.StatusUnauthorized || status == http.StatusForbidden {
@@ -5085,7 +5086,34 @@ func writeExecutorError(c *gin.Context, err error) {
 	if err != nil {
 		_ = c.Error(err)
 	}
+	if shouldThrottleDownstreamExecutorError(status) {
+		var ctx context.Context = context.Background()
+		if c != nil && c.Request != nil {
+			ctx = c.Request.Context()
+		}
+		if waitErr := util.SleepContext(ctx, s.downstreamExecutorErrorDelay()); waitErr != nil {
+			return
+		}
+	}
 	writeAPIError(c, status, errorMessage(err), code)
+}
+
+func shouldThrottleDownstreamExecutorError(status int) bool {
+	if status == http.StatusUnauthorized || status == http.StatusPaymentRequired ||
+		status == http.StatusForbidden || status == http.StatusRequestTimeout ||
+		status == http.StatusTooManyRequests {
+		return true
+	}
+	return status >= http.StatusInternalServerError
+}
+
+func (s *relayServer) downstreamExecutorErrorDelay() time.Duration {
+	if s == nil || s.cfg == nil {
+		return 0
+	}
+	base := time.Duration(s.cfg.Streaming.BootstrapRetryBaseDelayMS) * time.Millisecond
+	max := time.Duration(s.cfg.Streaming.BootstrapRetryMaxDelayMS) * time.Millisecond
+	return util.BackoffDelay(1, base, max)
 }
 
 func statusCodeFromError(err error) int {

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -378,6 +378,46 @@ func TestRequestPolicyMiddlewareSetsCPAUsageAPIKey(t *testing.T) {
 	}
 }
 
+type testExecutorStatusError struct {
+	status int
+}
+
+func (e testExecutorStatusError) Error() string {
+	return http.StatusText(e.status)
+}
+
+func (e testExecutorStatusError) StatusCode() int {
+	return e.status
+}
+
+func TestWriteExecutorErrorThrottlesRetryableDownstreamError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	server := &relayServer{
+		cfg: &config.Config{
+			SDKConfig: config.SDKConfig{
+				Streaming: config.StreamingConfig{
+					BootstrapRetryBaseDelayMS: 50,
+					BootstrapRetryMaxDelayMS:  50,
+				},
+			},
+		},
+	}
+
+	started := time.Now()
+	server.writeExecutorError(c, testExecutorStatusError{status: http.StatusServiceUnavailable})
+	elapsed := time.Since(started)
+
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("expected downstream error delay >= 50ms, got %v", elapsed)
+	}
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unexpected status: %d", recorder.Code)
+	}
+}
+
 func TestRequestUsageTrackerFinalizesWithLastSuccessfulAttempt(t *testing.T) {
 	tracker := newRequestUsageTracker()
 	tracker.record(usagePayload{

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -7046,7 +7046,9 @@ async fn prepare_sidecar_launch_config_in_dir(
         "streaming".to_string(),
         json!({
             "keepalive-seconds": timeouts.sidecar_stream_keepalive_seconds,
-            "bootstrap-retries": timeouts.sidecar_streaming_bootstrap_retries,
+            "bootstrap-retries": timeouts.single_account_status_retry_attempts,
+            "bootstrap-retry-base-delay-ms": timeouts.single_account_status_retry_base_delay_ms,
+            "bootstrap-retry-max-delay-ms": timeouts.single_account_status_retry_max_delay_ms,
             "stream-open-timeout-ms": timeouts.sidecar_stream_open_timeout_ms,
             "stream-idle-timeout-ms": timeouts.sidecar_stream_idle_timeout_ms,
             "image-stream-open-timeout-ms": timeouts.sidecar_image_stream_open_timeout_ms,
@@ -15174,7 +15176,8 @@ fn backoff_retry_delay(retry_attempt: usize, base_delay_ms: u64, max_delay_ms: u
 fn should_retry_single_account_upstream_status(status: StatusCode) -> bool {
     matches!(
         status,
-        StatusCode::REQUEST_TIMEOUT
+        StatusCode::UNAUTHORIZED
+            | StatusCode::REQUEST_TIMEOUT
             | StatusCode::INTERNAL_SERVER_ERROR
             | StatusCode::BAD_GATEWAY
             | StatusCode::SERVICE_UNAVAILABLE
@@ -19246,6 +19249,9 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
     fn retries_single_account_for_transient_upstream_status() {
         assert!(should_retry_single_account_upstream_status(
             StatusCode::SERVICE_UNAVAILABLE
+        ));
+        assert!(should_retry_single_account_upstream_status(
+            StatusCode::UNAUTHORIZED
         ));
         assert!(should_retry_single_account_upstream_status(
             StatusCode::GATEWAY_TIMEOUT


### PR DESCRIPTION
﻿## Summary

- Codex sidecar 的 streaming bootstrap retry 在再次调用上游 executor 前等待，避免同一请求内 bootstrap 失败后立即重试。
- Codex WebSocket 上游重连 retry 在重建连接前等待，避免连接失败后立即连续重建。
- Codex relay 在返回可重试失败给 Codex 客户端前等待第一拍，避免 Cockpit 毫秒级秒回放大客户端重试。
- 本地 `auth_unavailable` / `auth_not_found` 认证选择失败返回 `503 Service Unavailable`。
- 短时间过密失败会对上游造成无必要请求压力，本次让 Codex sidecar 的显式 retry 点和下游失败响应进入等待节奏。

## Root Cause

复现实例是 Codex API 遇到 `502 upstream_error` 或本地 `auth_unavailable` 后，日志中出现一串不同 `requestId` 的失败请求。

问题本体分两层：

- Cockpit 的部分 Codex sidecar retry 点失败后会很快再次尝试，缺少统一等待。
- Cockpit 对 Codex 客户端返回可重试失败过快，客户端收到失败后马上创建新请求，放大成短时间密集失败。

这会让日志里出现毫秒级失败响应，也会对上游造成无必要的请求压力。

## Behavior

- streaming bootstrap retry 复用现有 single-account retry 延迟，默认第一拍约 `300ms`。
- WebSocket session send retry 复用同一套延迟，重建上游 websocket 前等待。
- Codex relay 对 `401`、`402`、`403`、`408`、`429` 和 `5xx` 这类可重试失败响应增加第一拍等待。
- 本地无可用认证账号时返回 `503`，日志中显示 `auth_unavailable` / `auth_not_found` 的服务不可用语义。
- 已发送首个 stream payload 后仍保持原有行为，不再重新 bootstrap retry。
- 同一请求内部的多账号/多候选切换仍沿用现有 auth conductor 选择和 fallback 流程。

## Test Plan

- `git diff --check`
- `git diff --cached --check`
- `go test .`，目录：`sidecars/cockpit-cliproxy`
- `go test ./internal/util ./sdk/api/handlers ./sdk/cliproxy/auth`，目录：`sidecars/cockpit-cliproxy/cdk/CLIProxyAPI`

## Verification Notes

本地修复版日志已验证：

- 旧 `auth_unavailable`：`502`，`latencyMs=2~10ms`
- 新 `auth_unavailable`：`503`，`latencyMs≈300ms`
- 上游 `502 upstream_error` 后，Cockpit 写下游响应前有约 `300ms` 延迟

Closes #1269