### PR TITLE
fix(process): exclude Antigravity IDE shortcuts when launching legacy Antigravity

### DIFF
--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -8717,7 +8717,12 @@ fn try_launch_via_shortcut(shortcut_pattern: &str) -> Result<Option<u32>, String
                         .to_string_lossy()
                         .to_string();
                     let name_lower = name.to_lowercase();
-                    if name_lower.contains(shortcut_pattern) && name_lower.ends_with(".lnk") {
+                    let matches_pattern = if shortcut_pattern == "antigravity" {
+                        name_lower.contains("antigravity") && !name_lower.contains("antigravity ide")
+                    } else {
+                        name_lower.contains(shortcut_pattern)
+                    };
+                    if matches_pattern && name_lower.ends_with(".lnk") {
                         crate::modules::logger::log_info(&format!(
                             "[Shortcut Launch] 找到任务栏快捷方式: {}, 尝试通过快捷方式启动",
                             name


### PR DESCRIPTION
### Problem
On Windows, when switching accounts for legacy Antigravity, Cockpit Tools checks if the app is pinned to the taskbar by searching for `.lnk` shortcuts matching the keyword `"antigravity"`. Because the taskbar can contain `"Antigravity IDE.lnk"`, which matches the `"antigravity"` pattern, it incorrectly launches **Antigravity IDE** instead of the legacy **Antigravity** client.

### Solution
Exclude any shortcut names containing `"antigravity ide"` when searching for the legacy `"antigravity"` taskbar shortcut.
