### PR TITLE
Improve Codex session and API key management

### DIFF
--- a/docs/superpowers/investigations/2026-07-11-session-workspace-rebind.md
+++ b/docs/superpowers/investigations/2026-07-11-session-workspace-rebind.md
@@ -1,0 +1,38 @@
+# Codex Session Workspace Rebind Investigation
+
+## Conclusion
+
+A safe rebind cannot be implemented as a single SQLite update. Current Codex stores or derives a thread workspace in multiple layers, while the official app-server protocol already supports an explicit cwd override on resume and turn start.
+
+## Persisted state
+
+- The rollout `session_meta.payload.cwd` is the canonical cwd used when Codex rebuilds thread metadata.
+- `state_5.sqlite.threads.cwd` is the indexed cwd used for thread listing and filtering.
+- `.codex-global-state.json` contains Desktop-owned `thread-workspace-root-hints`, saved workspace roots, project order, projectless thread IDs, and per-thread writable roots.
+- Later `turn_context.cwd` values describe individual turns, but current state extraction deliberately keeps a non-empty session-meta cwd as the thread cwd.
+
+## Runtime behavior
+
+- App-server `thread/resume` accepts an optional `cwd` override.
+- App-server `turn/start` accepts an optional cwd override documented to apply to that turn and subsequent turns.
+- Cockpit cannot assume that editing Desktop global state alone changes the runtime cwd of an already running thread.
+
+## Required safety contract
+
+1. Stop every Codex process using the affected Codex home.
+2. Validate that the target path is absolute and exists.
+3. Back up the rollout, SQLite database, session index, and Desktop global state before writing.
+4. Update the canonical rollout session metadata and indexed SQLite cwd.
+5. Update the thread's Desktop workspace-root hint without rewriting unrelated saved projects or project order.
+6. Rebuild or reopen through the official app-server and verify that thread listing reports the target cwd.
+7. Resume with an explicit cwd override and verify thread settings before reporting success.
+8. Restore the complete backup if any validation fails.
+
+## Blocker
+
+The Desktop global-state schema is not part of the public Rust protocol and may change independently of Codex CLI/app-server versions. Implementation should remain blocked until Cockpit defines and tests version-aware parsing for `thread-workspace-root-hints`; otherwise a local repair could change sidebar grouping without reliably changing execution context.
+
+## Related upstream requests
+
+- openai/codex#25498: move threads between projects and expose project binding APIs.
+- openai/codex#15347: remap moved workspace paths without losing thread history.

--- a/docs/superpowers/plans/2026-07-11-session-manager-tools.md
+++ b/docs/superpowers/plans/2026-07-11-session-manager-tools.md
@@ -1,0 +1,57 @@
+# Session Manager Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users open a session rollout directly and filter normal conversations, external runs, and subagent runs with accurate token-status text.
+
+**Architecture:** Extend the existing Rust session snapshot and Tauri command surface, then wire the new fields/actions through the existing TypeScript service, store, and session-manager component. Reuse Tauri's opener plugin and existing session discovery; add no dependencies.
+
+**Tech Stack:** Rust, Tauri 2, React 19, TypeScript, i18next.
+
+---
+
+### Task 1: Open rollout file
+
+**Files:**
+- Modify: `src-tauri/src/modules/codex_session_manager.rs`
+- Modify: `src-tauri/src/commands/codex_instance.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src/services/codexInstanceService.ts`
+- Modify: `src/stores/useCodexInstanceStore.ts`
+- Modify: `src/components/codex/CodexSessionManager.tsx`
+- Modify: `src/locales/en.json`
+- Modify: `src/locales/zh-CN.json`
+
+- [ ] Add a Rust resolver that returns the unique rollout path for a session ID and errors clearly for zero or multiple matches.
+- [ ] Add and register a Tauri command that opens the resolved rollout path with the system default application.
+- [ ] Expose the command through the TypeScript service and store.
+- [ ] Add a file icon action beside copy-ID and open-location with translated tooltip text.
+- [ ] Add Rust unit coverage for unique, missing, and ambiguous rollout resolution.
+- [ ] Run targeted Rust tests and TypeScript typecheck.
+
+### Task 2: Classify and filter session types
+
+**Files:**
+- Modify: `src-tauri/src/modules/codex_session_manager.rs`
+- Modify: `src/types/codex.ts`
+- Modify: `src/components/codex/CodexSessionManager.tsx`
+- Modify: `src/locales/en.json`
+- Modify: `src/locales/zh-CN.json`
+
+- [ ] Add a serialized `session_type` value to each session record: `normal`, `external`, or `subagent`.
+- [ ] Classify parent-linked, `thread_source=subagent`, and `source.subagent` records as subagents; classify top-level non-Codex originators as external; classify remaining records as normal.
+- [ ] Add Rust unit tests for Codex Desktop, Multica, Claude Code, guardian, and explorer metadata.
+- [ ] Add a compact frontend filter defaulting to normal conversations and supporting external, subagent, and all records.
+- [ ] Preserve search, group selection, export, and trash behavior against the filtered list.
+- [ ] Display input/output when available, total-only when input/output are zero but total is positive, and no token label when statistics are unavailable.
+- [ ] Run targeted Rust tests, TypeScript typecheck, and production build.
+
+### Task 3: Workspace rebind discovery
+
+**Files:**
+- Create: `docs/superpowers/investigations/2026-07-11-session-workspace-rebind.md`
+
+- [ ] Trace every current Codex state location that stores or derives thread workspace binding.
+- [ ] Separate display-only grouping metadata from runtime cwd and Desktop saved-project mappings.
+- [ ] Document supported fields, close-process requirements, backup boundary, validation checks, and unresolved version-specific risks.
+- [ ] Stop after investigation if an atomic, reversible write contract cannot be demonstrated.

--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -839,15 +839,35 @@ pub async fn codex_import_sessions(
 }
 
 #[tauri::command]
-pub async fn codex_open_session_location(app: AppHandle, session_id: String) -> Result<(), String> {
+pub async fn codex_open_session_location(
+    app: AppHandle,
+    session_id: String,
+    instance_id: String,
+) -> Result<(), String> {
     let location_dir = tauri::async_runtime::spawn_blocking(move || {
-        modules::codex_session_manager::resolve_session_location_dir(session_id)
+        modules::codex_session_manager::resolve_session_location_dir(session_id, instance_id)
     })
     .await
     .map_err(|error| format!("打开 Codex 会话位置失败: {}", error))??;
     app.opener()
         .open_path(location_dir.to_string_lossy().to_string(), None::<String>)
         .map_err(|error| format!("打开 Codex 会话位置失败: {}", error))
+}
+
+#[tauri::command]
+pub async fn codex_open_session_rollout(
+    app: AppHandle,
+    session_id: String,
+    instance_id: String,
+) -> Result<(), String> {
+    let rollout_path = tauri::async_runtime::spawn_blocking(move || {
+        modules::codex_session_manager::resolve_session_rollout_path(session_id, instance_id)
+    })
+    .await
+    .map_err(|error| format!("打开 Codex 会话文件失败: {}", error))??;
+    app.opener()
+        .open_path(rollout_path.to_string_lossy().to_string(), None::<String>)
+        .map_err(|error| format!("打开 Codex 会话文件失败: {}", error))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1144,6 +1144,7 @@ pub fn run() {
             commands::codex_instance::codex_preview_session_import,
             commands::codex_instance::codex_import_sessions,
             commands::codex_instance::codex_open_session_location,
+            commands::codex_instance::codex_open_session_rollout,
             commands::codex_instance::codex_create_instance,
             commands::codex_instance::codex_update_instance,
             commands::codex_instance::codex_delete_instance,

--- a/src-tauri/src/modules/codex_session_manager.rs
+++ b/src-tauri/src/modules/codex_session_manager.rs
@@ -49,9 +49,18 @@ pub struct CodexSessionRecord {
     pub session_id: String,
     pub title: String,
     pub cwd: String,
+    pub session_type: CodexSessionType,
     pub updated_at: Option<i64>,
     pub location_count: usize,
     pub locations: Vec<CodexSessionLocation>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodexSessionType {
+    Normal,
+    External,
+    Subagent,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -214,6 +223,7 @@ struct ThreadSnapshot {
     id: String,
     title: String,
     cwd: String,
+    session_type: CodexSessionType,
     updated_at: Option<i64>,
     rollout_path: PathBuf,
     session_index_entry: JsonValue,
@@ -471,19 +481,19 @@ pub fn list_sessions_across_instances(
                         session_id: snapshot.id.clone(),
                         title: snapshot.title.clone(),
                         cwd: snapshot.cwd.clone(),
+                        session_type: snapshot.session_type,
                         updated_at: snapshot.updated_at,
                         location_count: 0,
                         locations: Vec::new(),
                     });
 
-            if entry.updated_at.is_none() {
-                entry.updated_at = snapshot.updated_at;
-            }
-            if entry.title.trim().is_empty() {
+            let snapshot_is_newer =
+                snapshot.updated_at.unwrap_or_default() > entry.updated_at.unwrap_or_default();
+            if snapshot_is_newer {
                 entry.title = snapshot.title.clone();
-            }
-            if entry.cwd.trim().is_empty() {
                 entry.cwd = snapshot.cwd.clone();
+                entry.session_type = snapshot.session_type;
+                entry.updated_at = snapshot.updated_at;
             }
 
             entry.locations.push(CodexSessionLocation {
@@ -1390,42 +1400,53 @@ pub fn import_sessions(
     })
 }
 
-pub fn resolve_session_location_dir(session_id: String) -> Result<PathBuf, String> {
+pub fn resolve_session_location_dir(
+    session_id: String,
+    instance_id: String,
+) -> Result<PathBuf, String> {
+    let rollout_path = resolve_session_rollout_path(session_id, instance_id)?;
+    rollout_path
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| format!("无法解析会话文件所在目录: {}", rollout_path.display()))
+}
+
+pub fn resolve_session_rollout_path(
+    session_id: String,
+    instance_id: String,
+) -> Result<PathBuf, String> {
     let session_id = session_id.trim().to_string();
     if session_id.is_empty() {
         return Err("请选择一条会话".to_string());
     }
-    let instances = collect_instances()?;
-    let mut best_snapshot: Option<ThreadSnapshot> = None;
-    for instance in &instances {
-        for snapshot in load_thread_snapshots(instance)? {
-            if snapshot.id != session_id {
-                continue;
-            }
-            let should_replace = best_snapshot
-                .as_ref()
-                .map(|current| {
-                    snapshot.updated_at.unwrap_or_default() > current.updated_at.unwrap_or_default()
-                })
-                .unwrap_or(true);
-            if should_replace {
-                best_snapshot = Some(snapshot);
-            }
-        }
+    let instance_id = instance_id.trim().to_string();
+    if instance_id.is_empty() {
+        return Err("请选择会话所在实例".to_string());
     }
-    let Some(snapshot) = best_snapshot else {
-        return Err("未找到该会话文件".to_string());
-    };
-    snapshot
-        .rollout_path
-        .parent()
-        .map(Path::to_path_buf)
-        .ok_or_else(|| {
-            format!(
-                "无法解析会话文件所在目录: {}",
-                snapshot.rollout_path.display()
-            )
-        })
+    let instances = collect_instances()?;
+    let instance = instances
+        .iter()
+        .find(|instance| instance.id == instance_id)
+        .ok_or_else(|| "未找到所选实例".to_string())?;
+    resolve_rollout_path_from_snapshots(load_thread_snapshots(instance)?, &session_id)
+}
+
+fn resolve_rollout_path_from_snapshots(
+    snapshots: Vec<ThreadSnapshot>,
+    session_id: &str,
+) -> Result<PathBuf, String> {
+    let mut matches = snapshots
+        .into_iter()
+        .filter(|snapshot| snapshot.id == session_id)
+        .map(|snapshot| snapshot.rollout_path)
+        .collect::<Vec<_>>();
+    matches.sort();
+    matches.dedup();
+    match matches.as_slice() {
+        [] => Err("未在所选实例中找到该会话文件".to_string()),
+        [path] => Ok(path.clone()),
+        _ => Err("所选实例中存在多个同 ID 会话文件，无法确定要打开哪一个".to_string()),
+    }
 }
 
 fn collect_instances() -> Result<Vec<CodexSyncInstance>, String> {
@@ -1936,6 +1957,7 @@ fn load_thread_snapshots(instance: &CodexSyncInstance) -> Result<Vec<ThreadSnaps
                 .and_then(session_index_title)
                 .unwrap_or_else(|| id.clone());
             let cwd = session_meta_cwd(&session_meta).unwrap_or_else(|| "未知工作目录".to_string());
+            let session_type = classify_session_type(&session_meta);
             let updated_at = resolve_thread_snapshot_updated_at_seconds(
                 session_index_map.get(&id),
                 &rollout_path,
@@ -1949,6 +1971,7 @@ fn load_thread_snapshots(instance: &CodexSyncInstance) -> Result<Vec<ThreadSnaps
                 id,
                 title,
                 cwd,
+                session_type,
                 updated_at,
                 rollout_path,
                 session_index_entry,
@@ -1958,6 +1981,44 @@ fn load_thread_snapshots(instance: &CodexSyncInstance) -> Result<Vec<ThreadSnaps
     }
 
     Ok(snapshots)
+}
+
+fn classify_session_type(meta: &JsonValue) -> CodexSessionType {
+    let payload = meta.get("payload").unwrap_or(meta);
+    let has_parent = payload
+        .get("parent_thread_id")
+        .and_then(JsonValue::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
+    let is_subagent = payload
+        .get("thread_source")
+        .and_then(JsonValue::as_str)
+        .is_some_and(|value| value.eq_ignore_ascii_case("subagent"))
+        || payload
+            .get("source")
+            .and_then(|source| source.get("subagent"))
+            .is_some();
+    if has_parent || is_subagent {
+        return CodexSessionType::Subagent;
+    }
+    if payload
+        .get("history_mode")
+        .and_then(JsonValue::as_str)
+        .is_some_and(|value| value.eq_ignore_ascii_case("legacy"))
+    {
+        return CodexSessionType::External;
+    }
+
+    let is_external = payload
+        .get("originator")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some_and(|value| !value.to_ascii_lowercase().starts_with("codex"));
+    if is_external {
+        CodexSessionType::External
+    } else {
+        CodexSessionType::Normal
+    }
 }
 
 fn list_rollout_files(root_dir: &Path) -> Result<Vec<PathBuf>, String> {
@@ -2941,6 +3002,97 @@ mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    #[test]
+    fn classifies_normal_external_and_subagent_sessions() {
+        assert_eq!(
+            classify_session_type(&json!({
+                "payload": { "originator": "Codex Desktop", "source": "vscode" }
+            })),
+            CodexSessionType::Normal
+        );
+        assert_eq!(
+            classify_session_type(&json!({
+                "payload": { "originator": "multica-agent-sdk", "source": "vscode" }
+            })),
+            CodexSessionType::External
+        );
+        assert_eq!(
+            classify_session_type(&json!({
+                "payload": {
+                    "originator": "Codex Desktop",
+                    "source": "vscode",
+                    "history_mode": "legacy"
+                }
+            })),
+            CodexSessionType::External
+        );
+        assert_eq!(
+            classify_session_type(&json!({
+                "payload": { "originator": "Codex Desktop", "thread_source": "subagent" }
+            })),
+            CodexSessionType::Subagent
+        );
+        assert_eq!(
+            classify_session_type(&json!({
+                "payload": {
+                    "originator": "Claude Code",
+                    "source": { "subagent": { "other": "explorer" } }
+                }
+            })),
+            CodexSessionType::Subagent
+        );
+        assert_eq!(
+            classify_session_type(&json!({
+                "payload": {
+                    "originator": "Claude Code",
+                    "parent_thread_id": "parent-1",
+                    "source": { "subagent": { "other": "guardian" } }
+                }
+            })),
+            CodexSessionType::Subagent
+        );
+    }
+
+    fn test_snapshot(session_id: &str, rollout_path: &str) -> ThreadSnapshot {
+        ThreadSnapshot {
+            id: session_id.to_string(),
+            title: String::new(),
+            cwd: String::new(),
+            session_type: CodexSessionType::Normal,
+            updated_at: None,
+            rollout_path: PathBuf::from(rollout_path),
+            session_index_entry: JsonValue::Null,
+            source_root: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn resolves_unique_rollout_path_from_selected_instance() {
+        let path = resolve_rollout_path_from_snapshots(
+            vec![test_snapshot("session-1", "sessions/rollout-1.jsonl")],
+            "session-1",
+        )
+        .expect("unique rollout should resolve");
+        assert_eq!(path, PathBuf::from("sessions/rollout-1.jsonl"));
+    }
+
+    #[test]
+    fn rejects_missing_or_ambiguous_rollout_paths() {
+        let missing = resolve_rollout_path_from_snapshots(Vec::new(), "session-1")
+            .expect_err("missing rollout should fail");
+        assert!(missing.contains("未在所选实例中找到"));
+
+        let ambiguous = resolve_rollout_path_from_snapshots(
+            vec![
+                test_snapshot("session-1", "sessions/a.jsonl"),
+                test_snapshot("session-1", "sessions/b.jsonl"),
+            ],
+            "session-1",
+        )
+        .expect_err("ambiguous rollout should fail");
+        assert!(ambiguous.contains("多个同 ID"));
+    }
+
     fn make_temp_dir(prefix: &str) -> PathBuf {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -3142,6 +3294,7 @@ mod tests {
             id: session_id.to_string(),
             title: "Deleted title".to_string(),
             cwd: "/tmp/project".to_string(),
+            session_type: CodexSessionType::Normal,
             updated_at: Some(1_780_362_123),
             rollout_path: rollout_path.clone(),
             session_index_entry: json!({

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -1309,7 +1309,6 @@ fn build_cursor_display_info(lang: &str) -> AccountDisplayInfo {
 
 #[cfg(not(target_os = "macos"))]
 
-#[derive(Debug, Clone)]
 #[cfg(not(target_os = "macos"))]
 
 #[cfg(not(target_os = "macos"))]

--- a/src/components/codex/CodexModelProviderManager.tsx
+++ b/src/components/codex/CodexModelProviderManager.tsx
@@ -14,6 +14,7 @@ import {
   ArrowDown,
   ArrowUp,
   CircleAlert,
+  Check,
   ChevronDown,
   Copy,
   Clock,
@@ -79,6 +80,7 @@ import {
   listCodexModelProviders,
   normalizeCodexModelProviderBaseUrl,
   removeApiKeyFromCodexModelProvider,
+  renameApiKeyOnCodexModelProvider,
   queryCodexModelProviderUsage,
   saveCodexModelProviderDetectedIntegrationType,
   testCodexModelProviderConnection,
@@ -581,6 +583,11 @@ export function CodexModelProviderManager({
   );
   const [formError, setFormError] = useState<string | null>(null);
   const [form, setForm] = useState<ProviderFormState>(EMPTY_FORM);
+  const [editingApiKeyName, setEditingApiKeyName] = useState<{
+    providerId: string;
+    apiKeyId: string;
+    value: string;
+  } | null>(null);
   const [currentAccount, setCurrentAccount] = useState<CodexAccount | null>(
     null,
   );
@@ -2165,6 +2172,27 @@ export function CodexModelProviderManager({
     },
     [parseServiceError, reloadProviders, t],
   );
+
+  const handleSaveApiKeyName = useCallback(async () => {
+    if (!editingApiKeyName) return;
+    try {
+      await renameApiKeyOnCodexModelProvider(
+        editingApiKeyName.providerId,
+        editingApiKeyName.apiKeyId,
+        editingApiKeyName.value,
+      );
+      setEditingApiKeyName(null);
+      await reloadProviders();
+    } catch (err) {
+      setNotice({
+        tone: "error",
+        text: t("codex.modelProviders.updateFailed", {
+          defaultValue: "更新供应商失败：{{error}}",
+          error: parseServiceError(err),
+        }),
+      });
+    }
+  }, [editingApiKeyName, parseServiceError, reloadProviders, t]);
 
   const handleBatchDeleteProviders = useCallback(async () => {
     const ids = Array.from(selectedProviderIds);
@@ -4642,15 +4670,79 @@ export function CodexModelProviderManager({
                       {currentEditingProvider.apiKeys.map((item) => (
                         <div className="codex-provider-key-row" key={item.id}>
                           <div className="codex-provider-key-text">
-                            <span className="codex-provider-key-name">
-                              {item.name ||
-                                t(
-                                  "codex.modelProviders.unnamedKey",
-                                  "未命名 Key",
-                                )}
-                            </span>
+                            {editingApiKeyName?.providerId ===
+                              currentEditingProvider.id &&
+                            editingApiKeyName.apiKeyId === item.id ? (
+                              <input
+                                className="form-input"
+                                value={editingApiKeyName.value}
+                                onChange={(event) =>
+                                  setEditingApiKeyName((current) =>
+                                    current
+                                      ? { ...current, value: event.target.value }
+                                      : current,
+                                  )
+                                }
+                                onKeyDown={(event) => {
+                                  if (event.key === "Enter") {
+                                    event.preventDefault();
+                                    void handleSaveApiKeyName();
+                                  }
+                                  if (event.key === "Escape") {
+                                    setEditingApiKeyName(null);
+                                  }
+                                }}
+                                autoFocus
+                                disabled={saving}
+                              />
+                            ) : (
+                              <span className="codex-provider-key-name">
+                                {item.name ||
+                                  t(
+                                    "codex.modelProviders.unnamedKey",
+                                    "未命名 Key",
+                                  )}
+                              </span>
+                            )}
                             <code>{maskApiKey(item.apiKey)}</code>
                           </div>
+                          {editingApiKeyName?.providerId ===
+                            currentEditingProvider.id &&
+                          editingApiKeyName.apiKeyId === item.id ? (
+                            <>
+                              <button
+                                className="action-btn"
+                                onClick={() => void handleSaveApiKeyName()}
+                                disabled={saving}
+                                title={t("common.save", "保存")}
+                              >
+                                <Check size={12} />
+                              </button>
+                              <button
+                                className="action-btn"
+                                onClick={() => setEditingApiKeyName(null)}
+                                disabled={saving}
+                                title={t("common.cancel", "取消")}
+                              >
+                                <X size={12} />
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              className="action-btn"
+                              onClick={() =>
+                                setEditingApiKeyName({
+                                  providerId: currentEditingProvider.id,
+                                  apiKeyId: item.id,
+                                  value: item.name,
+                                })
+                              }
+                              disabled={saving}
+                              title={t("common.edit", "编辑")}
+                            >
+                              <Pencil size={12} />
+                            </button>
+                          )}
                           <button
                             className="action-btn danger"
                             onClick={() =>

--- a/src/components/codex/CodexSessionManager.tsx
+++ b/src/components/codex/CodexSessionManager.tsx
@@ -2,7 +2,7 @@ import { type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } fr
 import { useTranslation } from 'react-i18next';
 import { confirm as confirmDialog, open as openFileDialog, save as saveFileDialog } from '@tauri-apps/plugin-dialog';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { Check, ChevronDown, ChevronRight, Copy, Download, Eye, Folder, FolderOpen, Minimize2, RefreshCw, RotateCcw, Search, Trash2, Upload, X } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, Copy, Download, Eye, FileText, Folder, FolderOpen, Minimize2, RefreshCw, RotateCcw, Search, Trash2, Upload, X } from 'lucide-react';
 import { ModalErrorMessage, useModalErrorState } from '../ModalErrorMessage';
 import { SingleSelectDropdown, type SingleSelectOption } from '../SingleSelectDropdown';
 import { useEscClose } from '../../hooks/useEscClose';
@@ -32,6 +32,13 @@ type SessionGroup = {
 
 type InstanceSortField = 'createdAt' | 'lastLaunchedAt';
 type InstanceSortDirection = 'asc' | 'desc';
+type SessionTypeFilter = 'normal' | 'external' | 'subagent' | 'all';
+type SessionOpenAction = 'rollout' | 'location';
+
+interface SessionOpenTarget {
+  session: CodexSessionRecord;
+  action: SessionOpenAction;
+}
 type SessionTransferStatus = 'running' | 'success' | 'error';
 type ExportSelectionFilter = 'all' | 'selected' | 'unselected';
 
@@ -146,8 +153,11 @@ function formatLargeNumber(value: number): string {
   return value.toLocaleString();
 }
 
-function formatTokenStats(stats?: CodexSessionTokenStats): string {
+function formatTokenStats(stats: CodexSessionTokenStats | undefined, totalLabel: string): string {
   if (stats) {
+    if (stats.inputTokens === 0 && stats.outputTokens === 0 && stats.totalTokens > 0) {
+      return totalLabel;
+    }
     return `${formatLargeNumber(stats.inputTokens)} / ${formatLargeNumber(stats.outputTokens)} tokens`;
   }
 
@@ -240,6 +250,7 @@ export function CodexSessionManager() {
   const previewSessionImport = useCodexInstanceStore((state) => state.previewSessionImport);
   const importSessions = useCodexInstanceStore((state) => state.importSessions);
   const openSessionLocation = useCodexInstanceStore((state) => state.openSessionLocation);
+  const openSessionRollout = useCodexInstanceStore((state) => state.openSessionRollout);
   const [sessions, setSessions] = useState<CodexSessionRecord[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [expandedGroups, setExpandedGroups] = useState<string[]>([]);
@@ -281,6 +292,9 @@ export function CodexSessionManager() {
   const [loadedTokenGroupCwds, setLoadedTokenGroupCwds] = useState<string[]>([]);
   const [titleSearchInput, setTitleSearchInput] = useState('');
   const [appliedTitleSearch, setAppliedTitleSearch] = useState('');
+  const [sessionTypeFilter, setSessionTypeFilter] = useState<SessionTypeFilter>('normal');
+  const [sessionOpenTarget, setSessionOpenTarget] = useState<SessionOpenTarget | null>(null);
+  const [sessionOpenInstanceId, setSessionOpenInstanceId] = useState('');
   const {
     message: restoreModalError,
     scrollKey: restoreModalErrorScrollKey,
@@ -308,10 +322,14 @@ export function CodexSessionManager() {
   const transferTaskIdRef = useRef<string | null>(null);
   const isZh = i18n.resolvedLanguage?.toLowerCase().startsWith('zh') ?? true;
 
-  const groupedSessions = useMemo(() => buildGroups(sessions), [sessions]);
+  const visibleSessions = useMemo(
+    () => sessions.filter((session) => sessionTypeFilter === 'all' || session.sessionType === sessionTypeFilter),
+    [sessionTypeFilter, sessions],
+  );
+  const groupedSessions = useMemo(() => buildGroups(visibleSessions), [visibleSessions]);
   const allSessionIds = useMemo(
-    () => Array.from(new Set(sessions.map((session) => session.sessionId))),
-    [sessions],
+    () => Array.from(new Set(visibleSessions.map((session) => session.sessionId))),
+    [visibleSessions],
   );
   const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
   const selectedTrashIdSet = useMemo(() => new Set(selectedTrashIds), [selectedTrashIds]);
@@ -360,6 +378,15 @@ export function CodexSessionManager() {
           : instance.name || t('instances.defaultName', '默认实例'),
       })),
     [orderedInstances, t],
+  );
+  const sessionTypeOptions = useMemo<SingleSelectOption[]>(
+    () => [
+      { value: 'normal', label: t('codex.sessionManager.types.normal', '普通对话') },
+      { value: 'external', label: t('codex.sessionManager.types.external', '外部运行') },
+      { value: 'subagent', label: t('codex.sessionManager.types.subagent', '子代理') },
+      { value: 'all', label: t('codex.sessionManager.types.all', '全部类型') },
+    ],
+    [t],
   );
   const importReadyItems = useMemo(
     () => importPreview?.items.filter((item) => item.status === 'ready') ?? [],
@@ -1250,6 +1277,13 @@ export function CodexSessionManager() {
 
   useEscClose(showImportModal, handleCloseImportModal);
 
+  const handleCloseSessionOpenModal = () => {
+    setSessionOpenTarget(null);
+    setSessionOpenInstanceId('');
+  };
+
+  useEscClose(Boolean(sessionOpenTarget), handleCloseSessionOpenModal);
+
   const handleChangeImportTarget = async (targetInstanceId: string) => {
     setImportTargetInstanceId(targetInstanceId);
     setImportModalError(null);
@@ -1357,15 +1391,43 @@ export function CodexSessionManager() {
     }
   };
 
-  const handleOpenSessionLocation = async (
+  const openSessionTarget = async (target: SessionOpenTarget, instanceId: string) => {
+    if (target.action === 'rollout') {
+      await openSessionRollout(target.session.sessionId, instanceId);
+    } else {
+      await openSessionLocation(target.session.sessionId, instanceId);
+    }
+  };
+
+  const handleOpenSession = async (
     event: MouseEvent<HTMLButtonElement>,
-    sessionId: string,
+    session: CodexSessionRecord,
+    action: SessionOpenAction,
   ) => {
     event.preventDefault();
     event.stopPropagation();
     setMessage(null);
+    const target = { session, action };
+    if (session.locations.length > 1) {
+      setSessionOpenTarget(target);
+      setSessionOpenInstanceId(session.locations[0]?.instanceId ?? '');
+      return;
+    }
     try {
-      await openSessionLocation(sessionId);
+      const instanceId = session.locations[0]?.instanceId;
+      if (!instanceId) throw new Error(t('codex.sessionManager.messages.missingLocation', '未找到会话所在实例'));
+      await openSessionTarget(target, instanceId);
+    } catch (error) {
+      setMessage({ text: String(error), tone: 'error' });
+    }
+  };
+
+  const handleConfirmSessionOpen = async () => {
+    if (!sessionOpenTarget || !sessionOpenInstanceId) return;
+    setMessage(null);
+    try {
+      await openSessionTarget(sessionOpenTarget, sessionOpenInstanceId);
+      handleCloseSessionOpenModal();
     } catch (error) {
       setMessage({ text: String(error), tone: 'error' });
     }
@@ -1423,6 +1485,17 @@ export function CodexSessionManager() {
               />
             </div>
           </label>
+          <SingleSelectDropdown
+            className="codex-session-manager__type-filter"
+            value={sessionTypeFilter}
+            options={sessionTypeOptions}
+            onChange={(value) => {
+              setSessionTypeFilter(value as SessionTypeFilter);
+              setSelectedIds([]);
+            }}
+            disabled={loading}
+            ariaLabel={t('codex.sessionManager.types.label', '会话类型')}
+          />
           <button
             className="btn btn-secondary codex-session-manager__search-button"
             type="button"
@@ -1642,7 +1715,14 @@ export function CodexSessionManager() {
                   <div className="codex-session-folder__children">
                     {group.sessions.map((session) => {
                       const hasRunningLocation = session.locations.some((location) => location.running);
-                      const tokenText = formatTokenStats(tokenStatsBySessionId[session.sessionId]);
+                      const tokenStats = tokenStatsBySessionId[session.sessionId];
+                      const tokenText = formatTokenStats(
+                        tokenStats,
+                        t('codex.sessionManager.labels.totalTokens', {
+                          defaultValue: '{{count}} total',
+                          count: formatLargeNumber(tokenStats?.totalTokens ?? 0),
+                        }),
+                      );
                       return (
                         <div className="codex-session-row" key={session.sessionId}>
                           <label className="codex-session-row__left">
@@ -1680,7 +1760,16 @@ export function CodexSessionManager() {
                             <button
                               className="codex-session-row__copy-button"
                               type="button"
-                              onClick={(event) => void handleOpenSessionLocation(event, session.sessionId)}
+                              onClick={(event) => void handleOpenSession(event, session, 'rollout')}
+                              title={t('codex.sessionManager.actions.openRollout', '打开会话文件')}
+                              aria-label={t('codex.sessionManager.actions.openRollout', '打开会话文件')}
+                            >
+                              <FileText size={14} />
+                            </button>
+                            <button
+                              className="codex-session-row__copy-button"
+                              type="button"
+                              onClick={(event) => void handleOpenSession(event, session, 'location')}
                               title={t('codex.sessionManager.actions.openLocation', '打开位置')}
                               aria-label={t('codex.sessionManager.actions.openLocation', '打开位置')}
                             >
@@ -1708,6 +1797,42 @@ export function CodexSessionManager() {
               </section>
             );
           })}
+        </div>
+      ) : null}
+
+      {sessionOpenTarget ? (
+        <div className="modal-overlay" onClick={handleCloseSessionOpenModal}>
+          <div className="modal codex-session-open-modal" onClick={(event) => event.stopPropagation()}>
+            <div className="modal-header">
+              <h2>{t('codex.sessionManager.openModal.title', '选择会话实例')}</h2>
+              <button className="modal-close" type="button" onClick={handleCloseSessionOpenModal} aria-label={t('common.close', '关闭')}>
+                <X size={18} />
+              </button>
+            </div>
+            <div className="modal-body">
+              <p className="codex-session-target-modal__hint">
+                {t('codex.sessionManager.openModal.hint', '这个会话存在于多个实例中，请选择要打开的副本。')}
+              </p>
+              <SingleSelectDropdown
+                className="codex-session-target-modal__select"
+                value={sessionOpenInstanceId}
+                options={sessionOpenTarget.session.locations.map((location) => ({
+                  value: location.instanceId,
+                  label: location.instanceName,
+                }))}
+                onChange={setSessionOpenInstanceId}
+                ariaLabel={t('codex.sessionManager.openModal.instance', '会话实例')}
+              />
+            </div>
+            <div className="modal-footer">
+              <button className="btn btn-secondary" type="button" onClick={handleCloseSessionOpenModal}>
+                {t('common.cancel', '取消')}
+              </button>
+              <button className="btn btn-primary" type="button" onClick={() => void handleConfirmSessionOpen()} disabled={!sessionOpenInstanceId}>
+                {t('common.open', '打开')}
+              </button>
+            </div>
+          </div>
         </div>
       ) : null}
 

--- a/src/components/codex/CodexSessionManager.tsx
+++ b/src/components/codex/CodexSessionManager.tsx
@@ -1718,10 +1718,13 @@ export function CodexSessionManager() {
                       const tokenStats = tokenStatsBySessionId[session.sessionId];
                       const tokenText = formatTokenStats(
                         tokenStats,
-                        t('codex.sessionManager.labels.totalTokens', {
-                          defaultValue: '{{count}} total',
-                          count: formatLargeNumber(tokenStats?.totalTokens ?? 0),
-                        }),
+                        t(
+                          'codex.sessionManager.labels.totalTokens',
+                          '{{value}} total',
+                          {
+                            value: formatLargeNumber(tokenStats?.totalTokens ?? 0),
+                          },
+                        ),
                       );
                       return (
                         <div className="codex-session-row" key={session.sessionId}>

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -2438,7 +2438,8 @@
         "selectAllSessions": "تحديد كل الجلسات",
         "clearSelectedSessions": "إلغاء تحديد الكل",
         "copyToInstance": "نسخ إلى المثيل",
-        "trash": "المهملات"
+        "trash": "المهملات",
+        "openRollout": "فتح ملف الجلسة"
       },
       "confirm": {
         "title": "نقل إلى المهملات",
@@ -2465,13 +2466,15 @@
         "syncNeedTwo": "يلزم وجود مثيلين على الأقل لمزامنة الجلسات",
         "pickRestoreOne": "يرجى تحديد جلسة واحدة على الأقل لاستعادتها",
         "repairVisibilitySkippedOnly": "لم يتم العثور على اختلافات provider قابلة للكتابة؛ تم تخطي {{count}} ملف state_5.sqlite غير صالح أو تالف. يجب أن يعيد Codex إنشاءها قبل إصلاح سجلات SQLite فيها.",
-        "repairVisibilitySkippedWithBase": "{{message}}؛ تم تخطي {{count}} ملف state_5.sqlite غير صالح أو تالف. يجب أن يعيد Codex إنشاءها قبل إصلاح سجلات SQLite فيها."
+        "repairVisibilitySkippedWithBase": "{{message}}؛ تم تخطي {{count}} ملف state_5.sqlite غير صالح أو تالف. يجب أن يعيد Codex إنشاءها قبل إصلاح سجلات SQLite فيها.",
+        "missingLocation": "تعذر العثور على مثيل الجلسة"
       },
       "groupCount": "{{count}} جلسة",
       "updatedAt": "تم التحديث",
       "labels": {
         "sessionId": "معرّف الجلسة",
-        "tokenUsage": "استخدام الرموز"
+        "tokenUsage": "استخدام الرموز",
+        "totalTokens": "الإجمالي {{count}}"
       },
       "locationRunning": " (قيد التشغيل)",
       "untitled": "جلسة بدون عنوان",
@@ -2640,6 +2643,18 @@
         "removeItem": "إزالة",
         "emptyFilteredTitle": "لا توجد جلسات مطابقة",
         "emptyFilteredDesc": "عدّل البحث أو المصدر أو حالة التحديد ثم حاول مرة أخرى."
+      },
+      "types": {
+        "label": "نوع الجلسة",
+        "normal": "المحادثات",
+        "external": "عمليات تشغيل خارجية",
+        "subagent": "الوكلاء الفرعيون",
+        "all": "كل الأنواع"
+      },
+      "openModal": {
+        "title": "اختيار مثيل الجلسة",
+        "hint": "هذه الجلسة موجودة في عدة مثيلات. اختر النسخة التي تريد فتحها.",
+        "instance": "مثيل الجلسة"
       }
     },
     "api": {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -2474,7 +2474,7 @@
       "labels": {
         "sessionId": "معرّف الجلسة",
         "tokenUsage": "استخدام الرموز",
-        "totalTokens": "الإجمالي {{count}}"
+        "totalTokens": "الإجمالي {{value}}"
       },
       "locationRunning": " (قيد التشغيل)",
       "untitled": "جلسة بدون عنوان",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "ID relace",
         "tokenUsage": "Využití tokenů",
-        "totalTokens": "Celkem {{count}}"
+        "totalTokens": "Celkem {{value}}"
       },
       "locationRunning": " (spuštěno)",
       "untitled": "Nepojmenovaná relace",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Vybrat všechny relace",
         "clearSelectedSessions": "Zrušit výběr",
         "copyToInstance": "Kopírovat do instance",
-        "trash": "Koš"
+        "trash": "Koš",
+        "openRollout": "Otevřít soubor relace"
       },
       "confirm": {
         "title": "Přesunout do koše",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Pro synchronizaci relací jsou potřeba alespoň dvě instance",
         "pickRestoreOne": "Vyberte prosím alespoň jednu relaci k obnovení",
         "repairVisibilitySkippedOnly": "Nebyly nalezeny žádné zapisovatelné rozdíly provideru; přeskočeno {{count}} neplatných nebo poškozených souborů state_5.sqlite. Codex je musí znovu vygenerovat, než bude možné opravit jejich záznamy SQLite.",
-        "repairVisibilitySkippedWithBase": "{{message}}; přeskočeno {{count}} neplatných nebo poškozených souborů state_5.sqlite. Codex je musí znovu vygenerovat, než bude možné opravit jejich záznamy SQLite."
+        "repairVisibilitySkippedWithBase": "{{message}}; přeskočeno {{count}} neplatných nebo poškozených souborů state_5.sqlite. Codex je musí znovu vygenerovat, než bude možné opravit jejich záznamy SQLite.",
+        "missingLocation": "Instanci relace se nepodařilo najít"
       },
       "groupCount": "{{count}} relací",
       "updatedAt": "Aktualizováno",
       "labels": {
         "sessionId": "ID relace",
-        "tokenUsage": "Využití tokenů"
+        "tokenUsage": "Využití tokenů",
+        "totalTokens": "Celkem {{count}}"
       },
       "locationRunning": " (spuštěno)",
       "untitled": "Nepojmenovaná relace",
@@ -2593,6 +2596,18 @@
         "removeItem": "Odebrat",
         "emptyFilteredTitle": "Žádné odpovídající relace",
         "emptyFilteredDesc": "Upravte hledání, zdroj nebo stav výběru a zkuste to znovu."
+      },
+      "types": {
+        "label": "Typ relace",
+        "normal": "Konverzace",
+        "external": "Externí běhy",
+        "subagent": "Podřízení agenti",
+        "all": "Všechny typy"
+      },
+      "openModal": {
+        "title": "Vybrat instanci relace",
+        "hint": "Tato relace existuje ve více instancích. Vyberte kopii, kterou chcete otevřít.",
+        "instance": "Instance relace"
       }
     },
     "api": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "Sitzungs-ID",
         "tokenUsage": "Token-Nutzung",
-        "totalTokens": "{{count}} insgesamt"
+        "totalTokens": "{{value}} insgesamt"
       },
       "locationRunning": " (wird ausgeführt)",
       "untitled": "Unbenannte Sitzung",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Alle Sitzungen wählen",
         "clearSelectedSessions": "Auswahl aufheben",
         "copyToInstance": "In Instanz kopieren",
-        "trash": "Papierkorb"
+        "trash": "Papierkorb",
+        "openRollout": "Sitzungsdatei öffnen"
       },
       "confirm": {
         "title": "In den Papierkorb verschieben",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Mindestens zwei Instanzen sind erforderlich, um Sitzungen zu synchronisieren",
         "pickRestoreOne": "Bitte wählen Sie mindestens eine Sitzung zur Wiederherstellung aus",
         "repairVisibilitySkippedOnly": "Es wurden keine schreibbaren Provider-Unterschiede gefunden; {{count}} ungültige oder beschädigte state_5.sqlite-Datei(en) wurden übersprungen. Codex muss sie neu erstellen, bevor ihre SQLite-Einträge repariert werden können.",
-        "repairVisibilitySkippedWithBase": "{{message}}; {{count}} ungültige oder beschädigte state_5.sqlite-Datei(en) wurden übersprungen. Codex muss sie neu erstellen, bevor ihre SQLite-Einträge repariert werden können."
+        "repairVisibilitySkippedWithBase": "{{message}}; {{count}} ungültige oder beschädigte state_5.sqlite-Datei(en) wurden übersprungen. Codex muss sie neu erstellen, bevor ihre SQLite-Einträge repariert werden können.",
+        "missingLocation": "Die Sitzungsinstanz wurde nicht gefunden"
       },
       "groupCount": "{{count}} Sitzungen",
       "updatedAt": "Aktualisiert",
       "labels": {
         "sessionId": "Sitzungs-ID",
-        "tokenUsage": "Token-Nutzung"
+        "tokenUsage": "Token-Nutzung",
+        "totalTokens": "{{count}} insgesamt"
       },
       "locationRunning": " (wird ausgeführt)",
       "untitled": "Unbenannte Sitzung",
@@ -2593,6 +2596,18 @@
         "removeItem": "Entfernen",
         "emptyFilteredTitle": "Keine passenden Sitzungen",
         "emptyFilteredDesc": "Suche, Quelle oder Auswahlstatus anpassen und erneut versuchen."
+      },
+      "types": {
+        "label": "Sitzungstyp",
+        "normal": "Unterhaltungen",
+        "external": "Externe Ausführungen",
+        "subagent": "Unteragenten",
+        "all": "Alle Typen"
+      },
+      "openModal": {
+        "title": "Sitzungsinstanz auswählen",
+        "hint": "Diese Sitzung ist in mehreren Instanzen vorhanden. Wählen Sie die zu öffnende Kopie.",
+        "instance": "Sitzungsinstanz"
       }
     },
     "api": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -3145,7 +3145,7 @@
       "labels": {
         "sessionId": "Session ID",
         "tokenUsage": "Token Usage",
-        "totalTokens": "{{count}} total"
+        "totalTokens": "{{value}} total"
       },
       "locationRunning": " (running)",
       "untitled": "Untitled session",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -3109,7 +3109,8 @@
         "clearSelectedSessions": "Deselect All",
         "expand": "Expand",
         "collapse": "Collapse",
-        "trash": "Trash"
+        "trash": "Trash",
+        "openRollout": "Open Session File"
       },
       "confirm": {
         "title": "Move to Trash",
@@ -3136,13 +3137,15 @@
         "pickRestoreOne": "Please select at least one session to restore",
         "syncNeedTwo": "At least two instances are required to sync sessions",
         "repairVisibilitySkippedOnly": "No writable session index differences were found; skipped {{count}} invalid or corrupted SQLite session database(s). Codex must regenerate them before their records can be repaired.",
-        "repairVisibilitySkippedWithBase": "{{message}}; skipped {{count}} invalid or corrupted SQLite session database(s). Codex must regenerate them before their records can be repaired."
+        "repairVisibilitySkippedWithBase": "{{message}}; skipped {{count}} invalid or corrupted SQLite session database(s). Codex must regenerate them before their records can be repaired.",
+        "missingLocation": "The session instance could not be found"
       },
       "groupCount": "{{count}} sessions",
       "updatedAt": "Updated",
       "labels": {
         "sessionId": "Session ID",
-        "tokenUsage": "Token Usage"
+        "tokenUsage": "Token Usage",
+        "totalTokens": "{{count}} total"
       },
       "locationRunning": " (running)",
       "untitled": "Untitled session",
@@ -3311,6 +3314,18 @@
         "removeItem": "Remove",
         "emptyFilteredTitle": "No sessions match",
         "emptyFilteredDesc": "Adjust search, source, or selection state and try again."
+      },
+      "types": {
+        "label": "Session type",
+        "normal": "Conversations",
+        "external": "External runs",
+        "subagent": "Subagents",
+        "all": "All types"
+      },
+      "openModal": {
+        "title": "Select Session Instance",
+        "hint": "This session exists in multiple instances. Choose which copy to open.",
+        "instance": "Session instance"
       }
     },
     "groups": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3105,6 +3105,7 @@
         "importSessions": "Import Sessions",
         "copySessionId": "Copy Session ID",
         "openLocation": "Open Location",
+        "openRollout": "Open Session File",
         "selectAllSessions": "Select All Sessions",
         "clearSelectedSessions": "Deselect All",
         "expand": "Expand",
@@ -3123,6 +3124,13 @@
         "searchTitle": "No matching sessions found",
         "searchDesc": "Adjust the title keywords and try again."
       },
+      "types": {
+        "label": "Session type",
+        "normal": "Conversations",
+        "external": "External runs",
+        "subagent": "Subagents",
+        "all": "All types"
+      },
       "search": {
         "titleLabel": "Title",
         "contentLabel": "Conversation",
@@ -3136,13 +3144,15 @@
         "pickRestoreOne": "Please select at least one session to restore",
         "syncNeedTwo": "At least two instances are required to sync sessions",
         "repairVisibilitySkippedOnly": "No writable session index differences were found; skipped {{count}} invalid or corrupted SQLite session database(s). Codex must regenerate them before their records can be repaired.",
-        "repairVisibilitySkippedWithBase": "{{message}}; skipped {{count}} invalid or corrupted SQLite session database(s). Codex must regenerate them before their records can be repaired."
+        "repairVisibilitySkippedWithBase": "{{message}}; skipped {{count}} invalid or corrupted SQLite session database(s). Codex must regenerate them before their records can be repaired.",
+        "missingLocation": "The session instance could not be found"
       },
       "groupCount": "{{count}} sessions",
       "updatedAt": "Updated",
       "labels": {
         "sessionId": "Session ID",
-        "tokenUsage": "Token Usage"
+        "tokenUsage": "Token Usage",
+        "totalTokens": "{{count}} total"
       },
       "locationRunning": " (running)",
       "untitled": "Untitled session",
@@ -3311,6 +3321,11 @@
         "removeItem": "Remove",
         "emptyFilteredTitle": "No sessions match",
         "emptyFilteredDesc": "Adjust search, source, or selection state and try again."
+      },
+      "openModal": {
+        "title": "Select Session Instance",
+        "hint": "This session exists in multiple instances. Choose which copy to open.",
+        "instance": "Session instance"
       }
     },
     "groups": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3152,7 +3152,7 @@
       "labels": {
         "sessionId": "Session ID",
         "tokenUsage": "Token Usage",
-        "totalTokens": "{{count}} total"
+        "totalTokens": "{{value}} total"
       },
       "locationRunning": " (running)",
       "untitled": "Untitled session",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Seleccionar sesiones",
         "clearSelectedSessions": "Deseleccionar",
         "copyToInstance": "Copiar a instancia",
-        "trash": "Papelera"
+        "trash": "Papelera",
+        "openRollout": "Abrir archivo de sesión"
       },
       "confirm": {
         "title": "Mover a la papelera",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Se requieren al menos dos instancias para sincronizar sesiones",
         "pickRestoreOne": "Selecciona al menos una sesión para restaurar",
         "repairVisibilitySkippedOnly": "No se encontraron diferencias de proveedor que se puedan escribir; se omitieron {{count}} archivo(s) state_5.sqlite no válidos o dañados. Codex debe regenerarlos antes de poder reparar sus registros SQLite.",
-        "repairVisibilitySkippedWithBase": "{{message}}; se omitieron {{count}} archivo(s) state_5.sqlite no válidos o dañados. Codex debe regenerarlos antes de poder reparar sus registros SQLite."
+        "repairVisibilitySkippedWithBase": "{{message}}; se omitieron {{count}} archivo(s) state_5.sqlite no válidos o dañados. Codex debe regenerarlos antes de poder reparar sus registros SQLite.",
+        "missingLocation": "No se encontró la instancia de la sesión"
       },
       "groupCount": "{{count}} sesiones",
       "updatedAt": "Actualizado",
       "labels": {
         "sessionId": "ID de sesión",
-        "tokenUsage": "Uso de tokens"
+        "tokenUsage": "Uso de tokens",
+        "totalTokens": "{{count}} en total"
       },
       "locationRunning": " (en ejecución)",
       "untitled": "Sesión sin título",
@@ -2593,6 +2596,18 @@
         "removeItem": "Retirar",
         "emptyFilteredTitle": "Sin sesiones coincidentes",
         "emptyFilteredDesc": "Ajusta búsqueda, origen o selección e inténtalo de nuevo."
+      },
+      "types": {
+        "label": "Tipo de sesión",
+        "normal": "Conversaciones",
+        "external": "Ejecuciones externas",
+        "subagent": "Subagentes",
+        "all": "Todos los tipos"
+      },
+      "openModal": {
+        "title": "Seleccionar instancia de sesión",
+        "hint": "Esta sesión existe en varias instancias. Elige la copia que quieres abrir.",
+        "instance": "Instancia de sesión"
       }
     },
     "api": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "ID de sesión",
         "tokenUsage": "Uso de tokens",
-        "totalTokens": "{{count}} en total"
+        "totalTokens": "{{value}} en total"
       },
       "locationRunning": " (en ejecución)",
       "untitled": "Sesión sin título",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "ID de session",
         "tokenUsage": "Utilisation des tokens",
-        "totalTokens": "{{count}} au total"
+        "totalTokens": "{{value}} au total"
       },
       "locationRunning": " (en cours d’exécution)",
       "untitled": "Session sans titre",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Tout sélectionner",
         "clearSelectedSessions": "Désélectionner",
         "copyToInstance": "Copier vers instance",
-        "trash": "Corbeille"
+        "trash": "Corbeille",
+        "openRollout": "Ouvrir le fichier de session"
       },
       "confirm": {
         "title": "Déplacer vers la corbeille",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Au moins deux instances sont nécessaires pour synchroniser les sessions",
         "pickRestoreOne": "Veuillez sélectionner au moins une session à restaurer",
         "repairVisibilitySkippedOnly": "Aucune différence de fournisseur inscriptible n’a été trouvée ; {{count}} fichier(s) state_5.sqlite invalides ou corrompus ont été ignorés. Codex doit les régénérer avant que leurs enregistrements SQLite puissent être réparés.",
-        "repairVisibilitySkippedWithBase": "{{message}} ; {{count}} fichier(s) state_5.sqlite invalides ou corrompus ont été ignorés. Codex doit les régénérer avant que leurs enregistrements SQLite puissent être réparés."
+        "repairVisibilitySkippedWithBase": "{{message}} ; {{count}} fichier(s) state_5.sqlite invalides ou corrompus ont été ignorés. Codex doit les régénérer avant que leurs enregistrements SQLite puissent être réparés.",
+        "missingLocation": "L’instance de session est introuvable"
       },
       "groupCount": "{{count}} sessions​",
       "updatedAt": "Mis à jour",
       "labels": {
         "sessionId": "ID de session",
-        "tokenUsage": "Utilisation des tokens"
+        "tokenUsage": "Utilisation des tokens",
+        "totalTokens": "{{count}} au total"
       },
       "locationRunning": " (en cours d’exécution)",
       "untitled": "Session sans titre",
@@ -2593,6 +2596,18 @@
         "removeItem": "Retirer",
         "emptyFilteredTitle": "Aucune session trouvée",
         "emptyFilteredDesc": "Ajustez la recherche, la source ou la sélection puis réessayez."
+      },
+      "types": {
+        "label": "Type de session",
+        "normal": "Conversations",
+        "external": "Exécutions externes",
+        "subagent": "Sous-agents",
+        "all": "Tous les types"
+      },
+      "openModal": {
+        "title": "Sélectionner une instance de session",
+        "hint": "Cette session existe dans plusieurs instances. Choisissez la copie à ouvrir.",
+        "instance": "Instance de session"
       }
     },
     "api": {

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -2591,7 +2591,7 @@
       "labels": {
         "sessionId": "ID sesi",
         "tokenUsage": "Penggunaan token",
-        "totalTokens": "Total {{count}}"
+        "totalTokens": "Total {{value}}"
       },
       "locationRunning": " (berjalan)",
       "untitled": "Sesi tanpa judul",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -2555,7 +2555,8 @@
         "selectAllSessions": "Pilih semua sesi",
         "clearSelectedSessions": "Batal pilih",
         "copyToInstance": "Salin ke instans",
-        "trash": "Sampah"
+        "trash": "Sampah",
+        "openRollout": "Buka file sesi"
       },
       "confirm": {
         "title": "Pindahkan ke Sampah",
@@ -2582,13 +2583,15 @@
         "syncNeedTwo": "Setidaknya dua instansi diperlukan untuk menyinkronkan sesi",
         "pickRestoreOne": "Pilih setidaknya satu sesi untuk dipulihkan",
         "repairVisibilitySkippedOnly": "Tidak ditemukan perbedaan provider yang dapat ditulis; {{count}} file state_5.sqlite yang tidak valid atau rusak dilewati. Codex harus membuatnya ulang sebelum catatan SQLite di dalamnya dapat diperbaiki.",
-        "repairVisibilitySkippedWithBase": "{{message}}; {{count}} file state_5.sqlite yang tidak valid atau rusak dilewati. Codex harus membuatnya ulang sebelum catatan SQLite di dalamnya dapat diperbaiki."
+        "repairVisibilitySkippedWithBase": "{{message}}; {{count}} file state_5.sqlite yang tidak valid atau rusak dilewati. Codex harus membuatnya ulang sebelum catatan SQLite di dalamnya dapat diperbaiki.",
+        "missingLocation": "Instans sesi tidak ditemukan"
       },
       "groupCount": "{{count}} sesi",
       "updatedAt": "Diperbarui",
       "labels": {
         "sessionId": "ID sesi",
-        "tokenUsage": "Penggunaan token"
+        "tokenUsage": "Penggunaan token",
+        "totalTokens": "Total {{count}}"
       },
       "locationRunning": " (berjalan)",
       "untitled": "Sesi tanpa judul",
@@ -2757,6 +2760,18 @@
         "removeItem": "Keluarkan",
         "emptyFilteredTitle": "Tidak ada sesi cocok",
         "emptyFilteredDesc": "Ubah pencarian, sumber, atau status pilihan lalu coba lagi."
+      },
+      "types": {
+        "label": "Jenis sesi",
+        "normal": "Percakapan",
+        "external": "Proses eksternal",
+        "subagent": "Subagen",
+        "all": "Semua jenis"
+      },
+      "openModal": {
+        "title": "Pilih instans sesi",
+        "hint": "Sesi ini ada di beberapa instans. Pilih salinan yang akan dibuka.",
+        "instance": "Instans sesi"
       }
     },
     "modelProviders": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Seleziona sessioni",
         "clearSelectedSessions": "Deseleziona",
         "copyToInstance": "Copia in istanza",
-        "trash": "Cestino"
+        "trash": "Cestino",
+        "openRollout": "Apri file sessione"
       },
       "confirm": {
         "title": "Sposta nel cestino",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Sono necessarie almeno due istanze per sincronizzare le sessioni",
         "pickRestoreOne": "Seleziona almeno una sessione da ripristinare",
         "repairVisibilitySkippedOnly": "Non sono state trovate differenze provider scrivibili; sono stati ignorati {{count}} file state_5.sqlite non validi o danneggiati. Codex deve rigenerarli prima di poter riparare i relativi record SQLite.",
-        "repairVisibilitySkippedWithBase": "{{message}}; sono stati ignorati {{count}} file state_5.sqlite non validi o danneggiati. Codex deve rigenerarli prima di poter riparare i relativi record SQLite."
+        "repairVisibilitySkippedWithBase": "{{message}}; sono stati ignorati {{count}} file state_5.sqlite non validi o danneggiati. Codex deve rigenerarli prima di poter riparare i relativi record SQLite.",
+        "missingLocation": "Impossibile trovare l’istanza della sessione"
       },
       "groupCount": "{{count}} sessioni",
       "updatedAt": "Aggiornato",
       "labels": {
         "sessionId": "ID sessione",
-        "tokenUsage": "Utilizzo token"
+        "tokenUsage": "Utilizzo token",
+        "totalTokens": "{{count}} in totale"
       },
       "locationRunning": " (in esecuzione)",
       "untitled": "Sessione senza titolo",
@@ -2593,6 +2596,18 @@
         "removeItem": "Rimuovi",
         "emptyFilteredTitle": "Nessuna sessione trovata",
         "emptyFilteredDesc": "Modifica ricerca, origine o stato di selezione e riprova."
+      },
+      "types": {
+        "label": "Tipo di sessione",
+        "normal": "Conversazioni",
+        "external": "Esecuzioni esterne",
+        "subagent": "Sottoagenti",
+        "all": "Tutti i tipi"
+      },
+      "openModal": {
+        "title": "Seleziona istanza sessione",
+        "hint": "Questa sessione esiste in più istanze. Scegli la copia da aprire.",
+        "instance": "Istanza sessione"
       }
     },
     "api": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "ID sessione",
         "tokenUsage": "Utilizzo token",
-        "totalTokens": "{{count}} in totale"
+        "totalTokens": "{{value}} in totale"
       },
       "locationRunning": " (in esecuzione)",
       "untitled": "Sessione senza titolo",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "全セッションを選択",
         "clearSelectedSessions": "選択解除",
         "copyToInstance": "インスタンスへコピー",
-        "trash": "ゴミ箱"
+        "trash": "ゴミ箱",
+        "openRollout": "セッションファイルを開く"
       },
       "confirm": {
         "title": "ゴミ箱へ移動",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "セッションを同期するには少なくとも2つのインスタンスが必要です",
         "pickRestoreOne": "復元するセッションを 1 つ以上選択してください",
         "repairVisibilitySkippedOnly": "書き込み可能な provider 差分は見つかりませんでした。無効または破損した state_5.sqlite ファイル {{count}} 件をスキップしました。SQLite レコードを修復するには、先に Codex がそれらを再生成する必要があります。",
-        "repairVisibilitySkippedWithBase": "{{message}}。無効または破損した state_5.sqlite ファイル {{count}} 件をスキップしました。SQLite レコードを修復するには、先に Codex がそれらを再生成する必要があります。"
+        "repairVisibilitySkippedWithBase": "{{message}}。無効または破損した state_5.sqlite ファイル {{count}} 件をスキップしました。SQLite レコードを修復するには、先に Codex がそれらを再生成する必要があります。",
+        "missingLocation": "セッションのインスタンスが見つかりません"
       },
       "groupCount": "{{count}} 件のセッション",
       "updatedAt": "更新済み",
       "labels": {
         "sessionId": "セッション ID",
-        "tokenUsage": "Token 使用量"
+        "tokenUsage": "Token 使用量",
+        "totalTokens": "合計 {{count}}"
       },
       "locationRunning": "（実行中）",
       "untitled": "無題のセッション",
@@ -2593,6 +2596,18 @@
         "removeItem": "外す",
         "emptyFilteredTitle": "一致する会話がありません",
         "emptyFilteredDesc": "検索、ソース、選択状態を調整してください。"
+      },
+      "types": {
+        "label": "セッション種別",
+        "normal": "会話",
+        "external": "外部実行",
+        "subagent": "サブエージェント",
+        "all": "すべての種別"
+      },
+      "openModal": {
+        "title": "セッションのインスタンスを選択",
+        "hint": "このセッションは複数のインスタンスにあります。開くコピーを選択してください。",
+        "instance": "セッションのインスタンス"
       }
     },
     "api": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "セッション ID",
         "tokenUsage": "Token 使用量",
-        "totalTokens": "合計 {{count}}"
+        "totalTokens": "合計 {{value}}"
       },
       "locationRunning": "（実行中）",
       "untitled": "無題のセッション",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "모든 세션 선택",
         "clearSelectedSessions": "선택 해제",
         "copyToInstance": "인스턴스에 복사",
-        "trash": "휴지통"
+        "trash": "휴지통",
+        "openRollout": "세션 파일 열기"
       },
       "confirm": {
         "title": "휴지통으로 이동",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "세션을 동기화하려면 인스턴스가 두 개 이상 필요합니다",
         "pickRestoreOne": "복원할 세션을 하나 이상 선택하세요",
         "repairVisibilitySkippedOnly": "쓸 수 있는 provider 차이가 발견되지 않았습니다. 유효하지 않거나 손상된 state_5.sqlite 파일 {{count}}개를 건너뛰었습니다. 해당 SQLite 레코드를 복구하려면 먼저 Codex가 이 파일들을 다시 생성해야 합니다.",
-        "repairVisibilitySkippedWithBase": "{{message}}; 유효하지 않거나 손상된 state_5.sqlite 파일 {{count}}개를 건너뛰었습니다. 해당 SQLite 레코드를 복구하려면 먼저 Codex가 이 파일들을 다시 생성해야 합니다."
+        "repairVisibilitySkippedWithBase": "{{message}}; 유효하지 않거나 손상된 state_5.sqlite 파일 {{count}}개를 건너뛰었습니다. 해당 SQLite 레코드를 복구하려면 먼저 Codex가 이 파일들을 다시 생성해야 합니다.",
+        "missingLocation": "세션 인스턴스를 찾을 수 없습니다"
       },
       "groupCount": "{{count}}개 세션",
       "updatedAt": "업데이트됨",
       "labels": {
         "sessionId": "세션 ID",
-        "tokenUsage": "토큰 사용량"
+        "tokenUsage": "토큰 사용량",
+        "totalTokens": "총 {{count}}"
       },
       "locationRunning": " (실행 중)",
       "untitled": "제목 없는 세션",
@@ -2593,6 +2596,18 @@
         "removeItem": "제외",
         "emptyFilteredTitle": "일치하는 세션 없음",
         "emptyFilteredDesc": "검색어, 출처 또는 선택 상태를 조정하세요."
+      },
+      "types": {
+        "label": "세션 유형",
+        "normal": "대화",
+        "external": "외부 실행",
+        "subagent": "하위 에이전트",
+        "all": "모든 유형"
+      },
+      "openModal": {
+        "title": "세션 인스턴스 선택",
+        "hint": "이 세션은 여러 인스턴스에 있습니다. 열 복사본을 선택하세요.",
+        "instance": "세션 인스턴스"
       }
     },
     "api": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "세션 ID",
         "tokenUsage": "토큰 사용량",
-        "totalTokens": "총 {{count}}"
+        "totalTokens": "총 {{value}}"
       },
       "locationRunning": " (실행 중)",
       "untitled": "제목 없는 세션",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Zaznacz sesje",
         "clearSelectedSessions": "Odznacz wszystko",
         "copyToInstance": "Kopiuj do instancji",
-        "trash": "Kosz"
+        "trash": "Kosz",
+        "openRollout": "Otwórz plik sesji"
       },
       "confirm": {
         "title": "Przenieś do kosza",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Do synchronizacji sesji wymagane są co najmniej dwie instancje",
         "pickRestoreOne": "Wybierz co najmniej jedną sesję do przywrócenia",
         "repairVisibilitySkippedOnly": "Nie znaleziono zapisywalnych różnic provider; pominięto {{count}} nieprawidłowych lub uszkodzonych plików state_5.sqlite. Codex musi je ponownie wygenerować, zanim będzie można naprawić ich rekordy SQLite.",
-        "repairVisibilitySkippedWithBase": "{{message}}; pominięto {{count}} nieprawidłowych lub uszkodzonych plików state_5.sqlite. Codex musi je ponownie wygenerować, zanim będzie można naprawić ich rekordy SQLite."
+        "repairVisibilitySkippedWithBase": "{{message}}; pominięto {{count}} nieprawidłowych lub uszkodzonych plików state_5.sqlite. Codex musi je ponownie wygenerować, zanim będzie można naprawić ich rekordy SQLite.",
+        "missingLocation": "Nie znaleziono instancji sesji"
       },
       "groupCount": "{{count}} sesji",
       "updatedAt": "Zaktualizowano",
       "labels": {
         "sessionId": "ID sesji",
-        "tokenUsage": "Zużycie tokenów"
+        "tokenUsage": "Zużycie tokenów",
+        "totalTokens": "Łącznie {{count}}"
       },
       "locationRunning": " (uruchomiona)",
       "untitled": "Sesja bez tytułu",
@@ -2593,6 +2596,18 @@
         "removeItem": "Usuń",
         "emptyFilteredTitle": "Brak pasujących sesji",
         "emptyFilteredDesc": "Zmień wyszukiwanie, źródło lub stan wyboru i spróbuj ponownie."
+      },
+      "types": {
+        "label": "Typ sesji",
+        "normal": "Rozmowy",
+        "external": "Uruchomienia zewnętrzne",
+        "subagent": "Podagenci",
+        "all": "Wszystkie typy"
+      },
+      "openModal": {
+        "title": "Wybierz instancję sesji",
+        "hint": "Ta sesja istnieje w wielu instancjach. Wybierz kopię do otwarcia.",
+        "instance": "Instancja sesji"
       }
     },
     "api": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "ID sesji",
         "tokenUsage": "Zużycie tokenów",
-        "totalTokens": "Łącznie {{count}}"
+        "totalTokens": "Łącznie {{value}}"
       },
       "locationRunning": " (uruchomiona)",
       "untitled": "Sesja bez tytułu",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "ID da sessão",
         "tokenUsage": "Uso de tokens",
-        "totalTokens": "{{count}} no total"
+        "totalTokens": "{{value}} no total"
       },
       "locationRunning": " (em execução)",
       "untitled": "Sessão sem título",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Selecionar sessões",
         "clearSelectedSessions": "Desmarcar tudo",
         "copyToInstance": "Copiar para instância",
-        "trash": "Lixeira"
+        "trash": "Lixeira",
+        "openRollout": "Abrir arquivo da sessão"
       },
       "confirm": {
         "title": "Mover para a lixeira",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Pelo menos duas instâncias são necessárias para sincronizar sessões",
         "pickRestoreOne": "Selecione pelo menos uma sessão para restaurar",
         "repairVisibilitySkippedOnly": "Nenhuma diferença de provider gravável foi encontrada; {{count}} arquivo(s) state_5.sqlite inválidos ou corrompidos foram ignorados. O Codex precisa recriá-los antes que seus registros SQLite possam ser reparados.",
-        "repairVisibilitySkippedWithBase": "{{message}}; {{count}} arquivo(s) state_5.sqlite inválidos ou corrompidos foram ignorados. O Codex precisa recriá-los antes que seus registros SQLite possam ser reparados."
+        "repairVisibilitySkippedWithBase": "{{message}}; {{count}} arquivo(s) state_5.sqlite inválidos ou corrompidos foram ignorados. O Codex precisa recriá-los antes que seus registros SQLite possam ser reparados.",
+        "missingLocation": "A instância da sessão não foi encontrada"
       },
       "groupCount": "{{count}} sessões",
       "updatedAt": "Atualizado",
       "labels": {
         "sessionId": "ID da sessão",
-        "tokenUsage": "Uso de tokens"
+        "tokenUsage": "Uso de tokens",
+        "totalTokens": "{{count}} no total"
       },
       "locationRunning": " (em execução)",
       "untitled": "Sessão sem título",
@@ -2593,6 +2596,18 @@
         "removeItem": "Remover",
         "emptyFilteredTitle": "Nenhuma sessão encontrada",
         "emptyFilteredDesc": "Ajuste busca, origem ou estado de seleção e tente novamente."
+      },
+      "types": {
+        "label": "Tipo de sessão",
+        "normal": "Conversas",
+        "external": "Execuções externas",
+        "subagent": "Subagentes",
+        "all": "Todos os tipos"
+      },
+      "openModal": {
+        "title": "Selecionar instância da sessão",
+        "hint": "Esta sessão existe em várias instâncias. Escolha a cópia que deseja abrir.",
+        "instance": "Instância da sessão"
       }
     },
     "api": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Выбрать все сессии",
         "clearSelectedSessions": "Снять выбор",
         "copyToInstance": "Копировать в экземпляр",
-        "trash": "Корзина"
+        "trash": "Корзина",
+        "openRollout": "Открыть файл сеанса"
       },
       "confirm": {
         "title": "Переместить в корзину",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Для синхронизации сессий требуется как минимум два экземпляра",
         "pickRestoreOne": "Выберите хотя бы одну сессию для восстановления",
         "repairVisibilitySkippedOnly": "Записываемые различия provider не найдены; пропущено {{count}} недействительных или поврежденных файлов state_5.sqlite. Codex должен создать их заново, прежде чем можно будет исправить их записи SQLite.",
-        "repairVisibilitySkippedWithBase": "{{message}}; пропущено {{count}} недействительных или поврежденных файлов state_5.sqlite. Codex должен создать их заново, прежде чем можно будет исправить их записи SQLite."
+        "repairVisibilitySkippedWithBase": "{{message}}; пропущено {{count}} недействительных или поврежденных файлов state_5.sqlite. Codex должен создать их заново, прежде чем можно будет исправить их записи SQLite.",
+        "missingLocation": "Экземпляр сеанса не найден"
       },
       "groupCount": "{{count}} сессий",
       "updatedAt": "Обновлено",
       "labels": {
         "sessionId": "ID сессии",
-        "tokenUsage": "Использование токенов"
+        "tokenUsage": "Использование токенов",
+        "totalTokens": "Всего {{count}}"
       },
       "locationRunning": " (запущено)",
       "untitled": "Сессия без названия",
@@ -2593,6 +2596,18 @@
         "removeItem": "Убрать",
         "emptyFilteredTitle": "Подходящих сеансов нет",
         "emptyFilteredDesc": "Измените поиск, источник или состояние выбора."
+      },
+      "types": {
+        "label": "Тип сеанса",
+        "normal": "Диалоги",
+        "external": "Внешние запуски",
+        "subagent": "Субагенты",
+        "all": "Все типы"
+      },
+      "openModal": {
+        "title": "Выбрать экземпляр сеанса",
+        "hint": "Этот сеанс существует в нескольких экземплярах. Выберите копию для открытия.",
+        "instance": "Экземпляр сеанса"
       }
     },
     "api": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "ID сессии",
         "tokenUsage": "Использование токенов",
-        "totalTokens": "Всего {{count}}"
+        "totalTokens": "Всего {{value}}"
       },
       "locationRunning": " (запущено)",
       "untitled": "Сессия без названия",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "Oturum kimliği",
         "tokenUsage": "Token kullanımı",
-        "totalTokens": "Toplam {{count}}"
+        "totalTokens": "Toplam {{value}}"
       },
       "locationRunning": " (çalışıyor)",
       "untitled": "Adsız oturum",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Tüm oturumları seç",
         "clearSelectedSessions": "Seçimi kaldır",
         "copyToInstance": "Örneğe kopyala",
-        "trash": "Çöp kutusu"
+        "trash": "Çöp kutusu",
+        "openRollout": "Oturum dosyasını aç"
       },
       "confirm": {
         "title": "Çöp kutusuna taşı",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Oturumları eşitlemek için en az iki örnek gerekir",
         "pickRestoreOne": "Lütfen geri yüklenecek en az bir oturum seçin",
         "repairVisibilitySkippedOnly": "Yazılabilir provider farkı bulunamadı; geçersiz veya bozuk {{count}} state_5.sqlite dosyası atlandı. Bu SQLite kayıtları onarılmadan önce Codex bu dosyaları yeniden oluşturmalıdır.",
-        "repairVisibilitySkippedWithBase": "{{message}}; geçersiz veya bozuk {{count}} state_5.sqlite dosyası atlandı. Bu SQLite kayıtları onarılmadan önce Codex bu dosyaları yeniden oluşturmalıdır."
+        "repairVisibilitySkippedWithBase": "{{message}}; geçersiz veya bozuk {{count}} state_5.sqlite dosyası atlandı. Bu SQLite kayıtları onarılmadan önce Codex bu dosyaları yeniden oluşturmalıdır.",
+        "missingLocation": "Oturum örneği bulunamadı"
       },
       "groupCount": "{{count}} oturum",
       "updatedAt": "Güncellendi",
       "labels": {
         "sessionId": "Oturum kimliği",
-        "tokenUsage": "Token kullanımı"
+        "tokenUsage": "Token kullanımı",
+        "totalTokens": "Toplam {{count}}"
       },
       "locationRunning": " (çalışıyor)",
       "untitled": "Adsız oturum",
@@ -2593,6 +2596,18 @@
         "removeItem": "Çıkar",
         "emptyFilteredTitle": "Eşleşen oturum yok",
         "emptyFilteredDesc": "Arama, kaynak veya seçim durumunu değiştirip tekrar deneyin."
+      },
+      "types": {
+        "label": "Oturum türü",
+        "normal": "Konuşmalar",
+        "external": "Harici çalıştırmalar",
+        "subagent": "Alt aracılar",
+        "all": "Tüm türler"
+      },
+      "openModal": {
+        "title": "Oturum örneğini seç",
+        "hint": "Bu oturum birden fazla örnekte bulunuyor. Açılacak kopyayı seçin.",
+        "instance": "Oturum örneği"
       }
     },
     "api": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -2427,7 +2427,7 @@
       "labels": {
         "sessionId": "ID phiên",
         "tokenUsage": "Mức dùng token",
-        "totalTokens": "Tổng cộng {{count}}"
+        "totalTokens": "Tổng cộng {{value}}"
       },
       "locationRunning": " (đang chạy)",
       "untitled": "Phiên chưa đặt tên",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -2391,7 +2391,8 @@
         "selectAllSessions": "Chọn mọi phiên",
         "clearSelectedSessions": "Bỏ chọn",
         "copyToInstance": "Sao chép sang phiên bản",
-        "trash": "Thùng rác"
+        "trash": "Thùng rác",
+        "openRollout": "Mở tệp phiên"
       },
       "confirm": {
         "title": "Chuyển vào thùng rác",
@@ -2418,13 +2419,15 @@
         "syncNeedTwo": "Cần ít nhất hai phiên bản để đồng bộ phiên",
         "pickRestoreOne": "Hãy chọn ít nhất một phiên để khôi phục",
         "repairVisibilitySkippedOnly": "Không tìm thấy khác biệt provider có thể ghi; đã bỏ qua {{count}} tệp state_5.sqlite không hợp lệ hoặc bị hỏng. Codex phải tạo lại chúng trước khi có thể sửa các bản ghi SQLite bên trong.",
-        "repairVisibilitySkippedWithBase": "{{message}}; đã bỏ qua {{count}} tệp state_5.sqlite không hợp lệ hoặc bị hỏng. Codex phải tạo lại chúng trước khi có thể sửa các bản ghi SQLite bên trong."
+        "repairVisibilitySkippedWithBase": "{{message}}; đã bỏ qua {{count}} tệp state_5.sqlite không hợp lệ hoặc bị hỏng. Codex phải tạo lại chúng trước khi có thể sửa các bản ghi SQLite bên trong.",
+        "missingLocation": "Không tìm thấy phiên bản chứa phiên này"
       },
       "groupCount": "{{count}} phiên",
       "updatedAt": "Đã cập nhật",
       "labels": {
         "sessionId": "ID phiên",
-        "tokenUsage": "Mức dùng token"
+        "tokenUsage": "Mức dùng token",
+        "totalTokens": "Tổng cộng {{count}}"
       },
       "locationRunning": " (đang chạy)",
       "untitled": "Phiên chưa đặt tên",
@@ -2593,6 +2596,18 @@
         "removeItem": "Bỏ",
         "emptyFilteredTitle": "Không có phiên phù hợp",
         "emptyFilteredDesc": "Điều chỉnh tìm kiếm, nguồn hoặc trạng thái chọn rồi thử lại."
+      },
+      "types": {
+        "label": "Loại phiên",
+        "normal": "Cuộc trò chuyện",
+        "external": "Lần chạy bên ngoài",
+        "subagent": "Tác nhân phụ",
+        "all": "Tất cả loại"
+      },
+      "openModal": {
+        "title": "Chọn phiên bản của phiên",
+        "hint": "Phiên này tồn tại trong nhiều phiên bản. Hãy chọn bản sao cần mở.",
+        "instance": "Phiên bản của phiên"
       }
     },
     "api": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -3105,6 +3105,7 @@
         "importSessions": "导入会话",
         "copySessionId": "复制会话 ID",
         "openLocation": "打开位置",
+        "openRollout": "打开会话文件",
         "selectAllSessions": "全选全部会话",
         "clearSelectedSessions": "取消全选",
         "expand": "展开",
@@ -3123,6 +3124,13 @@
         "searchTitle": "未找到匹配会话",
         "searchDesc": "请调整标题关键词后再试。"
       },
+      "types": {
+        "label": "会话类型",
+        "normal": "普通对话",
+        "external": "外部运行",
+        "subagent": "子代理",
+        "all": "全部类型"
+      },
       "search": {
         "titleLabel": "标题",
         "contentLabel": "对话内容",
@@ -3136,13 +3144,15 @@
         "pickRestoreOne": "请至少选择一条待恢复会话",
         "syncNeedTwo": "至少需要两个实例才能同步会话",
         "repairVisibilitySkippedOnly": "未发现需要写入的会话索引差异；已跳过 {{count}} 个无效或损坏的 SQLite 会话库，需由 Codex 重新生成后才能修复其中的记录",
-        "repairVisibilitySkippedWithBase": "{{message}}；已跳过 {{count}} 个无效或损坏的 SQLite 会话库，需由 Codex 重新生成后才能修复其中的记录"
+        "repairVisibilitySkippedWithBase": "{{message}}；已跳过 {{count}} 个无效或损坏的 SQLite 会话库，需由 Codex 重新生成后才能修复其中的记录",
+        "missingLocation": "未找到会话所在实例"
       },
       "groupCount": "{{count}} 条会话",
       "updatedAt": "最近更新",
       "labels": {
         "sessionId": "会话 ID",
-        "tokenUsage": "Token使用"
+        "tokenUsage": "Token使用",
+        "totalTokens": "共 {{count}}"
       },
       "locationRunning": "（运行中）",
       "untitled": "未命名会话",
@@ -3311,6 +3321,11 @@
         "removeItem": "移出",
         "emptyFilteredTitle": "当前筛选无会话",
         "emptyFilteredDesc": "调整搜索、来源或选择状态后再试。"
+      },
+      "openModal": {
+        "title": "选择会话实例",
+        "hint": "这个会话存在于多个实例中，请选择要打开的副本。",
+        "instance": "会话实例"
       }
     },
     "groups": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -3152,7 +3152,7 @@
       "labels": {
         "sessionId": "会话 ID",
         "tokenUsage": "Token使用",
-        "totalTokens": "共 {{count}}"
+        "totalTokens": "共 {{value}}"
       },
       "locationRunning": "（运行中）",
       "untitled": "未命名会话",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -2544,7 +2544,7 @@
       "labels": {
         "sessionId": "會話 ID",
         "tokenUsage": "Token 使用",
-        "totalTokens": "共 {{count}}"
+        "totalTokens": "共 {{value}}"
       },
       "locationRunning": "（執行中）",
       "untitled": "未命名會話",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -2508,7 +2508,8 @@
         "selectAllSessions": "全選全部會話",
         "clearSelectedSessions": "取消全選",
         "copyToInstance": "複製到實例",
-        "trash": "垃圾桶"
+        "trash": "垃圾桶",
+        "openRollout": "開啟工作階段檔案"
       },
       "confirm": {
         "title": "移到垃圾桶",
@@ -2535,13 +2536,15 @@
         "syncNeedTwo": "至少需要兩個實例才能同步會話",
         "pickRestoreOne": "請至少選擇一個要還原的工作階段",
         "repairVisibilitySkippedOnly": "未發現需要寫入的 provider 差異；已略過 {{count}} 個無效或損毀的 state_5.sqlite，需由 Codex 重新產生後才能修復其中的 SQLite 記錄。",
-        "repairVisibilitySkippedWithBase": "{{message}}；已略過 {{count}} 個無效或損毀的 state_5.sqlite，需由 Codex 重新產生後才能修復其中的 SQLite 記錄。"
+        "repairVisibilitySkippedWithBase": "{{message}}；已略過 {{count}} 個無效或損毀的 state_5.sqlite，需由 Codex 重新產生後才能修復其中的 SQLite 記錄。",
+        "missingLocation": "找不到工作階段所在的執行個體"
       },
       "groupCount": "{{count}} 條會話",
       "updatedAt": "最近更新",
       "labels": {
         "sessionId": "會話 ID",
-        "tokenUsage": "Token 使用"
+        "tokenUsage": "Token 使用",
+        "totalTokens": "共 {{count}}"
       },
       "locationRunning": "（執行中）",
       "untitled": "未命名會話",
@@ -2710,6 +2713,18 @@
         "removeItem": "移出",
         "emptyFilteredTitle": "目前篩選無會話",
         "emptyFilteredDesc": "調整搜尋、來源或選取狀態後再試。"
+      },
+      "types": {
+        "label": "工作階段類型",
+        "normal": "一般對話",
+        "external": "外部執行",
+        "subagent": "子代理",
+        "all": "全部類型"
+      },
+      "openModal": {
+        "title": "選擇工作階段執行個體",
+        "hint": "這個工作階段存在於多個執行個體中，請選擇要開啟的副本。",
+        "instance": "工作階段執行個體"
       }
     },
     "modelProviders": {

--- a/src/services/codexInstanceService.ts
+++ b/src/services/codexInstanceService.ts
@@ -299,8 +299,13 @@ export async function importSessions(
   });
 }
 
-export async function openSessionLocation(sessionId: string): Promise<void> {
+export async function openSessionLocation(sessionId: string, instanceId: string): Promise<void> {
   return await invoke("codex_open_session_location", {
     sessionId,
+    instanceId,
   });
+}
+
+export async function openSessionRollout(sessionId: string, instanceId: string): Promise<void> {
+  return await invoke("codex_open_session_rollout", { sessionId, instanceId });
 }

--- a/src/services/codexModelProviderService.ts
+++ b/src/services/codexModelProviderService.ts
@@ -433,9 +433,6 @@ function ensureApiKeyOnProvider(
   const now = Date.now();
   const existing = provider.apiKeys.find((item) => sanitizeApiKey(item.apiKey) === normalized);
   if (existing) {
-    if (apiKeyName && sanitizeName(apiKeyName)) {
-      existing.name = sanitizeName(apiKeyName);
-    }
     existing.updatedAt = now;
     return;
   }
@@ -660,6 +657,25 @@ export async function removeApiKeyFromCodexModelProvider(
   }
   provider.apiKeys = nextApiKeys;
   provider.updatedAt = Date.now();
+  await writeProviders(providers);
+  return { ...provider, apiKeys: provider.apiKeys.map((item) => ({ ...item })) };
+}
+
+export async function renameApiKeyOnCodexModelProvider(
+  providerId: string,
+  apiKeyId: string,
+  name: string,
+): Promise<CodexModelProvider> {
+  const providers = await ensureProvidersLoaded();
+  const provider = providers.find((item) => item.id === providerId);
+  if (!provider) throw new Error('PROVIDER_NOT_FOUND');
+  const apiKey = provider.apiKeys.find((item) => item.id === apiKeyId);
+  if (!apiKey) throw new Error('API_KEY_NOT_FOUND');
+
+  const now = Date.now();
+  apiKey.name = sanitizeName(name);
+  apiKey.updatedAt = now;
+  provider.updatedAt = now;
   await writeProviders(providers);
   return { ...provider, apiKeys: provider.apiKeys.map((item) => ({ ...item })) };
 }

--- a/src/stores/useCodexInstanceStore.ts
+++ b/src/stores/useCodexInstanceStore.ts
@@ -57,7 +57,8 @@ type CodexInstanceStoreState = InstanceStoreState & {
     sessionIds: string[],
     transferId?: string | null,
   ) => Promise<CodexSessionImportSummary>;
-  openSessionLocation: (sessionId: string) => Promise<void>;
+  openSessionLocation: (sessionId: string, instanceId: string) => Promise<void>;
+  openSessionRollout: (sessionId: string, instanceId: string) => Promise<void>;
 };
 
 type CodexInstanceStoreHook = {
@@ -181,8 +182,12 @@ const importSessions = async (
   return summary;
 };
 
-const openSessionLocation = async (sessionId: string): Promise<void> => {
-  await codexInstanceService.openSessionLocation(sessionId);
+const openSessionLocation = async (sessionId: string, instanceId: string): Promise<void> => {
+  await codexInstanceService.openSessionLocation(sessionId, instanceId);
+};
+
+const openSessionRollout = async (sessionId: string, instanceId: string): Promise<void> => {
+  await codexInstanceService.openSessionRollout(sessionId, instanceId);
 };
 
 typedBaseStore.setState({
@@ -203,6 +208,7 @@ typedBaseStore.setState({
   previewSessionImport,
   importSessions,
   openSessionLocation,
+  openSessionRollout,
 });
 
 export const useCodexInstanceStore = typedBaseStore;

--- a/src/styles/pages/codex.css
+++ b/src/styles/pages/codex.css
@@ -11193,6 +11193,16 @@
   border-radius: 10px;
 }
 
+.codex-session-manager__type-filter {
+  width: 168px;
+  min-width: 150px;
+}
+
+.codex-session-manager__type-filter .single-select-dropdown-trigger {
+  min-height: 36px;
+  height: 36px;
+}
+
 .codex-session-manager__actions {
   display: flex;
   justify-content: flex-end;
@@ -11366,6 +11376,10 @@
     width: 100%;
   }
 
+  .codex-session-manager__type-filter {
+    width: 100%;
+  }
+
   .codex-session-manager__search-button {
     width: 100%;
   }
@@ -11514,7 +11528,9 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-shrink: 0;
+  flex-shrink: 1;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .codex-session-row__title {
@@ -11572,6 +11588,30 @@
   margin-right: 8px;
   white-space: nowrap;
   opacity: 0.85;
+}
+
+.codex-session-open-modal {
+  width: min(440px, calc(100vw - 32px));
+}
+
+@media (max-width: 640px) {
+  .codex-session-row {
+    flex-wrap: wrap;
+  }
+
+  .codex-session-row__left,
+  .codex-session-row__right {
+    width: 100%;
+  }
+
+  .codex-session-row__right {
+    padding-left: 34px;
+    justify-content: flex-start;
+  }
+
+  .codex-session-row__tokens {
+    margin-left: auto;
+  }
 }
 
 .codex-session-restore-modal {

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -323,6 +323,7 @@ export interface CodexSessionRecord {
   sessionId: string;
   title: string;
   cwd: string;
+  sessionType: 'normal' | 'external' | 'subagent';
   updatedAt?: number | null;
   locationCount: number;
   locations: CodexSessionLocation[];


### PR DESCRIPTION
## What changed

- classify Codex sessions as conversations, external imports, or subagent runs
- show conversations by default and provide a compact type filter
- open rollout JSONL files with the operating system's default application
- require an explicit instance choice when the same session exists in multiple instances
- preserve total-only token usage instead of displaying it as zero input/output
- improve narrow-screen action layout and add translations for all supported locales
- preserve saved API key names when reusing a key from the account overview
- add an explicit inline rename action for existing provider API keys
- remove a stray `derive` attribute from the current base so Windows Rust tests compile

## Why

The session manager currently mixes user conversations with imported runs and background subagents. It also makes inspecting an unfamiliar record cumbersome, and a duplicated session ID can resolve to the wrong instance when opening its file.

The provider flow also reused the provider name as the API key name when adding an account from an existing saved key, overwriting the key's user-defined label.

The new session classification uses existing rollout metadata. Claude history converted by Codex is identified through `history_mode: legacy`; parent/thread-source metadata takes precedence for subagents.

## Safety

Opening a rollout is location-specific. The backend no longer chooses the newest matching file across instances, and rejects missing or ambiguous paths.

Workspace rebinding is intentionally not implemented. The investigation notes why updating only rollout metadata would leave SQLite, Desktop state, and runtime cwd inconsistent.

Reusing an existing provider key no longer mutates its name. Renaming is performed only through the explicit rename action.

## Validation

- `npm run typecheck`
- `node scripts/check_locales.cjs`
- `npx vite build`
- `cargo test --lib codex_session_manager` (14 passed)
- `git diff --check`
