### PR TITLE
fix(antigravity): support system credential mode for legacy get_current_account on windows

### DIFF
--- a/src-tauri/src/commands/antigravity_legacy_instance.rs
+++ b/src-tauri/src/commands/antigravity_legacy_instance.rs
@@ -21,6 +21,34 @@ fn resolve_default_account_id(settings: &DefaultInstanceSettings) -> Option<Stri
 }
 
 fn resolve_local_account_id() -> Option<String> {
+    #[cfg(target_os = "windows")]
+    {
+        use modules::antigravity_legacy_instance::{resolve_auth_mode, AntigravityDesktopAuthMode};
+        match resolve_auth_mode() {
+            AntigravityDesktopAuthMode::SystemCredential => {
+                if let Ok(Some(system_credential)) = modules::antigravity_credential::read_antigravity_system_credential() {
+                    if let Ok(accounts) = modules::list_accounts() {
+                        for account in accounts {
+                            if account.token.refresh_token == system_credential.refresh_token {
+                                return Some(account.id);
+                            }
+                        }
+                    }
+                }
+                None
+            }
+            AntigravityDesktopAuthMode::LegacyStateDb => {
+                resolve_local_account_id_from_db()
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        resolve_local_account_id_from_db()
+    }
+}
+
+fn resolve_local_account_id_from_db() -> Option<String> {
     let default_dir = modules::antigravity_legacy_instance::get_default_user_data_dir().ok()?;
     let db_path = default_dir
         .join("User")

--- a/src-tauri/src/modules/antigravity_legacy_instance.rs
+++ b/src-tauri/src/modules/antigravity_legacy_instance.rs
@@ -26,7 +26,7 @@ pub struct InstanceDefaults {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AntigravityDesktopAuthMode {
+pub enum AntigravityDesktopAuthMode {
     LegacyStateDb,
     SystemCredential,
 }
@@ -166,7 +166,7 @@ fn compare_versions(left: &str, right: &str) -> Option<std::cmp::Ordering> {
     Some(std::cmp::Ordering::Equal)
 }
 
-fn resolve_auth_mode() -> AntigravityDesktopAuthMode {
+pub fn resolve_auth_mode() -> AntigravityDesktopAuthMode {
     let info = crate::commands::system::resolve_antigravity_installed_version_info_for_target(
         Some("antigravity"),
     )


### PR DESCRIPTION
Resolves #1199 and #976.

This PR adds support for retrieving the currently active account for the **Antigravity (non-IDE)** Windows client when it is running version 2.0.0 or higher.

### Background
* In `cockpit-tools`, the non-IDE client is represented by the `Legacy` target runtime.
* Prior to version 2.0.0, the non-IDE client stored account credentials in an SQLite database (`state.vscdb`), but from version 2.0.0+ onwards it writes credentials directly to the **Windows Credential Manager** (`SystemCredential` auth mode).
* While account injection already had dual-mode database/credential manager support, account *verification/detection* on the backend (the Tauri command `get_current_account` which delegates to the platform adapter) unconditionally looked in the SQLite database for the Legacy target, failing to detect login state for 2.0.0+ installations.

### Changes
* Exported `AntigravityDesktopAuthMode` and `resolve_auth_mode` in `crates/cockpit-core/src/modules/antigravity_legacy_instance.rs`.
* In `crates/cockpit-antigravity-adapter/src/main.rs`, updated `resolve_legacy_local_account_id()` on Windows to:
  * Check the resolved authentication mode (`resolve_auth_mode()`).
  * If the mode is `SystemCredential`, retrieve active credentials via Windows Credential Manager (`read_antigravity_system_credential()`) and match against known account refresh tokens.
  * If the mode is `LegacyStateDb`, fall back to the SQLite `state.vscdb` logic.
