### PR TITLE
[codex] fix: 记住账号总览排序方式

### DIFF
--- a/src/hooks/useProviderAccountsPage.ts
+++ b/src/hooks/useProviderAccountsPage.ts
@@ -171,6 +171,7 @@ export interface ProviderPageConfig<TAccount extends ProviderAccountBase> {
   /** OAuth 成功后的提示文案（可选） */
   resolveOauthSuccessMessage?: () => string;
   defaultSortBy?: string;
+  sortPreferenceStorageKey?: string;
 }
 
 export interface ProviderAccountBase {
@@ -195,6 +196,43 @@ const FILTER_FIELD_SORT_BY = 'sort_by';
 const FILTER_FIELD_SORT_DIRECTION = 'sort_direction';
 const FILTER_FIELD_TAGS = 'tags';
 const FILTER_FIELD_GROUP_BY_TAG = 'group_by_tag';
+
+interface ProviderSortPreference {
+  sortBy?: string | null;
+  sortDirection?: SortDirection | null;
+}
+
+function readProviderSortPreference(storageKey?: string | null): ProviderSortPreference | null {
+  if (!storageKey) return null;
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const payload = parsed as Record<string, unknown>;
+    return {
+      sortBy: typeof payload.sortBy === 'string' ? payload.sortBy.trim() : null,
+      sortDirection:
+        payload.sortDirection === 'asc' || payload.sortDirection === 'desc'
+          ? payload.sortDirection
+          : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeProviderSortPreference(
+  storageKey: string | undefined,
+  preference: Required<ProviderSortPreference>,
+): void {
+  if (!storageKey) return;
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(preference));
+  } catch {
+    // ignore persistence failures
+  }
+}
 
 const normalizeStringArray = (value: unknown): string[] =>
   Array.isArray(value)
@@ -775,6 +813,7 @@ export function useProviderAccountsPage<TAccount extends ProviderAccountBase>(
     oauthTabKeys: oauthTabKeysConfig,
     dataService,
     defaultSortBy: defaultSortByConfig,
+    sortPreferenceStorageKey,
   } = config;
   const defaultSortBy = defaultSortByConfig?.trim() || DEFAULT_SORT_BY;
 
@@ -885,6 +924,10 @@ export function useProviderAccountsPage<TAccount extends ProviderAccountBase>(
 
   // ─── Sort ─────────────────────────────────────────────────────────────
   const [sortBy, setSortBy] = useState<string>(() => {
+    const savedPreference = readProviderSortPreference(sortPreferenceStorageKey);
+    if (savedPreference?.sortBy?.trim()) {
+      return savedPreference.sortBy.trim();
+    }
     if (!readAccountsOverviewFilterPersistenceEnabled(filterPersistenceScope)) {
       return defaultSortBy;
     }
@@ -896,6 +939,10 @@ export function useProviderAccountsPage<TAccount extends ProviderAccountBase>(
     return saved?.trim() ? saved : defaultSortBy;
   });
   const [sortDirection, setSortDirection] = useState<SortDirection>(() => {
+    const savedPreference = readProviderSortPreference(sortPreferenceStorageKey);
+    if (savedPreference?.sortDirection) {
+      return savedPreference.sortDirection;
+    }
     if (!readAccountsOverviewFilterPersistenceEnabled(filterPersistenceScope)) {
       return DEFAULT_SORT_DIRECTION;
     }
@@ -906,6 +953,13 @@ export function useProviderAccountsPage<TAccount extends ProviderAccountBase>(
     );
     return normalizeSortDirection(saved);
   });
+
+  useEffect(() => {
+    writeProviderSortPreference(sortPreferenceStorageKey, {
+      sortBy,
+      sortDirection,
+    });
+  }, [sortBy, sortDirection, sortPreferenceStorageKey]);
 
   useEffect(() => {
     if (!filterPersistenceEnabled) {

--- a/src/pages/CodexAccountsContent.tsx
+++ b/src/pages/CodexAccountsContent.tsx
@@ -307,6 +307,7 @@ const CODEX_CUSTOM_SORT_ORDER_KEY =
   "agtools.codex.accounts.custom_sort_order.v1";
 const CODEX_CUSTOM_SORT_ACTIVE_KEY =
   "agtools.codex.accounts.custom_sort_active.v1";
+const CODEX_SORT_PREFERENCE_KEY = "agtools.codex.accounts.sort_preference.v1";
 const DEFAULT_CODEX_API_PROVIDER_ID = OPENAI_OFFICIAL_PRESET_ID;
 const DEFAULT_CODEX_API_BASE_URL = OPENAI_OFFICIAL_BASE_URL;
 const CODEX_LOCAL_ACCESS_FALLBACK_PORT = 54140;
@@ -1293,6 +1294,7 @@ export function CodexAccountsContent() {
     },
     getDisplayEmail: (account) => account.email ?? account.id,
     defaultSortBy: readCodexCustomSortActive() ? "custom" : undefined,
+    sortPreferenceStorageKey: CODEX_SORT_PREFERENCE_KEY,
   });
 
   const {


### PR DESCRIPTION
## 变更内容

- Codex 账号总览会单独记住排序字段和排序方向。
- 用户选过“按订阅有效期”或其它排序方式后，切换界面、重启软件或更新版本后仍会恢复上次选择。
- 不新增功能开关，也不改变首次进入页面时的默认排序逻辑。

## 背景

Codex 账号总览已经提供“按订阅有效期”等排序选项，但排序选择没有独立记忆。用户每次重启后容易回到默认的“按创建时间”，管理多个订阅账号时需要反复手动切回。

这次只把排序选择作为 Codex 账号总览的页面偏好保存下来。已有“筛选记忆”逻辑保持不变，标签、筛选、分组等行为不受影响。

## 验证

- npm run typecheck