### PR TITLE
feat(codex-api): add per-client-key account pools and usage stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test:codex-api-key-scope": "node --test src/utils/codexApiKeyAccountScope.test.ts",
     "typecheck": "tsc --noEmit",
     "prebuild": "npm run typecheck",
     "build": "npm run sync-version && tsc && vite build",

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/auth/selector.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/auth/selector.go
@@ -478,9 +478,9 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 //  7. conversation_id field in request body
 //  8. Stable hash from first few messages content (fallback)
 //
-// Note: The cache key includes provider, session ID, and model to handle cases where
-// a session uses multiple models (e.g., gemini-2.5-pro and gemini-3-flash-preview)
-// that may be supported by different auth credentials, and to avoid cross-provider conflicts.
+// Note: The cache key includes provider, an optional caller namespace, session ID, and
+// model to handle cases where a session uses multiple models (e.g., gemini-2.5-pro and
+// gemini-3-flash-preview), and to avoid cross-provider or cross-caller conflicts.
 func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	entry := selectorLogEntry(ctx)
 	primaryID, fallbackID := extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
@@ -495,7 +495,8 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		return nil, err
 	}
 
-	cacheKey := provider + "::" + primaryID + "::" + model
+	namespace := sessionAffinityNamespace(opts.Metadata)
+	cacheKey := sessionAffinityCacheKey(provider, namespace, primaryID, model)
 
 	if cachedAuthID, ok := s.cache.GetAndRefresh(cacheKey); ok {
 		for _, auth := range available {
@@ -515,7 +516,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	}
 
 	if fallbackID != "" && fallbackID != primaryID {
-		fallbackKey := provider + "::" + fallbackID + "::" + model
+		fallbackKey := sessionAffinityCacheKey(provider, namespace, fallbackID, model)
 		if cachedAuthID, ok := s.cache.Get(fallbackKey); ok {
 			for _, auth := range available {
 				if auth.ID == cachedAuthID {
@@ -534,6 +535,21 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	s.cache.Set(cacheKey, auth.ID)
 	entry.Infof("session-affinity: cache miss, new binding | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 	return auth, nil
+}
+
+func sessionAffinityNamespace(metadata map[string]any) string {
+	if metadata == nil {
+		return ""
+	}
+	value, _ := metadata[cliproxyexecutor.SessionAffinityNamespaceMetadataKey].(string)
+	return strings.TrimSpace(value)
+}
+
+func sessionAffinityCacheKey(provider, namespace, sessionID, model string) string {
+	if namespace == "" {
+		return provider + "::" + sessionID + "::" + model
+	}
+	return provider + "::" + namespace + "::" + sessionID + "::" + model
 }
 
 func selectorLogEntry(ctx context.Context) *log.Entry {

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/executor/types.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/executor/types.go
@@ -23,6 +23,10 @@ const ReasoningEffortMetadataKey = "reasoning_effort"
 // ServiceTierMetadataKey stores the client-requested service tier for usage logs.
 const ServiceTierMetadataKey = "service_tier"
 
+// SessionAffinityNamespaceMetadataKey separates session-affinity cache entries
+// for callers that share the same downstream session identifier.
+const SessionAffinityNamespaceMetadataKey = "session_affinity_namespace"
+
 const (
 	// PinnedAuthMetadataKey locks execution to a specific auth ID.
 	PinnedAuthMetadataKey = "pinned_auth_id"

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -102,6 +102,7 @@ type apiKeySpec struct {
 	Label           string               `json:"label"`
 	Key             string               `json:"key"`
 	ProviderGateway *providerGatewaySpec `json:"providerGateway,omitempty"`
+	AccountIDs      []string             `json:"accountIds"`
 	ModelPrefix     string               `json:"modelPrefix,omitempty"`
 	AllowedModels   []string             `json:"allowedModels"`
 	ExcludedModels  []string             `json:"excludedModels"`
@@ -1592,6 +1593,7 @@ func (s *quotaReserveSelector) Stop() {
 func (s *cockpitSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
 	_ = provider
 	_ = opts
+	auths = s.filterAuthsForAPIKeyScope(ctx, auths)
 	now := time.Now()
 	available := make([]*coreauth.Auth, 0, len(auths))
 	quotaReserveReasons := make([]string, 0)
@@ -1621,6 +1623,38 @@ func (s *cockpitSelector) Pick(ctx context.Context, provider, model string, opts
 	selected := ordered[0]
 	s.emitAuthSelected(ctx, selected, provider, model, len(auths), len(available))
 	return selected, nil
+}
+
+func (s *cockpitSelector) filterAuthsForAPIKeyScope(ctx context.Context, auths []*coreauth.Auth) []*coreauth.Auth {
+	if s == nil || s.manifest == nil || ctx == nil {
+		return auths
+	}
+	spec, _ := ctx.Value(clientAPIKeyContextKey).(*apiKeySpec)
+	if spec == nil || len(spec.AccountIDs) == 0 {
+		return auths
+	}
+
+	allowedAccountIDs := make(map[string]struct{}, len(spec.AccountIDs))
+	for _, accountID := range spec.AccountIDs {
+		if accountID = strings.TrimSpace(accountID); accountID != "" {
+			allowedAccountIDs[accountID] = struct{}{}
+		}
+	}
+	if len(allowedAccountIDs) == 0 {
+		return nil
+	}
+
+	scoped := make([]*coreauth.Auth, 0, len(auths))
+	for _, auth := range auths {
+		account := s.accountForAuth(auth)
+		if account == nil {
+			continue
+		}
+		if _, allowed := allowedAccountIDs[account.ID]; allowed {
+			scoped = append(scoped, auth)
+		}
+	}
+	return scoped
 }
 
 func quotaReserveBlockReason(account *accountSpec, now time.Time) string {
@@ -2306,6 +2340,7 @@ func buildCoreAuthSelector(cfg *config.Config, selector coreauth.Selector, m *ma
 			Fallback: selector,
 			TTL:      ttl,
 		})
+		selector = &cockpitSessionAffinitySelector{inner: selector}
 	}
 	if m != nil {
 		selector = &quotaReserveSelector{manifest: m, fallback: selector, quota: quota}
@@ -2320,6 +2355,25 @@ func buildCoreAuthManager(cfg *config.Config, selector coreauth.Selector, hook c
 	}
 	selector = buildCoreAuthSelector(cfg, selector, m, quota)
 	return coreauth.NewManager(tokenStore, selector, hook)
+}
+
+type cockpitSessionAffinitySelector struct {
+	inner coreauth.Selector
+}
+
+func (s *cockpitSessionAffinitySelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
+	if s == nil || s.inner == nil {
+		return nil, errors.New("session affinity selector is unavailable")
+	}
+	if spec, _ := ctx.Value(clientAPIKeyContextKey).(*apiKeySpec); spec != nil && strings.TrimSpace(spec.ID) != "" {
+		metadata := make(map[string]any, len(opts.Metadata)+1)
+		for key, value := range opts.Metadata {
+			metadata[key] = value
+		}
+		metadata[cliproxyexecutor.SessionAffinityNamespaceMetadataKey] = spec.ID
+		opts.Metadata = metadata
+	}
+	return s.inner.Pick(ctx, provider, model, opts, auths)
 }
 
 type sidecarRuntime struct {

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -102,6 +102,130 @@ func TestClientCatalogModelsIncludesAutoReviewWithoutPrefix(t *testing.T) {
 	}
 }
 
+func TestCockpitSelectorRestrictsAuthsToClientAPIKeyAccountScope(t *testing.T) {
+	highQuotaAccount := &accountSpec{
+		ID:       "account-high",
+		AuthID:   "account-high.json",
+		PlanRank: intPtrForTest(500),
+	}
+	scopedAccount := &accountSpec{
+		ID:       "account-scoped",
+		AuthID:   "account-scoped.json",
+		PlanRank: intPtrForTest(300),
+	}
+	selector := &cockpitSelector{
+		manifest: &manifest{
+			RoutingStrategy: "auto",
+			accountByAuthID: map[string]*accountSpec{
+				"account-high.json":   highQuotaAccount,
+				"account-scoped.json": scopedAccount,
+			},
+			accountByID: map[string]*accountSpec{
+				"account-high":   highQuotaAccount,
+				"account-scoped": scopedAccount,
+			},
+		},
+	}
+	apiKey := &apiKeySpec{
+		ID:         "key-scoped",
+		Label:      "Scoped client",
+		AccountIDs: []string{"account-scoped"},
+	}
+	ctx := context.WithValue(context.Background(), clientAPIKeyContextKey, apiKey)
+	auths := []*coreauth.Auth{
+		{ID: "account-high.json", Provider: "codex", Status: coreauth.StatusActive},
+		{ID: "account-scoped.json", Provider: "codex", Status: coreauth.StatusActive},
+	}
+
+	selected, err := selector.Pick(ctx, "codex", "gpt-5.6-sol", cliproxyexecutor.Options{}, auths)
+
+	if err != nil {
+		t.Fatalf("pick scoped auth: %v", err)
+	}
+	if selected.ID != "account-scoped.json" {
+		t.Fatalf("expected only scoped account to be selected, got %q", selected.ID)
+	}
+}
+
+func TestCockpitSessionAffinitySeparatesClientAPIKeyScopes(t *testing.T) {
+	highQuotaAccount := &accountSpec{
+		ID:       "account-high",
+		AuthID:   "account-high.json",
+		PlanRank: intPtrForTest(500),
+	}
+	scopedAccount := &accountSpec{
+		ID:       "account-scoped",
+		AuthID:   "account-scoped.json",
+		PlanRank: intPtrForTest(300),
+	}
+	fallback := &cockpitSelector{
+		manifest: &manifest{
+			RoutingStrategy: "auto",
+			accountByAuthID: map[string]*accountSpec{
+				"account-high.json":   highQuotaAccount,
+				"account-scoped.json": scopedAccount,
+			},
+			accountByID: map[string]*accountSpec{
+				"account-high":   highQuotaAccount,
+				"account-scoped": scopedAccount,
+			},
+		},
+	}
+	selector := &cockpitSessionAffinitySelector{
+		inner: coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
+			Fallback: fallback,
+			TTL:      time.Hour,
+		}),
+	}
+	auths := []*coreauth.Auth{
+		{ID: "account-high.json", Provider: "codex", Status: coreauth.StatusActive},
+		{ID: "account-scoped.json", Provider: "codex", Status: coreauth.StatusActive},
+	}
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Session-ID": []string{"shared-session"}},
+	}
+	defaultKey := &apiKeySpec{
+		ID:         "default-key",
+		AccountIDs: []string{"account-high", "account-scoped"},
+	}
+	scopedKey := &apiKeySpec{
+		ID:         "scoped-key",
+		AccountIDs: []string{"account-scoped"},
+	}
+
+	first, err := selector.Pick(
+		context.WithValue(context.Background(), clientAPIKeyContextKey, defaultKey),
+		"codex",
+		"gpt-5.4",
+		opts,
+		auths,
+	)
+	if err != nil {
+		t.Fatalf("pick default key auth: %v", err)
+	}
+	if first.ID != "account-high.json" {
+		t.Fatalf("expected default key to select high quota auth, got %q", first.ID)
+	}
+
+	second, err := selector.Pick(
+		context.WithValue(context.Background(), clientAPIKeyContextKey, scopedKey),
+		"codex",
+		"gpt-5.4",
+		opts,
+		auths,
+	)
+	if err != nil {
+		t.Fatalf("pick scoped key auth: %v", err)
+	}
+	if second.ID != "account-scoped.json" {
+		t.Fatalf("expected scoped key not to reuse default key affinity auth, got %q", second.ID)
+	}
+}
+
+func intPtrForTest(value int) *int {
+	return &value
+}
+
 func TestCanonicalModelForClientModelHandlesPrefixAliasAndSnapshot(t *testing.T) {
 	spec := &apiKeySpec{ModelPrefix: "team"}
 	m := &manifest{

--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -3073,6 +3073,8 @@ pub async fn codex_local_access_update_api_key(
     model_prefix: Option<String>,
     allowed_models: Option<Vec<String>>,
     excluded_models: Option<Vec<String>>,
+    account_ids: Option<Vec<String>>,
+    inherit_account_pool: Option<bool>,
 ) -> Result<CodexLocalAccessState, String> {
     codex_local_access::update_local_access_api_key(
         api_key_id,
@@ -3081,6 +3083,8 @@ pub async fn codex_local_access_update_api_key(
         model_prefix,
         allowed_models,
         excluded_models,
+        account_ids,
+        inherit_account_pool,
     )
     .await
 }

--- a/src-tauri/src/models/codex_local_access.rs
+++ b/src-tauri/src/models/codex_local_access.rs
@@ -377,6 +377,8 @@ pub struct CodexLocalAccessApiKey {
     pub key: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_gateway: Option<CodexLocalAccessProviderGateway>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inherit_account_pool: Option<bool>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub account_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -20,6 +20,7 @@ use crate::modules::{
     account, codex_account, codex_oauth, codex_protocol, codex_quota, codex_wakeup, logger, process,
 };
 use base64::{engine::general_purpose, Engine as _};
+use chrono::{Datelike, Duration as ChronoDuration, Local, LocalResult, NaiveDate, TimeZone};
 use futures_util::{SinkExt, StreamExt};
 use rand::{distributions::Alphanumeric, Rng};
 use reqwest::header::{HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
@@ -121,9 +122,6 @@ const TIMEOUT_PRESET_NAME_MAX_CHARS: usize = 40;
 const RESPONSE_AFFINITY_TTL_MS: i64 = 24 * 60 * 60 * 1000;
 const MAX_RESPONSE_AFFINITY_BINDINGS: usize = 4096;
 const PREPARED_ACCOUNT_CACHE_TTL_MS: i64 = 30 * 1000;
-const DAY_WINDOW_MS: i64 = 24 * 60 * 60 * 1000;
-const WEEK_WINDOW_MS: i64 = 7 * DAY_WINDOW_MS;
-const MONTH_WINDOW_MS: i64 = 30 * DAY_WINDOW_MS;
 const STATE_RECENT_USAGE_EVENT_LIMIT: usize = 100;
 const DEFAULT_MODEL_PRICING_VERSION: u64 = 1;
 const COOLDOWN_KEY_SEPARATOR: &str = "\u{1f}";
@@ -4828,9 +4826,7 @@ fn parse_codex_retry_after(status: StatusCode, error_body: &str) -> Option<Durat
 
 fn empty_stats_snapshot() -> CodexLocalAccessStats {
     let now = now_ms();
-    let day_since = now.saturating_sub(DAY_WINDOW_MS);
-    let week_since = now.saturating_sub(WEEK_WINDOW_MS);
-    let month_since = now.saturating_sub(MONTH_WINDOW_MS);
+    let window_starts = calendar_stats_window_starts(now);
     CodexLocalAccessStats {
         since: now,
         updated_at: now,
@@ -4839,7 +4835,7 @@ fn empty_stats_snapshot() -> CodexLocalAccessStats {
         models: Vec::new(),
         api_keys: Vec::new(),
         daily: CodexLocalAccessStatsWindow {
-            since: day_since,
+            since: window_starts.day,
             updated_at: now,
             totals: CodexLocalAccessUsageStats::default(),
             accounts: Vec::new(),
@@ -4847,7 +4843,7 @@ fn empty_stats_snapshot() -> CodexLocalAccessStats {
             api_keys: Vec::new(),
         },
         weekly: CodexLocalAccessStatsWindow {
-            since: week_since,
+            since: window_starts.week,
             updated_at: now,
             totals: CodexLocalAccessUsageStats::default(),
             accounts: Vec::new(),
@@ -4855,7 +4851,7 @@ fn empty_stats_snapshot() -> CodexLocalAccessStats {
             api_keys: Vec::new(),
         },
         monthly: CodexLocalAccessStatsWindow {
-            since: month_since,
+            since: window_starts.month,
             updated_at: now,
             totals: CodexLocalAccessUsageStats::default(),
             accounts: Vec::new(),
@@ -4863,6 +4859,52 @@ fn empty_stats_snapshot() -> CodexLocalAccessStats {
             api_keys: Vec::new(),
         },
         events: Vec::new(),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StatsWindowStarts {
+    day: i64,
+    week: i64,
+    month: i64,
+}
+
+fn local_date_start_ms(date: NaiveDate) -> i64 {
+    let midnight = date
+        .and_hms_opt(0, 0, 0)
+        .expect("a calendar date must have a midnight");
+    match Local.from_local_datetime(&midnight) {
+        LocalResult::Single(value) => value.timestamp_millis(),
+        LocalResult::Ambiguous(first, second) => {
+            first.timestamp_millis().min(second.timestamp_millis())
+        }
+        LocalResult::None => (1..=24 * 60 * 60)
+            .find_map(|seconds| {
+                let candidate = midnight.checked_add_signed(ChronoDuration::seconds(seconds))?;
+                Local
+                    .from_local_datetime(&candidate)
+                    .earliest()
+                    .map(|value| value.timestamp_millis())
+            })
+            .unwrap_or_else(|| Local.from_utc_datetime(&midnight).timestamp_millis()),
+    }
+}
+
+fn calendar_stats_window_starts(now_ms: i64) -> StatsWindowStarts {
+    let local_now = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(now_ms)
+        .unwrap_or_else(chrono::Utc::now)
+        .with_timezone(&Local);
+    let day = local_now.date_naive();
+    let week = day
+        .checked_sub_signed(ChronoDuration::days(
+            day.weekday().num_days_from_monday() as i64
+        ))
+        .unwrap_or(day);
+    let month = NaiveDate::from_ymd_opt(day.year(), day.month(), 1).unwrap_or(day);
+    StatsWindowStarts {
+        day: local_date_start_ms(day),
+        week: local_date_start_ms(week),
+        month: local_date_start_ms(month),
     }
 }
 
@@ -5553,11 +5595,11 @@ fn load_local_access_usage_events_since(
 }
 
 fn stats_range_since(stats_range: Option<&str>) -> Option<i64> {
-    let now = now_ms();
+    let window_starts = calendar_stats_window_starts(now_ms());
     match stats_range.map(str::trim) {
-        Some("daily") => Some(now.saturating_sub(DAY_WINDOW_MS)),
-        Some("weekly") => Some(now.saturating_sub(WEEK_WINDOW_MS)),
-        Some("monthly") => Some(now.saturating_sub(MONTH_WINDOW_MS)),
+        Some("daily") => Some(window_starts.day),
+        Some("weekly") => Some(window_starts.week),
+        Some("monthly") => Some(window_starts.month),
         _ => None,
     }
 }
@@ -6053,9 +6095,10 @@ fn apply_usage_event_to_window(
 }
 
 fn recompute_time_windows(stats: &mut CodexLocalAccessStats, now: i64) {
-    let day_since = now.saturating_sub(DAY_WINDOW_MS);
-    let week_since = now.saturating_sub(WEEK_WINDOW_MS);
-    let month_since = now.saturating_sub(MONTH_WINDOW_MS);
+    let window_starts = calendar_stats_window_starts(now);
+    let day_since = window_starts.day;
+    let week_since = window_starts.week;
+    let month_since = window_starts.month;
 
     trim_recent_events(&mut stats.events, month_since);
 
@@ -9302,7 +9345,7 @@ fn load_stats_from_disk() -> Result<CodexLocalAccessStats, String> {
             error
         ));
     }
-    let month_since = now_ms().saturating_sub(MONTH_WINDOW_MS);
+    let month_since = calendar_stats_window_starts(now_ms()).month;
     parsed.events = match load_local_access_usage_events_since(month_since) {
         Ok(events) => events,
         Err(error) => {
@@ -19873,8 +19916,9 @@ mod tests {
         build_local_access_api_key, build_local_models_response,
         build_model_provider_gateway_test_collection, build_ordered_account_ids,
         build_request_routing_hint, build_upstream_websocket_url, calculate_usage_cost_usd,
-        canonical_model_for_client_model, classify_upstream_error_category,
-        cleanup_profile_takeover_without_backup, cleanup_provider_gateway_profile_model_overrides,
+        calendar_stats_window_starts, canonical_model_for_client_model,
+        classify_upstream_error_category, cleanup_profile_takeover_without_backup,
+        cleanup_provider_gateway_profile_model_overrides,
         collect_local_access_profile_takeover_dirs_from_store, compare_routing_candidates,
         default_codex_model_ids, effective_api_key_account_ids, empty_stats_snapshot,
         extract_usage_capture, filter_bound_oauth_quota_reserve_account,
@@ -19925,7 +19969,7 @@ mod tests {
         CODEX_AUTO_REVIEW_MODEL_ID, CODEX_IMAGE_MODEL_ID,
         CODEX_LOCAL_ACCESS_TEST_DISABLE_IMAGE_GENERATION_HEADER, CODEX_PROFILE_AUTH_FILE,
         CODEX_PROFILE_CONFIG_FILE, CODEX_PROVIDER_MODEL_BACKUP_FILE,
-        CODEX_PROVIDER_MODEL_CATALOG_FILE, DAY_WINDOW_MS, DEFAULT_MAX_RETRY_INTERVAL_MS,
+        CODEX_PROVIDER_MODEL_CATALOG_FILE, DEFAULT_MAX_RETRY_INTERVAL_MS,
         DEFAULT_MODEL_PRICING_VERSION, DEFAULT_SESSION_AFFINITY_TTL_MS, MAX_HTTP_REQUEST_BYTES,
     };
     use crate::models::codex::{
@@ -22135,7 +22179,16 @@ supports_websockets = false
 
     #[test]
     fn api_key_usage_stats_are_isolated_by_time_window() {
-        let now = 20 * DAY_WINDOW_MS;
+        use chrono::{Local, TimeZone};
+
+        let local_timestamp = |year, month, day, hour, minute| {
+            Local
+                .with_ymd_and_hms(year, month, day, hour, minute, 0)
+                .single()
+                .expect("test local datetime should be unambiguous")
+                .timestamp_millis()
+        };
+        let now = local_timestamp(2026, 5, 20, 12, 0);
         let event =
             |timestamp: i64, api_key_id: &str, total_tokens: u64| CodexLocalAccessUsageEvent {
                 timestamp,
@@ -22148,10 +22201,12 @@ supports_websockets = false
             };
         let mut stats = empty_stats_snapshot();
         stats.events = vec![
-            event(now - 10 * DAY_WINDOW_MS, "key-a", 400),
-            event(now - 2 * DAY_WINDOW_MS, "key-a", 200),
-            event(now - DAY_WINDOW_MS / 2, "key-a", 100),
-            event(now - DAY_WINDOW_MS / 2, "key-b", 50),
+            event(local_timestamp(2026, 4, 30, 23, 59), "key-a", 500),
+            event(local_timestamp(2026, 5, 1, 0, 1), "key-a", 400),
+            event(local_timestamp(2026, 5, 17, 23, 59), "key-a", 300),
+            event(local_timestamp(2026, 5, 19, 23, 59), "key-a", 200),
+            event(local_timestamp(2026, 5, 20, 0, 1), "key-a", 100),
+            event(local_timestamp(2026, 5, 20, 0, 1), "key-b", 50),
         ];
 
         recompute_time_windows(&mut stats, now);
@@ -22168,12 +22223,19 @@ supports_websockets = false
         assert_eq!(usage(&stats.daily, "key-a"), (1, 100));
         assert_eq!(usage(&stats.daily, "key-b"), (1, 50));
         assert_eq!(usage(&stats.weekly, "key-a"), (2, 300));
-        assert_eq!(usage(&stats.monthly, "key-a"), (3, 700));
+        assert_eq!(usage(&stats.monthly, "key-a"), (4, 1000));
+        let starts = calendar_stats_window_starts(now);
+        assert_eq!(stats.daily.since, local_timestamp(2026, 5, 20, 0, 0));
+        assert_eq!(stats.weekly.since, local_timestamp(2026, 5, 18, 0, 0));
+        assert_eq!(stats.monthly.since, local_timestamp(2026, 5, 1, 0, 0));
+        assert_eq!(stats.daily.since, starts.day);
+        assert_eq!(stats.weekly.since, starts.week);
+        assert_eq!(stats.monthly.since, starts.month);
 
-        recompute_time_windows(&mut stats, now + 2 * DAY_WINDOW_MS);
+        recompute_time_windows(&mut stats, local_timestamp(2026, 5, 21, 0, 1));
         assert!(stats.daily.api_keys.is_empty());
         assert_eq!(usage(&stats.weekly, "key-a"), (2, 300));
-        assert_eq!(usage(&stats.monthly, "key-a"), (3, 700));
+        assert_eq!(usage(&stats.monthly, "key-a"), (4, 1000));
     }
 
     #[test]

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -410,6 +410,7 @@ struct ResolvedLocalApiKey {
     id: String,
     label: String,
     provider_gateway: Option<CodexLocalAccessProviderGateway>,
+    inherit_account_pool: bool,
     account_ids: Vec<String>,
     model_prefix: Option<String>,
     allowed_models: Vec<String>,
@@ -1625,13 +1626,28 @@ fn selected_accounts_have_image_generation_capacity(
     collection: &CodexLocalAccessCollection,
     health_by_account_id: Option<&HashMap<String, RuntimeAccountHealth>>,
 ) -> bool {
-    if collection.image_generation_mode == CodexLocalAccessImageGenerationMode::Disabled {
+    let accounts = codex_account::list_accounts_checked().ok();
+    selected_account_ids_have_image_generation_capacity(
+        &collection.account_ids,
+        collection.image_generation_mode,
+        accounts.as_deref(),
+        health_by_account_id,
+    )
+}
+
+fn selected_account_ids_have_image_generation_capacity(
+    account_ids: &[String],
+    image_generation_mode: CodexLocalAccessImageGenerationMode,
+    accounts: Option<&[CodexAccount]>,
+    health_by_account_id: Option<&HashMap<String, RuntimeAccountHealth>>,
+) -> bool {
+    if image_generation_mode == CodexLocalAccessImageGenerationMode::Disabled {
         return false;
     }
-    let Ok(accounts) = codex_account::list_accounts_checked() else {
+    let Some(accounts) = accounts else {
         return true;
     };
-    let selected: HashSet<&str> = collection.account_ids.iter().map(String::as_str).collect();
+    let selected: HashSet<&str> = account_ids.iter().map(String::as_str).collect();
     accounts.into_iter().any(|account| {
         selected.contains(account.id.as_str())
             && !account.is_api_key_auth()
@@ -1833,7 +1849,51 @@ fn visible_codex_model_ids_for_api_key(
     api_key: &ResolvedLocalApiKey,
     health_by_account_id: Option<&HashMap<String, RuntimeAccountHealth>>,
 ) -> Vec<String> {
-    let mut visible = visible_codex_model_ids_for_collection(collection, health_by_account_id);
+    let accounts = codex_account::list_accounts_checked().ok();
+    visible_codex_model_ids_for_api_key_with_optional_accounts(
+        collection,
+        api_key,
+        accounts.as_deref(),
+        health_by_account_id,
+    )
+}
+
+fn visible_codex_model_ids_for_api_key_with_accounts(
+    collection: &CodexLocalAccessCollection,
+    api_key: &ResolvedLocalApiKey,
+    accounts: &[CodexAccount],
+    health_by_account_id: Option<&HashMap<String, RuntimeAccountHealth>>,
+) -> Vec<String> {
+    visible_codex_model_ids_for_api_key_with_optional_accounts(
+        collection,
+        api_key,
+        Some(accounts),
+        health_by_account_id,
+    )
+}
+
+fn visible_codex_model_ids_for_api_key_with_optional_accounts(
+    collection: &CodexLocalAccessCollection,
+    api_key: &ResolvedLocalApiKey,
+    accounts: Option<&[CodexAccount]>,
+    health_by_account_id: Option<&HashMap<String, RuntimeAccountHealth>>,
+) -> Vec<String> {
+    let scoped_account_ids = scoped_collection_account_ids(collection, api_key);
+    let image_allowed = selected_account_ids_have_image_generation_capacity(
+        &scoped_account_ids,
+        collection.image_generation_mode,
+        accounts,
+        health_by_account_id,
+    );
+    let base = supported_codex_model_ids()
+        .into_iter()
+        .filter(|model| model != CODEX_IMAGE_MODEL_ID || image_allowed)
+        .collect();
+    let mut visible = apply_model_filters(
+        apply_model_aliases_to_ids(base, &collection.model_aliases),
+        &[],
+        &collection.excluded_models,
+    );
     if let Some(provider_gateway) = api_key.provider_gateway.as_ref() {
         let mut seen: HashSet<String> = visible
             .iter()
@@ -6966,10 +7026,6 @@ fn sidecar_auth_ids_for_account_ids_with_overrides(
     values
 }
 
-fn sidecar_auth_ids_for_account_ids(account_ids: Vec<String>) -> Vec<String> {
-    sidecar_auth_ids_for_account_ids_with_overrides(account_ids, &HashMap::new())
-}
-
 fn sidecar_duration_ms(value_ms: i64) -> String {
     format!("{}ms", value_ms.max(1))
 }
@@ -7024,9 +7080,19 @@ fn sidecar_codex_key_model_values(collection: &CodexLocalAccessCollection) -> Ve
         .collect()
 }
 
+fn legacy_api_key_is_active(collection: &CodexLocalAccessCollection) -> bool {
+    let key = collection.api_key.trim();
+    !key.is_empty()
+        && !collection.account_ids.is_empty()
+        && !collection
+            .api_keys
+            .iter()
+            .any(|item| item.key.trim() == key)
+}
+
 fn sidecar_api_key_manifest_values(collection: &CodexLocalAccessCollection) -> Vec<Value> {
     let mut values = Vec::new();
-    if !collection.api_key.trim().is_empty() && !collection.account_ids.is_empty() {
+    if legacy_api_key_is_active(collection) {
         values.push(json!({
             "id": "legacy",
             "label": default_local_api_key_label(),
@@ -7060,6 +7126,60 @@ fn sidecar_api_key_manifest_values(collection: &CodexLocalAccessCollection) -> V
     values
 }
 
+fn api_key_inherits_account_pool(api_key: &CodexLocalAccessApiKey) -> bool {
+    if api_key.provider_gateway.is_some() {
+        return false;
+    }
+    api_key
+        .inherit_account_pool
+        .unwrap_or_else(|| api_key.account_ids.is_empty())
+}
+
+fn api_key_has_fixed_account_scope(
+    collection: &CodexLocalAccessCollection,
+    api_key: &CodexLocalAccessApiKey,
+) -> bool {
+    if api_key.provider_gateway.is_some() {
+        return true;
+    }
+
+    collection.bound_oauth_account_id.is_some()
+        && collection.account_ids.is_empty()
+        && api_key.account_ids.len() == 1
+        && api_key.id == provider_gateway_api_key_id(&api_key.account_ids[0])
+}
+
+fn validate_api_key_account_scope_update(
+    collection: &CodexLocalAccessCollection,
+    api_key: &CodexLocalAccessApiKey,
+    account_ids: Option<&[String]>,
+    inherit_account_pool: Option<bool>,
+) -> Result<(), String> {
+    if !api_key_has_fixed_account_scope(collection, api_key) {
+        return Ok(());
+    }
+
+    let requested_inherit = inherit_account_pool.unwrap_or_else(|| {
+        account_ids
+            .map(|ids| ids.is_empty())
+            .unwrap_or_else(|| api_key_inherits_account_pool(api_key))
+    });
+    if requested_inherit {
+        return Err("固定账号 Key 不支持继承服务账号池".to_string());
+    }
+    if account_ids.is_some_and(|ids| ids.is_empty()) {
+        return Err("固定账号 Key 不能清空账号范围".to_string());
+    }
+    if let Some(requested_account_ids) = account_ids {
+        let expected_account_ids = normalize_account_id_list(api_key.account_ids.clone());
+        let requested_account_ids = normalize_account_id_list(requested_account_ids.to_vec());
+        if requested_account_ids != expected_account_ids {
+            return Err("固定账号 Key 不支持修改账号范围".to_string());
+        }
+    }
+    Ok(())
+}
+
 fn codex_app_speed_service_tier(speed: &CodexAppSpeed) -> Option<&'static str> {
     match speed {
         CodexAppSpeed::Fast => Some("priority"),
@@ -7071,10 +7191,7 @@ fn effective_api_key_account_ids(
     collection: &CodexLocalAccessCollection,
     api_key: &CodexLocalAccessApiKey,
 ) -> Vec<String> {
-    if api_key.provider_gateway.is_some() {
-        return api_key.account_ids.clone();
-    }
-    if api_key.account_ids.is_empty() {
+    if api_key_inherits_account_pool(api_key) {
         collection.account_ids.clone()
     } else {
         api_key.account_ids.clone()
@@ -7140,23 +7257,31 @@ fn remove_account_refs_from_collection(
     changed
 }
 
-fn sidecar_client_api_keys(collection: &CodexLocalAccessCollection) -> Vec<String> {
+fn sidecar_client_api_keys(
+    collection: &CodexLocalAccessCollection,
+    account_overrides: &HashMap<String, CodexAccount>,
+) -> Vec<String> {
     let mut keys = Vec::new();
     let mut seen = HashSet::new();
-    if !collection.api_key.trim().is_empty()
-        && !collection.account_ids.is_empty()
+    if legacy_api_key_is_active(collection)
+        && !sidecar_auth_ids_for_account_ids_with_overrides(
+            collection.account_ids.clone(),
+            account_overrides,
+        )
+        .is_empty()
         && seen.insert(collection.api_key.trim().to_string())
     {
         keys.push(collection.api_key.trim().to_string());
     }
     for item in &collection.api_keys {
         let key = item.key.trim();
-        if item.enabled
-            && !key.is_empty()
-            && (item.provider_gateway.is_some()
-                || !effective_api_key_account_ids(collection, item).is_empty())
-            && seen.insert(key.to_string())
-        {
+        let has_resolvable_scope = item.provider_gateway.is_some()
+            || !sidecar_auth_ids_for_account_ids_with_overrides(
+                effective_api_key_account_ids(collection, item),
+                account_overrides,
+            )
+            .is_empty();
+        if item.enabled && !key.is_empty() && has_resolvable_scope && seen.insert(key.to_string()) {
             keys.push(key.to_string());
         }
     }
@@ -7168,7 +7293,7 @@ fn sidecar_api_key_account_scope_values(
     account_overrides: &HashMap<String, CodexAccount>,
 ) -> Value {
     let mut values = Map::new();
-    if !collection.api_key.trim().is_empty() && !collection.account_ids.is_empty() {
+    if legacy_api_key_is_active(collection) {
         let auth_ids = sidecar_auth_ids_for_account_ids_with_overrides(
             collection.account_ids.clone(),
             account_overrides,
@@ -7834,7 +7959,7 @@ async fn prepare_sidecar_launch_config_in_dir(
     config.insert("debug".to_string(), json!(collection.debug_logs));
     config.insert(
         "api-keys".to_string(),
-        json!(sidecar_client_api_keys(collection)),
+        json!(sidecar_client_api_keys(collection, &account_overrides)),
     );
     config.insert(
         "api-key-account-ids".to_string(),
@@ -8817,6 +8942,7 @@ fn build_local_access_api_key(label: Option<&str>) -> CodexLocalAccessApiKey {
         label: normalize_api_key_label(label, &default_local_api_key_label()),
         key: generate_local_api_key(),
         provider_gateway: None,
+        inherit_account_pool: Some(true),
         account_ids: Vec::new(),
         model_prefix: None,
         allowed_models: Vec::new(),
@@ -8843,6 +8969,7 @@ fn normalize_collection_api_keys(collection: &mut CodexLocalAccessCollection) ->
             label: default_local_api_key_label(),
             key,
             provider_gateway: None,
+            inherit_account_pool: Some(true),
             account_ids: Vec::new(),
             model_prefix: None,
             allowed_models: Vec::new(),
@@ -8883,6 +9010,11 @@ fn normalize_collection_api_keys(collection: &mut CodexLocalAccessCollection) ->
             changed = true;
         } else {
             item.account_ids = original_account_ids;
+        }
+        let inherit_account_pool = api_key_inherits_account_pool(&item);
+        if item.inherit_account_pool != Some(inherit_account_pool) {
+            item.inherit_account_pool = Some(inherit_account_pool);
+            changed = true;
         }
         if item.created_at <= 0 {
             item.created_at = now;
@@ -8955,6 +9087,7 @@ fn resolve_collection_api_key(
             id: item.id.clone(),
             label: item.label.clone(),
             provider_gateway: item.provider_gateway.clone(),
+            inherit_account_pool: api_key_inherits_account_pool(item),
             account_ids: item.account_ids.clone(),
             model_prefix: item.model_prefix.clone(),
             allowed_models: item.allowed_models.clone(),
@@ -8966,6 +9099,7 @@ fn resolve_collection_api_key(
                     id: "legacy".to_string(),
                     label: default_local_api_key_label(),
                     provider_gateway: None,
+                    inherit_account_pool: true,
                     account_ids: Vec::new(),
                     model_prefix: None,
                     allowed_models: Vec::new(),
@@ -8981,7 +9115,7 @@ fn scoped_collection_account_ids(
     collection: &CodexLocalAccessCollection,
     api_key: &ResolvedLocalApiKey,
 ) -> Vec<String> {
-    if api_key.account_ids.is_empty() {
+    if api_key.inherit_account_pool {
         collection.account_ids.clone()
     } else {
         api_key.account_ids.clone()
@@ -11366,12 +11500,17 @@ fn build_request_state_snapshot(runtime: &GatewayRuntime) -> CodexLocalAccessSta
     build_state_snapshot_inner(runtime, false)
 }
 
+fn build_fresh_state_snapshot(runtime: &mut GatewayRuntime) -> CodexLocalAccessState {
+    recompute_time_windows(&mut runtime.stats, now_ms());
+    build_state_snapshot(runtime)
+}
+
 async fn snapshot_state() -> Result<CodexLocalAccessState, String> {
     ensure_runtime_loaded_without_start().await?;
     if let Err(err) = ensure_gateway_matches_runtime().await {
         let mut runtime = gateway_runtime().lock().await;
         runtime.last_error = Some(err);
-        return Ok(build_state_snapshot(&runtime));
+        return Ok(build_fresh_state_snapshot(&mut runtime));
     }
     let mut runtime = gateway_runtime().lock().await;
     if runtime
@@ -11385,13 +11524,13 @@ async fn snapshot_state() -> Result<CodexLocalAccessState, String> {
     {
         runtime.last_error = None;
     }
-    Ok(build_state_snapshot(&runtime))
+    Ok(build_fresh_state_snapshot(&mut runtime))
 }
 
 async fn snapshot_state_without_gateway_reload() -> Result<CodexLocalAccessState, String> {
     ensure_runtime_loaded_without_start().await?;
-    let runtime = gateway_runtime().lock().await;
-    Ok(build_state_snapshot(&runtime))
+    let mut runtime = gateway_runtime().lock().await;
+    Ok(build_fresh_state_snapshot(&mut runtime))
 }
 
 pub async fn get_local_access_state() -> Result<CodexLocalAccessState, String> {
@@ -11890,6 +12029,7 @@ fn build_provider_gateway_collection_for_profile(
         label: format!("Provider Gateway: {}", account.email),
         key: key.clone(),
         provider_gateway: Some(provider_gateway.clone()),
+        inherit_account_pool: Some(false),
         account_ids: vec![account.id.clone()],
         model_prefix: None,
         allowed_models: Vec::new(),
@@ -11944,6 +12084,7 @@ fn build_bound_oauth_local_gateway_collection_for_profile(
         label: format!("Bound OAuth Local Gateway: {}", account.email),
         key: key.clone(),
         provider_gateway: None,
+        inherit_account_pool: Some(false),
         account_ids: vec![account.id.clone()],
         model_prefix: None,
         allowed_models: Vec::new(),
@@ -12124,6 +12265,7 @@ fn build_model_provider_gateway_test_collection(
         label: provider_gateway_test_api_key_label(request),
         key: collection.api_key.clone(),
         provider_gateway,
+        inherit_account_pool: Some(false),
         account_ids: vec![account.id.clone()],
         model_prefix: None,
         allowed_models: vec![client_model_id.trim().to_string()],
@@ -14646,18 +14788,24 @@ pub async fn remove_deleted_accounts_from_local_access_pool(
         return Ok(());
     };
 
-    let before_account_ids = collection.account_ids.clone();
-    collection.account_ids.retain(|id| !remove_ids.contains(id));
-    if collection.account_ids == before_account_ids {
+    if !remove_account_refs_from_collection(&mut collection, &remove_ids) {
         return Ok(());
     }
 
     collection.updated_at = now_ms();
     save_collection_to_disk(&collection)?;
 
-    let mut runtime = gateway_runtime().lock().await;
-    if runtime.loaded {
-        sync_runtime_collection(&mut runtime, collection);
+    let runtime_loaded = {
+        let mut runtime = gateway_runtime().lock().await;
+        if runtime.loaded {
+            sync_runtime_collection(&mut runtime, collection);
+            true
+        } else {
+            false
+        }
+    };
+    if runtime_loaded {
+        ensure_gateway_matches_runtime().await?;
     }
 
     Ok(())
@@ -14782,6 +14930,8 @@ pub async fn update_local_access_api_key(
     model_prefix: Option<String>,
     allowed_models: Option<Vec<String>>,
     excluded_models: Option<Vec<String>>,
+    account_ids: Option<Vec<String>>,
+    inherit_account_pool: Option<bool>,
 ) -> Result<CodexLocalAccessState, String> {
     ensure_runtime_loaded().await?;
     let maybe_collection = {
@@ -14800,6 +14950,13 @@ pub async fn update_local_access_api_key(
     else {
         return Err("API Key 不存在".to_string());
     };
+    let normalized_account_ids = account_ids.map(normalize_account_id_list);
+    validate_api_key_account_scope_update(
+        &collection,
+        &collection.api_keys[index],
+        normalized_account_ids.as_deref(),
+        inherit_account_pool,
+    )?;
     if let Some(label) = label {
         collection.api_keys[index].label = normalize_api_key_label(Some(label.as_str()), "API Key");
     }
@@ -14815,11 +14972,21 @@ pub async fn update_local_access_api_key(
     if let Some(excluded_models) = excluded_models {
         collection.api_keys[index].excluded_models = normalize_model_rule_list(excluded_models);
     }
+    if let Some(account_ids) = normalized_account_ids {
+        if inherit_account_pool.is_none() {
+            collection.api_keys[index].inherit_account_pool = Some(account_ids.is_empty());
+        }
+        collection.api_keys[index].account_ids = account_ids;
+    }
+    if let Some(inherit_account_pool) = inherit_account_pool {
+        collection.api_keys[index].inherit_account_pool = Some(inherit_account_pool);
+    }
     collection.api_keys[index].updated_at = now_ms();
     if !collection.api_keys.iter().any(|item| item.enabled) {
         collection.api_keys[index].enabled = true;
     }
     normalize_collection_api_keys(&mut collection);
+    let _ = sanitize_collection(&mut collection)?;
     collection.updated_at = now_ms();
     save_collection_to_disk(&collection)?;
     {
@@ -19697,10 +19864,10 @@ mod tests {
     use super::{
         account_model_rule_blocks_model, account_requires_bound_oauth_local_gateway,
         account_requires_provider_gateway, account_upstream_base_url, align_codex_prompt_cache,
-        append_usage_event, apply_codex_official_headers, apply_routing_strategy,
-        backup_current_profile_model_before_provider_gateway, bound_oauth_quota_refresh_failures,
-        bound_oauth_quota_reserve_blocks_account, bridge_websocket_streams,
-        build_account_scoped_upstream_body, build_base_url_with_host,
+        api_key_inherits_account_pool, append_usage_event, apply_codex_official_headers,
+        apply_routing_strategy, backup_current_profile_model_before_provider_gateway,
+        bound_oauth_quota_refresh_failures, bound_oauth_quota_reserve_blocks_account,
+        bridge_websocket_streams, build_account_scoped_upstream_body, build_base_url_with_host,
         build_chat_completion_payload, build_chat_completion_stream_body,
         build_codex_client_models_response, build_collection_base_url, build_images_api_payload,
         build_local_access_api_key, build_local_models_response,
@@ -19709,7 +19876,8 @@ mod tests {
         canonical_model_for_client_model, classify_upstream_error_category,
         cleanup_profile_takeover_without_backup, cleanup_provider_gateway_profile_model_overrides,
         collect_local_access_profile_takeover_dirs_from_store, compare_routing_candidates,
-        default_codex_model_ids, extract_usage_capture, filter_bound_oauth_quota_reserve_account,
+        default_codex_model_ids, effective_api_key_account_ids, empty_stats_snapshot,
+        extract_usage_capture, filter_bound_oauth_quota_reserve_account,
         insert_local_access_usage_event, inspect_local_access_profile_config,
         is_codex_local_access_auth_text, is_codex_local_access_config_for_api_key,
         is_image_generation_capability_error, is_local_access_eligible_account,
@@ -19719,28 +19887,33 @@ mod tests {
         macos_proxy_url_from_scutil_map, max_credential_attempts_for_strategy,
         merge_collection_and_account_excluded_models, model_pricing,
         model_provider_direct_test_client_model, model_provider_test_uses_provider_gateway,
-        normalize_account_model_rules, normalize_custom_routing_rules,
-        normalized_sidecar_error_category, open_local_access_logs_db_once, parse_codex_retry_after,
+        normalize_account_id_list, normalize_account_model_rules, normalize_collection_api_keys,
+        normalize_custom_routing_rules, normalized_sidecar_error_category,
+        open_local_access_logs_db_once, parse_codex_retry_after,
         parse_responses_payload_from_upstream, parse_websocket_upstream_error,
         prepare_gateway_request, prepare_gateway_request_with_default_service_tier,
         prepare_sidecar_launch_config_in_dir, prepare_websocket_initial_request,
-        profile_base_url_matches, provider_gateway_bound_oauth_account_id_for_account,
+        profile_base_url_matches, provider_gateway_api_key_id,
+        provider_gateway_bound_oauth_account_id_for_account,
         provider_gateway_default_model_for_account,
         provider_gateway_image_generation_mode_for_account, provider_gateway_model_slots,
-        provider_gateway_models_for_account, read_http_request, recover_invalid_stats_file,
-        remove_account_refs_from_collection, remove_codex_local_access_config,
-        reprice_request_logs_for_collection, request_image_generation_mode, resolve_plan_rank,
-        resolve_supported_model_alias, resolve_upstream_target,
-        restore_config_toml_from_takeover_backup, sanitize_collection_with_accounts,
-        scutil_proxy_map, should_retry_single_account_upstream_status,
-        should_treat_response_as_stream, should_try_next_account, sidecar_account_manifest_value,
-        sidecar_api_key_account_scope_values, sidecar_auth_file_name,
-        sidecar_auth_json_for_account, sidecar_auths_dir,
-        sidecar_cached_account_usable_after_prepare_error, sidecar_codex_api_key_auth_id,
-        sidecar_config_fingerprint, sidecar_payload_default_service_tier,
-        sidecar_quota_reserve_snapshot_value, sidecar_routing_strategy_value, sidecar_stable_id,
-        supported_codex_model_ids, system_proxy_target_scheme, system_proxy_value_url,
-        validate_client_model_visible, visible_codex_model_ids_for_api_key, websocket_accept_value,
+        provider_gateway_models_for_account, read_http_request, recompute_time_windows,
+        recover_invalid_stats_file, remove_account_refs_from_collection,
+        remove_codex_local_access_config, reprice_request_logs_for_collection,
+        request_image_generation_mode, resolve_plan_rank, resolve_supported_model_alias,
+        resolve_upstream_target, restore_config_toml_from_takeover_backup,
+        sanitize_collection_with_accounts, scutil_proxy_map,
+        should_retry_single_account_upstream_status, should_treat_response_as_stream,
+        should_try_next_account, sidecar_account_manifest_value,
+        sidecar_api_key_account_scope_values, sidecar_api_key_manifest_values,
+        sidecar_auth_file_name, sidecar_auth_json_for_account, sidecar_auths_dir,
+        sidecar_cached_account_usable_after_prepare_error, sidecar_client_api_keys,
+        sidecar_codex_api_key_auth_id, sidecar_config_fingerprint,
+        sidecar_payload_default_service_tier, sidecar_quota_reserve_snapshot_value,
+        sidecar_routing_strategy_value, sidecar_stable_id, supported_codex_model_ids,
+        system_proxy_target_scheme, system_proxy_value_url, validate_api_key_account_scope_update,
+        validate_client_model_visible, visible_codex_model_ids_for_api_key,
+        visible_codex_model_ids_for_api_key_with_accounts, websocket_accept_value,
         websocket_connect_error_from_http_response, windows_proxy_url_from_server,
         windows_reg_dword_enabled, windows_reg_query_map,
         write_local_access_profile_model_override, write_local_access_profile_takeover,
@@ -19749,9 +19922,10 @@ mod tests {
         CodexModelProviderGatewayChatTestRequest, GatewayResponseAdapter, ParsedRequest,
         ResolvedLocalApiKey, ResponseUsageCollector, RoutingCandidate, SidecarUsageDetails,
         SidecarUsageEvent, UsageCapture, BOUND_OAUTH_QUOTA_RESERVE_MAX_SNAPSHOT_AGE_SECONDS,
-        CODEX_AUTO_REVIEW_MODEL_ID, CODEX_LOCAL_ACCESS_TEST_DISABLE_IMAGE_GENERATION_HEADER,
-        CODEX_PROFILE_AUTH_FILE, CODEX_PROFILE_CONFIG_FILE, CODEX_PROVIDER_MODEL_BACKUP_FILE,
-        CODEX_PROVIDER_MODEL_CATALOG_FILE, DEFAULT_MAX_RETRY_INTERVAL_MS,
+        CODEX_AUTO_REVIEW_MODEL_ID, CODEX_IMAGE_MODEL_ID,
+        CODEX_LOCAL_ACCESS_TEST_DISABLE_IMAGE_GENERATION_HEADER, CODEX_PROFILE_AUTH_FILE,
+        CODEX_PROFILE_CONFIG_FILE, CODEX_PROVIDER_MODEL_BACKUP_FILE,
+        CODEX_PROVIDER_MODEL_CATALOG_FILE, DAY_WINDOW_MS, DEFAULT_MAX_RETRY_INTERVAL_MS,
         DEFAULT_MODEL_PRICING_VERSION, DEFAULT_SESSION_AFFINITY_TTL_MS, MAX_HTTP_REQUEST_BYTES,
     };
     use crate::models::codex::{
@@ -19762,7 +19936,8 @@ mod tests {
         CodexLocalAccessAccountModelRule, CodexLocalAccessClientBaseUrlHost,
         CodexLocalAccessCustomRoutingRule, CodexLocalAccessImageGenerationMode,
         CodexLocalAccessProviderGateway, CodexLocalAccessQuotaReserve, CodexLocalAccessRequestKind,
-        CodexLocalAccessRoutingStrategy, CodexLocalAccessStats, CodexLocalAccessTimeouts,
+        CodexLocalAccessRoutingStrategy, CodexLocalAccessStats, CodexLocalAccessStatsWindow,
+        CodexLocalAccessTimeouts, CodexLocalAccessUsageEvent,
     };
     use crate::models::{
         DefaultInstanceSettings, InstanceLaunchMode, InstanceProfile, InstanceStore,
@@ -19872,6 +20047,67 @@ mod tests {
         });
         account.usage_updated_at = Some(chrono::Utc::now().timestamp());
         account
+    }
+
+    #[test]
+    fn custom_api_key_scope_filters_duplicates_and_updates_manifest_scope() {
+        let mut collection = test_local_access_collection(vec![
+            "account-a".to_string(),
+            "account-b".to_string(),
+            "account-c".to_string(),
+        ]);
+        let mut api_key = build_local_access_api_key(Some("Team A"));
+        api_key.key = "team-a-key".to_string();
+        api_key.inherit_account_pool = Some(false);
+        api_key.account_ids = normalize_account_id_list(vec![
+            "account-b".to_string(),
+            "account-b".to_string(),
+            " account-c ".to_string(),
+            "".to_string(),
+        ]);
+        collection.api_keys = vec![api_key];
+
+        let manifest_values = sidecar_api_key_manifest_values(&collection);
+        let scoped = manifest_values
+            .iter()
+            .find(|value| value.get("key").and_then(Value::as_str) == Some("team-a-key"))
+            .expect("scoped key should be emitted");
+
+        let account_ids = scoped
+            .get("accountIds")
+            .and_then(Value::as_array)
+            .expect("accountIds should be an array")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>();
+
+        assert_eq!(account_ids, vec!["account-b", "account-c"]);
+    }
+
+    #[test]
+    fn legacy_api_key_scope_migrates_from_account_ids() {
+        let mut collection =
+            test_local_access_collection(vec!["account-a".to_string(), "account-b".to_string()]);
+        let mut inherited_key = build_local_access_api_key(Some("Inherited"));
+        inherited_key.inherit_account_pool = None;
+        inherited_key.account_ids.clear();
+        let mut scoped_key = build_local_access_api_key(Some("Scoped"));
+        scoped_key.inherit_account_pool = None;
+        scoped_key.account_ids = vec!["account-b".to_string()];
+        collection.api_keys = vec![inherited_key, scoped_key];
+
+        assert!(normalize_collection_api_keys(&mut collection));
+
+        assert_eq!(collection.api_keys[0].inherit_account_pool, Some(true));
+        assert_eq!(collection.api_keys[1].inherit_account_pool, Some(false));
+        assert_eq!(
+            effective_api_key_account_ids(&collection, &collection.api_keys[0]),
+            vec!["account-a", "account-b"]
+        );
+        assert_eq!(
+            effective_api_key_account_ids(&collection, &collection.api_keys[1]),
+            vec!["account-b"]
+        );
     }
 
     #[test]
@@ -20429,6 +20665,7 @@ wire_api = "responses"
             "account-c".to_string(),
         ]);
         let mut scoped_key = build_local_access_api_key(Some("scoped"));
+        scoped_key.inherit_account_pool = Some(false);
         scoped_key.account_ids = vec!["account-b".to_string(), "account-c".to_string()];
         collection.api_keys = vec![scoped_key];
         collection.custom_routing_rules = vec![
@@ -20469,6 +20706,167 @@ wire_api = "responses"
         assert!(collection.account_model_rules.is_empty());
         assert!(collection.bound_oauth_account_id.is_none());
         assert!(collection.bound_oauth_quota_reserve.is_none());
+    }
+
+    #[test]
+    fn custom_scope_does_not_broaden_when_last_account_is_removed() {
+        let mut collection =
+            test_local_access_collection(vec!["account-a".to_string(), "account-b".to_string()]);
+        let mut scoped_key = build_local_access_api_key(Some("scoped"));
+        scoped_key.key = "scoped-key".to_string();
+        scoped_key.inherit_account_pool = Some(false);
+        scoped_key.account_ids = vec!["account-b".to_string()];
+        collection.api_keys = vec![scoped_key];
+
+        assert!(remove_account_refs_from_collection(
+            &mut collection,
+            &HashSet::from(["account-b".to_string()]),
+        ));
+
+        let api_key = &collection.api_keys[0];
+        assert!(!api_key_inherits_account_pool(api_key));
+        assert!(api_key.account_ids.is_empty());
+        assert!(effective_api_key_account_ids(&collection, api_key).is_empty());
+        assert!(sidecar_api_key_manifest_values(&collection)
+            .iter()
+            .all(|value| value.get("key").and_then(Value::as_str) != Some("scoped-key")));
+    }
+
+    #[test]
+    fn deleted_scoped_account_does_not_fall_back_to_legacy_sidecar_pool() {
+        let mut collection = test_local_access_collection(vec!["account-a".to_string()]);
+        let mut scoped_key = build_local_access_api_key(Some("Scoped"));
+        scoped_key.key = collection.api_key.clone();
+        scoped_key.inherit_account_pool = Some(false);
+        scoped_key.account_ids = vec!["account-b".to_string()];
+        collection.api_keys = vec![scoped_key];
+
+        assert!(remove_account_refs_from_collection(
+            &mut collection,
+            &HashSet::from(["account-b".to_string()]),
+        ));
+
+        assert!(collection.api_keys[0].account_ids.is_empty());
+        assert!(sidecar_api_key_manifest_values(&collection)
+            .iter()
+            .all(|value| value.get("key").and_then(Value::as_str) != Some("local-api-key")));
+        assert!(!sidecar_client_api_keys(&collection, &HashMap::new())
+            .iter()
+            .any(|key| key == "local-api-key"));
+        assert!(
+            sidecar_api_key_account_scope_values(&collection, &HashMap::new())
+                .get("local-api-key")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn sidecar_excludes_key_with_unresolved_custom_scope() {
+        let mut collection = test_local_access_collection(vec!["account-a".to_string()]);
+        let mut scoped_key = build_local_access_api_key(Some("Scoped"));
+        scoped_key.key = "scoped-key".to_string();
+        scoped_key.inherit_account_pool = Some(false);
+        scoped_key.account_ids = vec!["missing-account".to_string()];
+        collection.api_keys = vec![scoped_key];
+
+        assert!(!sidecar_client_api_keys(&collection, &HashMap::new())
+            .iter()
+            .any(|key| key == "scoped-key"));
+        assert!(
+            sidecar_api_key_account_scope_values(&collection, &HashMap::new())
+                .get("scoped-key")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn bound_oauth_gateway_key_rejects_inherited_or_empty_scope_updates() {
+        let account_id = "api-bound-oauth-1".to_string();
+        let mut collection = test_local_access_collection(Vec::new());
+        collection.bound_oauth_account_id = Some("oauth-1".to_string());
+
+        let mut api_key = build_local_access_api_key(Some("Bound OAuth Local Gateway"));
+        api_key.id = provider_gateway_api_key_id(&account_id);
+        api_key.inherit_account_pool = Some(false);
+        api_key.account_ids = vec![account_id.clone()];
+
+        assert!(validate_api_key_account_scope_update(
+            &collection,
+            &api_key,
+            Some(&[]),
+            Some(true),
+        )
+        .is_err());
+        assert!(validate_api_key_account_scope_update(
+            &collection,
+            &api_key,
+            Some(&[]),
+            Some(false),
+        )
+        .is_err());
+        assert!(
+            validate_api_key_account_scope_update(&collection, &api_key, None, Some(true),)
+                .is_err()
+        );
+        assert!(validate_api_key_account_scope_update(
+            &collection,
+            &api_key,
+            Some(&[account_id.clone()]),
+            Some(false),
+        )
+        .is_ok());
+        assert!(validate_api_key_account_scope_update(
+            &collection,
+            &api_key,
+            Some(&["api-bound-oauth-2".to_string()]),
+            Some(false),
+        )
+        .is_err());
+        assert!(validate_api_key_account_scope_update(
+            &collection,
+            &api_key,
+            Some(&[account_id.clone(), "api-bound-oauth-2".to_string()]),
+            Some(false),
+        )
+        .is_err());
+
+        let regular_collection = test_local_access_collection(vec!["account-a".to_string()]);
+        let regular_key = build_local_access_api_key(Some("Regular Key"));
+        assert!(validate_api_key_account_scope_update(
+            &regular_collection,
+            &regular_key,
+            None,
+            Some(true),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn custom_scope_model_visibility_uses_scoped_accounts_for_image_capacity() {
+        let mut paid_account = test_account_with_plan("pro");
+        paid_account.id = "account-paid".to_string();
+        let mut free_account = test_account_with_plan("free");
+        free_account.id = "account-free".to_string();
+        let collection = test_local_access_collection(vec![paid_account.id.clone()]);
+        let api_key = ResolvedLocalApiKey {
+            id: "key-scoped".to_string(),
+            label: "Scoped".to_string(),
+            provider_gateway: None,
+            inherit_account_pool: false,
+            account_ids: vec![free_account.id.clone()],
+            model_prefix: None,
+            allowed_models: Vec::new(),
+            excluded_models: Vec::new(),
+        };
+
+        let models = visible_codex_model_ids_for_api_key_with_accounts(
+            &collection,
+            &api_key,
+            &[paid_account, free_account],
+            None,
+        );
+
+        assert!(!models.iter().any(|model| model == CODEX_IMAGE_MODEL_ID));
     }
 
     #[test]
@@ -21736,6 +22134,49 @@ supports_websockets = false
     }
 
     #[test]
+    fn api_key_usage_stats_are_isolated_by_time_window() {
+        let now = 20 * DAY_WINDOW_MS;
+        let event =
+            |timestamp: i64, api_key_id: &str, total_tokens: u64| CodexLocalAccessUsageEvent {
+                timestamp,
+                api_key_id: api_key_id.to_string(),
+                api_key_label: api_key_id.to_string(),
+                request_kind: CodexLocalAccessRequestKind::Text,
+                success: true,
+                total_tokens,
+                ..Default::default()
+            };
+        let mut stats = empty_stats_snapshot();
+        stats.events = vec![
+            event(now - 10 * DAY_WINDOW_MS, "key-a", 400),
+            event(now - 2 * DAY_WINDOW_MS, "key-a", 200),
+            event(now - DAY_WINDOW_MS / 2, "key-a", 100),
+            event(now - DAY_WINDOW_MS / 2, "key-b", 50),
+        ];
+
+        recompute_time_windows(&mut stats, now);
+
+        let usage = |window: &CodexLocalAccessStatsWindow, api_key_id: &str| {
+            let usage = &window
+                .api_keys
+                .iter()
+                .find(|item| item.api_key_id == api_key_id)
+                .expect("API key stats should exist")
+                .usage;
+            (usage.request_count, usage.total_tokens)
+        };
+        assert_eq!(usage(&stats.daily, "key-a"), (1, 100));
+        assert_eq!(usage(&stats.daily, "key-b"), (1, 50));
+        assert_eq!(usage(&stats.weekly, "key-a"), (2, 300));
+        assert_eq!(usage(&stats.monthly, "key-a"), (3, 700));
+
+        recompute_time_windows(&mut stats, now + 2 * DAY_WINDOW_MS);
+        assert!(stats.daily.api_keys.is_empty());
+        assert_eq!(usage(&stats.weekly, "key-a"), (2, 300));
+        assert_eq!(usage(&stats.monthly, "key-a"), (3, 700));
+    }
+
+    #[test]
     fn extracts_usage_from_codex_response_completed_payload() {
         let payload = json!({
             "type": "response.completed",
@@ -22342,6 +22783,7 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
             id: "key-1".to_string(),
             label: "Key".to_string(),
             provider_gateway: None,
+            inherit_account_pool: true,
             account_ids: Vec::new(),
             model_prefix: Some("team".to_string()),
             allowed_models: vec!["gpt-*".to_string()],
@@ -22372,6 +22814,7 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
             id: "key-1".to_string(),
             label: "Key".to_string(),
             provider_gateway: None,
+            inherit_account_pool: true,
             account_ids: Vec::new(),
             model_prefix: None,
             allowed_models: Vec::new(),
@@ -22408,6 +22851,7 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
                 model_capabilities: HashMap::new(),
                 vision_routing_model: None,
             }),
+            inherit_account_pool: false,
             account_ids: vec!["account-1".to_string()],
             model_prefix: None,
             allowed_models: Vec::new(),
@@ -23620,6 +24064,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
             id: "client-key-1".to_string(),
             label: "Client".to_string(),
             provider_gateway: None,
+            inherit_account_pool: true,
             account_ids: Vec::new(),
             model_prefix: None,
             allowed_models: Vec::new(),
@@ -23659,6 +24104,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
             id: "client-key-1".to_string(),
             label: "Client".to_string(),
             provider_gateway: None,
+            inherit_account_pool: true,
             account_ids: Vec::new(),
             model_prefix: None,
             allowed_models: Vec::new(),
@@ -23734,6 +24180,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
             id: "client-key-1".to_string(),
             label: "Client".to_string(),
             provider_gateway: None,
+            inherit_account_pool: true,
             account_ids: Vec::new(),
             model_prefix: None,
             allowed_models: Vec::new(),
@@ -23795,6 +24242,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
             id: "client-key-1".to_string(),
             label: "Client".to_string(),
             provider_gateway: None,
+            inherit_account_pool: true,
             account_ids: Vec::new(),
             model_prefix: None,
             allowed_models: Vec::new(),
@@ -24211,6 +24659,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
             provider_gateway_bound_oauth_account_id_for_account(&account);
         let mut api_key = build_local_access_api_key(Some("Bound OAuth Local Gateway"));
         api_key.key = collection.api_key.clone();
+        api_key.inherit_account_pool = Some(false);
         api_key.account_ids = vec![account.id.clone()];
         collection.api_keys = vec![api_key];
 
@@ -24283,6 +24732,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
         collection.api_keys.clear();
         let mut api_key = build_local_access_api_key(Some("Temporary"));
         api_key.key = "local-test-key".to_string();
+        api_key.inherit_account_pool = Some(false);
         api_key.account_ids = vec![account.id.clone()];
         collection.api_keys.push(api_key);
 
@@ -24412,6 +24862,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
 
         let mut collection = test_local_access_collection(vec![account_id.clone()]);
         let mut api_key = build_local_access_api_key(Some("Provider Gateway"));
+        api_key.inherit_account_pool = Some(false);
         api_key.provider_gateway = Some(CodexLocalAccessProviderGateway {
             base_url: "https://api.deepseek.com/v1".to_string(),
             api_key: "sk-test".to_string(),
@@ -24462,6 +24913,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
         collection.bound_oauth_account_id =
             provider_gateway_bound_oauth_account_id_for_account(&account);
         let mut api_key = build_local_access_api_key(Some("Provider Gateway"));
+        api_key.inherit_account_pool = Some(false);
         api_key.provider_gateway = Some(CodexLocalAccessProviderGateway {
             base_url: "https://api.deepseek.com/v1".to_string(),
             api_key: "sk-test".to_string(),

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -3380,8 +3380,21 @@
         "pricingRepriced": "Historical estimates were recalculated with current prices"
       },
       "keys": {
-        "policyTitle": "Model Policy",
-        "advancedPolicyTitle": "Advanced: Model Policy",
+        "policyTitle": "Account Pool & Model Policy",
+        "advancedPolicyTitle": "Account Pool & Model Policy",
+        "accountScope": "Account Rotation Scope",
+        "accountScopeInherit": "Follow the service account pool automatically",
+        "accountScopeFixed": "This Key is fixed to its bound account and cannot inherit the service pool",
+        "accountScopeSelected": "{{count}} accounts selected",
+        "accountScopeInheritedCount": "Account pool: inheriting {{count}}",
+        "accountScopeUnavailable": "Account pool: no available accounts",
+        "accountScopeCount": "Account pool: {{selected}}/{{total}}",
+        "accountScopeRequired": "Select at least one account for a custom pool",
+        "accountScopeModeInherit": "Inherit Service Pool",
+        "accountScopeModeCustom": "Custom Account Pool",
+        "usageRange": "API key usage period",
+        "unsaved": "Unsaved",
+        "resetPolicy": "Discard Changes",
         "modelPrefix": "Model Prefix",
         "modelPrefixPlaceholder": "Example: codex",
         "allowedModels": "Allowed Models",
@@ -3389,7 +3402,7 @@
         "excludedModels": "Excluded Models",
         "excludedModelsPlaceholder": "One model or wildcard per line",
         "savePolicy": "Save Policy",
-        "policySaved": "Key model policy saved"
+        "policySaved": "API key policy saved"
       },
       "routing": {
         "optionsTitle": "Routing Options",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -3311,6 +3311,11 @@
         "models": "Models & Capabilities",
         "logs": "Stats & Logs"
       },
+      "statsRange": {
+        "today": "Today",
+        "thisWeek": "This week",
+        "thisMonth": "This month"
+      },
       "healthTitle": "Service Health",
       "compat": {
         "title": "Protocol Compat",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3380,8 +3380,21 @@
         "pricingRepriced": "Historical estimates were recalculated with current prices"
       },
       "keys": {
-        "policyTitle": "Model Policy",
-        "advancedPolicyTitle": "Advanced: Model Policy",
+        "policyTitle": "Account Pool & Model Policy",
+        "advancedPolicyTitle": "Account Pool & Model Policy",
+        "accountScope": "Account Rotation Scope",
+        "accountScopeInherit": "Follow the service account pool automatically",
+        "accountScopeFixed": "This Key is fixed to its bound account and cannot inherit the service pool",
+        "accountScopeSelected": "{{count}} accounts selected",
+        "accountScopeInheritedCount": "Account pool: inheriting {{count}}",
+        "accountScopeUnavailable": "Account pool: no available accounts",
+        "accountScopeCount": "Account pool: {{selected}}/{{total}}",
+        "accountScopeRequired": "Select at least one account for a custom pool",
+        "accountScopeModeInherit": "Inherit Service Pool",
+        "accountScopeModeCustom": "Custom Account Pool",
+        "usageRange": "API key usage period",
+        "unsaved": "Unsaved",
+        "resetPolicy": "Discard Changes",
         "modelPrefix": "Model Prefix",
         "modelPrefixPlaceholder": "Example: codex",
         "allowedModels": "Allowed Models",
@@ -3389,7 +3402,7 @@
         "excludedModels": "Excluded Models",
         "excludedModelsPlaceholder": "One model or wildcard per line",
         "savePolicy": "Save Policy",
-        "policySaved": "Key model policy saved"
+        "policySaved": "API key policy saved"
       },
       "routing": {
         "optionsTitle": "Routing Options",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3311,6 +3311,11 @@
         "models": "Models & Capabilities",
         "logs": "Stats & Logs"
       },
+      "statsRange": {
+        "today": "Today",
+        "thisWeek": "This week",
+        "thisMonth": "This month"
+      },
       "healthTitle": "Service Health",
       "compat": {
         "title": "Protocol Compat",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -3311,6 +3311,11 @@
         "models": "模型与能力",
         "logs": "统计与日志"
       },
+      "statsRange": {
+        "today": "今日",
+        "thisWeek": "本周",
+        "thisMonth": "本月"
+      },
       "healthTitle": "服务健康",
       "compat": {
         "title": "协议兼容",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -3380,8 +3380,21 @@
         "pricingRepriced": "历史估值已按当前价格重算"
       },
       "keys": {
-        "policyTitle": "模型策略",
-        "advancedPolicyTitle": "高级功能：模型策略",
+        "policyTitle": "账号池与模型策略",
+        "advancedPolicyTitle": "账号池与模型策略",
+        "accountScope": "账号轮转范围",
+        "accountScopeInherit": "随服务账号池自动更新",
+        "accountScopeFixed": "此 Key 已固定绑定账号，不能继承服务池",
+        "accountScopeSelected": "已选择 {{count}} 个账号",
+        "accountScopeInheritedCount": "账号池：继承 {{count}} 个",
+        "accountScopeUnavailable": "账号池：无可用账号",
+        "accountScopeCount": "账号池：{{selected}}/{{total}}",
+        "accountScopeRequired": "自定义账号池至少需要选择 1 个账号",
+        "accountScopeModeInherit": "继承服务池",
+        "accountScopeModeCustom": "自定义账号池",
+        "usageRange": "Key 用量统计周期",
+        "unsaved": "未保存",
+        "resetPolicy": "撤销修改",
         "modelPrefix": "模型前缀",
         "modelPrefixPlaceholder": "例如 codex",
         "allowedModels": "允许模型",
@@ -3389,7 +3402,7 @@
         "excludedModels": "排除模型",
         "excludedModelsPlaceholder": "每行一个模型或通配符",
         "savePolicy": "保存策略",
-        "policySaved": "Key 模型策略已保存"
+        "policySaved": "Key 策略已保存"
       },
       "routing": {
         "optionsTitle": "调度选项",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -3101,6 +3101,11 @@
         "models": "模型與能力",
         "logs": "統計與日誌"
       },
+      "statsRange": {
+        "today": "今日",
+        "thisWeek": "本週",
+        "thisMonth": "本月"
+      },
       "healthTitle": "服務健康",
       "compat": {
         "title": "協議相容",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -3158,8 +3158,21 @@
         "pricingRepriced": "歷史估值已按目前價格重算"
       },
       "keys": {
-        "policyTitle": "模型策略",
-        "advancedPolicyTitle": "進階功能：模型策略",
+        "policyTitle": "帳號池與模型策略",
+        "advancedPolicyTitle": "帳號池與模型策略",
+        "accountScope": "帳號輪轉範圍",
+        "accountScopeInherit": "隨服務帳號池自動更新",
+        "accountScopeFixed": "此 Key 已固定綁定帳號，不能繼承服務池",
+        "accountScopeSelected": "已選擇 {{count}} 個帳號",
+        "accountScopeInheritedCount": "帳號池：繼承 {{count}} 個",
+        "accountScopeUnavailable": "帳號池：無可用帳號",
+        "accountScopeCount": "帳號池：{{selected}}/{{total}}",
+        "accountScopeRequired": "自訂帳號池至少需要選擇 1 個帳號",
+        "accountScopeModeInherit": "繼承服務池",
+        "accountScopeModeCustom": "自訂帳號池",
+        "usageRange": "Key 用量統計週期",
+        "unsaved": "尚未儲存",
+        "resetPolicy": "撤銷修改",
         "modelPrefix": "模型前綴",
         "modelPrefixPlaceholder": "例如 codex",
         "allowedModels": "允許模型",
@@ -3167,7 +3180,7 @@
         "excludedModels": "排除模型",
         "excludedModelsPlaceholder": "每行一個模型或萬用字元",
         "savePolicy": "儲存策略",
-        "policySaved": "Key 模型策略已儲存"
+        "policySaved": "Key 策略已儲存"
       },
       "routing": {
         "optionsTitle": "調度選項",

--- a/src/pages/CodexApiServicePage.css
+++ b/src/pages/CodexApiServicePage.css
@@ -887,6 +887,45 @@
   min-width: 0;
 }
 
+.codex-api-service-usage-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+  padding: 2px 0;
+}
+
+.codex-api-service-usage-context {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.codex-api-service-usage-context > svg {
+  flex: 0 0 auto;
+  color: var(--primary);
+}
+
+.codex-api-service-usage-context > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.codex-api-service-usage-context strong {
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.codex-api-service-usage-context span {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
 .codex-api-service-key-card {
   display: grid;
   gap: 10px;
@@ -900,10 +939,30 @@
 
 .codex-api-service-key-main {
   display: grid;
-  grid-template-columns: minmax(180px, 0.9fr) minmax(260px, 1.25fr) minmax(78px, auto) minmax(56px, auto) minmax(42px, auto) auto;
+  grid-template-columns: minmax(180px, 0.9fr) minmax(260px, 1.25fr) minmax(78px, auto) minmax(122px, auto) auto;
   align-items: center;
   gap: 8px;
   min-width: 0;
+}
+
+.codex-api-service-key-last-used {
+  display: grid !important;
+  align-content: center;
+  gap: 2px;
+}
+
+.codex-api-service-key-last-used small {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1;
+}
+
+.codex-api-service-key-last-used strong {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
 }
 
 .codex-api-service-key-main > span:not(.codex-api-service-pill) {
@@ -928,6 +987,108 @@
   flex-wrap: nowrap;
   align-self: center;
   height: 34px;
+}
+
+.api-key-details-row {
+  display: grid;
+  grid-template-columns: minmax(190px, 0.55fr) minmax(500px, 1.45fr);
+  gap: 10px;
+  min-width: 0;
+}
+
+.api-key-routing-summary {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--codex-api-border-soft);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-card) 72%, transparent);
+}
+
+.api-key-routing-summary > svg {
+  flex: 0 0 auto;
+  color: var(--primary);
+}
+
+.api-key-routing-summary > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.api-key-routing-summary span,
+.api-key-usage-grid span {
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.api-key-routing-summary strong,
+.api-key-usage-grid strong {
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.api-key-routing-summary.warning {
+  border-color: color-mix(in srgb, var(--warning) 32%, var(--codex-api-border-soft));
+  background: color-mix(in srgb, var(--warning) 8%, transparent);
+}
+
+.api-key-routing-summary.warning > svg,
+.api-key-routing-summary.warning strong {
+  color: var(--warning);
+}
+
+.api-key-usage-grid {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.9fr) repeat(4, minmax(84px, 1fr));
+  align-items: stretch;
+  min-width: 0;
+  border: 1px solid var(--codex-api-border-soft);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-card) 72%, transparent);
+  overflow: hidden;
+}
+
+.api-key-usage-grid > div {
+  display: grid;
+  align-content: center;
+  gap: 3px;
+  min-width: 0;
+  min-height: 48px;
+  padding: 7px 10px;
+  border-left: 1px solid var(--codex-api-border-soft);
+}
+
+.api-key-usage-grid > div:first-child {
+  border-left: 0;
+}
+
+.api-key-usage-grid .api-key-usage-grid-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
+  color: var(--primary);
+}
+
+.api-key-usage-grid-head svg {
+  flex: 0 0 auto;
+}
+
+.api-key-usage-grid-head span {
+  color: var(--primary);
+  font-size: 11px;
+  font-weight: 700;
 }
 
 .codex-api-service-key-advanced-toggle {
@@ -967,6 +1128,15 @@
   font-weight: 700;
 }
 
+.api-key-policy-dirty {
+  padding: 2px 6px;
+  border: 1px solid color-mix(in srgb, var(--warning) 32%, var(--codex-api-border-soft));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--warning) 8%, transparent);
+  color: var(--warning);
+  line-height: 1.2;
+}
+
 .codex-api-service-key-advanced-state svg {
   transition: transform 0.16s ease;
 }
@@ -985,9 +1155,147 @@
   background: color-mix(in srgb, var(--bg-card) 78%, transparent);
 }
 
+.api-key-account-scope {
+  display: grid;
+  gap: 9px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--codex-api-border-soft);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-surface) 68%, transparent);
+}
+
+.api-key-account-scope-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+}
+
+.api-key-account-scope-header > span:first-child {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 750;
+  line-height: 1.35;
+}
+
+.api-key-account-scope-hint {
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.api-key-account-scope-mode {
+  display: inline-flex;
+  justify-self: start;
+  gap: 3px;
+  max-width: 100%;
+  padding: 3px;
+  border: 1px solid var(--codex-api-border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-secondary) 82%, transparent);
+}
+
+.api-key-account-scope-mode button {
+  min-height: 28px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.api-key-account-scope-mode button.active {
+  background: color-mix(in srgb, var(--primary) 11%, transparent);
+  color: var(--primary);
+}
+
+.api-key-account-scope-mode button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.api-key-account-scope-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+  min-width: 0;
+}
+
+.api-key-account-scope-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  min-height: 42px;
+  padding: 8px 9px;
+  border: 1px solid var(--codex-api-border-soft);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-card) 66%, transparent);
+  cursor: pointer;
+  transition: border-color 0.16s ease, background 0.16s ease;
+}
+
+.api-key-account-scope-item:hover {
+  border-color: color-mix(in srgb, var(--primary) 22%, var(--codex-api-border-soft));
+  background: color-mix(in srgb, var(--primary) 5%, var(--bg-card));
+}
+
+.api-key-account-scope-item input {
+  flex: 0 0 15px;
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--color-primary);
+}
+
+.api-key-account-scope-item input:disabled {
+  cursor: not-allowed;
+}
+
+.api-key-account-scope-item:has(input:disabled) {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.api-key-account-scope-item > span {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.api-key-account-scope-item strong,
+.api-key-account-scope-item small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.api-key-account-scope-item strong {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.api-key-account-scope-item small {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.2;
+}
+
 .codex-api-service-policy-grid {
   display: grid;
-  grid-template-columns: minmax(180px, 0.75fr) minmax(240px, 1fr) minmax(240px, 1fr) minmax(132px, auto);
+  grid-template-columns: minmax(180px, 0.75fr) minmax(240px, 1fr) minmax(240px, 1fr) minmax(190px, auto);
   align-items: start;
   gap: 10px;
   min-width: 0;
@@ -1033,6 +1341,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: flex-end;
+  gap: 6px;
   height: 96px;
   min-width: 0;
 }
@@ -1183,9 +1492,13 @@
 }
 
 .codex-api-service-range-tabs button {
-  min-width: 34px;
-  height: 24px;
-  padding: 0 8px;
+  display: grid;
+  grid-template-columns: auto auto;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 54px;
+  height: 30px;
+  padding: 0 9px;
   border: 0;
   border-radius: 9px;
   background: transparent;
@@ -1193,6 +1506,17 @@
   font-size: 11px;
   font-weight: 700;
   cursor: pointer;
+}
+
+.codex-api-service-range-tabs button small {
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 650;
+}
+
+.codex-api-service-range-tabs button.active small {
+  color: currentColor;
+  opacity: 0.72;
 }
 
 .codex-api-service-range-tabs button.active {
@@ -1690,6 +2014,10 @@
     grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
   }
 
+  .api-key-details-row {
+    grid-template-columns: 1fr;
+  }
+
   .codex-api-service-policy-grid {
     grid-template-columns: 1fr 1fr;
   }
@@ -1711,6 +2039,32 @@
 }
 
 @media (max-width: 860px) {
+  .codex-api-service-usage-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .codex-api-service-usage-toolbar .codex-api-service-range-tabs {
+    align-self: flex-start;
+  }
+
+  .api-key-usage-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .api-key-usage-grid > div,
+  .api-key-usage-grid > div:first-child {
+    border-top: 1px solid var(--codex-api-border-soft);
+    border-left: 1px solid var(--codex-api-border-soft);
+  }
+
+  .api-key-usage-grid > div:nth-child(-n + 2) {
+    border-top: 0;
+  }
+
+  .api-key-usage-grid > div:nth-child(odd) {
+    border-left: 0;
+  }
   .codex-api-service-page .page-tabs-row-with-leading {
     grid-template-columns: 1fr;
     justify-items: stretch;
@@ -1842,6 +2196,41 @@
 
   .codex-api-service-key-main {
     grid-template-columns: 1fr;
+  }
+
+  .api-key-usage-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .api-key-usage-grid > div,
+  .api-key-usage-grid > div:first-child,
+  .api-key-usage-grid > div:nth-child(-n + 2) {
+    border-top: 1px solid var(--codex-api-border-soft);
+    border-left: 0;
+  }
+
+  .api-key-usage-grid > div:first-child {
+    border-top: 0;
+  }
+
+  .api-key-account-scope-header,
+  .codex-api-service-policy-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .api-key-account-scope-hint {
+    white-space: normal;
+  }
+
+  .api-key-account-scope-mode,
+  .codex-api-service-range-tabs {
+    width: 100%;
+  }
+
+  .api-key-account-scope-mode button,
+  .codex-api-service-range-tabs button {
+    flex: 1 1 0;
   }
 
   .codex-api-service-policy-actions .btn {

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -2464,20 +2464,20 @@ export function CodexApiServicePage() {
     {
       key: "daily" as const,
       label: t("codex.localAccess.statsRange.daily", "日"),
-      window: "24h",
-      title: t("codex.apiService.statsRange.last24Hours", "近 24 小时"),
+      window: t("codex.apiService.statsRange.today", "Today"),
+      title: t("codex.apiService.statsRange.today", "Today"),
     },
     {
       key: "weekly" as const,
       label: t("codex.localAccess.statsRange.weekly", "周"),
-      window: "7d",
-      title: t("codex.apiService.statsRange.last7Days", "近 7 天"),
+      window: t("codex.apiService.statsRange.thisWeek", "This week"),
+      title: t("codex.apiService.statsRange.thisWeek", "This week"),
     },
     {
       key: "monthly" as const,
       label: t("codex.localAccess.statsRange.monthly", "月"),
-      window: "30d",
-      title: t("codex.apiService.statsRange.last30Days", "近 30 天"),
+      window: t("codex.apiService.statsRange.thisMonth", "This month"),
+      title: t("codex.apiService.statsRange.thisMonth", "This month"),
     },
   ];
   const selectedStatsRangeOption =

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -26,6 +26,7 @@ import {
   ShieldCheck,
   SlidersHorizontal,
   Trash2,
+  Undo2,
   Users,
   Wrench,
   X,
@@ -43,6 +44,11 @@ import {
 } from "../stores/usePlatformLayoutStore";
 import { getPlatformLabel } from "../utils/platformMeta";
 import { useCodexAccountStore } from "../stores/useCodexAccountStore";
+import {
+  isCodexApiKeyScopeAccountActive,
+  reconcileCodexApiKeyScopeAccountIds,
+  selectCodexApiKeyScopeAccounts,
+} from "../utils/codexApiKeyAccountScope";
 import * as codexLocalAccessService from "../services/codexLocalAccessService";
 import * as codexInstanceService from "../services/codexInstanceService";
 import {
@@ -54,9 +60,11 @@ import { CODEX_API_SERVICE_BIND_ID } from "../types/instance";
 import type {
   CodexLocalAccessAddressKind,
   CodexLocalAccessAccountModelRule,
+  CodexLocalAccessApiKey,
   CodexLocalAccessChatMessage,
   CodexLocalAccessChatStreamEvent,
   CodexLocalAccessClientBaseUrlHost,
+  CodexLocalAccessCollection,
   CodexLocalAccessCustomRoutingRule,
   CodexLocalAccessGatewayMode,
   CodexLocalAccessImageGenerationMode,
@@ -104,6 +112,8 @@ interface ApiKeyPolicyDraft {
   modelPrefix: string;
   allowedModels: string;
   excludedModels: string;
+  inheritAccountPool: boolean;
+  accountIds: string[];
 }
 
 interface TestChatMessage {
@@ -314,6 +324,65 @@ function parseModelRuleText(value: string): string[] {
 
 function serializeModelRules(values: string[] | null | undefined): string {
   return (values ?? []).join("\n");
+}
+
+function apiKeyInheritsAccountPool(apiKey: CodexLocalAccessApiKey): boolean {
+  return (
+    apiKey.inheritAccountPool ?? ((apiKey.accountIds?.length ?? 0) === 0)
+  );
+}
+
+function apiKeyHasFixedAccountScope(
+  apiKey: CodexLocalAccessApiKey,
+  collection: CodexLocalAccessCollection | null,
+): boolean {
+  if (apiKey.providerGateway) return true;
+  const accountIds = apiKey.accountIds ?? [];
+  return Boolean(
+    collection?.boundOauthAccountId &&
+      collection.accountIds.length === 0 &&
+      accountIds.length === 1 &&
+      apiKey.id === `provider_gateway_${accountIds[0]}`,
+  );
+}
+
+function apiKeyPolicyDraftFromValue(
+  apiKey: CodexLocalAccessApiKey,
+): ApiKeyPolicyDraft {
+  return {
+    modelPrefix: apiKey.modelPrefix ?? "",
+    allowedModels: serializeModelRules(apiKey.allowedModels),
+    excludedModels: serializeModelRules(apiKey.excludedModels),
+    inheritAccountPool: apiKeyInheritsAccountPool(apiKey),
+    accountIds: apiKey.accountIds ?? [],
+  };
+}
+
+function sameStringList(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+function apiKeyPolicyDraftIsDirty(
+  apiKey: CodexLocalAccessApiKey,
+  draft: ApiKeyPolicyDraft,
+): boolean {
+  const persisted = apiKeyPolicyDraftFromValue(apiKey);
+  return (
+    draft.modelPrefix !== persisted.modelPrefix ||
+    draft.allowedModels !== persisted.allowedModels ||
+    draft.excludedModels !== persisted.excludedModels ||
+    draft.inheritAccountPool !== persisted.inheritAccountPool ||
+    !sameStringList(draft.accountIds, persisted.accountIds)
+  );
+}
+
+function toggleStringSelection(values: string[], value: string): string[] {
+  return values.includes(value)
+    ? values.filter((item) => item !== value)
+    : [...values, value];
 }
 
 function parseModelAliasText(value: string): CodexLocalAccessModelAlias[] {
@@ -639,11 +708,12 @@ export function CodexApiServicePage() {
   const selectedTimeoutPresetIsCustom = Boolean(
     selectedTimeoutPreset && !selectedTimeoutPreset.builtin,
   );
-  const selectedStatsWindow =
-    useMemo<CodexLocalAccessStatsWindow | null>(() => {
-      if (!stats) return null;
-      return stats[statsRange];
-    }, [stats, statsRange]);
+  const selectedStatsWindow: CodexLocalAccessStatsWindow | null = stats
+    ? stats[statsRange]
+    : null;
+  const apiKeyStatsById = new Map(
+    (selectedStatsWindow?.apiKeys ?? []).map((item) => [item.apiKeyId, item]),
+  );
   const totals = selectedStatsWindow?.totals;
   const memberIds = collection?.accountIds ?? [];
   const localAccessAccounts = useMemo(() => accounts, [accounts]);
@@ -655,6 +725,10 @@ export function CodexApiServicePage() {
         )
         .filter((account): account is CodexAccount => Boolean(account)),
     [memberIds, localAccessAccounts],
+  );
+  const memberAccountIds = useMemo(
+    () => memberAccounts.map((account) => account.id),
+    [memberAccounts],
   );
   const accountModelRuleCount = collection?.accountModelRules.length ?? 0;
   const accountModelRuleAllSelected =
@@ -891,6 +965,13 @@ export function CodexApiServicePage() {
     return nextState;
   }, []);
 
+  const handleStatsRangeChange = useCallback(
+    (nextRange: StatsRangeKey) => {
+      setStatsRange(nextRange);
+    },
+    [],
+  );
+
   useEffect(() => {
     mountedRef.current = true;
     void reloadState().catch((err) =>
@@ -1022,16 +1103,17 @@ export function CodexApiServicePage() {
         (collection?.apiKeys ?? []).map((apiKey) => [apiKey.id, apiKey.label]),
       ),
     );
-    setApiKeyPolicyDrafts(
+    setApiKeyPolicyDrafts((currentDrafts) =>
       Object.fromEntries(
-        (collection?.apiKeys ?? []).map((apiKey) => [
-          apiKey.id,
-          {
-            modelPrefix: apiKey.modelPrefix ?? "",
-            allowedModels: serializeModelRules(apiKey.allowedModels),
-            excludedModels: serializeModelRules(apiKey.excludedModels),
-          },
-        ]),
+        (collection?.apiKeys ?? []).map((apiKey) => {
+          const currentDraft = currentDrafts[apiKey.id];
+          return [
+            apiKey.id,
+            currentDraft && apiKeyPolicyDraftIsDirty(apiKey, currentDraft)
+              ? currentDraft
+              : apiKeyPolicyDraftFromValue(apiKey),
+          ];
+        }),
       ),
     );
   }, [collection?.apiKeys]);
@@ -1538,6 +1620,35 @@ export function CodexApiServicePage() {
   const handleSaveApiKeyPolicy = async (apiKeyId: string) => {
     const draft = apiKeyPolicyDrafts[apiKeyId];
     if (!draft) return;
+    const apiKey = collection?.apiKeys.find((item) => item.id === apiKeyId);
+    if (!apiKey) return;
+    const accountIds = reconcileCodexApiKeyScopeAccountIds({
+      accounts: localAccessAccounts,
+      restrictFreeAccounts: collection?.restrictFreeAccounts ?? true,
+      persistedAccountIds: apiKey.accountIds ?? [],
+      draftAccountIds: draft.accountIds,
+    });
+    if (
+      apiKeyHasFixedAccountScope(apiKey, collection) &&
+      (draft.inheritAccountPool || accountIds.length === 0)
+    ) {
+      setError(
+        t(
+          "codex.apiService.keys.accountScopeFixed",
+          "此 Key 已固定绑定账号，不能继承服务池或清空账号范围",
+        ),
+      );
+      return;
+    }
+    if (!draft.inheritAccountPool && accountIds.length === 0) {
+      setError(
+        t(
+          "codex.apiService.keys.accountScopeRequired",
+          "自定义账号池至少需要选择 1 个账号",
+        ),
+      );
+      return;
+    }
     await runAction(
       async () => {
         const next = await codexLocalAccessService.updateCodexLocalAccessApiKey(
@@ -1546,12 +1657,31 @@ export function CodexApiServicePage() {
             modelPrefix: draft.modelPrefix.trim(),
             allowedModels: parseModelRuleText(draft.allowedModels),
             excludedModels: parseModelRuleText(draft.excludedModels),
+            accountIds,
+            inheritAccountPool: draft.inheritAccountPool,
           },
         );
         setState(next);
+        const savedApiKey = next.collection?.apiKeys.find(
+          (item) => item.id === apiKeyId,
+        );
+        if (savedApiKey) {
+          setApiKeyPolicyDrafts((drafts) => ({
+            ...drafts,
+            [apiKeyId]: apiKeyPolicyDraftFromValue(savedApiKey),
+          }));
+        }
       },
-      t("codex.apiService.keys.policySaved", "Key 模型策略已保存"),
+      t("codex.apiService.keys.policySaved", "Key 策略已保存"),
     );
+  };
+
+  const handleResetApiKeyPolicy = (apiKey: CodexLocalAccessApiKey) => {
+    setApiKeyPolicyDrafts((drafts) => ({
+      ...drafts,
+      [apiKey.id]: apiKeyPolicyDraftFromValue(apiKey),
+    }));
+    setError("");
   };
 
   const handleToggleApiKey = async (apiKeyId: string, enabled: boolean) => {
@@ -2334,16 +2464,25 @@ export function CodexApiServicePage() {
     {
       key: "daily" as const,
       label: t("codex.localAccess.statsRange.daily", "日"),
+      window: "24h",
+      title: t("codex.apiService.statsRange.last24Hours", "近 24 小时"),
     },
     {
       key: "weekly" as const,
       label: t("codex.localAccess.statsRange.weekly", "周"),
+      window: "7d",
+      title: t("codex.apiService.statsRange.last7Days", "近 7 天"),
     },
     {
       key: "monthly" as const,
       label: t("codex.localAccess.statsRange.monthly", "月"),
+      window: "30d",
+      title: t("codex.apiService.statsRange.last30Days", "近 30 天"),
     },
   ];
+  const selectedStatsRangeOption =
+    statsRangeOptions.find((option) => option.key === statsRange) ??
+    statsRangeOptions[0];
   const requestLogKindOptions: Array<{
     value: RequestLogKindFilter;
     label: string;
@@ -2682,6 +2821,45 @@ export function CodexApiServicePage() {
           </div>
         )}
 
+        <section className="codex-api-service-usage-toolbar">
+          <div className="codex-api-service-usage-context">
+            <Activity size={16} />
+            <div>
+              <strong>
+                {t("codex.apiService.usage.title", "用量统计")}
+              </strong>
+              <span>
+                {selectedStatsRangeOption.title}
+                {stats?.updatedAt
+                  ? ` · ${t("codex.apiService.usage.lastRecorded", "最近入账")} ${formatDateTime(stats.updatedAt)}`
+                  : ""}
+              </span>
+            </div>
+          </div>
+          <div
+            className="codex-api-service-range-tabs"
+            role="group"
+            aria-label={t(
+              "codex.apiService.keys.usageRange",
+              "Key 用量统计周期",
+            )}
+          >
+            {statsRangeOptions.map((option) => (
+              <button
+                key={option.key}
+                type="button"
+                className={statsRange === option.key ? "active" : ""}
+                aria-pressed={statsRange === option.key}
+                title={option.title}
+                onClick={() => handleStatsRangeChange(option.key)}
+              >
+                <span>{option.label}</span>
+                <small>{option.window}</small>
+              </button>
+            ))}
+          </div>
+        </section>
+
         <section className="codex-api-service-summary-grid">
           {summaryCards.map((item) => (
             <div key={item.key} className="codex-api-service-summary-card">
@@ -2976,22 +3154,57 @@ export function CodexApiServicePage() {
           <section className="codex-api-service-panel">
             <div className="codex-api-service-panel-head">
               <h2>{t("codex.localAccess.apiKeysTitle", "客户端 Key")}</h2>
-              <button
-                type="button"
-                className="btn btn-primary btn-sm"
-                onClick={() => void handleCreateApiKey()}
-                disabled={busy || !collection}
-              >
-                <Plus size={14} />
-                {t("codex.localAccess.apiKeyAdd", "新增 Key")}
-              </button>
+              <div className="codex-api-service-head-actions">
+                <button
+                  type="button"
+                  className="btn btn-primary btn-sm"
+                  onClick={() => void handleCreateApiKey()}
+                  disabled={busy || !collection}
+                >
+                  <Plus size={14} />
+                  {t("codex.localAccess.apiKeyAdd", "新增 Key")}
+                </button>
+              </div>
             </div>
             <div className="codex-api-service-table">
               {(collection?.apiKeys ?? []).map((apiKey) => {
                 const labelDraft = apiKeyDrafts[apiKey.id] ?? apiKey.label;
-                const keyStats = selectedStatsWindow?.apiKeys.find(
-                  (item) => item.apiKeyId === apiKey.id,
+                const policyDraft =
+                  apiKeyPolicyDrafts[apiKey.id] ??
+                  apiKeyPolicyDraftFromValue(apiKey);
+                const persistedInheritAccountPool =
+                  apiKeyInheritsAccountPool(apiKey);
+                const persistedAccountIds = apiKey.accountIds ?? [];
+                const accountScopeLocked = apiKeyHasFixedAccountScope(
+                  apiKey,
+                  collection,
                 );
+                const keySelectableAccounts = selectCodexApiKeyScopeAccounts({
+                  accounts: localAccessAccounts,
+                  restrictFreeAccounts: collection?.restrictFreeAccounts ?? true,
+                  scopedAccountIds: apiKey.accountIds ?? [],
+                });
+                const keySelectableAccountIds = keySelectableAccounts.map(
+                  (account) => account.id,
+                );
+                const keySelectableAccountIdSet = new Set(
+                  keySelectableAccounts.map((account) => account.id),
+                );
+                const policyDirty = apiKeyPolicyDraftIsDirty(
+                  apiKey,
+                  policyDraft,
+                );
+                const customScopeInvalid =
+                  !policyDraft.inheritAccountPool &&
+                  policyDraft.accountIds.length === 0;
+                const keyStats = apiKeyStatsById.get(apiKey.id);
+                const keyUsage = keyStats?.usage;
+                const keySuccessRate =
+                  keyUsage && keyUsage.requestCount > 0
+                    ? Math.round(
+                        (keyUsage.successCount / keyUsage.requestCount) * 100,
+                      )
+                    : 0;
                 const policyExpanded = expandedApiKeyPolicyIds.has(apiKey.id);
                 return (
                   <div key={apiKey.id} className="codex-api-service-key-card">
@@ -3025,9 +3238,11 @@ export function CodexApiServicePage() {
                           ? t("common.enabled", "已启用")
                           : t("common.disabled", "已停用")}
                       </span>
-                      <span>{formatDateTime(apiKey.lastUsedAt)}</span>
-                      <span>
-                        {formatCompactNumber(keyStats?.usage.requestCount ?? 0)}
+                      <span className="codex-api-service-key-last-used">
+                        <small>
+                          {t("codex.apiService.keys.lastUsed", "最近使用")}
+                        </small>
+                        <strong>{formatDateTime(apiKey.lastUsedAt)}</strong>
                       </span>
                       <div className="codex-api-service-row-actions">
                         <button
@@ -3036,6 +3251,7 @@ export function CodexApiServicePage() {
                           onClick={() =>
                             void handleCopy(`apiKey:${apiKey.id}`, apiKey.key)
                           }
+                          title={t("common.copy", "复制")}
                         >
                           {copiedField === `apiKey:${apiKey.id}` ? (
                             <Check size={14} />
@@ -3050,6 +3266,11 @@ export function CodexApiServicePage() {
                             void handleToggleApiKey(apiKey.id, !apiKey.enabled)
                           }
                           disabled={busy}
+                          title={
+                            apiKey.enabled
+                              ? t("common.disable", "停用")
+                              : t("common.enable", "启用")
+                          }
                         >
                           <Power size={14} />
                         </button>
@@ -3058,6 +3279,10 @@ export function CodexApiServicePage() {
                           className="folder-icon-btn"
                           onClick={() => void handleRotateApiKey(apiKey.id)}
                           disabled={busy}
+                          title={t(
+                            "codex.localAccess.apiKeyRotate",
+                            "轮换 Key",
+                          )}
                         >
                           <RefreshCw size={14} />
                         </button>
@@ -3068,9 +3293,85 @@ export function CodexApiServicePage() {
                           disabled={
                             busy || (collection?.apiKeys.length ?? 0) <= 1
                           }
+                          title={t("common.delete", "删除")}
                         >
                           <Trash2 size={14} />
                         </button>
+                      </div>
+                    </div>
+                    <div className="api-key-details-row">
+                      <div
+                        className={`api-key-routing-summary ${
+                          !persistedInheritAccountPool &&
+                          persistedAccountIds.length === 0
+                            ? "warning"
+                            : ""
+                        }`}
+                      >
+                        <Route size={16} />
+                        <div>
+                          <span>
+                            {t("codex.apiService.keys.routingAccounts", "分流账号")}
+                          </span>
+                          <strong>
+                            {persistedInheritAccountPool
+                              ? t(
+                                  "codex.apiService.keys.accountScopeInheritedCount",
+                                  "继承服务池 · {{count}} 个账号",
+                                  { count: memberIds.length },
+                                )
+                              : persistedAccountIds.length === 0
+                                ? t(
+                                    "codex.apiService.keys.accountScopeUnavailable",
+                                    "无可用账号",
+                                  )
+                                : t(
+                                    "codex.apiService.keys.accountScopeCount",
+                                    "自定义 · {{selected}}/{{total}} 个账号",
+                                    {
+                                      selected: persistedAccountIds.length,
+                                      total: keySelectableAccountIds.length,
+                                    },
+                                  )}
+                          </strong>
+                        </div>
+                      </div>
+                      <div
+                        key={statsRange}
+                        className="api-key-usage-grid"
+                        aria-live="polite"
+                        aria-label={`${selectedStatsRangeOption.title} Key 用量`}
+                      >
+                        <div className="api-key-usage-grid-head">
+                          <Activity size={14} />
+                          <span>{selectedStatsRangeOption.title}</span>
+                        </div>
+                        <div>
+                          <span>
+                            {t("codex.localAccess.stats.requests", "请求")}
+                          </span>
+                          <strong>
+                            {formatCompactNumber(keyUsage?.requestCount ?? 0)}
+                          </strong>
+                        </div>
+                        <div>
+                          <span>Token</span>
+                          <strong>{formatAccountTokenUsage(keyUsage)}</strong>
+                        </div>
+                        <div>
+                          <span>
+                            {t("codex.localAccess.stats.successRateLabel", "成功率")}
+                          </span>
+                          <strong>{keySuccessRate}%</strong>
+                        </div>
+                        <div>
+                          <span>
+                            {t("codex.localAccess.stats.estimatedCost", "估算费用")}
+                          </span>
+                          <strong>
+                            {formatUsdCost(keyUsage?.estimatedCostUsd ?? 0)}
+                          </strong>
+                        </div>
                       </div>
                     </div>
                     <button
@@ -3084,11 +3385,19 @@ export function CodexApiServicePage() {
                         <span>
                           {t(
                             "codex.apiService.keys.advancedPolicyTitle",
-                            "高级功能：模型策略",
+                            "账号池与模型策略",
                           )}
                         </span>
                       </span>
                       <span className="codex-api-service-key-advanced-state">
+                        {policyDirty && (
+                          <span className="api-key-policy-dirty">
+                            {t(
+                              "codex.apiService.keys.unsaved",
+                              "未保存",
+                            )}
+                          </span>
+                        )}
                         {policyExpanded
                           ? t("common.collapse", "收起")
                           : t("common.expand", "展开")}
@@ -3097,6 +3406,177 @@ export function CodexApiServicePage() {
                     </button>
                     {policyExpanded && (
                       <div className="codex-api-service-key-policy">
+                        <div className="api-key-account-scope">
+                          <div className="api-key-account-scope-header">
+                            <span>
+                              {t(
+                                "codex.apiService.keys.accountScope",
+                                "账号轮转范围",
+                              )}
+                            </span>
+                            <span className="api-key-account-scope-hint">
+                              {accountScopeLocked
+                                ? t(
+                                    "codex.apiService.keys.accountScopeFixed",
+                                    "此 Key 已固定绑定账号，不能继承服务池或清空账号范围",
+                                  )
+                                : policyDraft.inheritAccountPool
+                                  ? t(
+                                      "codex.apiService.keys.accountScopeInherit",
+                                      "随服务账号池自动更新",
+                                    )
+                                  : customScopeInvalid
+                                    ? t(
+                                        "codex.apiService.keys.accountScopeRequired",
+                                        "自定义账号池至少需要选择 1 个账号",
+                                      )
+                                    : t(
+                                        "codex.apiService.keys.accountScopeSelected",
+                                        "已选择 {{count}} 个账号",
+                                        { count: policyDraft.accountIds.length },
+                                      )}
+                            </span>
+                          </div>
+                          <div
+                            className="api-key-account-scope-mode"
+                            role="group"
+                            aria-label={t(
+                              "codex.apiService.keys.accountScope",
+                              "账号轮转范围",
+                            )}
+                          >
+                            <button
+                              type="button"
+                              className={
+                                policyDraft.inheritAccountPool ? "active" : ""
+                              }
+                              aria-pressed={policyDraft.inheritAccountPool}
+                              onClick={() =>
+                                setApiKeyPolicyDrafts((drafts) => ({
+                                  ...drafts,
+                                  [apiKey.id]: {
+                                    ...(drafts[apiKey.id] ?? policyDraft),
+                                    inheritAccountPool: true,
+                                  },
+                                }))
+                              }
+                              disabled={busy || accountScopeLocked}
+                              title={
+                                accountScopeLocked
+                                  ? t(
+                                      "codex.apiService.keys.accountScopeFixed",
+                                      "此 Key 已固定绑定账号，不能继承服务池或清空账号范围",
+                                    )
+                                  : undefined
+                              }
+                            >
+                              {t(
+                                "codex.apiService.keys.accountScopeModeInherit",
+                                "继承服务池",
+                              )}
+                            </button>
+                            <button
+                              type="button"
+                              className={
+                                policyDraft.inheritAccountPool ? "" : "active"
+                              }
+                              aria-pressed={!policyDraft.inheritAccountPool}
+                              onClick={() =>
+                                setApiKeyPolicyDrafts((drafts) => {
+                                  const currentDraft =
+                                    drafts[apiKey.id] ?? policyDraft;
+                                  const reusableAccountIds =
+                                    currentDraft.accountIds.filter((accountId) =>
+                                      keySelectableAccountIdSet.has(accountId),
+                                    );
+                                  return {
+                                    ...drafts,
+                                    [apiKey.id]: {
+                                      ...currentDraft,
+                                      inheritAccountPool: false,
+                                      accountIds:
+                                        reusableAccountIds.length > 0
+                                          ? reusableAccountIds
+                                          : memberAccountIds,
+                                    },
+                                  };
+                                })
+                              }
+                              disabled={
+                                busy ||
+                                accountScopeLocked ||
+                                keySelectableAccounts.length === 0
+                              }
+                            >
+                              {t(
+                                "codex.apiService.keys.accountScopeModeCustom",
+                                "自定义账号池",
+                              )}
+                            </button>
+                          </div>
+                          {keySelectableAccounts.length === 0 ? (
+                            <div className="codex-api-service-empty">
+                              {t(
+                                "codex.localAccess.emptyMembers",
+                                "当前集合暂无账号",
+                              )}
+                            </div>
+                          ) : (
+                            <div className="api-key-account-scope-grid">
+                              {keySelectableAccounts.map((account) => {
+                                const presentation =
+                                  buildCodexAccountPresentation(account, t);
+                                return (
+                                  <label
+                                    key={account.id}
+                                    className="api-key-account-scope-item"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={isCodexApiKeyScopeAccountActive({
+                                        accountId: account.id,
+                                        inheritAccountPool:
+                                          policyDraft.inheritAccountPool,
+                                        accountIds: policyDraft.accountIds,
+                                        inheritedAccountIds: memberAccountIds,
+                                      })}
+                                      onChange={() =>
+                                        setApiKeyPolicyDrafts((drafts) => {
+                                          const currentDraft =
+                                            drafts[apiKey.id] ?? policyDraft;
+                                          return {
+                                            ...drafts,
+                                            [apiKey.id]: {
+                                              ...currentDraft,
+                                              accountIds:
+                                                toggleStringSelection(
+                                                  currentDraft.accountIds,
+                                                  account.id,
+                                                ),
+                                            },
+                                          };
+                                        })
+                                      }
+                                      disabled={
+                                        busy ||
+                                        policyDraft.inheritAccountPool ||
+                                        accountScopeLocked
+                                      }
+                                    />
+                                    <span>
+                                      <strong title={presentation.displayName}>
+                                        {maskAccountText(
+                                          presentation.displayName,
+                                        )}
+                                      </strong>
+                                      <small>{presentation.planLabel}</small>
+                                    </span>
+                                  </label>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
                         <div className="codex-api-service-policy-grid">
                           <label>
                             <span>
@@ -3106,18 +3586,12 @@ export function CodexApiServicePage() {
                               )}
                             </span>
                             <input
-                              value={
-                                apiKeyPolicyDrafts[apiKey.id]?.modelPrefix ?? ""
-                              }
+                              value={policyDraft.modelPrefix}
                               onChange={(event) =>
                                 setApiKeyPolicyDrafts((drafts) => ({
                                   ...drafts,
                                   [apiKey.id]: {
-                                    ...(drafts[apiKey.id] ?? {
-                                      modelPrefix: "",
-                                      allowedModels: "",
-                                      excludedModels: "",
-                                    }),
+                                    ...(drafts[apiKey.id] ?? policyDraft),
                                     modelPrefix: event.target.value,
                                   },
                                 }))
@@ -3137,19 +3611,12 @@ export function CodexApiServicePage() {
                               )}
                             </span>
                             <textarea
-                              value={
-                                apiKeyPolicyDrafts[apiKey.id]?.allowedModels ??
-                                ""
-                              }
+                              value={policyDraft.allowedModels}
                               onChange={(event) =>
                                 setApiKeyPolicyDrafts((drafts) => ({
                                   ...drafts,
                                   [apiKey.id]: {
-                                    ...(drafts[apiKey.id] ?? {
-                                      modelPrefix: "",
-                                      allowedModels: "",
-                                      excludedModels: "",
-                                    }),
+                                    ...(drafts[apiKey.id] ?? policyDraft),
                                     allowedModels: event.target.value,
                                   },
                                 }))
@@ -3169,19 +3636,12 @@ export function CodexApiServicePage() {
                               )}
                             </span>
                             <textarea
-                              value={
-                                apiKeyPolicyDrafts[apiKey.id]?.excludedModels ??
-                                ""
-                              }
+                              value={policyDraft.excludedModels}
                               onChange={(event) =>
                                 setApiKeyPolicyDrafts((drafts) => ({
                                   ...drafts,
                                   [apiKey.id]: {
-                                    ...(drafts[apiKey.id] ?? {
-                                      modelPrefix: "",
-                                      allowedModels: "",
-                                      excludedModels: "",
-                                    }),
+                                    ...(drafts[apiKey.id] ?? policyDraft),
                                     excludedModels: event.target.value,
                                   },
                                 }))
@@ -3196,11 +3656,25 @@ export function CodexApiServicePage() {
                           <div className="codex-api-service-policy-actions">
                             <button
                               type="button"
+                              className="btn btn-ghost btn-sm"
+                              onClick={() => handleResetApiKeyPolicy(apiKey)}
+                              disabled={busy || !policyDirty}
+                            >
+                              <Undo2 size={14} />
+                              {t(
+                                "codex.apiService.keys.resetPolicy",
+                                "撤销修改",
+                              )}
+                            </button>
+                            <button
+                              type="button"
                               className="btn btn-secondary btn-sm"
                               onClick={() =>
                                 void handleSaveApiKeyPolicy(apiKey.id)
                               }
-                              disabled={busy}
+                              disabled={
+                                busy || !policyDirty || customScopeInvalid
+                              }
                             >
                               <Check size={14} />
                               {t(
@@ -3624,18 +4098,6 @@ export function CodexApiServicePage() {
                 ))}
               </div>
               <div className="codex-api-service-head-actions">
-                <div className="codex-api-service-range-tabs">
-                  {statsRangeOptions.map((option) => (
-                    <button
-                      key={option.key}
-                      type="button"
-                      className={statsRange === option.key ? "active" : ""}
-                      onClick={() => setStatsRange(option.key)}
-                    >
-                      {option.label}
-                    </button>
-                  ))}
-                </div>
                 <button
                   type="button"
                   className="btn btn-danger btn-sm"

--- a/src/services/codexLocalAccessService.ts
+++ b/src/services/codexLocalAccessService.ts
@@ -230,6 +230,8 @@ export async function updateCodexLocalAccessApiKey(
     modelPrefix?: string | null;
     allowedModels?: string[] | null;
     excludedModels?: string[] | null;
+    accountIds?: string[] | null;
+    inheritAccountPool?: boolean | null;
   },
 ): Promise<CodexLocalAccessState> {
   return await invoke("codex_local_access_update_api_key", {
@@ -239,6 +241,8 @@ export async function updateCodexLocalAccessApiKey(
     modelPrefix: payload.modelPrefix ?? null,
     allowedModels: payload.allowedModels ?? null,
     excludedModels: payload.excludedModels ?? null,
+    accountIds: payload.accountIds ?? null,
+    inheritAccountPool: payload.inheritAccountPool ?? null,
   });
 }
 

--- a/src/types/codexLocalAccess.ts
+++ b/src/types/codexLocalAccess.ts
@@ -60,6 +60,8 @@ export interface CodexLocalAccessApiKey {
   id: string;
   label: string;
   key: string;
+  providerGateway?: unknown | null;
+  inheritAccountPool?: boolean;
   accountIds?: string[];
   modelPrefix?: string | null;
   allowedModels: string[];

--- a/src/utils/codexApiKeyAccountScope.test.ts
+++ b/src/utils/codexApiKeyAccountScope.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isCodexApiKeyScopeAccountActive,
+  reconcileCodexApiKeyScopeAccountIds,
+  selectCodexApiKeyScopeAccounts,
+} from "./codexApiKeyAccountScope.ts";
+import type { CodexAccount } from "../types/codex.ts";
+
+const oauthAccount = (
+  id: string,
+  planType = "plus",
+): CodexAccount => ({
+  id,
+  auth_mode: "oauth",
+  plan_type: planType,
+} as CodexAccount);
+
+test("includes a valid OAuth account that is outside the default service pool", () => {
+  const selected = selectCodexApiKeyScopeAccounts({
+    restrictFreeAccounts: true,
+    scopedAccountIds: [],
+    accounts: [
+      oauthAccount("default-pool-account"),
+      oauthAccount("pro-account", "pro"),
+    ],
+  });
+
+  assert.deepEqual(
+    selected.map((account) => account.id),
+    ["default-pool-account", "pro-account"],
+  );
+});
+
+test("excludes provider-gateway accounts but keeps a persisted fixed scope visible", () => {
+  const selected = selectCodexApiKeyScopeAccounts({
+    restrictFreeAccounts: true,
+    scopedAccountIds: ["provider-gateway-account"],
+    accounts: [
+      oauthAccount("pro-account", "pro"),
+      {
+        id: "provider-gateway-account",
+        auth_mode: "apikey",
+        api_wire_api: "chat_completions",
+        plan_type: "API_KEY",
+      } as CodexAccount,
+    ],
+  });
+
+  assert.deepEqual(
+    selected.map((account) => account.id),
+    ["pro-account", "provider-gateway-account"],
+  );
+});
+
+test("excludes a provider-gateway account inferred from its upstream URL", () => {
+  const selected = selectCodexApiKeyScopeAccounts({
+    restrictFreeAccounts: true,
+    scopedAccountIds: [],
+    accounts: [
+      oauthAccount("pro-account", "pro"),
+      {
+        id: "provider-gateway-account",
+        auth_mode: "apikey",
+        api_base_url: "https://api.deepseek.com/v1",
+        plan_type: "API_KEY",
+      } as CodexAccount,
+    ],
+  });
+
+  assert.deepEqual(
+    selected.map((account) => account.id),
+    ["pro-account"],
+  );
+});
+
+test("preserves an existing scoped account that is temporarily absent while filtering invalid new selections", () => {
+  const accountIds = reconcileCodexApiKeyScopeAccountIds({
+    accounts: [oauthAccount("pro-account", "pro")],
+    restrictFreeAccounts: true,
+    persistedAccountIds: ["temporarily-unavailable-account"],
+    draftAccountIds: [
+      "temporarily-unavailable-account",
+      "pro-account",
+      "new-provider-gateway-account",
+    ],
+  });
+
+  assert.deepEqual(accountIds, [
+    "temporarily-unavailable-account",
+    "pro-account",
+  ]);
+});
+
+test("marks only service-pool accounts as active when the key inherits its account pool", () => {
+  assert.equal(
+    isCodexApiKeyScopeAccountActive({
+      accountId: "default-pool-account",
+      inheritAccountPool: true,
+      accountIds: ["pro-account"],
+      inheritedAccountIds: ["default-pool-account"],
+    }),
+    true,
+  );
+  assert.equal(
+    isCodexApiKeyScopeAccountActive({
+      accountId: "pro-account",
+      inheritAccountPool: true,
+      accountIds: ["pro-account"],
+      inheritedAccountIds: ["default-pool-account"],
+    }),
+    false,
+  );
+});

--- a/src/utils/codexApiKeyAccountScope.ts
+++ b/src/utils/codexApiKeyAccountScope.ts
@@ -1,0 +1,79 @@
+import type { CodexAccount } from "../types/codex.ts";
+import { isCodexLocalAccessEligibleAccount } from "./codexLocalAccessAccounts.ts";
+
+interface SelectCodexApiKeyScopeAccountsOptions<T extends CodexAccount> {
+  accounts: T[];
+  restrictFreeAccounts: boolean;
+  scopedAccountIds: string[];
+}
+
+interface ReconcileCodexApiKeyScopeAccountIdsOptions<
+  T extends CodexAccount,
+> {
+  accounts: T[];
+  restrictFreeAccounts: boolean;
+  persistedAccountIds: string[];
+  draftAccountIds: string[];
+}
+
+interface IsCodexApiKeyScopeAccountActiveOptions {
+  accountId: string;
+  inheritAccountPool: boolean;
+  accountIds: string[];
+  inheritedAccountIds: string[];
+}
+
+export function selectCodexApiKeyScopeAccounts<T extends CodexAccount>({
+  accounts,
+  restrictFreeAccounts,
+  scopedAccountIds,
+}: SelectCodexApiKeyScopeAccountsOptions<T>): T[] {
+  const scopedIds = new Set(scopedAccountIds);
+  const seenIds = new Set<string>();
+
+  return accounts.filter((account) => {
+    if (!account.id || seenIds.has(account.id)) return false;
+    seenIds.add(account.id);
+
+    if (scopedIds.has(account.id)) return true;
+    return isCodexLocalAccessEligibleAccount(account, restrictFreeAccounts);
+  });
+}
+
+export function reconcileCodexApiKeyScopeAccountIds<T extends CodexAccount>({
+  accounts,
+  restrictFreeAccounts,
+  persistedAccountIds,
+  draftAccountIds,
+}: ReconcileCodexApiKeyScopeAccountIdsOptions<T>): string[] {
+  const selectableAccountIds = new Set(
+    selectCodexApiKeyScopeAccounts({
+      accounts,
+      restrictFreeAccounts,
+      scopedAccountIds: persistedAccountIds,
+    }).map((account) => account.id),
+  );
+  const loadedAccountIds = new Set(accounts.map((account) => account.id));
+  const persistedAccountIdSet = new Set(persistedAccountIds);
+  const seenAccountIds = new Set<string>();
+
+  return draftAccountIds.filter((accountId) => {
+    if (!accountId || seenAccountIds.has(accountId)) return false;
+    seenAccountIds.add(accountId);
+    return (
+      selectableAccountIds.has(accountId) ||
+      (persistedAccountIdSet.has(accountId) && !loadedAccountIds.has(accountId))
+    );
+  });
+}
+
+export function isCodexApiKeyScopeAccountActive({
+  accountId,
+  inheritAccountPool,
+  accountIds,
+  inheritedAccountIds,
+}: IsCodexApiKeyScopeAccountActiveOptions): boolean {
+  return inheritAccountPool
+    ? inheritedAccountIds.includes(accountId)
+    : accountIds.includes(accountId);
+}

--- a/src/utils/codexLocalAccessAccounts.ts
+++ b/src/utils/codexLocalAccessAccounts.ts
@@ -2,7 +2,7 @@ import {
   isCodexApiKeyAccount,
   isCodexExplicitFreePlanType,
   type CodexAccount,
-} from '../types/codex';
+} from '../types/codex.ts';
 
 const CHAT_COMPLETIONS_PROVIDER_HOSTS = [
   "api.deepseek.com",


### PR DESCRIPTION
## Summary

- Let each client API key inherit the service account pool or select its own eligible account set.
- Carry account IDs through TypeScript, Tauri, Rust, and the sidecar manifest, then enforce the scope before credential selection.
- Namespace session-affinity cache entries by client key so identical downstream session IDs cannot cross key scopes.
- Track per-key requests, tokens, success rate, and estimated cost for today, the current week, and the current month in local time.
- Recompute calendar windows when state is refreshed and present routing scope plus labeled usage metrics in the client-key UI.

## Behavior

- Existing keys with no explicit account IDs continue to inherit the service pool.
- Custom scopes require at least one eligible account and preserve temporarily unavailable persisted accounts.
- Provider-gateway and fixed-scope keys cannot be accidentally converted to an empty or inherited scope.
- Embedded-gateway and sidecar routing apply the same account restrictions.
- Daily usage starts at local midnight, weekly usage starts Monday at local midnight, and monthly usage starts on the first day of the local month.

## Tests

- `npm run test:codex-api-key-scope` (5 passed)
- `cargo test -q custom_api_key_scope_filters_duplicates_and_updates_manifest_scope --lib` (passed)
- `cargo test -q api_key_usage_stats_are_isolated_by_time_window --lib` (passed)
- `rustfmt --edition 2021 --check src-tauri/src/modules/codex_local_access.rs` (passed)
- Go sidecar regression coverage is included in `main_test.go`; Go is unavailable in the local Windows environment, so CI should execute it.

## Baseline note

On the latest `main` (`31a36176`), `npm run typecheck` currently fails in eight unrelated account pages because handlers accepting an optional `incognito` boolean are passed directly as mouse handlers. This PR does not modify those files; its focused Node and Rust tests pass on the updated base.