### PR TITLE
[codex] fix: 修复请求日志悬浮窗显示完整错误详情

### DIFF
--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -3902,9 +3902,11 @@ export function CodexApiServicePage() {
                     </div>
                   )}
                   {requestLogEvents.map((event, index) => {
-                    const errorDetail = truncateRequestLogErrorDetail(
-                      cleanRequestLogErrorDetail(event.errorMessage),
+                    const fullErrorDetail = cleanRequestLogErrorDetail(
+                      event.errorMessage,
                     );
+                    const errorDetail =
+                      truncateRequestLogErrorDetail(fullErrorDetail);
                     return (
                       <div
                         key={`${event.timestamp}-${event.requestId || event.apiKeyId}-${index}`}
@@ -3967,7 +3969,7 @@ export function CodexApiServicePage() {
                           {errorDetail ? (
                             <span
                               className="codex-api-service-log-error-detail"
-                              title={errorDetail}
+                              title={fullErrorDetail}
                             >
                               {errorDetail}
                             </span>


### PR DESCRIPTION
﻿### 变更
- 修复“统计与日志”页请求日志错误详情的悬浮窗显示不完整问题。
- 保留列表中的截断显示，`title` 改为使用清理后的完整错误文本。

### 原因
原实现把同一个截断后的错误详情同时用于页面正文和悬浮提示，导致鼠标悬停时只能看到省略内容。

### 验证
- `npm run typecheck`

### 对应 issue
Closes #1318

### 说明
<img width="1314" height="208" alt="afterfix" src="https://github.com/user-attachments/assets/0d0eec32-dcfd-417b-9475-1bb3c4aab934" />

