### PR TITLE
fix: 解决 Antigravity 筛选/排序配置未持久化问题（严重影响用户体验）及免费账号重置时间显示异常

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -516,7 +516,23 @@ function MainApp() {
   const sideNavClassicFirstSyncDone = useSideNavLayoutStore((state) => state.classicFirstSyncDone);
   const markSideNavClassicFirstSyncDone = useSideNavLayoutStore((state) => state.markClassicFirstSyncDone);
   const syncSidebarEntriesFromDashboard = usePlatformLayoutStore((state) => state.syncSidebarEntriesFromDashboard);
-  const [page, setPage] = useState<Page>('dashboard');
+  const [page, setPage] = useState<Page>(() => {
+    try {
+      const saved = localStorage.getItem('agtools.active_page');
+      if (saved) {
+        return saved as Page;
+      }
+    } catch {}
+    return 'dashboard';
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('agtools.active_page', page);
+    } catch (e) {
+      console.warn('Failed to save active page to localStorage:', e);
+    }
+  }, [page]);
   const [showUpdateNotification, setShowUpdateNotification] = useState(false);
   const [updateNotificationKey, setUpdateNotificationKey] = useState(0);
   const [showCloseDialog, setShowCloseDialog] = useState(false);


### PR DESCRIPTION
目前版本中存在几个严重阻碍日常使用的体验硬伤，导致大量重复操作和数据无法对齐：

1. **Antigravity 面板配置“每次刷新/重启即丢失” (严重折磨用户体验，极大时间浪费)**
   - **痛点**：用户只要切换页面、刷新或重启软件，之前精心设置的**筛选条件（只看某类型账号）、排序规则（按综合配额降序）、视图排版、邮箱眼睛隐藏/显示状态就会全部被抹除重置**。对于管理几十上百个账号的用户来说，每一次点击都是折磨。这实际上构成了严重的体验退化（Regression）。
   - **备份漏洞**：这些重要偏好无法随配置备份而恢复。一旦换机或重装，所有状态必须手动重调。
2. **左侧导航状态丢失 (流失上下文)**
   - **痛点**：每次打开应用都会强制进入 Dashboard，丢失上一次正在操作的菜单，破坏上下文连贯性。
3. **免费账号 5 小时刷新倒计时完全失效 (黑盒体验)**
   - **痛点**：免费账号的 5h 配额在重置时间超出 5 小时后（经常发生），重置时间直接变空白，用户完全不知道配额何时刷新，甚至以为软件损坏，产生了严重的体验黑盒。

------

#### 🛠️ 解决方案与低风险设计 (Solutions & Low Risk Design)

为解决上述卡点，本次提交对状态存储进行了加固，并且**确保修改高内聚、零副作用**，非常安全：

##### **1. 状态强制持久化与全量备份支持 (零丢配置)**

- **`src/pages/AccountsPage.tsx`**：重构了状态初始化和 `useEffect` 持久化机制。使视图、筛选类型、排序等直接绑定 `localStorage`，不受“筛选条件记忆”全局开关的偶然性影响，每次操作立时落盘。添加事件监听，在配置文件恢复导入时，**界面可无感、实时刷新呈现最新的偏好选择**。
- **`src/App.tsx`**：实现左侧导航 Tab 页面的自动记忆，重开即直达上次处理位置。
- **`src/services/dataTransferService.ts`**：扩展 `DataTransferConfigBundle` 传输实体，将上述页面配置加入全局同步链路。**（注意：出于安全性与业务逻辑，已精准排除了临时标签选择项 `tag_filter`）**。

##### **2. 5 小时配额重置时间精准兜底**

- **`src/presentation/platformAccountPresentation.ts`**：在 `getAntigravityQuotaDisplayItems` 中，针对免费账号（`FREE`）做逻辑修补：优先提取 5 小时配额自身的重置时间，如果遇到上述失效空白情况，**立即且自动回退周重置时间 (`weekly.reset_time`) 作为兜底展示**，消除体验黑盒。

------

#### 🧪 验证与质量保证 (Validation & Verification)

- **类型安全**：本地成功通过 `npm run typecheck` (`tsc --noEmit`) 零报错，未引入任何破坏性变更或隐式类型漏洞。
- **冒烟测试**：
  - Antigravity 界面状态更改后重启，全部保留；
  - 导出包含配置的备份包，再次导入，配置完全按预期应用，且标签过滤项未受干扰；
  - 免费账号卡片下的重置时间展示均有正确数值，不再有空白行。