### PR TITLE
feat(codex): display additional rate limits

### DIFF
--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -8851,7 +8851,7 @@ export function CodexAccountsPage() {
                 )}
                 {quotaItems.map((item) => {
                   const QuotaIcon =
-                    item.key === "secondary"
+                    item.key === "secondary" || item.key.endsWith(":secondary")
                       ? Calendar
                       : item.key === "code_review"
                         ? BookOpen

--- a/src/presentation/platformAccountPresentation.ts
+++ b/src/presentation/platformAccountPresentation.ts
@@ -32,6 +32,7 @@ import {
 } from "../types/codebuddy";
 import {
   formatCodexResetTime,
+  getCodexAdditionalQuotaWindows,
   getCodexCodeReviewQuotaMetric,
   getCodexEffectiveQuotaPercentages,
   getCodexPlanBadgePresentation,
@@ -718,6 +719,27 @@ export function buildCodexAccountPresentation(
               ? weeklyBlocksHourlyHint
               : undefined,
         }));
+  const additionalQuotaItems =
+    !isCodexChatCompletionsApiKeyAccount(account) && newApiQuotaItems.length === 0
+      ? getCodexAdditionalQuotaWindows(account.quota).map((window) => {
+          const hintText = [window.limitName, window.meteredFeature]
+            .filter(Boolean)
+            .join(" · ");
+          return {
+            key: window.id,
+            label: `${window.limitLabel} ${window.label}`,
+            percentage: window.percentage,
+            quotaClass: getCodexQuotaClass(window.percentage),
+            valueText: `${window.percentage}%`,
+            resetText: window.resetTime
+              ? formatCodexResetTime(window.resetTime, t)
+              : "",
+            resetAt: window.resetTime,
+            hintText: hintText || undefined,
+          };
+        })
+      : [];
+  quotaItems.push(...additionalQuotaItems);
   const codeReviewMetric = getCodexCodeReviewQuotaMetric(account.quota);
   if (codeReviewMetric) {
     quotaItems.push({

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -168,6 +168,21 @@ export interface CodexCodeReviewQuotaMetric {
   resetTime?: number;
 }
 
+export interface CodexAdditionalQuotaWindow {
+  id: string;
+  label: string;
+  percentage: number;
+  resetTime?: number;
+  windowMinutes?: number;
+  limitName: string;
+  limitLabel: string;
+  meteredFeature: string;
+  windowKind: "primary" | "secondary";
+  sourceIndex: number;
+  allowed?: boolean;
+  limitReached?: boolean;
+}
+
 export interface CodexInstanceThreadSyncItem {
   instanceId: string;
   instanceName: string;
@@ -521,6 +536,93 @@ export function getCodexCodeReviewQuotaMetric(
       ? normalizeCodeReviewWindow(secondaryWindow, "weekly")
       : null)
   );
+}
+
+function normalizeCodexAdditionalLimitLabel(
+  limitName: string,
+  meteredFeature: string,
+): string {
+  const fallback = limitName || meteredFeature;
+  if (!fallback) return "Additional";
+  return fallback
+    .replace(/^gpt[-\s]*/i, "GPT ")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeCodexUnixSeconds(value: unknown): number | undefined {
+  const timestamp = toFiniteNumber(value);
+  if (timestamp === undefined || timestamp <= 0) return undefined;
+  return Math.floor(timestamp > 10_000_000_000 ? timestamp / 1000 : timestamp);
+}
+
+function normalizeAdditionalRateLimitWindow(
+  window: JsonRecord,
+  fallback: "hourly" | "weekly",
+): Pick<CodexQuotaWindow, "label" | "percentage" | "resetTime" | "windowMinutes"> | null {
+  const usedPercent = toFiniteNumber(window.used_percent);
+  if (usedPercent === undefined) return null;
+  const percentage = Math.max(0, Math.min(100, 100 - Math.round(usedPercent)));
+  const limitWindowSeconds = toFiniteNumber(window.limit_window_seconds);
+  const windowMinutes =
+    limitWindowSeconds !== undefined && limitWindowSeconds > 0
+      ? Math.ceil(limitWindowSeconds / 60)
+      : undefined;
+
+  return {
+    label: getCodexQuotaWindowLabel(windowMinutes, fallback),
+    percentage,
+    resetTime: normalizeCodexUnixSeconds(window.reset_at),
+    windowMinutes,
+  };
+}
+
+export function getCodexAdditionalQuotaWindows(
+  quota: CodexQuota | undefined,
+): CodexAdditionalQuotaWindow[] {
+  const raw = toJsonRecord(quota?.raw_data);
+  const additionalRateLimits = raw?.additional_rate_limits;
+  if (!Array.isArray(additionalRateLimits)) return [];
+
+  return additionalRateLimits.flatMap((entry, sourceIndex) => {
+    const record = toJsonRecord(entry);
+    const rateLimit = toJsonRecord(record?.rate_limit);
+    if (!record || !rateLimit) return [];
+
+    const limitName = toStringValue(record.limit_name) || "";
+    const meteredFeature = toStringValue(record.metered_feature) || "";
+    const limitLabel = normalizeCodexAdditionalLimitLabel(
+      limitName,
+      meteredFeature,
+    );
+    const allowed = toBoolValue(rateLimit.allowed);
+    const limitReached = toBoolValue(rateLimit.limit_reached);
+    const result: CodexAdditionalQuotaWindow[] = [];
+
+    ([
+      ["primary_window", "primary", "hourly"] as const,
+      ["secondary_window", "secondary", "weekly"] as const,
+    ]).forEach(([windowKey, windowKind, fallback]) => {
+      const window = toJsonRecord(rateLimit[windowKey]);
+      if (!window) return;
+      const normalized = normalizeAdditionalRateLimitWindow(window, fallback);
+      if (!normalized) return;
+      result.push({
+        id: `additional:${sourceIndex}:${windowKind}`,
+        sourceIndex,
+        windowKind,
+        limitName,
+        limitLabel,
+        meteredFeature,
+        allowed,
+        limitReached,
+        ...normalized,
+      });
+    });
+
+    return result;
+  });
 }
 
 export function isCodexApiKeyAccount(account: CodexAccount): boolean {


### PR DESCRIPTION
## Summary
- Parse Codex `quota.raw_data.additional_rate_limits[]` into additional quota windows.
- Display model-specific additional limits (for example GPT-5.3-Codex-Spark) alongside the existing Codex 5h/Weekly quota items.
- Reuse the existing quota item presentation so card, table, and custom sort views receive the extra metrics consistently.

## Details
The ChatGPT wham usage response can include independent model caps under `additional_rate_limits`, e.g. `GPT-5.3-Codex-Spark` / `codex_bengalfox`. The account already stores this raw response, but the UI only rendered the primary `rate_limit` windows. This change converts each additional limit's primary/secondary windows to remaining percentages (`100 - used_percent`) and keeps the raw limit name/metered feature in the tooltip.

## Test Plan
- [x] `npm run typecheck`
- [x] `npm run build`
