### PR TITLE
feat(codex): add additional quota visibility toggle

### DIFF
--- a/src/components/QuickSettingsPopover.tsx
+++ b/src/components/QuickSettingsPopover.tsx
@@ -23,7 +23,9 @@ import {
 } from '../utils/accountFilters';
 import { getSubscriptionTier } from '../utils/account';
 import {
+  isCodexAdditionalQuotaVisibleByDefault,
   isCodexCodeReviewQuotaVisibleByDefault,
+  persistCodexAdditionalQuotaVisible,
   persistCodexCodeReviewQuotaVisible,
 } from '../utils/codexPreferences';
 import {
@@ -414,6 +416,9 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
   const [codexAccountGroups, setCodexAccountGroups] = useState<CodexAccountGroup[]>([]);
   const [codexShowCodeReviewQuota, setCodexShowCodeReviewQuota] = useState(
     isCodexCodeReviewQuotaVisibleByDefault,
+  );
+  const [codexShowAdditionalQuota, setCodexShowAdditionalQuota] = useState(
+    isCodexAdditionalQuotaVisibleByDefault,
   );
   const [currentAccountRefreshMap, setCurrentAccountRefreshMap] =
     useState<CurrentAccountRefreshMinutesMap>(() => buildDefaultCurrentAccountRefreshMinutesMap());
@@ -1804,6 +1809,11 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
     persistCodexCodeReviewQuotaVisible(checked);
   };
 
+  const handleCodexAdditionalQuotaToggle = (checked: boolean) => {
+    setCodexShowAdditionalQuota(checked);
+    persistCodexAdditionalQuotaVisible(checked);
+  };
+
   const overlayContent = isOpen ? (
     <div className="qs-overlay">
       <div className="qs-modal" ref={modalRef}>
@@ -2596,6 +2606,23 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
                         type="checkbox"
                         checked={codexShowCodeReviewQuota}
                         onChange={(e) => handleCodexCodeReviewQuotaToggle(e.target.checked)}
+                      />
+                      <span className="qs-switch-slider"></span>
+                    </label>
+                  </div>
+                </div>
+
+                <div className="qs-row">
+                  <div className="qs-row-label">
+                    <Zap size={15} />
+                    <span>{t('codex.list.showAdditionalQuota', '显示模型专属配额（如 GPT-5.3）')}</span>
+                  </div>
+                  <div className="qs-row-control">
+                    <label className="qs-switch">
+                      <input
+                        type="checkbox"
+                        checked={codexShowAdditionalQuota}
+                        onChange={(e) => handleCodexAdditionalQuotaToggle(e.target.checked)}
                       />
                       <span className="qs-switch-slider"></span>
                     </label>

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -164,7 +164,9 @@ import {
   type InstanceProfile,
 } from "../types/instance";
 import {
+  CODEX_ADDITIONAL_QUOTA_VISIBILITY_CHANGED_EVENT,
   CODEX_CODE_REVIEW_QUOTA_VISIBILITY_CHANGED_EVENT,
+  isCodexAdditionalQuotaVisibleByDefault,
   isCodexCodeReviewQuotaVisibleByDefault,
 } from "../utils/codexPreferences";
 import { emitAccountsChanged } from "../utils/accountSyncEvents";
@@ -3328,6 +3330,9 @@ export function CodexAccountsPage() {
   const [showCodeReviewQuota, setShowCodeReviewQuota] = useState<boolean>(
     isCodexCodeReviewQuotaVisibleByDefault,
   );
+  const [showAdditionalQuota, setShowAdditionalQuota] = useState<boolean>(
+    isCodexAdditionalQuotaVisibleByDefault,
+  );
   const [customSortOrder, setCustomSortOrder] = useState<string[]>(
     readCodexCustomSortOrder,
   );
@@ -3943,15 +3948,26 @@ export function CodexAccountsPage() {
     const syncCodeReviewVisibility = () => {
       setShowCodeReviewQuota(isCodexCodeReviewQuotaVisibleByDefault());
     };
+    const syncAdditionalQuotaVisibility = () => {
+      setShowAdditionalQuota(isCodexAdditionalQuotaVisibleByDefault());
+    };
 
     window.addEventListener(
       CODEX_CODE_REVIEW_QUOTA_VISIBILITY_CHANGED_EVENT,
       syncCodeReviewVisibility as EventListener,
     );
+    window.addEventListener(
+      CODEX_ADDITIONAL_QUOTA_VISIBILITY_CHANGED_EVENT,
+      syncAdditionalQuotaVisibility as EventListener,
+    );
     return () => {
       window.removeEventListener(
         CODEX_CODE_REVIEW_QUOTA_VISIBILITY_CHANGED_EVENT,
         syncCodeReviewVisibility as EventListener,
+      );
+      window.removeEventListener(
+        CODEX_ADDITIONAL_QUOTA_VISIBILITY_CHANGED_EVENT,
+        syncAdditionalQuotaVisibility as EventListener,
       );
     };
   }, []);
@@ -8830,6 +8846,24 @@ export function CodexAccountsPage() {
       ? t("accounts.defaultGroup", "默认分组")
       : groupKey;
 
+  const resolveVisibleQuotaItems = useCallback(
+    (
+      presentation: ReturnType<typeof buildCodexAccountPresentation>,
+      isApiKeyAccount: boolean,
+      isNewApiAccount: boolean,
+    ) => {
+      if (isApiKeyAccount && !isNewApiAccount) return [];
+      return presentation.quotaItems.filter((item) => {
+        if (!showCodeReviewQuota && item.key === "code_review") return false;
+        if (!showAdditionalQuota && item.key.startsWith("additional:")) {
+          return false;
+        }
+        return true;
+      });
+    },
+    [showAdditionalQuota, showCodeReviewQuota],
+  );
+
   const resolveCompactQuotaItems = useCallback(
     (presentation: ReturnType<typeof buildCodexAccountPresentation>) => {
       const standardQuotaItems = presentation.quotaItems.filter(
@@ -9027,14 +9061,11 @@ export function CodexAccountsPage() {
       const isSavingApiKeyName = savingApiKeyNameId === account.id;
       const planClass = presentation.planClass || "unknown";
       const isSelected = selected.has(account.id);
-      const quotaItems =
-        isApiKeyAccount && !isNewApiAccount
-          ? []
-          : showCodeReviewQuota
-            ? presentation.quotaItems
-            : presentation.quotaItems.filter(
-                (item) => item.key !== "code_review",
-              );
+      const quotaItems = resolveVisibleQuotaItems(
+        presentation,
+        isApiKeyAccount,
+        isNewApiAccount,
+      );
       const reauthErrorMeta = resolveQuotaErrorMeta(
         account.requires_reauth && account.reauth_reason
           ? {
@@ -10355,14 +10386,11 @@ export function CodexAccountsPage() {
         isApiKeyAccount && editingApiKeyNameId === account.id;
       const isSavingApiKeyName = savingApiKeyNameId === account.id;
       const planClass = presentation.planClass || "unknown";
-      const quotaItems =
-        isApiKeyAccount && !isNewApiAccount
-          ? []
-          : showCodeReviewQuota
-            ? presentation.quotaItems
-            : presentation.quotaItems.filter(
-                (item) => item.key !== "code_review",
-              );
+      const quotaItems = resolveVisibleQuotaItems(
+        presentation,
+        isApiKeyAccount,
+        isNewApiAccount,
+      );
       const reauthErrorMeta = resolveQuotaErrorMeta(
         account.requires_reauth && account.reauth_reason
           ? {

--- a/src/pages/CodexInstancesPage.tsx
+++ b/src/pages/CodexInstancesPage.tsx
@@ -21,7 +21,9 @@ import {
 } from "../presentation/platformAccountPresentation";
 import * as codexInstanceService from "../services/codexInstanceService";
 import {
+  CODEX_ADDITIONAL_QUOTA_VISIBILITY_CHANGED_EVENT,
   CODEX_CODE_REVIEW_QUOTA_VISIBILITY_CHANGED_EVENT,
+  isCodexAdditionalQuotaVisibleByDefault,
   isCodexCodeReviewQuotaVisibleByDefault,
 } from "../utils/codexPreferences";
 import {
@@ -70,6 +72,9 @@ export function CodexInstancesContent({
   const [showCodeReviewQuota, setShowCodeReviewQuota] = useState<boolean>(
     isCodexCodeReviewQuotaVisibleByDefault,
   );
+  const [showAdditionalQuota, setShowAdditionalQuota] = useState<boolean>(
+    isCodexAdditionalQuotaVisibleByDefault,
+  );
   const [launchModal, setLaunchModal] = useState<CodexLaunchModalState | null>(
     null,
   );
@@ -90,29 +95,39 @@ export function CodexInstancesContent({
     const syncCodeReviewVisibility = () => {
       setShowCodeReviewQuota(isCodexCodeReviewQuotaVisibleByDefault());
     };
+    const syncAdditionalQuotaVisibility = () => {
+      setShowAdditionalQuota(isCodexAdditionalQuotaVisibleByDefault());
+    };
 
     window.addEventListener(
       CODEX_CODE_REVIEW_QUOTA_VISIBILITY_CHANGED_EVENT,
       syncCodeReviewVisibility as EventListener,
+    );
+    window.addEventListener(
+      CODEX_ADDITIONAL_QUOTA_VISIBILITY_CHANGED_EVENT,
+      syncAdditionalQuotaVisibility as EventListener,
     );
     return () => {
       window.removeEventListener(
         CODEX_CODE_REVIEW_QUOTA_VISIBILITY_CHANGED_EVENT,
         syncCodeReviewVisibility as EventListener,
       );
+      window.removeEventListener(
+        CODEX_ADDITIONAL_QUOTA_VISIBILITY_CHANGED_EVENT,
+        syncAdditionalQuotaVisibility as EventListener,
+      );
     };
   }, []);
 
   const resolvePresentation = (account: CodexAccount) => {
     const presentation = buildCodexAccountPresentation(account, t);
-    if (showCodeReviewQuota) {
-      return presentation;
-    }
     return {
       ...presentation,
-      quotaItems: presentation.quotaItems.filter(
-        (item) => item.key !== "code_review",
-      ),
+      quotaItems: presentation.quotaItems.filter((item) => {
+        if (!showCodeReviewQuota && item.key === "code_review") return false;
+        if (!showAdditionalQuota && item.key.startsWith("additional:")) return false;
+        return true;
+      }),
     };
   };
 

--- a/src/utils/codexPreferences.ts
+++ b/src/utils/codexPreferences.ts
@@ -1,7 +1,10 @@
 const CODEX_SHOW_CODE_REVIEW_QUOTA_STORAGE_KEY = 'agtools.codex_show_code_review_quota';
+const CODEX_SHOW_ADDITIONAL_QUOTA_STORAGE_KEY = 'agtools.codex_show_additional_quota';
 
 export const CODEX_CODE_REVIEW_QUOTA_VISIBILITY_CHANGED_EVENT =
   'agtools:codex-code-review-quota-visibility-changed';
+export const CODEX_ADDITIONAL_QUOTA_VISIBILITY_CHANGED_EVENT =
+  'agtools:codex-additional-quota-visibility-changed';
 
 export function isCodexCodeReviewQuotaVisibleByDefault(): boolean {
   try {
@@ -11,11 +14,30 @@ export function isCodexCodeReviewQuotaVisibleByDefault(): boolean {
   }
 }
 
+export function isCodexAdditionalQuotaVisibleByDefault(): boolean {
+  try {
+    return localStorage.getItem(CODEX_SHOW_ADDITIONAL_QUOTA_STORAGE_KEY) !== '0';
+  } catch {
+    return true;
+  }
+}
+
 export function persistCodexCodeReviewQuotaVisible(visible: boolean): void {
   try {
     localStorage.setItem(CODEX_SHOW_CODE_REVIEW_QUOTA_STORAGE_KEY, visible ? '1' : '0');
     window.dispatchEvent(
       new CustomEvent(CODEX_CODE_REVIEW_QUOTA_VISIBILITY_CHANGED_EVENT, { detail: visible }),
+    );
+  } catch {
+    // ignore localStorage write failures
+  }
+}
+
+export function persistCodexAdditionalQuotaVisible(visible: boolean): void {
+  try {
+    localStorage.setItem(CODEX_SHOW_ADDITIONAL_QUOTA_STORAGE_KEY, visible ? '1' : '0');
+    window.dispatchEvent(
+      new CustomEvent(CODEX_ADDITIONAL_QUOTA_VISIBILITY_CHANGED_EVENT, { detail: visible }),
     );
   } catch {
     // ignore localStorage write failures


### PR DESCRIPTION
## Summary
- add a Codex quick setting to show/hide additional model-specific quota rows such as GPT-5.3/Spark
- keep additional quota visible by default, while persisting the user preference in localStorage
- apply the same visibility setting to Codex account cards and instance account previews

## Validation
- npm run typecheck
- git diff --check
