### PR TITLE
[codex] feat: 请求日志显示账号名称

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -279,13 +279,23 @@ type usageFinalizeInput struct {
 	errorMessage  string
 }
 
+type selectedAccountRecord struct {
+	AccountID    string
+	AccountEmail string
+	AuthID       string
+}
+
 type requestUsageTracker struct {
-	mu      sync.Mutex
-	records map[string][]usagePayload
+	mu               sync.Mutex
+	records          map[string][]usagePayload
+	selectedAccounts map[string]selectedAccountRecord
 }
 
 func newRequestUsageTracker() *requestUsageTracker {
-	return &requestUsageTracker{records: make(map[string][]usagePayload)}
+	return &requestUsageTracker{
+		records:          make(map[string][]usagePayload),
+		selectedAccounts: make(map[string]selectedAccountRecord),
+	}
 }
 
 func (t *requestUsageTracker) record(payload usagePayload) {
@@ -302,6 +312,23 @@ func (t *requestUsageTracker) record(payload usagePayload) {
 	t.mu.Unlock()
 }
 
+func (t *requestUsageTracker) recordSelectedAccount(requestID string, account *accountSpec, authID string) {
+	if t == nil {
+		return
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" || account == nil {
+		return
+	}
+	t.mu.Lock()
+	t.selectedAccounts[requestID] = selectedAccountRecord{
+		AccountID:    strings.TrimSpace(account.ID),
+		AccountEmail: strings.TrimSpace(account.Email),
+		AuthID:       strings.TrimSpace(authID),
+	}
+	t.mu.Unlock()
+}
+
 func (t *requestUsageTracker) finalize(requestID string, input usageFinalizeInput) (usagePayload, bool) {
 	requestID = strings.TrimSpace(requestID)
 	if requestID == "" {
@@ -309,10 +336,14 @@ func (t *requestUsageTracker) finalize(requestID string, input usageFinalizeInpu
 	}
 
 	var records []usagePayload
+	var selected selectedAccountRecord
+	var selectedOK bool
 	if t != nil {
 		t.mu.Lock()
 		records = append(records, t.records[requestID]...)
 		delete(t.records, requestID)
+		selected, selectedOK = t.selectedAccounts[requestID]
+		delete(t.selectedAccounts, requestID)
 		t.mu.Unlock()
 	}
 
@@ -350,6 +381,15 @@ func (t *requestUsageTracker) finalize(requestID string, input usageFinalizeInpu
 	}
 	if strings.TrimSpace(payload.RequestKind) == "" {
 		payload.RequestKind = strings.TrimSpace(input.requestKind)
+	}
+	if selectedOK {
+		payload.AccountID = selected.AccountID
+		payload.AccountEmail = selected.AccountEmail
+		payload.AuthID = selected.AuthID
+	} else {
+		payload.AccountID = ""
+		payload.AccountEmail = ""
+		payload.AuthID = ""
 	}
 	if input.status > 0 {
 		payload.Status = input.status
@@ -1405,6 +1445,27 @@ type cockpitSelector struct {
 	cursor   int
 }
 
+type recordingSelector struct {
+	inner    coreauth.Selector
+	manifest *manifest
+	tracker  *requestUsageTracker
+}
+
+func (s *recordingSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
+	auth, err := s.inner.Pick(ctx, provider, model, opts, auths)
+	if err != nil || auth == nil || s.tracker == nil {
+		return auth, err
+	}
+	s.tracker.recordSelectedAccount(internallogging.GetRequestID(ctx), accountForAuthInManifest(s.manifest, auth), auth.ID)
+	return auth, nil
+}
+
+func (s *recordingSelector) Stop() {
+	if stoppable, ok := s.inner.(coreauth.StoppableSelector); ok {
+		stoppable.Stop()
+	}
+}
+
 type quotaReserveSelector struct {
 	manifest *manifest
 	fallback coreauth.Selector
@@ -2297,12 +2358,15 @@ func buildCoreAuthSelector(cfg *config.Config, selector coreauth.Selector, m *ma
 	return selector
 }
 
-func buildCoreAuthManager(cfg *config.Config, selector coreauth.Selector, hook coreauth.Hook, m *manifest, quota *quotaReserveStateStore) *coreauth.Manager {
+func buildCoreAuthManager(cfg *config.Config, selector coreauth.Selector, hook coreauth.Hook, m *manifest, quota *quotaReserveStateStore, tracker *requestUsageTracker) *coreauth.Manager {
 	tokenStore := sdkauth.GetTokenStore()
 	if dirSetter, ok := tokenStore.(interface{ SetBaseDir(string) }); ok && cfg != nil {
 		dirSetter.SetBaseDir(cfg.AuthDir)
 	}
 	selector = buildCoreAuthSelector(cfg, selector, m, quota)
+	if tracker != nil {
+		selector = &recordingSelector{inner: selector, manifest: m, tracker: tracker}
+	}
 	return coreauth.NewManager(tokenStore, selector, hook)
 }
 
@@ -5986,7 +6050,7 @@ func main() {
 	policy := &requestPolicy{manifest: m, emitter: emitter, tracker: usageTracker}
 	hook := &authHook{manifest: m, emitter: emitter}
 	selector := &cockpitSelector{manifest: m, emitter: emitter, quota: quotaState}
-	coreManager := buildCoreAuthManager(cfg, selector, hook, m, quotaState)
+	coreManager := buildCoreAuthManager(cfg, selector, hook, m, quotaState, usageTracker)
 
 	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -587,7 +587,7 @@ func TestSidecarRuntimeRegistersConfigCodexAPIKeyAuths(t *testing.T) {
 		accountByAPIKey: map[string]*accountSpec{"sk-upstream": account},
 		ModelIDs:        []string{"gpt-5.4"},
 	}
-	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil)
+	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
 
 	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager)
 	if err != nil {
@@ -680,7 +680,7 @@ func TestManifestRegisteredModelsPreserveReasoningEffortThroughThinkingPipeline(
 		Provider: "codex",
 		Status:   coreauth.StatusActive,
 	}
-	manager := buildCoreAuthManager(&config.Config{}, &cockpitSelector{}, nil, nil, nil)
+	manager := buildCoreAuthManager(&config.Config{}, &cockpitSelector{}, nil, nil, nil, nil)
 	registered, err := manager.Register(context.Background(), auth)
 	if err != nil {
 		t.Fatalf("register auth: %v", err)
@@ -841,6 +841,10 @@ func TestWriteExecutorErrorThrottlesRetryableDownstreamError(t *testing.T) {
 
 func TestRequestUsageTrackerFinalizesWithLastSuccessfulAttempt(t *testing.T) {
 	tracker := newRequestUsageTracker()
+	tracker.recordSelectedAccount("req-1", &accountSpec{
+		ID:    "account-ok",
+		Email: "ok@example.com",
+	}, "auth-ok")
 	tracker.record(usagePayload{
 		Type:          "usage",
 		RequestID:     "req-1",
@@ -889,6 +893,113 @@ func TestRequestUsageTrackerFinalizesWithLastSuccessfulAttempt(t *testing.T) {
 	}
 	if payload.LatencyMS != 446_000 || payload.APIKeyID != "key_1" {
 		t.Fatalf("final request metadata was not applied: %#v", payload)
+	}
+}
+
+func TestRequestUsageTrackerFinalizesWithSelectedAccount(t *testing.T) {
+	tracker := newRequestUsageTracker()
+	tracker.recordSelectedAccount("req-selected", &accountSpec{
+		ID:    "account-selected",
+		Email: "selected@example.com",
+	}, "auth-selected")
+
+	payload, ok := tracker.finalize("req-selected", usageFinalizeInput{
+		spec:          &apiKeySpec{ID: "key_1", Label: "Default"},
+		requestKind:   "text",
+		model:         "gpt-5.5",
+		status:        http.StatusOK,
+		latencyMS:     100,
+		completedAtMS: 123,
+	})
+
+	if !ok {
+		t.Fatal("expected finalized usage payload")
+	}
+	if payload.AccountID != "account-selected" || payload.AccountEmail != "selected@example.com" || payload.AuthID != "auth-selected" {
+		t.Fatalf("expected selected account metadata, got %#v", payload)
+	}
+}
+
+func TestRequestUsageTrackerSelectedAccountOverridesUsageAccount(t *testing.T) {
+	tracker := newRequestUsageTracker()
+	tracker.recordSelectedAccount("req-usage", &accountSpec{
+		ID:    "account-selected",
+		Email: "selected@example.com",
+	}, "auth-selected")
+	tracker.record(usagePayload{
+		Type:         "usage",
+		RequestID:    "req-usage",
+		AccountID:    "account-usage",
+		AccountEmail: "usage@example.com",
+		AuthID:       "auth-usage",
+		Success:      true,
+	})
+
+	payload, ok := tracker.finalize("req-usage", usageFinalizeInput{
+		status:        http.StatusOK,
+		latencyMS:     100,
+		completedAtMS: 123,
+	})
+
+	if !ok {
+		t.Fatal("expected finalized usage payload")
+	}
+	if payload.AccountID != "account-selected" || payload.AccountEmail != "selected@example.com" || payload.AuthID != "auth-selected" {
+		t.Fatalf("selected account metadata should win, got %#v", payload)
+	}
+}
+
+type countingSelector struct {
+	auth  *coreauth.Auth
+	count int
+}
+
+func (s *countingSelector) Pick(context.Context, string, string, cliproxyexecutor.Options, []*coreauth.Auth) (*coreauth.Auth, error) {
+	s.count++
+	return s.auth, nil
+}
+
+func TestRecordingSelectorRecordsSessionAffinityCacheHit(t *testing.T) {
+	account := &accountSpec{ID: "account-selected", Email: "selected@example.com"}
+	m := &manifest{
+		accountByAuthID: map[string]*accountSpec{"auth-selected": account},
+		accountByID:     map[string]*accountSpec{"account-selected": account},
+		accountByAPIKey: map[string]*accountSpec{},
+	}
+	auth := &coreauth.Auth{ID: "auth-selected", Provider: "codex", Status: coreauth.StatusActive}
+	fallback := &countingSelector{auth: auth}
+	affinity := coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Hour,
+	})
+	tracker := newRequestUsageTracker()
+	selector := &recordingSelector{inner: affinity, manifest: m, tracker: tracker}
+	headers := make(http.Header)
+	headers.Set("X-Session-ID", "session-selected")
+	opts := cliproxyexecutor.Options{Headers: headers}
+
+	ctx1 := internallogging.WithRequestID(context.Background(), "req-first")
+	if _, err := selector.Pick(ctx1, "codex", "gpt-5.5", opts, []*coreauth.Auth{auth}); err != nil {
+		t.Fatalf("first pick: %v", err)
+	}
+	ctx2 := internallogging.WithRequestID(context.Background(), "req-cache")
+	if _, err := selector.Pick(ctx2, "codex", "gpt-5.5", opts, []*coreauth.Auth{auth}); err != nil {
+		t.Fatalf("cache pick: %v", err)
+	}
+	if fallback.count != 1 {
+		t.Fatalf("expected second pick to use affinity cache, fallback count=%d", fallback.count)
+	}
+
+	payload, ok := tracker.finalize("req-cache", usageFinalizeInput{
+		status:        http.StatusOK,
+		latencyMS:     100,
+		completedAtMS: 123,
+	})
+	if !ok {
+		t.Fatal("expected finalized usage payload")
+	}
+	if payload.AccountID != "account-selected" || payload.AccountEmail != "selected@example.com" || payload.AuthID != "auth-selected" {
+		t.Fatalf("expected cache hit selected account metadata, got %#v", payload)
 	}
 }
 

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -656,6 +656,17 @@ export function CodexApiServicePage() {
         .filter((account): account is CodexAccount => Boolean(account)),
     [memberIds, localAccessAccounts],
   );
+  const accountDisplayNames = useMemo(() => {
+    const next = new Map<string, string>();
+    localAccessAccounts.forEach((account) => {
+      const displayName = buildCodexAccountPresentation(account, t).displayName;
+      const accountId = account.id.trim();
+      const email = account.email.trim();
+      if (accountId) next.set(accountId, displayName);
+      if (email) next.set(email, displayName);
+    });
+    return next;
+  }, [localAccessAccounts, t]);
   const accountModelRuleCount = collection?.accountModelRules.length ?? 0;
   const accountModelRuleAllSelected =
     memberAccounts.length > 0 &&
@@ -3931,6 +3942,11 @@ export function CodexApiServicePage() {
                     const errorDetail = truncateRequestLogErrorDetail(
                       cleanRequestLogErrorDetail(event.errorMessage),
                     );
+                    const accountDisplayName =
+                      accountDisplayNames.get(event.accountId.trim()) ||
+                      accountDisplayNames.get(event.email.trim()) ||
+                      event.email ||
+                      event.accountId;
                     return (
                       <div
                         key={`${event.timestamp}-${event.requestId || event.apiKeyId}-${index}`}
@@ -3964,7 +3980,7 @@ export function CodexApiServicePage() {
                             {event.apiKeyLabel || event.apiKeyId || "-"}
                           </span>
                           <span>
-                            {maskAccountText(event.email || event.accountId)}
+                            {maskAccountText(accountDisplayName)}
                           </span>
                           <span>{formatLatencyMs(event.latencyMs)}</span>
                           <span>


### PR DESCRIPTION
﻿## 摘要
- 在 Codex API 服务的请求日志中，账号列改为显示现有账号展示名。
- 保留客户端 Key 列的原有回退逻辑：有 Key 名称显示名称，缺少名称时退回内部 ID。

## 根因
请求日志的账号列直接渲染 `event.email || event.accountId`，API Key 账号就会显示成 `api-key-a5b393a8` 这类生成标识，而不是用户设置的账号显示名。

## 验证
- `npm run typecheck`
- 已准备 release-dev 热更新命令，可用正式数据目录 `C:\Users\Administrator\.antigravity_cockpit` 做本地验证。

<img width="943" height="214" alt="image" src="https://github.com/user-attachments/assets/36bc1dfd-66ac-40dd-94bd-f2d49be8a29a" />


Fixes #1302
