### PR TITLE
fix(codex): support opaque access-token-only accounts

### DIFF
--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -3319,7 +3319,13 @@ fn build_auth_file_value(account: &CodexAccount) -> Result<serde_json::Value, St
         tokens: Some(CodexAuthTokens {
             id_token: account.tokens.id_token.clone(),
             access_token: account.tokens.access_token.clone(),
-            refresh_token: normalize_optional_ref(account.tokens.refresh_token.as_deref()),
+            // Codex CLI's auth.json parser requires the refresh_token key to
+            // exist even for access-token-only accounts. Use an empty string so
+            // Cockpit can switch short-lived opaque `at-...` credentials without
+            // inventing a refresh token that would be sent to OAuth refresh.
+            refresh_token: Some(
+                normalize_optional_ref(account.tokens.refresh_token.as_deref()).unwrap_or_default(),
+            ),
             account_id: account.account_id.clone(),
         }),
         last_refresh: Some(serde_json::Value::String(
@@ -6839,7 +6845,7 @@ mod tests {
     }
 
     #[test]
-    fn build_auth_file_value_omits_refresh_token_when_account_has_none() {
+    fn build_auth_file_value_writes_empty_refresh_token_when_account_has_none() {
         let mut account = CodexAccount::new(
             "codex-cpa-account".to_string(),
             "cpa@example.com".to_string(),
@@ -6857,7 +6863,10 @@ mod tests {
             .and_then(|value| value.as_object())
             .expect("tokens object");
 
-        assert!(!tokens.contains_key("refresh_token"));
+        assert_eq!(
+            tokens.get("refresh_token").and_then(|value| value.as_str()),
+            Some("")
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/codex_oauth.rs
+++ b/src-tauri/src/modules/codex_oauth.rs
@@ -843,7 +843,23 @@ pub fn jwt_token_expiration_timestamp(token: &str) -> Option<i64> {
 }
 
 pub fn is_token_expired(access_token: &str) -> bool {
-    is_jwt_token_expired(access_token)
+    let token = access_token.trim();
+    if token.is_empty() {
+        return true;
+    }
+
+    // Some short-lived Codex credentials are opaque ChatGPT access tokens
+    // (`at-...`) rather than JWTs. They do not carry a local `exp` claim, so
+    // treating them as expired makes Cockpit immediately force an OAuth refresh
+    // and reject access-token-only imports. Let the first real upstream request
+    // decide whether the opaque token is still accepted; 401 handling will mark
+    // it invalid when it actually dies. Other malformed/non-JWT values still
+    // fail closed instead of being treated as valid.
+    if token.split('.').count() != 3 {
+        return !token.starts_with("at-");
+    }
+
+    is_jwt_token_expired(token)
 }
 
 pub async fn refresh_access_token(refresh_token: &str) -> Result<CodexTokens, String> {
@@ -929,4 +945,53 @@ pub async fn refresh_access_token_with_fallback(
         access_token,
         refresh_token: new_refresh_token,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_token_expired, TOKEN_REFRESH_SKEW_SECONDS};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+
+    fn make_jwt(exp: i64) -> String {
+        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"none","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::json!({ "exp": exp }).to_string());
+        format!("{}.{}.sig", header, payload)
+    }
+
+    #[test]
+    fn opaque_access_token_is_not_locally_expired() {
+        assert!(!is_token_expired("at-short-lived-opaque-token"));
+    }
+
+    #[test]
+    fn unknown_non_jwt_access_token_is_expired() {
+        assert!(is_token_expired("opaque-without-known-prefix"));
+    }
+
+    #[test]
+    fn empty_access_token_is_expired() {
+        assert!(is_token_expired("   "));
+    }
+
+    #[test]
+    fn malformed_jwt_access_token_is_expired() {
+        assert!(is_token_expired("not-valid.jwt.token"));
+    }
+
+    #[test]
+    fn jwt_shaped_at_access_token_is_expired_when_malformed() {
+        assert!(is_token_expired("at-not.valid.jwt"));
+    }
+
+    #[test]
+    fn expired_jwt_access_token_is_expired() {
+        let expired = chrono::Utc::now().timestamp() - 3600;
+        assert!(is_token_expired(&make_jwt(expired)));
+    }
+
+    #[test]
+    fn fresh_jwt_access_token_is_not_expired() {
+        let fresh = chrono::Utc::now().timestamp() + TOKEN_REFRESH_SKEW_SECONDS + 3600;
+        assert!(!is_token_expired(&make_jwt(fresh)));
+    }
 }


### PR DESCRIPTION
## Summary
- Treat opaque `at-*` Codex access tokens as access-token-only credentials instead of immediately marking them locally expired.
- Keep malformed/non-`at-*` non-JWT values fail-closed, and preserve normal JWT expiry handling.
- Serialize `refresh_token: ""` for access-token-only `auth.json` output so modern Codex CLI parsers accept the file without inventing a refresh token.

## Why
Some imported Codex/ChatGPT accounts only provide a short-lived opaque `at-*` access token and no real OAuth refresh token. Cockpit previously treated non-JWT access tokens as expired, then attempted an OAuth refresh with missing or unsuitable refresh credentials. The current access token can still be accepted by the upstream Codex/ChatGPT endpoint, so this blocks otherwise usable access-token-only accounts.

## Test Plan
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -p cockpit-tools --lib codex_oauth::tests -- --nocapture`
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -p cockpit-tools --lib build_auth_file_value_writes_empty_refresh_token_when_account_has_none -- --nocapture`
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -p cockpit-tools --lib`
- `npm run typecheck`

## Notes
This is separate from #1405, which only surfaces additional Codex rate limits in the UI.
