### PR TITLE
修复 Codex token 刷新权威冲突

### DIFF
--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/config.example.yaml
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/config.example.yaml
@@ -103,6 +103,8 @@ disable-image-generation: false
 # Core auth auto-refresh worker pool size (OAuth/file-based auth token refresh).
 # When > 0, overrides the default worker count (16).
 # auth-auto-refresh-workers: 16
+# Set true to disable background OAuth/file-based auth token refresh.
+# disable-auth-auto-refresh: false
 
 # Quota exceeded behavior
 quota-exceeded:

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/config/config.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/config/config.go
@@ -81,6 +81,9 @@ type Config struct {
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
 
+	// DisableAuthAutoRefresh disables the core auth auto-refresh loop.
+	DisableAuthAutoRefresh bool `yaml:"disable-auth-auto-refresh" json:"disable-auth-auto-refresh"`
+
 	// RequestRetry defines the retry times when the request failed.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`
 	// MaxRetryCredentials defines the maximum number of credentials to try for a failed request.

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/service.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/service.go
@@ -930,7 +930,7 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 
 	// Prefer core auth manager auto refresh if available.
-	if s.coreManager != nil && !homeEnabled {
+	if s.coreManager != nil && !homeEnabled && !s.cfg.DisableAuthAutoRefresh {
 		interval := 15 * time.Minute
 		s.coreManager.StartAutoRefresh(context.Background(), interval)
 		log.Infof("core auth auto-refresh started (interval=%s)", interval)
@@ -1856,7 +1856,7 @@ func (s *Service) StartRuntime(ctx context.Context) error {
 		s.hooks.OnAfterStart(s)
 	}
 
-	if s.coreManager != nil {
+	if s.coreManager != nil && !s.cfg.DisableAuthAutoRefresh {
 		interval := 15 * time.Minute
 		s.coreManager.StartAutoRefresh(context.Background(), interval)
 		log.Infof("core auth auto-refresh started (interval=%s)", interval)

--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -4432,6 +4432,14 @@ fn write_managed_account_projections(account: &CodexAccount) {
             }
         }
     }
+    if let Err(err) =
+        crate::modules::codex_local_access::sync_sidecar_auth_file_for_account(account)
+    {
+        logger::log_warn(&format!(
+            "Codex Token 写穿 API Service sidecar 认证失败，已忽略: account_id={}, error={}",
+            account.id, err
+        ));
+    }
 }
 
 pub fn is_managed_auth_refresh_due(account: &CodexAccount) -> bool {

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -1057,6 +1057,12 @@ async fn invalidate_prepared_account(account_id: &str) {
     runtime.prepared_accounts.remove(account_id);
 }
 
+fn invalidate_prepared_account_if_unlocked(account_id: &str) {
+    if let Ok(mut runtime) = gateway_runtime().try_lock() {
+        runtime.prepared_accounts.remove(account_id);
+    }
+}
+
 fn try_get_cached_account_for_routing(account_id: &str) -> Option<CodexAccount> {
     let Ok(mut runtime) = gateway_runtime().try_lock() else {
         return None;
@@ -6851,6 +6857,45 @@ fn sidecar_auth_json_for_account(
     value
 }
 
+pub fn sync_sidecar_auth_file_for_account(account: &CodexAccount) -> Result<(), String> {
+    if account.is_api_key_auth() {
+        return Ok(());
+    }
+
+    let Some(collection) = load_collection_from_disk()? else {
+        return Ok(());
+    };
+    if !effective_sidecar_account_ids(&collection)
+        .iter()
+        .any(|account_id| account_id == &account.id)
+    {
+        return Ok(());
+    }
+
+    let base_dir = local_access_sidecar_dir()?;
+    let auths_dir = sidecar_auths_dir(&base_dir);
+    if !auths_dir.exists() {
+        return Ok(());
+    }
+
+    let proxy_signature = sidecar_effective_proxy_signature(&collection)?;
+    let auth_path = auths_dir.join(sidecar_auth_file_name(&account.id));
+    if !auth_path.exists() {
+        return Ok(());
+    }
+    let auth_json =
+        sidecar_auth_json_for_account(account, &collection, proxy_signature.proxy_url.as_deref());
+    let auth_content = serde_json::to_string_pretty(&auth_json)
+        .map_err(|e| format!("序列化 sidecar Codex OAuth 认证失败: {}", e))?;
+    write_string_atomic(&auth_path, &auth_content)?;
+    invalidate_prepared_account_if_unlocked(&account.id);
+    logger::log_codex_api_info(&format!(
+        "[CodexLocalAccess][sidecar] 已写穿 Cockpit Token Authority 凭证: account_id={}",
+        account.id
+    ));
+    Ok(())
+}
+
 fn sidecar_account_manifest_value(account: &CodexAccount, auth_id: Option<&str>) -> Value {
     json!({
         "id": account.id.clone(),
@@ -7328,6 +7373,7 @@ async fn prepare_sidecar_launch_config_in_dir(
     config.insert("logging-to-file".to_string(), json!(false));
     config.insert("commercial-mode".to_string(), json!(true));
     config.insert("ws-auth".to_string(), json!(true));
+    config.insert("disable-auth-auto-refresh".to_string(), json!(true));
     config.insert(
         "disable-image-generation".to_string(),
         sidecar_disable_image_generation_value(effective_image_generation_mode),
@@ -22694,6 +22740,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
         .expect("parse sidecar config");
 
         assert_eq!(config.get("disable-image-generation"), Some(&json!("chat")));
+        assert_eq!(config.get("disable-auth-auto-refresh"), Some(&json!(true)));
 
         fs::remove_dir_all(&dir).expect("cleanup temp dir");
     }


### PR DESCRIPTION
让 Cockpit Tools 作为唯一 token authority，禁用 sidecar 后台 OAuth 自动刷新，并在 Cockpit 刷新成功后写穿 sidecar 认证文件，避免 refresh_token_reused。

用于修复 issue: https://github.com/jlcodes99/cockpit-tools/issues/1328

仅供参考，gpt 5.5写的代码，没有测试过。核心目的在于禁止CPA自动刷新token，因为目前CPA更新后目前并不会把更新后的认证文件同步回Cockpit Tools。