### PR TITLE
feat: add Codex access token account import

### DIFF
--- a/docs/codex-access-token-import.md
+++ b/docs/codex-access-token-import.md
@@ -1,0 +1,30 @@
+﻿# Codex access token account import
+
+## Purpose
+
+Cockpit Tools supports adding a Codex account with only an account name and a Codex access token. The imported account is stored as a Codex OAuth account, not as an API key account.
+
+## Behavior
+
+- Open the Codex accounts page and choose the access token import tab.
+- Enter an account name and paste the Codex access token.
+- Cockpit saves the account with `auth_mode = OAuth`.
+- When switching an access-token-only account into a Codex home, Cockpit writes the official personal access token auth shape: `OPENAI_API_KEY = null` plus `personal_access_token`.
+- No API key auth file is created for this flow.
+- After import, Cockpit attempts to refresh the account profile and quota. If the token is expired or rejected, the account remains saved and the quota/profile error is shown in the normal Codex account UI.
+
+## Launching Codex
+
+- Use the Codex instances page to bind the imported account to an App-mode Codex instance and click start.
+- App-mode launch uses the existing Cockpit Codex instance path, including `CODEX_HOME`, `CODEX_ELECTRON_USER_DATA_PATH`, and `--user-data-dir`.
+- The CLI/terminal launch path remains separate and is used only for CLI-mode instances.
+
+## Sessions
+
+- Default Codex thread sync is enabled for new or missing default instance settings.
+- Before App-mode launch, Cockpit runs a targeted session visibility repair for the target instance and asks the official app-server to rebuild thread metadata.
+- Existing session import, export, restore, and trash management continue to use the existing Codex session manager.
+
+## Token lifetime
+
+Access-token-only accounts do not have a refresh token. When the access token expires, re-import or update the access token for that account.

--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -1018,6 +1018,29 @@ pub fn export_codex_accounts(account_ids: Vec<String>) -> Result<String, String>
     codex_account::export_accounts(&account_ids)
 }
 
+#[tauri::command]
+pub async fn import_codex_access_token_account(
+    app: AppHandle,
+    name: String,
+    access_token: String,
+) -> Result<CodexAccount, String> {
+    let account = codex_account::import_access_token_account(name, access_token)?;
+    let account_id = account.id.clone();
+
+    if let Err(error) = codex_account::refresh_account_profile(&account_id).await {
+        logger::log_warn(&format!(
+            "Codex access token account profile refresh failed after import: account_id={}, error={}",
+            account_id, error
+        ));
+    }
+
+    let refreshed = codex_account::load_account(&account_id).unwrap_or(account);
+    let mut accounts = refresh_imported_codex_accounts(&app, vec![refreshed]).await;
+    accounts
+        .pop()
+        .ok_or_else(|| "Account could not be loaded after import".to_string())
+}
+
 /// 从本地文件导入 Codex 账号
 #[tauri::command]
 pub async fn import_codex_from_files(

--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -385,6 +385,29 @@ fn log_session_visibility_repair_deferred_before_launch(
     ));
 }
 
+fn repair_session_visibility_before_app_launch(context: &str, instance_id: &str) {
+    let started = Instant::now();
+    match modules::codex_session_visibility::repair_session_visibility_for_launch_instance(
+        instance_id,
+    ) {
+        Ok(summary) => modules::logger::log_info(&format!(
+            "[Codex Session Visibility] {}: launch repair finished, instance_id={}, mutated_instances={}, metadata_failed={}, elapsed_ms={}",
+            context,
+            instance_id,
+            summary.mutated_instance_count,
+            summary.metadata_rebuild_failed_count,
+            started.elapsed().as_millis()
+        )),
+        Err(error) => modules::logger::log_warn(&format!(
+            "[Codex Session Visibility] {}: launch repair failed, instance_id={}, elapsed_ms={}, error={}",
+            context,
+            instance_id,
+            started.elapsed().as_millis(),
+            error
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1100,6 +1123,9 @@ async fn codex_start_instance_internal(
                 flow_started.elapsed().as_millis()
             ));
         }
+        if default_settings.launch_mode != InstanceLaunchMode::Cli {
+            repair_session_visibility_before_app_launch("before-start-default", DEFAULT_INSTANCE_ID);
+        }
         let sanitize_started = Instant::now();
         sanitize_codex_config_before_launch(&default_dir)?;
         modules::logger::log_info(&format!(
@@ -1245,6 +1271,9 @@ async fn codex_start_instance_internal(
         thread_sync_started.elapsed().as_millis(),
         flow_started.elapsed().as_millis()
     ));
+    if instance.launch_mode != InstanceLaunchMode::Cli {
+        repair_session_visibility_before_app_launch("before-start-instance", &instance.id);
+    }
     let sanitize_started = Instant::now();
     sanitize_codex_config_before_launch(instance_dir)?;
     modules::logger::log_info(&format!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -671,6 +671,7 @@ pub fn run() {
             commands::codex::clear_codex_batch_delete,
             commands::codex::import_codex_from_local,
             commands::codex::import_codex_from_json,
+            commands::codex::import_codex_access_token_account,
             commands::codex::export_codex_accounts,
             commands::codex::import_codex_from_files,
             commands::codex::start_codex_batch_import_from_files,

--- a/src-tauri/src/models/codex.rs
+++ b/src-tauri/src/models/codex.rs
@@ -273,6 +273,8 @@ pub struct CodexAuthFile {
     )]
     pub base_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub personal_access_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tokens: Option<CodexAuthTokens>,
     #[serde(default)]
     pub last_refresh: Option<serde_json::Value>, // 可以是字符串或数字

--- a/src-tauri/src/models/instance.rs
+++ b/src-tauri/src/models/instance.rs
@@ -67,13 +67,17 @@ pub struct DefaultInstanceSettings {
     pub app_speed: CodexAppSpeed,
     #[serde(default = "default_follow_local_account")]
     pub follow_local_account: bool,
-    #[serde(default)]
+    #[serde(default = "default_auto_sync_threads")]
     pub auto_sync_threads: bool,
     #[serde(default)]
     pub last_pid: Option<u32>,
 }
 
 fn default_follow_local_account() -> bool {
+    true
+}
+
+fn default_auto_sync_threads() -> bool {
     true
 }
 
@@ -86,7 +90,7 @@ impl Default for DefaultInstanceSettings {
             launch_mode: InstanceLaunchMode::App,
             app_speed: CodexAppSpeed::Standard,
             follow_local_account: true,
-            auto_sync_threads: false,
+            auto_sync_threads: true,
             last_pid: None,
         }
     }
@@ -132,4 +136,26 @@ impl InstanceProfileView {
 
 fn is_standard_app_speed(speed: &CodexAppSpeed) -> bool {
     matches!(speed, CodexAppSpeed::Standard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DefaultInstanceSettings;
+
+    #[test]
+    fn default_settings_enable_thread_sync_by_default() {
+        assert!(DefaultInstanceSettings::default().auto_sync_threads);
+
+        let decoded: DefaultInstanceSettings =
+            serde_json::from_str("{}").expect("decode default settings");
+        assert!(decoded.auto_sync_threads);
+    }
+
+    #[test]
+    fn default_settings_keep_explicit_thread_sync_choice() {
+        let decoded: DefaultInstanceSettings =
+            serde_json::from_str(r#"{"autoSyncThreads":false}"#)
+                .expect("decode default settings");
+        assert!(!decoded.auto_sync_threads);
+    }
 }

--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -3802,10 +3802,20 @@ fn build_auth_file_value(account: &CodexAccount) -> Result<serde_json::Value, St
         return Err("OAuth 账号缺少 access_token，无法写入 auth.json".to_string());
     }
 
+    if account.tokens.id_token.trim().is_empty()
+        && normalize_optional_ref(account.tokens.refresh_token.as_deref()).is_none()
+    {
+        return Ok(serde_json::json!({
+            "OPENAI_API_KEY": null,
+            "personal_access_token": account.tokens.access_token,
+        }));
+    }
+
     serde_json::to_value(CodexAuthFile {
         auth_mode: None,
         openai_api_key: Some(serde_json::Value::Null),
         base_url: None,
+        personal_access_token: None,
         tokens: Some(CodexAuthTokens {
             id_token: account.tokens.id_token.clone(),
             access_token: account.tokens.access_token.clone(),
@@ -4932,6 +4942,12 @@ pub fn import_from_local() -> Result<CodexAccount, String> {
         return upsert_account_from_auth_tokens(tokens);
     }
 
+    if let Some(personal_access_token) =
+        normalize_optional_ref(auth_file.personal_access_token.as_deref())
+    {
+        return upsert_account_from_access_token(personal_access_token, None);
+    }
+
     if let Some(api_key) = fallback_api_key {
         return upsert_api_key_account(
             api_key,
@@ -5725,6 +5741,27 @@ fn upsert_account_from_access_token(
     )
 }
 
+pub fn import_access_token_account(
+    account_name: String,
+    access_token: String,
+) -> Result<CodexAccount, String> {
+    let account_name =
+        normalize_optional_value(Some(account_name)).ok_or("账户名不能为空".to_string())?;
+    let access_token = normalize_optional_value(Some(access_token))
+        .ok_or("Codex access token 不能为空".to_string())?;
+    if !is_importable_access_token(&access_token) {
+        return Err("无效的 Codex access token".to_string());
+    }
+
+    upsert_account_from_access_token_with_hints(
+        access_token,
+        CodexAccessTokenImportHints {
+            account_name: Some(account_name),
+            ..Default::default()
+        },
+    )
+}
+
 fn upsert_account_from_access_token_with_hints(
     access_token: String,
     hints: CodexAccessTokenImportHints,
@@ -6128,6 +6165,19 @@ pub async fn import_from_json(json_content: &str) -> Result<Vec<CodexAccount>, S
 
         if let Some(tokens) = auth_file.tokens {
             let mut account = upsert_account_from_auth_tokens(tokens)?;
+            if let Some(value) = raw_value.as_ref() {
+                save_account_note_update_if_present(
+                    &mut account,
+                    codex_account_note_update_from_value(value),
+                )?;
+            }
+            return Ok(vec![account]);
+        }
+
+        if let Some(personal_access_token) =
+            normalize_optional_ref(auth_file.personal_access_token.as_deref())
+        {
+            let mut account = upsert_account_from_access_token(personal_access_token, None)?;
             if let Some(value) = raw_value.as_ref() {
                 save_account_note_update_if_present(
                     &mut account,
@@ -7543,8 +7593,9 @@ mod tests {
         resolve_api_provider_config, save_account, save_account_index,
         should_accept_authority_snapshot, sync_account_from_auth_dir,
         sync_managed_projection_from_auth_dir, upsert_account, upsert_account_for_reauth,
-        upsert_account_from_access_token, upsert_account_from_access_token_with_hints,
-        upsert_account_from_auth_tokens, validate_api_key_credentials, write_account_bundle_to_dir,
+        import_access_token_account, upsert_account_from_access_token,
+        upsert_account_from_access_token_with_hints, upsert_account_from_auth_tokens,
+        validate_api_key_credentials, write_account_bundle_to_dir,
         write_api_key_provider_to_config_toml, write_api_provider_to_config_toml,
         write_managed_projection_to_dir, write_quick_config_to_config_toml, ApiProviderConfig,
         CodexAccessTokenImportHints, CodexAccountIndex, CodexAccountSummary, CodexAuthFile,
@@ -7552,7 +7603,7 @@ mod tests {
         CODEX_ACCOUNT_DETAIL_SCHEMA_VERSION, CODEX_AUTHORIZATION_STATUS_PENDING,
         CODEX_AUTO_COMPACT_DEFAULT_LIMIT, CODEX_CONTEXT_WINDOW_1M_VALUE,
     };
-    use crate::models::codex::{CodexAccount, CodexApiProviderMode, CodexTokens};
+    use crate::models::codex::{CodexAccount, CodexApiProviderMode, CodexAuthMode, CodexTokens};
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     use std::fs;
     use std::path::Path;
@@ -7947,6 +7998,7 @@ mod tests {
             auth_mode: None,
             openai_api_key: Some(serde_json::Value::Null),
             base_url: None,
+            personal_access_token: None,
             tokens: Some(CodexAuthTokens {
                 id_token: tokens.id_token.clone(),
                 access_token: tokens.access_token.clone(),
@@ -8353,6 +8405,56 @@ mod tests {
         let persisted = load_account(&account.id).expect("persisted opaque account");
         assert_eq!(persisted.tokens.access_token, account.tokens.access_token);
         assert_eq!(persisted.account_id.as_deref(), Some("acc-team"));
+    }
+
+    #[test]
+    fn import_access_token_account_saves_named_oauth_account() {
+        let _lock = crate::modules::test_support::env_lock()
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let _env = TestEnvGuard::new("codex-access-token-named-import-test");
+        let access_token = make_jwt(serde_json::json!({
+            "email": "token-user@example.com",
+            "sub": "user-token",
+            "https://api.openai.com/auth": {
+                "chatgpt_user_id": "user-token",
+                "chatgpt_plan_type": "plus",
+                "chatgpt_account_id": "acc-token",
+                "organization_id": "org-token"
+            }
+        }));
+
+        let account = import_access_token_account("21798".to_string(), access_token.clone())
+            .expect("import access token account");
+
+        assert_eq!(account.auth_mode, CodexAuthMode::OAuth);
+        assert_eq!(account.email, "token-user@example.com");
+        assert_eq!(account.account_name.as_deref(), Some("21798"));
+        assert_eq!(account.account_id.as_deref(), Some("acc-token"));
+        assert_eq!(account.organization_id.as_deref(), Some("org-token"));
+        assert_eq!(account.tokens.id_token, "");
+        assert_eq!(account.tokens.access_token, access_token);
+        assert_eq!(account.tokens.refresh_token, None);
+        assert_eq!(account.openai_api_key, None);
+
+        let persisted = load_account(&account.id).expect("persisted account");
+        assert_eq!(persisted.auth_mode, CodexAuthMode::OAuth);
+        assert_eq!(persisted.account_name.as_deref(), Some("21798"));
+        assert_eq!(persisted.tokens.access_token, account.tokens.access_token);
+
+        let auth_file = build_auth_file_value(&persisted).expect("build auth file");
+        assert!(auth_file.get("auth_mode").is_none());
+        assert_eq!(
+            auth_file.get("OPENAI_API_KEY"),
+            Some(&serde_json::Value::Null)
+        );
+        assert_eq!(
+            auth_file
+                .get("personal_access_token")
+                .and_then(|value| value.as_str()),
+            Some(account.tokens.access_token.as_str())
+        );
+        assert!(auth_file.get("tokens").is_none());
     }
 
     #[test]

--- a/src-tauri/src/modules/codex_session_visibility.rs
+++ b/src-tauri/src/modules/codex_session_visibility.rs
@@ -455,6 +455,18 @@ pub fn repair_session_visibility_across_instances_with_target(
     )
 }
 
+pub fn repair_session_visibility_for_launch_instance(
+    instance_id: &str,
+) -> Result<CodexSessionVisibilityRepairSummary, String> {
+    let mut options = CodexSessionVisibilityRepairOptions::for_auto_repair_mode(
+        CodexSessionVisibilityAutoRepairMode::Current,
+    );
+    options.rebuild_metadata = true;
+    let selection =
+        RepairTargetSelection::from_inputs(None, None, Some(vec![instance_id.to_string()]))?;
+    repair_session_visibility_across_instances_with_options(options, None, None, selection)
+}
+
 fn repair_session_visibility_across_instances_with_options(
     options: CodexSessionVisibilityRepairOptions,
     run_id: Option<String>,

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -2681,6 +2681,7 @@ export function CodexAccountsPage() {
     refreshQuota,
     refreshSubscriptionInfo,
     hydrateAccountProfilesIfNeeded,
+    importAccessTokenAccount,
     updateAccountName,
     updateApiKeyCredentials,
     updateApiKeyBoundOAuthAccount,
@@ -3438,6 +3439,10 @@ export function CodexAccountsPage() {
   const [oauthTokenExchangeRetryVisible, setOauthTokenExchangeRetryVisible] =
     useState(false);
   const [switching, setSwitching] = useState<string | null>(null);
+  const [accessTokenAccountNameInput, setAccessTokenAccountNameInput] =
+    useState("");
+  const [accessTokenInput, setAccessTokenInput] = useState("");
+  const [accessTokenInputVisible, setAccessTokenInputVisible] = useState(false);
   const [apiKeyInput, setApiKeyInput] = useState("");
   const [apiKeyInputVisible, setApiKeyInputVisible] = useState(false);
   const [apiBaseUrlInput, setApiBaseUrlInput] = useState(
@@ -3466,6 +3471,13 @@ export function CodexAccountsPage() {
   const [savingApiKeyNameId, setSavingApiKeyNameId] = useState<string | null>(
     null,
   );
+
+  useEffect(() => {
+    if (showAddModal) return;
+    setAccessTokenAccountNameInput("");
+    setAccessTokenInput("");
+    setAccessTokenInputVisible(false);
+  }, [showAddModal]);
   const [editingApiKeyCredentialsId, setEditingApiKeyCredentialsId] = useState<
     string | null
   >(null);
@@ -6096,6 +6108,55 @@ export function CodexAccountsPage() {
           "成功导入 {{count}} 个账号",
         ).replace("{{count}}", String(imported.length)),
       );
+      setTimeout(() => {
+        closeAddModal();
+      }, 1200);
+    } catch (e) {
+      page.setAddStatus("error");
+      page.setAddMessage(
+        t("common.shared.token.importFailedMsg", "导入失败: {{error}}").replace(
+          "{{error}}",
+          String(e).replace(/^Error:\s*/, ""),
+        ),
+      );
+    }
+  };
+
+  const handleAccessTokenAccountImport = async () => {
+    const name = accessTokenAccountNameInput.trim();
+    const accessToken = accessTokenInput.trim();
+    if (!name) {
+      page.setAddStatus("error");
+      page.setAddMessage(
+        t("codex.accessTokenImport.nameRequired", "请输入账户名"),
+      );
+      return;
+    }
+    if (!accessToken) {
+      page.setAddStatus("error");
+      page.setAddMessage(
+        t(
+          "codex.accessTokenImport.tokenRequired",
+          "请输入 Codex access token",
+        ),
+      );
+      return;
+    }
+
+    page.setAddStatus("loading");
+    page.setAddMessage(t("common.shared.token.importing", "正在导入..."));
+    try {
+      const account = await importAccessTokenAccount(name, accessToken);
+      page.setAddStatus("success");
+      page.setAddMessage(
+        t("codex.accessTokenImport.success", {
+          defaultValue: "访问令牌账号已导入: {{name}}",
+          name: maskAccountText(account.account_name || account.email || name),
+        }),
+      );
+      setAccessTokenAccountNameInput("");
+      setAccessTokenInput("");
+      setAccessTokenInputVisible(false);
       setTimeout(() => {
         closeAddModal();
       }, 1200);
@@ -13255,6 +13316,15 @@ export function CodexAccountsPage() {
                     </span>
                   </button>
                   <button
+                    className={`modal-tab ${addTab === "access_token" ? "active" : ""}`}
+                    onClick={() => openCodexAddModal("access_token")}
+                  >
+                    <Link2 size={14} />
+                    <span className="modal-tab-label">
+                      {t("codex.addModal.accessToken", "访问令牌")}
+                    </span>
+                  </button>
+                  <button
                     className={`modal-tab ${addTab === "token" ? "active" : ""}`}
                     onClick={() => openCodexAddModal("token")}
                   >
@@ -13283,7 +13353,9 @@ export function CodexAccountsPage() {
                   </button>
                 </div>
                 <div className="modal-body">
-                  {addTab !== "oauth" && <MfaQuickCodeSelect />}
+                  {addTab !== "oauth" && addTab !== "access_token" && (
+                    <MfaQuickCodeSelect />
+                  )}
                   {addTab === "oauth" && (
                     <div className="add-section">
                       {reauthTargetEmail && (
@@ -13547,6 +13619,109 @@ export function CodexAccountsPage() {
                           </span>
                         </div>
                       )}
+                    </div>
+                  )}
+                  {addTab === "access_token" && (
+                    <div className="add-section">
+                      <p className="section-desc">
+                        {t(
+                          "codex.accessTokenImport.desc",
+                          "输入账号名和 Codex access token，Cockpit 会按 OAuth 账号保存，并通过实例模式启动 Codex Windows 客户端。",
+                        )}
+                      </p>
+                      <div className="oauth-link">
+                        <label>
+                          {t("codex.accessTokenImport.nameLabel", "账户名")}
+                        </label>
+                        <div className="oauth-url-box oauth-manual-input">
+                          <input
+                            type="text"
+                            value={accessTokenAccountNameInput}
+                            onChange={(event) =>
+                              setAccessTokenAccountNameInput(event.target.value)
+                            }
+                            placeholder={t(
+                              "codex.accessTokenImport.namePlaceholder",
+                              "例如 21798 / guohu / portia",
+                            )}
+                            autoComplete="off"
+                          />
+                        </div>
+                      </div>
+                      <div className="oauth-link">
+                        <label>
+                          {t(
+                            "codex.accessTokenImport.tokenLabel",
+                            "Codex access token",
+                          )}
+                        </label>
+                        <div className="oauth-url-box oauth-manual-input codex-secret-input">
+                          <input
+                            type={accessTokenInputVisible ? "text" : "password"}
+                            value={accessTokenInput}
+                            onChange={(event) =>
+                              setAccessTokenInput(event.target.value)
+                            }
+                            placeholder="eyJ... / at-..."
+                            autoComplete="off"
+                            spellCheck={false}
+                          />
+                          <button
+                            type="button"
+                            className="codex-secret-toggle-btn"
+                            onClick={() =>
+                              setAccessTokenInputVisible((visible) => !visible)
+                            }
+                            title={
+                              accessTokenInputVisible
+                                ? t(
+                                    "codex.accessTokenImport.hideToken",
+                                    "隐藏访问令牌",
+                                  )
+                                : t(
+                                    "codex.accessTokenImport.showToken",
+                                    "显示访问令牌",
+                                  )
+                            }
+                            aria-label={
+                              accessTokenInputVisible
+                                ? t(
+                                    "codex.accessTokenImport.hideToken",
+                                    "隐藏访问令牌",
+                                  )
+                                : t(
+                                    "codex.accessTokenImport.showToken",
+                                    "显示访问令牌",
+                                  )
+                            }
+                          >
+                            {accessTokenInputVisible ? (
+                              <EyeOff size={16} />
+                            ) : (
+                              <Eye size={16} />
+                            )}
+                          </button>
+                        </div>
+                      </div>
+                      <button
+                        className="btn btn-primary btn-full"
+                        onClick={() => void handleAccessTokenAccountImport()}
+                        disabled={
+                          addStatus === "loading" ||
+                          !accessTokenAccountNameInput.trim() ||
+                          !accessTokenInput.trim()
+                        }
+                      >
+                        {addStatus === "loading" ? (
+                          <RefreshCw size={16} className="loading-spinner" />
+                        ) : (
+                          <Link2 size={16} />
+                        )}
+                        {t(
+                          "codex.accessTokenImport.submit",
+                          "添加访问令牌账号",
+                        )}
+                      </button>
                     </div>
                   )}
                   {addTab === "apikey" && (

--- a/src/services/codexService.ts
+++ b/src/services/codexService.ts
@@ -158,6 +158,13 @@ export async function importCodexFromJson(jsonContent: string): Promise<CodexAcc
   return await invoke('import_codex_from_json', { jsonContent });
 }
 
+export async function importCodexAccessTokenAccount(
+  name: string,
+  accessToken: string,
+): Promise<CodexAccount> {
+  return await invoke('import_codex_access_token_account', { name, accessToken });
+}
+
 /** 导出 Codex 账号 */
 export async function exportCodexAccounts(accountIds: string[]): Promise<string> {
   return await invoke('export_codex_accounts', { accountIds });

--- a/src/stores/useCodexAccountStore.ts
+++ b/src/stores/useCodexAccountStore.ts
@@ -112,6 +112,7 @@ interface CodexAccountState {
   hydrateAccountProfilesIfNeeded: (accountIds?: string[]) => Promise<void>;
   importFromLocal: () => Promise<CodexAccount>;
   importFromJson: (jsonContent: string) => Promise<CodexAccount[]>;
+  importAccessTokenAccount: (name: string, accessToken: string) => Promise<CodexAccount>;
   updateAccountName: (accountId: string, name: string) => Promise<CodexAccount>;
   updateApiKeyCredentials: (
     accountId: string,
@@ -403,6 +404,17 @@ export const useCodexAccountStore = create<CodexAccountState>((set, get) => ({
       reason: 'import',
     });
     return accounts;
+  },
+
+  importAccessTokenAccount: async (name: string, accessToken: string) => {
+    const account = await codexService.importCodexAccessTokenAccount(name, accessToken);
+    await get().fetchAccounts();
+    await get().fetchCurrentAccount();
+    await emitAccountsChanged({
+      platformId: 'codex',
+      reason: 'import',
+    });
+    return account;
   },
 
   updateAccountName: async (accountId: string, name: string) => {


### PR DESCRIPTION
## Summary
- Add a Codex access token account import flow with account name + hidden token input.
- Store access-token-only accounts as Codex OAuth accounts and project them using the official `personal_access_token` auth shape.
- Preserve full OAuth token projection for refresh-token accounts and add compatibility for importing `auth.json` files with `personal_access_token`.
- Run targeted Codex session visibility repair before App-mode launches and default thread sync to enabled for new default settings.
- Document the access token import behavior and token lifetime limitation.

## Testing
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -p cockpit-tools --lib modules::codex_account::tests::import_access_token_account_saves_named_oauth_account -- --exact`
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo check -p cockpit-tools`
- `npm.cmd run typecheck`
- `git diff --cached --check`

## Notes
- No real access tokens or API keys are included.
- Direct push to upstream was denied for `daodeqing`, so this is submitted from a fork.