### PR TITLE
feat: 支持 Codex 切号同步 Hermes 额度

### DIFF
--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -13,7 +13,7 @@ use crate::models::codex_local_access::{
 };
 use crate::modules::{
     account, codex_account, codex_local_access, codex_oauth, codex_quota, codex_session_visibility,
-    codex_speed, codex_wakeup, codex_wakeup_scheduler, config, logger, openclaw_auth,
+    codex_speed, codex_wakeup, codex_wakeup_scheduler, config, hermes_auth, logger, openclaw_auth,
     opencode_auth, process,
 };
 use serde::{Deserialize, Serialize};
@@ -807,6 +807,17 @@ pub async fn switch_codex_account(
         }
     } else {
         logger::log_info("已关闭切换 Codex 时覆盖 OpenClaw 登录信息");
+    }
+
+    if user_config.hermes_auth_overwrite_on_switch {
+        match hermes_auth::replace_openai_codex_entry_from_codex(&account) {
+            Ok(()) => {}
+            Err(e) => {
+                logger::log_warn(&format!("Hermes auth 同步失败: {}", e));
+            }
+        }
+    } else {
+        logger::log_info("已关闭切换 Codex 时同步 Hermes 额度");
     }
 
     if user_config.codex_launch_on_switch {

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -178,6 +178,8 @@ pub struct GeneralConfig {
     pub ghcp_launch_on_switch: bool,
     /// 切换 Codex 时是否覆盖 OpenClaw 登录信息
     pub openclaw_auth_overwrite_on_switch: bool,
+    /// 切换 Codex 时是否同步 Hermes openai-codex 凭证
+    pub hermes_auth_overwrite_on_switch: bool,
     /// 切换 Codex 时是否自动启动/重启 Codex App
     pub codex_launch_on_switch: bool,
     /// 切换 Antigravity IDE 时是否自动启动/重启应用
@@ -2036,6 +2038,7 @@ pub fn save_network_config(
         ghcp_opencode_auth_overwrite_on_switch: current.ghcp_opencode_auth_overwrite_on_switch,
         ghcp_launch_on_switch: current.ghcp_launch_on_switch,
         openclaw_auth_overwrite_on_switch: current.openclaw_auth_overwrite_on_switch,
+        hermes_auth_overwrite_on_switch: current.hermes_auth_overwrite_on_switch,
         codex_launch_on_switch: current.codex_launch_on_switch,
         antigravity_launch_on_switch: current.antigravity_launch_on_switch,
         codex_restart_specified_app_on_switch: current.codex_restart_specified_app_on_switch,
@@ -2358,6 +2361,7 @@ pub fn get_general_config(app: tauri::AppHandle) -> Result<GeneralConfig, String
         ghcp_opencode_auth_overwrite_on_switch: user_config.ghcp_opencode_auth_overwrite_on_switch,
         ghcp_launch_on_switch: user_config.ghcp_launch_on_switch,
         openclaw_auth_overwrite_on_switch: user_config.openclaw_auth_overwrite_on_switch,
+        hermes_auth_overwrite_on_switch: user_config.hermes_auth_overwrite_on_switch,
         codex_launch_on_switch: user_config.codex_launch_on_switch,
         antigravity_launch_on_switch: user_config.antigravity_launch_on_switch,
         codex_restart_specified_app_on_switch: user_config.codex_restart_specified_app_on_switch,
@@ -2509,6 +2513,7 @@ pub fn save_general_config(
     ghcp_opencode_auth_overwrite_on_switch: Option<bool>,
     ghcp_launch_on_switch: Option<bool>,
     openclaw_auth_overwrite_on_switch: Option<bool>,
+    hermes_auth_overwrite_on_switch: Option<bool>,
     codex_launch_on_switch: bool,
     antigravity_launch_on_switch: Option<bool>,
     codex_restart_specified_app_on_switch: Option<bool>,
@@ -2794,6 +2799,8 @@ pub fn save_general_config(
         ghcp_launch_on_switch: ghcp_launch_on_switch.unwrap_or(current.ghcp_launch_on_switch),
         openclaw_auth_overwrite_on_switch: openclaw_auth_overwrite_on_switch
             .unwrap_or(current.openclaw_auth_overwrite_on_switch),
+        hermes_auth_overwrite_on_switch: hermes_auth_overwrite_on_switch
+            .unwrap_or(current.hermes_auth_overwrite_on_switch),
         codex_launch_on_switch,
         antigravity_launch_on_switch: antigravity_launch_on_switch
             .unwrap_or(current.antigravity_launch_on_switch),

--- a/src-tauri/src/modules/config.rs
+++ b/src-tauri/src/modules/config.rs
@@ -312,6 +312,9 @@ pub struct UserConfig {
     /// 切换 Codex 时是否覆盖 OpenClaw 登录信息
     #[serde(default = "default_openclaw_auth_overwrite_on_switch")]
     pub openclaw_auth_overwrite_on_switch: bool,
+    /// 切换 Codex 时是否同步 Hermes openai-codex 凭证
+    #[serde(default = "default_hermes_auth_overwrite_on_switch")]
+    pub hermes_auth_overwrite_on_switch: bool,
     /// 切换 Codex 时是否自动启动/重启 Codex App
     #[serde(default = "default_codex_launch_on_switch")]
     pub codex_launch_on_switch: bool,
@@ -795,6 +798,9 @@ fn default_ghcp_launch_on_switch() -> bool {
 fn default_openclaw_auth_overwrite_on_switch() -> bool {
     false
 }
+fn default_hermes_auth_overwrite_on_switch() -> bool {
+    false
+}
 fn default_codex_launch_on_switch() -> bool {
     true
 }
@@ -1043,6 +1049,7 @@ impl Default for UserConfig {
             ),
             ghcp_launch_on_switch: default_ghcp_launch_on_switch(),
             openclaw_auth_overwrite_on_switch: default_openclaw_auth_overwrite_on_switch(),
+            hermes_auth_overwrite_on_switch: default_hermes_auth_overwrite_on_switch(),
             codex_launch_on_switch: default_codex_launch_on_switch(),
             antigravity_launch_on_switch: default_antigravity_launch_on_switch(),
             codex_restart_specified_app_on_switch: default_codex_restart_specified_app_on_switch(),
@@ -2131,6 +2138,19 @@ mod tests {
         let cfg: UserConfig =
             serde_json::from_value(serde_json::json!({})).expect("反序列化默认配置应成功");
         assert!(!cfg.openclaw_auth_overwrite_on_switch);
+    }
+
+    #[test]
+    fn hermes_auth_overwrite_default_is_disabled() {
+        let cfg = UserConfig::default();
+        assert!(!cfg.hermes_auth_overwrite_on_switch);
+    }
+
+    #[test]
+    fn hermes_auth_overwrite_missing_field_falls_back_to_disabled() {
+        let cfg: UserConfig =
+            serde_json::from_value(serde_json::json!({})).expect("反序列化默认配置应成功");
+        assert!(!cfg.hermes_auth_overwrite_on_switch);
     }
 
     #[test]

--- a/src-tauri/src/modules/hermes_auth.rs
+++ b/src-tauri/src/modules/hermes_auth.rs
@@ -1,0 +1,355 @@
+use crate::models::codex::CodexAccount;
+use crate::modules::{codex_oauth, logger};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const HERMES_CODEX_PROVIDER: &str = "openai-codex";
+const HERMES_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+
+fn resolve_user_path(raw: &str) -> PathBuf {
+    let trimmed = raw.trim();
+    if trimmed == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+
+    if let Some(stripped) = trimmed
+        .strip_prefix("~/")
+        .or_else(|| trimmed.strip_prefix("~\\"))
+    {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(stripped);
+        }
+    }
+
+    PathBuf::from(trimmed)
+}
+
+fn get_hermes_home_dir() -> Result<PathBuf, String> {
+    if let Ok(value) = std::env::var("HERMES_HOME") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Ok(resolve_user_path(trimmed));
+        }
+    }
+
+    dirs::home_dir()
+        .map(|home| home.join(".hermes"))
+        .ok_or_else(|| "无法推断 Hermes 配置目录".to_string())
+}
+
+fn get_hermes_auth_json_path() -> Result<PathBuf, String> {
+    Ok(get_hermes_home_dir()?.join("auth.json"))
+}
+
+fn read_hermes_auth_json(path: &Path) -> Result<Value, String> {
+    match fs::read_to_string(path) {
+        Ok(content) => serde_json::from_str::<Value>(&content)
+            .map_err(|e| format!("解析 Hermes auth.json 失败 ({}): {}", path.display(), e)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(json!({})),
+        Err(err) => Err(format!(
+            "读取 Hermes auth.json 失败 ({}): {}",
+            path.display(),
+            err
+        )),
+    }
+}
+
+fn atomic_write(path: &Path, content: &str) -> Result<(), String> {
+    crate::modules::atomic_write::write_string_atomic(path, content)
+        .map_err(|e| format!("写入 Hermes auth.json 失败: {}", e))
+}
+
+fn codex_account_id(account: &CodexAccount) -> String {
+    account
+        .account_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn codex_refresh_token(account: &CodexAccount) -> String {
+    account
+        .tokens
+        .refresh_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn build_hermes_codex_tokens(account: &CodexAccount) -> Result<Value, String> {
+    if account.is_api_key_auth() {
+        return Err("Codex API Key 账号不支持同步到 Hermes openai-codex 凭证".to_string());
+    }
+    if account.tokens.access_token.trim().is_empty() {
+        return Err("Codex access_token 缺失，无法同步到 Hermes".to_string());
+    }
+
+    Ok(json!({
+        "access_token": account.tokens.access_token,
+        "account_id": codex_account_id(account),
+        "id_token": account.tokens.id_token,
+        "refresh_token": codex_refresh_token(account),
+    }))
+}
+
+fn ensure_object(value: &mut Value) -> &mut serde_json::Map<String, Value> {
+    if !value.is_object() {
+        *value = json!({});
+    }
+    value.as_object_mut().expect("value must be object")
+}
+
+fn update_provider_entry(auth_json: &mut Value, tokens: Value, refreshed_at: &str) {
+    let root = ensure_object(auth_json);
+    let providers_value = root.entry("providers").or_insert_with(|| json!({}));
+    let providers = ensure_object(providers_value);
+    let provider_value = providers
+        .entry(HERMES_CODEX_PROVIDER.to_string())
+        .or_insert_with(|| json!({}));
+    let provider = ensure_object(provider_value);
+
+    provider.insert("tokens".to_string(), tokens);
+    provider.insert(
+        "last_refresh".to_string(),
+        Value::String(refreshed_at.to_string()),
+    );
+    provider.insert(
+        "auth_mode".to_string(),
+        Value::String("chatgpt".to_string()),
+    );
+
+    for key in [
+        "last_auth_error",
+        "last_error_code",
+        "last_error_reason",
+        "last_error_message",
+        "last_error_reset_at",
+    ] {
+        provider.remove(key);
+    }
+}
+
+fn default_pool_entry() -> Value {
+    json!({
+        "id": "cockpit-codex",
+        "label": "Cockpit Codex",
+        "auth_type": "oauth",
+        "priority": 8,
+        "source": "cockpit",
+        "base_url": HERMES_CODEX_BASE_URL,
+        "request_count": 0,
+    })
+}
+
+fn update_pool_entry(
+    entry: &mut Value,
+    access_token: &str,
+    refresh_token: &str,
+    refreshed_at: &str,
+) {
+    let entry_obj = ensure_object(entry);
+    entry_obj.insert(
+        "access_token".to_string(),
+        Value::String(access_token.to_string()),
+    );
+    entry_obj.insert(
+        "refresh_token".to_string(),
+        Value::String(refresh_token.to_string()),
+    );
+    entry_obj.insert(
+        "last_refresh".to_string(),
+        Value::String(refreshed_at.to_string()),
+    );
+    entry_obj.insert("last_status".to_string(), Value::Null);
+    entry_obj.insert("last_status_at".to_string(), Value::Null);
+    entry_obj.insert("last_error_code".to_string(), Value::Null);
+    entry_obj.insert("last_error_reason".to_string(), Value::Null);
+    entry_obj.insert("last_error_message".to_string(), Value::Null);
+    entry_obj.insert("last_error_reset_at".to_string(), Value::Null);
+}
+
+fn update_credential_pool(
+    auth_json: &mut Value,
+    access_token: &str,
+    refresh_token: &str,
+    refreshed_at: &str,
+) {
+    let root = ensure_object(auth_json);
+    let pool_value = root.entry("credential_pool").or_insert_with(|| json!({}));
+    let pool = ensure_object(pool_value);
+    let entries_value = pool
+        .entry(HERMES_CODEX_PROVIDER.to_string())
+        .or_insert_with(|| json!([]));
+    if !entries_value.is_array() {
+        *entries_value = json!([]);
+    }
+    let entries = entries_value.as_array_mut().expect("value must be array");
+    if entries.is_empty() {
+        entries.push(default_pool_entry());
+    }
+    for entry in entries {
+        update_pool_entry(entry, access_token, refresh_token, refreshed_at);
+    }
+}
+
+fn apply_codex_account_to_hermes_auth_value(
+    auth_json: &mut Value,
+    account: &CodexAccount,
+    refreshed_at: &str,
+) -> Result<(), String> {
+    let tokens = build_hermes_codex_tokens(account)?;
+    let access_token = account.tokens.access_token.trim().to_string();
+    let refresh_token = codex_refresh_token(account);
+
+    update_provider_entry(auth_json, tokens, refreshed_at);
+    update_credential_pool(auth_json, &access_token, &refresh_token, refreshed_at);
+    ensure_object(auth_json).insert(
+        "updated_at".to_string(),
+        Value::String(refreshed_at.to_string()),
+    );
+    Ok(())
+}
+
+/// 使用当前 Codex 账号覆盖 Hermes openai-codex 凭证和凭证池，确保 Hermes 使用同一账号额度。
+pub fn replace_openai_codex_entry_from_codex(account: &CodexAccount) -> Result<(), String> {
+    if codex_oauth::is_token_expired(&account.tokens.access_token) {
+        return Err("Codex access_token 已过期，无法同步到 Hermes".to_string());
+    }
+
+    let auth_path = get_hermes_auth_json_path()?;
+    let mut auth_json = read_hermes_auth_json(&auth_path)?;
+    let refreshed_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    apply_codex_account_to_hermes_auth_value(&mut auth_json, account, &refreshed_at)?;
+
+    let content = serde_json::to_string_pretty(&auth_json)
+        .map_err(|e| format!("序列化 Hermes auth.json 失败: {}", e))?;
+    if let Some(parent) = auth_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("创建 Hermes 配置目录失败 ({}): {}", parent.display(), e))?;
+    }
+    atomic_write(&auth_path, &content)?;
+
+    logger::log_info(&format!(
+        "已更新 Hermes {} 凭证和 credential_pool: account_id={}, target_file={}",
+        HERMES_CODEX_PROVIDER,
+        account.id,
+        auth_path.display()
+    ));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::codex::{CodexAuthMode, CodexTokens};
+
+    fn make_oauth_account(refresh_token: Option<&str>) -> CodexAccount {
+        let tokens = CodexTokens {
+            id_token: "id.jwt.token".to_string(),
+            access_token: "at-live-token".to_string(),
+            refresh_token: refresh_token.map(|value| value.to_string()),
+        };
+        let mut account = CodexAccount::new(
+            "codex_test_account".to_string(),
+            "demo@example.com".to_string(),
+            tokens,
+        );
+        account.account_id = Some("chatgpt-account-id".to_string());
+        account
+    }
+
+    #[test]
+    fn applies_codex_account_to_provider_and_pool() {
+        let account = make_oauth_account(Some("rt-live-token"));
+        let mut auth = json!({
+            "providers": {
+                "openai-codex": {
+                    "auth_mode": "chatgpt",
+                    "last_auth_error": { "code": "rate_limited" },
+                    "last_error_code": "exhausted",
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                        "id_token": "old-id",
+                        "account_id": "old-account"
+                    }
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "primary",
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                        "last_status": "exhausted",
+                        "last_error_message": "old error"
+                    }
+                ]
+            }
+        });
+
+        apply_codex_account_to_hermes_auth_value(&mut auth, &account, "2026-07-07T00:00:00Z")
+            .expect("sync should succeed");
+
+        let provider = &auth["providers"][HERMES_CODEX_PROVIDER];
+        assert_eq!(provider["auth_mode"], "chatgpt");
+        assert!(provider.get("last_auth_error").is_none());
+        assert!(provider.get("last_error_code").is_none());
+        assert_eq!(provider["tokens"]["access_token"], "at-live-token");
+        assert_eq!(provider["tokens"]["refresh_token"], "rt-live-token");
+        assert_eq!(provider["tokens"]["id_token"], "id.jwt.token");
+        assert_eq!(provider["tokens"]["account_id"], "chatgpt-account-id");
+
+        let pool_entry = &auth["credential_pool"][HERMES_CODEX_PROVIDER][0];
+        assert_eq!(pool_entry["id"], "primary");
+        assert_eq!(pool_entry["access_token"], "at-live-token");
+        assert_eq!(pool_entry["refresh_token"], "rt-live-token");
+        assert!(pool_entry["last_status"].is_null());
+        assert!(pool_entry["last_error_message"].is_null());
+        assert_eq!(auth["updated_at"], "2026-07-07T00:00:00Z");
+    }
+
+    #[test]
+    fn creates_empty_refresh_token_pool_entry_for_access_token_only_accounts() {
+        let account = make_oauth_account(None);
+        let mut auth = json!({});
+
+        apply_codex_account_to_hermes_auth_value(&mut auth, &account, "2026-07-07T00:00:00Z")
+            .expect("access-token-only sync should succeed");
+
+        assert_eq!(
+            auth["providers"][HERMES_CODEX_PROVIDER]["tokens"]["refresh_token"],
+            ""
+        );
+        assert_eq!(
+            auth["credential_pool"][HERMES_CODEX_PROVIDER][0]["refresh_token"],
+            ""
+        );
+        assert_eq!(
+            auth["credential_pool"][HERMES_CODEX_PROVIDER][0]["base_url"],
+            HERMES_CODEX_BASE_URL
+        );
+    }
+
+    #[test]
+    fn rejects_codex_api_key_accounts() {
+        let mut account = make_oauth_account(Some("rt-live-token"));
+        account.auth_mode = CodexAuthMode::Apikey;
+        account.openai_api_key = Some("sk-test".to_string());
+        let mut auth = json!({});
+
+        let err =
+            apply_codex_account_to_hermes_auth_value(&mut auth, &account, "2026-07-07T00:00:00Z")
+                .expect_err("API key accounts should not sync to Hermes Codex OAuth");
+
+        assert!(err.contains("API Key"));
+        assert_eq!(auth, json!({}));
+    }
+}

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -46,6 +46,7 @@ pub mod github_copilot_account;
 pub mod github_copilot_instance;
 pub mod github_copilot_oauth;
 pub mod group_settings;
+pub mod hermes_auth;
 pub mod i18n;
 pub mod import;
 pub mod instance;

--- a/src/components/QuickSettingsPopover.tsx
+++ b/src/components/QuickSettingsPopover.tsx
@@ -107,6 +107,7 @@ interface GeneralConfig {
   ghcp_opencode_auth_overwrite_on_switch: boolean;
   ghcp_launch_on_switch: boolean;
   openclaw_auth_overwrite_on_switch: boolean;
+  hermes_auth_overwrite_on_switch: boolean;
   codex_launch_on_switch: boolean;
   antigravity_launch_on_switch: boolean;
   codex_restart_specified_app_on_switch: boolean;
@@ -1003,6 +1004,7 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
           ghcpOpencodeAuthOverwriteOnSwitch: merged.ghcp_opencode_auth_overwrite_on_switch,
           ghcpLaunchOnSwitch: merged.ghcp_launch_on_switch,
           openclawAuthOverwriteOnSwitch: merged.openclaw_auth_overwrite_on_switch,
+          hermesAuthOverwriteOnSwitch: merged.hermes_auth_overwrite_on_switch,
           codexLaunchOnSwitch: merged.codex_launch_on_switch,
           antigravityLaunchOnSwitch: merged.antigravity_launch_on_switch,
           codexRestartSpecifiedAppOnSwitch: merged.codex_restart_specified_app_on_switch,
@@ -2658,6 +2660,30 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
                         checked={config.openclaw_auth_overwrite_on_switch}
                         onChange={(e) =>
                           saveConfig({ openclaw_auth_overwrite_on_switch: e.target.checked })
+                        }
+                      />
+                      <span className="qs-switch-slider"></span>
+                    </label>
+                  </div>
+                </div>
+
+                <div className="qs-row">
+                  <div className="qs-row-label">
+                    <Zap size={15} />
+                    <span>
+                      {t(
+                        'settings.general.hermesAuthOverwrite',
+                        '切换 Codex 时同步 Hermes 额度'
+                      )}
+                    </span>
+                  </div>
+                  <div className="qs-row-control">
+                    <label className="qs-switch">
+                      <input
+                        type="checkbox"
+                        checked={config.hermes_auth_overwrite_on_switch}
+                        onChange={(e) =>
+                          saveConfig({ hermes_auth_overwrite_on_switch: e.target.checked })
                         }
                       />
                       <span className="qs-switch-slider"></span>

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -750,6 +750,8 @@
       "workbuddyPathReset": "إعادة إلى الافتراضي",
       "openclawAuthOverwrite": "استبدال تسجيل دخول OpenClaw عند تبديل Codex",
       "openclawAuthOverwriteDesc": "عند التعطيل، يتم تبديل Codex فقط ويحتفظ OpenClaw بحالة تسجيل الدخول الحالية",
+      "hermesAuthOverwrite": "مزامنة حصة Hermes عند تبديل Codex",
+      "hermesAuthOverwriteDesc": "يحدّث بيانات اعتماد Hermes openai-codex و credential_pool ليستخدم Hermes حصة حساب Codex المحدد.",
       "ghcpOpencodeAuthOverwrite": "استبدال تسجيل دخول OpenCode عند تبديل GitHub Copilot",
       "ghcpOpencodeRestart": "إعادة تشغيل OpenCode عند تبديل GitHub Copilot",
       "ghcpLaunchOnSwitch": "تشغيل تطبيق GitHub Copilot App تلقائيًا عند تبديل GitHub Copilot",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -704,6 +704,8 @@
       "workbuddyPathReset": "Obnovit výchozí",
       "openclawAuthOverwrite": "Při přepnutí Codexu přepsat přihlášení OpenClaw",
       "openclawAuthOverwriteDesc": "Pokud je vypnuto, přepne se pouze Codex a OpenClaw zůstane v aktuálním přihlášení",
+      "hermesAuthOverwrite": "Synchronizovat limit Hermes při přepnutí Codexu",
+      "hermesAuthOverwriteDesc": "Aktualizuje přihlašovací údaje Hermes openai-codex a credential_pool, aby Hermes používal limit vybraného účtu Codex.",
       "ghcpOpencodeAuthOverwrite": "Při přepnutí GitHub Copilot přepsat přihlášení OpenCode",
       "ghcpOpencodeRestart": "Restartovat OpenCode při přepnutí GitHub Copilot",
       "ghcpLaunchOnSwitch": "Při přepnutí GitHub Copilot automaticky spustit GitHub Copilot App",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -707,6 +707,8 @@
       "workbuddyPathReset": "Auf Standard zurücksetzen",
       "openclawAuthOverwrite": "OpenClaw-Anmeldung beim Wechsel von Codex überschreiben",
       "openclawAuthOverwriteDesc": "Wenn deaktiviert, wird nur Codex gewechselt und OpenClaw behält den aktuellen Anmeldestatus",
+      "hermesAuthOverwrite": "Hermes-Kontingent beim Codex-Wechsel synchronisieren",
+      "hermesAuthOverwriteDesc": "Aktualisiert die Hermes-openai-codex-Zugangsdaten und den credential_pool, damit Hermes das Kontingent des ausgewählten Codex-Kontos verwendet.",
       "ghcpOpencodeAuthOverwrite": "OpenCode-Anmeldung beim Wechsel von GitHub Copilot überschreiben",
       "ghcpOpencodeRestart": "OpenCode beim GitHub Copilot-Wechsel neu starten",
       "ghcpLaunchOnSwitch": "GitHub Copilot App beim Wechseln von GitHub Copilot automatisch starten",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1057,6 +1057,8 @@
       "workbuddyPathReset": "Reset to default",
       "openclawAuthOverwrite": "Overwrite OpenClaw login when switching Codex",
       "openclawAuthOverwriteDesc": "When off, only Codex is switched and OpenClaw keeps its current login state",
+      "hermesAuthOverwrite": "Sync Hermes quota when switching Codex",
+      "hermesAuthOverwriteDesc": "Updates Hermes openai-codex credentials and credential pool so Hermes uses the selected Codex account quota.",
       "ghcpOpencodeAuthOverwrite": "Overwrite OpenCode login when switching GitHub Copilot",
       "ghcpOpencodeRestart": "Restart OpenCode when switching GitHub Copilot",
       "ghcpLaunchOnSwitch": "Launch GitHub Copilot App when switching GitHub Copilot",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1117,6 +1117,8 @@
       "workbuddyPathReset": "Reset to default",
       "openclawAuthOverwrite": "Overwrite OpenClaw login when switching Codex",
       "openclawAuthOverwriteDesc": "When off, only Codex is switched and OpenClaw keeps its current login state",
+      "hermesAuthOverwrite": "Sync Hermes quota when switching Codex",
+      "hermesAuthOverwriteDesc": "Updates Hermes openai-codex credentials and credential pool so Hermes uses the selected Codex account quota.",
       "ghcpOpencodeAuthOverwrite": "Overwrite OpenCode login when switching GitHub Copilot",
       "ghcpOpencodeRestart": "Restart OpenCode when switching GitHub Copilot",
       "ghcpLaunchOnSwitch": "Launch GitHub Copilot App when switching GitHub Copilot",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -704,6 +704,8 @@
       "workbuddyPathReset": "Restablecer por defecto",
       "openclawAuthOverwrite": "Sobrescribir inicio de sesión de OpenClaw al cambiar Codex",
       "openclawAuthOverwriteDesc": "Si está desactivado, solo se cambia Codex y OpenClaw mantiene su sesión actual",
+      "hermesAuthOverwrite": "Sincronizar cuota de Hermes al cambiar Codex",
+      "hermesAuthOverwriteDesc": "Actualiza las credenciales openai-codex de Hermes y el credential_pool para que Hermes use la cuota de la cuenta Codex seleccionada.",
       "ghcpOpencodeAuthOverwrite": "Sobrescribir inicio de sesión de OpenCode al cambiar GitHub Copilot",
       "ghcpOpencodeRestart": "Reiniciar OpenCode al cambiar GitHub Copilot",
       "ghcpLaunchOnSwitch": "Iniciar GitHub Copilot App al cambiar GitHub Copilot",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -704,6 +704,8 @@
       "workbuddyPathReset": "Reinitialiser par defaut",
       "openclawAuthOverwrite": "Écraser la connexion OpenClaw lors du changement de Codex",
       "openclawAuthOverwriteDesc": "Si désactivé, seul Codex est changé et OpenClaw conserve son état de connexion actuel",
+      "hermesAuthOverwrite": "Synchroniser le quota Hermes lors du changement de Codex",
+      "hermesAuthOverwriteDesc": "Met à jour les identifiants openai-codex de Hermes et le credential_pool afin que Hermes utilise le quota du compte Codex sélectionné.",
       "ghcpOpencodeAuthOverwrite": "Écraser la connexion OpenCode lors du changement de GitHub Copilot",
       "ghcpOpencodeRestart": "Redémarrer OpenCode lors du changement de GitHub Copilot",
       "ghcpLaunchOnSwitch": "Lancer GitHub Copilot App lors du changement de GitHub Copilot",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -788,6 +788,8 @@
       "workbuddyPathReset": "Atur ulang ke bawaan",
       "openclawAuthOverwrite": "Timpa login OpenClaw saat mengganti Codex",
       "openclawAuthOverwriteDesc": "Jika dinonaktifkan, hanya Codex yang diganti dan OpenClaw mempertahankan status login saat ini",
+      "hermesAuthOverwrite": "Sinkronkan kuota Hermes saat mengganti Codex",
+      "hermesAuthOverwriteDesc": "Memperbarui kredensial openai-codex Hermes dan credential_pool agar Hermes memakai kuota akun Codex yang dipilih.",
       "ghcpOpencodeAuthOverwrite": "Timpa login OpenCode saat mengganti GitHub Copilot",
       "ghcpOpencodeRestart": "Mulai ulang OpenCode saat mengganti GitHub Copilot",
       "ghcpLaunchOnSwitch": "Luncurkan Aplikasi GitHub Copilot saat mengganti GitHub Copilot",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -704,6 +704,8 @@
       "workbuddyPathReset": "Ripristina predefinito",
       "openclawAuthOverwrite": "Sovrascrivi il login OpenClaw quando cambi Codex",
       "openclawAuthOverwriteDesc": "Se disattivato, viene cambiato solo Codex e OpenClaw mantiene lo stato di accesso corrente",
+      "hermesAuthOverwrite": "Sincronizza la quota Hermes quando cambi Codex",
+      "hermesAuthOverwriteDesc": "Aggiorna le credenziali openai-codex di Hermes e il credential_pool affinché Hermes usi la quota dell account Codex selezionato.",
       "ghcpOpencodeAuthOverwrite": "Sovrascrivi il login OpenCode quando cambi GitHub Copilot",
       "ghcpOpencodeRestart": "Riavvia OpenCode quando si cambia GitHub Copilot",
       "ghcpLaunchOnSwitch": "Avvia GitHub Copilot App quando cambi GitHub Copilot",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -707,6 +707,8 @@
       "workbuddyPathReset": "デフォルトに戻す",
       "openclawAuthOverwrite": "Codex 切り替え時に OpenClaw のログインを上書きする",
       "openclawAuthOverwriteDesc": "オフの場合は Codex のみ切り替え、OpenClaw は現在のログイン状態を維持します",
+      "hermesAuthOverwrite": "Codex 切り替え時に Hermes のクォータを同期",
+      "hermesAuthOverwriteDesc": "Hermes の openai-codex 認証情報と credential_pool を更新し、選択した Codex アカウントのクォータを Hermes で使用します。",
       "ghcpOpencodeAuthOverwrite": "GitHub Copilot 切り替え時に OpenCode のログインを上書きする",
       "ghcpOpencodeRestart": "GitHub Copilot 切替時に OpenCode を自動再起動",
       "ghcpLaunchOnSwitch": "GitHub Copilot 切替時に GitHub Copilot App を自動起動",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -707,6 +707,8 @@
       "workbuddyPathReset": "기본값으로 재설정",
       "openclawAuthOverwrite": "Codex 전환 시 OpenClaw 로그인 덮어쓰기",
       "openclawAuthOverwriteDesc": "끄면 Codex만 전환되고 OpenClaw는 현재 로그인 상태를 유지합니다",
+      "hermesAuthOverwrite": "Codex 전환 시 Hermes 할당량 동기화",
+      "hermesAuthOverwriteDesc": "Hermes openai-codex 자격 증명과 credential_pool을 업데이트하여 선택한 Codex 계정의 할당량을 Hermes에서 사용합니다.",
       "ghcpOpencodeAuthOverwrite": "GitHub Copilot 전환 시 OpenCode 로그인 덮어쓰기",
       "ghcpOpencodeRestart": "GitHub Copilot 전환 시 OpenCode 재시작",
       "ghcpLaunchOnSwitch": "GitHub Copilot 전환 시 GitHub Copilot App 자동 실행",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -707,6 +707,8 @@
       "workbuddyPathReset": "Przywróć domyślne",
       "openclawAuthOverwrite": "Nadpisuj logowanie OpenClaw podczas przełączania Codex",
       "openclawAuthOverwriteDesc": "Gdy wyłączone, przełączany jest tylko Codex, a OpenClaw zachowuje bieżący stan logowania",
+      "hermesAuthOverwrite": "Synchronizuj limit Hermes przy przełączaniu Codex",
+      "hermesAuthOverwriteDesc": "Aktualizuje dane logowania Hermes openai-codex i credential_pool, aby Hermes używał limitu wybranego konta Codex.",
       "ghcpOpencodeAuthOverwrite": "Nadpisuj logowanie OpenCode podczas przełączania GitHub Copilot",
       "ghcpOpencodeRestart": "Uruchom ponownie OpenCode przy przełączaniu GitHub Copilot",
       "ghcpLaunchOnSwitch": "Automatycznie uruchamiaj GitHub Copilot App podczas przełączania GitHub Copilot",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -707,6 +707,8 @@
       "workbuddyPathReset": "Redefinir para o padrao",
       "openclawAuthOverwrite": "Substituir o login do OpenClaw ao trocar o Codex",
       "openclawAuthOverwriteDesc": "Quando desligado, apenas o Codex é alternado e o OpenClaw mantém seu estado de login atual",
+      "hermesAuthOverwrite": "Sincronizar cota do Hermes ao trocar Codex",
+      "hermesAuthOverwriteDesc": "Atualiza as credenciais openai-codex do Hermes e o credential_pool para que o Hermes use a cota da conta Codex selecionada.",
       "ghcpOpencodeAuthOverwrite": "Substituir o login do OpenCode ao trocar o GitHub Copilot",
       "ghcpOpencodeRestart": "Reiniciar o OpenCode ao trocar o GitHub Copilot",
       "ghcpLaunchOnSwitch": "Iniciar GitHub Copilot App ao trocar GitHub Copilot",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -707,6 +707,8 @@
       "workbuddyPathReset": "Сбросить по умолчанию",
       "openclawAuthOverwrite": "Перезаписать логин OpenClaw при переключении Кодекса",
       "openclawAuthOverwriteDesc": "Если выключено, переключается только Codex, а OpenClaw сохраняет текущее состояние входа в систему.",
+      "hermesAuthOverwrite": "Синхронизировать лимит Hermes при переключении Codex",
+      "hermesAuthOverwriteDesc": "Обновляет учетные данные Hermes openai-codex и credential_pool, чтобы Hermes использовал лимит выбранной учетной записи Codex.",
       "ghcpOpencodeAuthOverwrite": "Перезаписать логин OpenCode при переключении GitHub Copilot",
       "ghcpOpencodeRestart": "Перезапускать OpenCode при переключении GitHub Copilot",
       "ghcpLaunchOnSwitch": "Автоматически запускать GitHub Copilot App при переключении GitHub Copilot",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -707,6 +707,8 @@
       "workbuddyPathReset": "Varsayılana sıfırla",
       "openclawAuthOverwrite": "Codex'i değiştirirken OpenClaw oturum açma bilgilerinin üzerine yazın",
       "openclawAuthOverwriteDesc": "Kapalıyken yalnızca Codex açılır ve OpenClaw mevcut oturum açma durumunu korur",
+      "hermesAuthOverwrite": "Codex değiştirirken Hermes kotasını eşitle",
+      "hermesAuthOverwriteDesc": "Hermes openai-codex kimlik bilgilerini ve credential_pool u günceller; Hermes seçili Codex hesabının kotasını kullanır.",
       "ghcpOpencodeAuthOverwrite": "GitHub Copilot değiştirirken OpenCode oturum açma bilgilerinin üzerine yazın",
       "ghcpOpencodeRestart": "GitHub Copilot değiştirildiğinde OpenCode'u yeniden başlat",
       "ghcpLaunchOnSwitch": "GitHub Copilot değiştirirken GitHub Copilot App'i otomatik başlat",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -707,6 +707,8 @@
       "workbuddyPathReset": "Đặt lại mặc định",
       "openclawAuthOverwrite": "Ghi đè đăng nhập OpenClaw khi chuyển đổi Codex",
       "openclawAuthOverwriteDesc": "Khi tắt, chỉ Codex được chuyển đổi và OpenClaw giữ trạng thái đăng nhập hiện tại",
+      "hermesAuthOverwrite": "Đồng bộ hạn mức Hermes khi chuyển Codex",
+      "hermesAuthOverwriteDesc": "Cập nhật thông tin đăng nhập openai-codex và credential_pool của Hermes để Hermes dùng hạn mức của tài khoản Codex đã chọn.",
       "ghcpOpencodeAuthOverwrite": "Ghi đè đăng nhập OpenCode khi chuyển đổi GitHub Copilot",
       "ghcpOpencodeRestart": "Khởi động lại OpenCode khi chuyển GitHub Copilot",
       "ghcpLaunchOnSwitch": "Tự động khởi chạy GitHub Copilot App khi chuyển GitHub Copilot",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1117,6 +1117,8 @@
       "workbuddyPathReset": "重置默认",
       "openclawAuthOverwrite": "切换 Codex 时覆盖 OpenClaw 登录信息",
       "openclawAuthOverwriteDesc": "关闭后仅切换 Codex，不会改写 OpenClaw 当前登录态",
+      "hermesAuthOverwrite": "切换 Codex 时同步 Hermes 额度",
+      "hermesAuthOverwriteDesc": "开启后会更新 ~/.hermes/auth.json 的 openai-codex 凭证和凭证池，让 Hermes 使用当前 Codex 账号额度",
       "ghcpOpencodeAuthOverwrite": "切换 GitHub Copilot 时覆盖 OpenCode 登录信息",
       "ghcpOpencodeRestart": "切换 GitHub Copilot 时自动重启 OpenCode",
       "ghcpLaunchOnSwitch": "切换 GitHub Copilot 时自动启动 GitHub Copilot App",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -704,6 +704,8 @@
       "workbuddyPathReset": "重設預設",
       "openclawAuthOverwrite": "切換 Codex 時覆蓋 OpenClaw 登入",
       "openclawAuthOverwriteDesc": "關閉時，僅切換 Codex，OpenClaw 保持目前登入狀態",
+      "hermesAuthOverwrite": "切換 Codex 時同步 Hermes 額度",
+      "hermesAuthOverwriteDesc": "開啟後會更新 ~/.hermes/auth.json 的 openai-codex 憑證與憑證池，讓 Hermes 使用目前 Codex 帳號額度",
       "ghcpOpencodeAuthOverwrite": "切換 GitHub Copilot 時覆蓋 OpenCode 登入",
       "ghcpOpencodeRestart": "切換 GitHub Copilot 時自動重新啟動 OpenCode",
       "ghcpLaunchOnSwitch": "切換 GitHub Copilot 時自動啟動 GitHub Copilot App",

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -188,6 +188,7 @@ interface GeneralConfig {
   opencode_sync_on_switch: boolean;
   opencode_auth_overwrite_on_switch: boolean;
   openclaw_auth_overwrite_on_switch: boolean;
+  hermes_auth_overwrite_on_switch: boolean;
   codex_launch_on_switch: boolean;
   antigravity_launch_on_switch: boolean;
   codex_restart_specified_app_on_switch: boolean;
@@ -528,6 +529,7 @@ export function SettingsPage() {
   const [opencodeSyncOnSwitch, setOpencodeSyncOnSwitch] = useState(false);
   const [opencodeAuthOverwriteOnSwitch, setOpencodeAuthOverwriteOnSwitch] = useState(false);
   const [openclawAuthOverwriteOnSwitch, setOpenclawAuthOverwriteOnSwitch] = useState(false);
+  const [hermesAuthOverwriteOnSwitch, setHermesAuthOverwriteOnSwitch] = useState(false);
   const [codexLaunchOnSwitch, setCodexLaunchOnSwitch] = useState(true);
   const [antigravityLaunchOnSwitch, setAntigravityLaunchOnSwitch] = useState(true);
   const [codexRestartSpecifiedAppOnSwitch, setCodexRestartSpecifiedAppOnSwitch] = useState(false);
@@ -962,6 +964,7 @@ export function SettingsPage() {
           opencodeSyncOnSwitch,
           opencodeAuthOverwriteOnSwitch,
           openclawAuthOverwriteOnSwitch,
+          hermesAuthOverwriteOnSwitch,
           codexLaunchOnSwitch,
           antigravityLaunchOnSwitch,
           codexRestartSpecifiedAppOnSwitch,
@@ -1116,6 +1119,7 @@ export function SettingsPage() {
     opencodeSyncOnSwitch,
     opencodeAuthOverwriteOnSwitch,
     openclawAuthOverwriteOnSwitch,
+    hermesAuthOverwriteOnSwitch,
     codexLaunchOnSwitch,
     antigravityLaunchOnSwitch,
     codexRestartSpecifiedAppOnSwitch,
@@ -1458,6 +1462,7 @@ export function SettingsPage() {
       setOpencodeSyncOnSwitch(config.opencode_sync_on_switch ?? false);
       setOpencodeAuthOverwriteOnSwitch(config.opencode_auth_overwrite_on_switch ?? false);
       setOpenclawAuthOverwriteOnSwitch(config.openclaw_auth_overwrite_on_switch ?? false);
+      setHermesAuthOverwriteOnSwitch(config.hermes_auth_overwrite_on_switch ?? false);
       setCodexLaunchOnSwitch(config.codex_launch_on_switch ?? true);
       setAntigravityLaunchOnSwitch(config.antigravity_launch_on_switch ?? true);
       setCodexRestartSpecifiedAppOnSwitch(
@@ -4020,6 +4025,23 @@ export function SettingsPage() {
                       type="checkbox"
                       checked={openclawAuthOverwriteOnSwitch}
                       onChange={(e) => setOpenclawAuthOverwriteOnSwitch(e.target.checked)}
+                    />
+                    <span className="slider"></span>
+                  </label>
+                </div>
+              </div>
+
+              <div className="settings-row">
+                <div className="row-label">
+                  <div className="row-title">{t('settings.general.hermesAuthOverwrite')}</div>
+                  <div className="row-desc">{t('settings.general.hermesAuthOverwriteDesc')}</div>
+                </div>
+                <div className="row-control">
+                  <label className="switch">
+                    <input
+                      type="checkbox"
+                      checked={hermesAuthOverwriteOnSwitch}
+                      onChange={(e) => setHermesAuthOverwriteOnSwitch(e.target.checked)}
                     />
                     <span className="slider"></span>
                   </label>


### PR DESCRIPTION
## Summary
- add an optional Hermes auth sync path when switching Codex accounts, updating `providers.openai-codex` and `credential_pool.openai-codex` in `~/.hermes/auth.json`
- expose the new switch in Settings and Quick Settings, defaulting it off so Codex switching no longer implicitly touches unrelated login state
- keep OpenClaw overwrite behind its existing independent toggle and add tests for safe defaults plus Hermes auth merging

## Notes
- Hermes sync only supports Codex OAuth accounts; API-key Codex accounts are rejected for this path
- sync failures are logged as warnings and do not block the Codex account switch itself

## Tests
- `cargo test --manifest-path src-tauri/Cargo.toml hermes_auth --lib`
- `npm run typecheck`
- `npm run build`
