### PR TITLE
feat(antigravity): dynamically resolve local active accounts when follow local account mode is active

### DIFF
--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -223,16 +223,31 @@ pub async fn get_current_account(
     runtime_target: Option<String>,
 ) -> Result<Option<models::Account>, String> {
     let runtime_target = normalize_antigravity_runtime_target(runtime_target.as_deref());
-    let bound_account_id = match runtime_target {
+    let (follow_local, bound_account_id) = match runtime_target {
         AntigravityRuntimeTarget::Legacy => {
             modules::antigravity_legacy_instance::load_default_settings()
                 .ok()
-                .and_then(|settings| settings.bind_account_id)
+                .map(|settings| (settings.follow_local_account, settings.bind_account_id))
+                .unwrap_or((true, None))
         }
         AntigravityRuntimeTarget::Ide => modules::instance::load_default_settings()
             .ok()
-            .and_then(|settings| settings.bind_account_id),
+            .map(|settings| (settings.follow_local_account, settings.bind_account_id))
+            .unwrap_or((true, None)),
     };
+
+    if follow_local {
+        let resolved_id = match runtime_target {
+            AntigravityRuntimeTarget::Legacy => crate::commands::antigravity_legacy_instance::resolve_local_account_id(),
+            AntigravityRuntimeTarget::Ide => crate::commands::instance::resolve_local_account_id(),
+        };
+        if let Some(account_id) = resolved_id.as_deref() {
+            if let Ok(mut account) = modules::load_account(account_id) {
+                let _ = modules::quota_cache::apply_cached_quota(&mut account, "authorized");
+                return Ok(Some(account));
+            }
+        }
+    }
 
     if let Some(account_id) = bound_account_id.as_deref() {
         match modules::load_account(account_id) {

--- a/src-tauri/src/commands/antigravity_legacy_instance.rs
+++ b/src-tauri/src/commands/antigravity_legacy_instance.rs
@@ -20,7 +20,7 @@ fn resolve_default_account_id(settings: &DefaultInstanceSettings) -> Option<Stri
     }
 }
 
-fn resolve_local_account_id() -> Option<String> {
+pub fn resolve_local_account_id() -> Option<String> {
     #[cfg(target_os = "windows")]
     {
         use modules::antigravity_legacy_instance::{resolve_auth_mode, AntigravityDesktopAuthMode};

--- a/src-tauri/src/commands/instance.rs
+++ b/src-tauri/src/commands/instance.rs
@@ -19,7 +19,7 @@ fn resolve_default_account_id(settings: &DefaultInstanceSettings) -> Option<Stri
     }
 }
 
-fn resolve_local_account_id() -> Option<String> {
+pub fn resolve_local_account_id() -> Option<String> {
     let db_path = modules::db::get_db_path().ok()?;
     let conn = Connection::open(&db_path).ok()?;
     let state_data: String = conn


### PR DESCRIPTION
### Problem / Motivation
Currently, when the 'Follow Local Account' setting is active, Cockpit Tools falls back to displaying the global active account in the UI. If a user switches the account inside the Antigravity IDE or Antigravity client externally, or if the two apps use different accounts, Cockpit Tools does not detect the change or reflect the correct accounts.

### Proposed Changes
When \get_current_account\ is called with no explicit bound account:
1. Dynamically read the local configuration file or Credential Manager for the corresponding target.
2. If found, load and return that local active account.
3. Fall back to the global active account only if no local active account is resolved.