### PR TITLE
feat(分组): 在分组内添加账号时自动加入当前分组

### DIFF
--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -542,6 +542,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     )
     return typeof saved === 'string' && saved.trim() ? saved : null
   })
+  const [addTargetGroupId, setAddTargetGroupId] = useState<string | null>(null)
   const [showAccountGroupModal, setShowAccountGroupModal] = useState(false)
   const [showAddToGroupModal, setShowAddToGroupModal] = useState(false)
   const [groupAccountPickerGroupId, setGroupAccountPickerGroupId] = useState<string | null>(null)
@@ -559,6 +560,43 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     if (!activeGroupId) return null
     return accountGroups.find((g) => g.id === activeGroupId) || null
   }, [accountGroups, activeGroupId])
+
+  const addTargetGroup = useMemo(() => {
+    if (!addTargetGroupId) return null
+    return accountGroups.find((group) => group.id === addTargetGroupId) || null
+  }, [accountGroups, addTargetGroupId])
+
+  const resolveValidAccountGroupId = useCallback(
+    (groupId?: string | null) => {
+      const normalized = groupId?.trim()
+      if (!normalized) return null
+      return accountGroups.some((group) => group.id === normalized) ? normalized : null
+    },
+    [accountGroups],
+  )
+
+  const assignAccountsToAddTargetGroup = useCallback(
+    async (
+      targetAccounts: Array<Account | null | undefined>,
+      targetGroupId = addTargetGroupId,
+    ) => {
+      const resolvedGroupId = resolveValidAccountGroupId(targetGroupId)
+      if (!resolvedGroupId) return
+
+      const accountIds = Array.from(
+        new Set(
+          targetAccounts
+            .map((account) => account?.id?.trim())
+            .filter((id): id is string => Boolean(id)),
+        ),
+      )
+      if (accountIds.length === 0) return
+
+      await assignAccountsToGroup(resolvedGroupId, accountIds)
+      await reloadAccountGroups()
+    },
+    [addTargetGroupId, reloadAccountGroups, resolveValidAccountGroupId],
+  )
 
   const groupAccountPickerGroup = useMemo(() => {
     if (!groupAccountPickerGroupId) return null
@@ -644,7 +682,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
   const addTabRef = useRef(addTab)
   const oauthUrlRef = useRef(oauthUrl)
   const addStatusRef = useRef(addStatus)
-  const activeGroupIdRef = useRef(activeGroupId)
+  const addTargetGroupIdRef = useRef<string | null>(null)
   const verificationHistoryRequestIdRef = useRef(0)
   const colorPickerRef = useRef<HTMLDivElement>(null)
 
@@ -653,8 +691,8 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     addTabRef.current = addTab
     oauthUrlRef.current = oauthUrl
     addStatusRef.current = addStatus
-    activeGroupIdRef.current = activeGroupId
-  }, [showAddModal, addTab, oauthUrl, addStatus, activeGroupId])
+    addTargetGroupIdRef.current = addTargetGroupId
+  }, [showAddModal, addTab, oauthUrl, addStatus, addTargetGroupId])
 
   useEffect(() => {
     const handleFeatureUnlockChanged = (event: Event) => {
@@ -1527,11 +1565,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
         const newAccount = await accountService.completeOAuthLogin()
         await fetchAccounts()
         await fetchCurrentAccount(antigravityRuntimeTarget)
-        // 如果在文件夹内添加，自动归入当前文件夹
-        if (activeGroupIdRef.current && newAccount?.id) {
-          await assignAccountsToGroup(activeGroupIdRef.current, [newAccount.id])
-          await reloadAccountGroups()
-        }
+        await assignAccountsToAddTargetGroup([newAccount], addTargetGroupIdRef.current)
         setAddStatus('success')
         setAddMessage(t('accounts.oauth.success'))
         setTimeout(() => {
@@ -1552,7 +1586,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
       if (unlistenUrl) unlistenUrl()
       if (unlistenCallback) unlistenCallback()
     }
-  }, [fetchAccounts, fetchCurrentAccount])
+  }, [assignAccountsToAddTargetGroup, fetchAccounts, fetchCurrentAccount])
 
   useEffect(() => {
     if (!showAddModal || addTab !== 'oauth' || oauthUrl) return
@@ -1726,10 +1760,11 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
   }, [])
 
   const openAddModal = useCallback((tab: 'oauth' | 'token' | 'import') => {
+    setAddTargetGroupId(resolveValidAccountGroupId(activeGroupId))
     setAddTab(tab)
     setShowAddModal(true)
     resetAddModalState()
-  }, [resetAddModalState])
+  }, [activeGroupId, resetAddModalState, resolveValidAccountGroupId])
 
   const consumeExternalProviderImport = useCallback(() => {
     const request = consumeQueuedExternalProviderImportForPlatform('antigravity')
@@ -1772,6 +1807,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
       accountService.cancelOAuthLogin().catch(() => { })
     }
     setShowAddModal(false)
+    setAddTargetGroupId(null)
     resetAddModalState()
     setOauthUrl('')
   }
@@ -1806,17 +1842,19 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
 
   const handleOAuthStart = async () => {
     await runModalAction(t('modals.import.oauthAction'), async () => {
-      await startOAuthLogin()
+      const account = await startOAuthLogin()
       await fetchAccounts()
       await fetchCurrentAccount(antigravityRuntimeTarget)
+      await assignAccountsToAddTargetGroup([account])
     })
   }
 
   const handleOAuthComplete = async () => {
     await runModalAction(t('modals.import.oauthAction'), async () => {
-      await accountService.completeOAuthLogin()
+      const account = await accountService.completeOAuthLogin()
       await fetchAccounts()
       await fetchCurrentAccount(antigravityRuntimeTarget)
+      await assignAccountsToAddTargetGroup([account])
     })
   }
 
@@ -1993,6 +2031,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
       await fetchAccounts()
       await Promise.allSettled(imported.map((acc) => refreshQuota(acc.id, antigravityRuntimeTarget)))
       await fetchAccounts()
+      await assignAccountsToAddTargetGroup(imported)
       if (imported.length === 0) {
         setAddStatus('error')
         setAddMessage(t('modals.import.noAccountsFound'))
@@ -2022,6 +2061,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
       await fetchAccounts()
       await refreshQuota(imported.id, antigravityRuntimeTarget)
       await fetchAccounts()
+      await assignAccountsToAddTargetGroup([imported])
       setAddStatus('success')
       setAddMessage(
         t('messages.importLocalSuccess', { email: maskAccountText(imported.email) })
@@ -2066,6 +2106,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
       await fetchAccounts()
       await Promise.allSettled(imported.map((acc) => refreshQuota(acc.id, antigravityRuntimeTarget)))
       await fetchAccounts()
+      await assignAccountsToAddTargetGroup(imported)
       if (imported.length === 0 && failed.length === 0) {
         setAddStatus('error')
         setAddMessage(t('modals.import.noAccountsFound'))
@@ -2101,6 +2142,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     setAddMessage(t('modals.import.importingExtension'))
     let unlistenProgress: UnlistenFn | undefined
     try {
+      const knownAccountIds = new Set(accounts.map((account) => account.id))
       unlistenProgress = await listen<ExtensionImportProgressPayload>(
         'accounts:extension-import-progress',
         (event) => {
@@ -2120,6 +2162,12 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
       const count = await accountService.syncFromExtension()
       await fetchAccounts()
       await fetchCurrentAccount(antigravityRuntimeTarget)
+      if (count > 0) {
+        const imported = (await accountService.listAccounts()).filter(
+          (account) => !knownAccountIds.has(account.id),
+        )
+        await assignAccountsToAddTargetGroup(imported)
+      }
       if (count === 0) {
         setAddStatus('error')
         setAddMessage(t('modals.import.noAccountsFound'))
@@ -2227,11 +2275,7 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
         importedAccounts.map((acc) => refreshQuota(acc.id, antigravityRuntimeTarget))
       )
       await fetchAccounts()
-      // 如果在文件夹内添加，自动归入当前文件夹
-      if (activeGroupId) {
-        await assignAccountsToGroup(activeGroupId, importedAccounts.map((acc) => acc.id))
-        await reloadAccountGroups()
-      }
+      await assignAccountsToAddTargetGroup(importedAccounts)
     }
 
     if (success === tokens.length) {
@@ -3995,6 +4039,17 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
             </div>
             <div className="modal-body">
               <MfaQuickCodeSelect />
+              {addTargetGroup && (
+                <div className="accounts-add-target-group-hint">
+                  <FolderPlus size={14} />
+                  <span>
+                    {t('accounts.addModal.targetGroup', {
+                      defaultValue: '将添加到分组：{{group}}',
+                      group: addTargetGroup.name,
+                    })}
+                  </span>
+                </div>
+              )}
               <div className="add-tabs">
                 <button
                   className={`add-tab ${addTab === 'oauth' ? 'active' : ''}`}

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -949,6 +949,12 @@ export function CodexAccountsPage() {
   const [groupQuickAddGroupId, setGroupQuickAddGroupId] = useState<
     string | null
   >(null);
+  const [codexAddTargetGroupId, setCodexAddTargetGroupId] = useState<
+    string | null
+  >(null);
+  const [batchImportTargetGroupId, setBatchImportTargetGroupId] = useState<
+    string | null
+  >(null);
   const [groupDeleteConfirm, setGroupDeleteConfirm] = useState<{
     id: string;
     name: string;
@@ -1077,6 +1083,47 @@ export function CodexAccountsPage() {
   const reloadCodexGroups = useCallback(async () => {
     setCodexGroups(await getCodexAccountGroups());
   }, []);
+
+  const codexAddTargetGroup = useMemo(() => {
+    if (!codexAddTargetGroupId) return null;
+    return (
+      codexGroups.find((group) => group.id === codexAddTargetGroupId) ?? null
+    );
+  }, [codexAddTargetGroupId, codexGroups]);
+
+  const resolveValidCodexGroupId = useCallback(
+    (groupId?: string | null) => {
+      const normalized = groupId?.trim();
+      if (!normalized) return null;
+      return codexGroups.some((group) => group.id === normalized)
+        ? normalized
+        : null;
+    },
+    [codexGroups],
+  );
+
+  const assignCodexAccountsToTargetGroup = useCallback(
+    async (
+      targetAccounts: Array<CodexAccount | null | undefined>,
+      targetGroupId = codexAddTargetGroupId,
+    ) => {
+      const resolvedGroupId = resolveValidCodexGroupId(targetGroupId);
+      if (!resolvedGroupId) return;
+
+      const accountIds = Array.from(
+        new Set(
+          targetAccounts
+            .map((account) => account?.id?.trim())
+            .filter((id): id is string => Boolean(id)),
+        ),
+      );
+      if (accountIds.length === 0) return;
+
+      await assignAccountsToCodexGroup(resolvedGroupId, accountIds);
+      await reloadCodexGroups();
+    },
+    [codexAddTargetGroupId, reloadCodexGroups, resolveValidCodexGroupId],
+  );
 
   useEffect(() => {
     reloadCodexGroups();
@@ -1553,6 +1600,7 @@ export function CodexAccountsPage() {
     setBatchImportResult(null);
     setBatchImportFilePaths([]);
     setBatchImportCheckQuota(false);
+    setBatchImportTargetGroupId(null);
     try {
       localStorage.removeItem(CODEX_BATCH_IMPORT_SESSION_STORAGE_KEY);
     } catch {
@@ -1654,6 +1702,9 @@ export function CodexAccountsPage() {
   const openCodexAddModal = useCallback(
     (tab: string, targetAccount?: CodexAccount | null) => {
       setReauthTargetAccount(targetAccount ?? null);
+      setCodexAddTargetGroupId(
+        targetAccount ? null : resolveValidCodexGroupId(activeGroupId),
+      );
       setReauthEmailCopied(false);
       if (!targetAccount) {
         setPendingOAuthEmailInput("");
@@ -1663,11 +1714,12 @@ export function CodexAccountsPage() {
       setPendingOAuthNoteModalOpen(false);
       openAddModal(tab);
     },
-    [openAddModal],
+    [activeGroupId, openAddModal, resolveValidCodexGroupId],
   );
 
   const closeCodexAddModal = useCallback(() => {
     setReauthTargetAccount(null);
+    setCodexAddTargetGroupId(null);
     setReauthEmailCopied(false);
     setPendingOAuthEmailInput("");
     setPendingOAuthNoteForm(EMPTY_CODEX_ACCOUNT_NOTE_FORM);
@@ -1688,6 +1740,7 @@ export function CodexAccountsPage() {
   useEffect(() => {
     if (showAddModal) return;
     setReauthTargetAccount(null);
+    setCodexAddTargetGroupId(null);
     setReauthEmailCopied(false);
     setPendingOAuthEmailInput("");
     setPendingOAuthNoteForm(EMPTY_CODEX_ACCOUNT_NOTE_FORM);
@@ -4201,6 +4254,7 @@ export function CodexAccountsPage() {
         );
       }
       await fetchAccounts();
+      await assignCodexAccountsToTargetGroup([account]);
       await emitAccountsChanged({
         platformId: "codex",
         accountId: account.id,
@@ -4226,6 +4280,7 @@ export function CodexAccountsPage() {
     }
   }, [
     buildPendingOAuthNoteUpdate,
+    assignCodexAccountsToTargetGroup,
     fetchAccounts,
     pendingOAuthEmailInput,
     resetAddModalState,
@@ -4258,42 +4313,50 @@ export function CodexAccountsPage() {
     [t],
   );
 
-  const completeOauthSuccess = useCallback(async () => {
-    oauthLog("授权完成并保存成功", { loginId: oauthLoginIdRef.current });
-    await fetchAccounts();
-    await fetchCurrentAccount();
-    await emitAccountsChanged({
-      platformId: "codex",
-      reason: "oauth",
-    });
-    setAddStatus("success");
-    setAddMessage(t("common.shared.oauth.success", "授权成功"));
-    oauthActiveRef.current = false;
-    oauthCompletingRef.current = false;
-    oauthLoginIdRef.current = null;
-    setOauthUrl("");
-    setOauthUrlCopied(false);
-    setOauthPrepareError(null);
-    setOauthPortInUse(null);
-    setOauthTimeoutInfo(null);
-    setOauthCallbackInput("");
-    setOauthCallbackSubmitting(false);
-    setOauthCallbackError(null);
-    setOauthTokenExchangeRetryVisible(false);
-    setTimeout(() => {
-      setShowAddModal(false);
-      resetAddModalState();
-    }, 1200);
-  }, [
-    fetchAccounts,
-    fetchCurrentAccount,
-    t,
-    oauthLog,
-    setAddStatus,
-    setAddMessage,
-    setShowAddModal,
-    resetAddModalState,
-  ]);
+  const completeOauthSuccess = useCallback(
+    async (account?: CodexAccount | null) => {
+      oauthLog("授权完成并保存成功", { loginId: oauthLoginIdRef.current });
+      await fetchAccounts();
+      await fetchCurrentAccount();
+      if (!reauthTargetAccountId) {
+        await assignCodexAccountsToTargetGroup([account]);
+      }
+      await emitAccountsChanged({
+        platformId: "codex",
+        reason: "oauth",
+      });
+      setAddStatus("success");
+      setAddMessage(t("common.shared.oauth.success", "授权成功"));
+      oauthActiveRef.current = false;
+      oauthCompletingRef.current = false;
+      oauthLoginIdRef.current = null;
+      setOauthUrl("");
+      setOauthUrlCopied(false);
+      setOauthPrepareError(null);
+      setOauthPortInUse(null);
+      setOauthTimeoutInfo(null);
+      setOauthCallbackInput("");
+      setOauthCallbackSubmitting(false);
+      setOauthCallbackError(null);
+      setOauthTokenExchangeRetryVisible(false);
+      setTimeout(() => {
+        setShowAddModal(false);
+        resetAddModalState();
+      }, 1200);
+    },
+    [
+      assignCodexAccountsToTargetGroup,
+      fetchAccounts,
+      fetchCurrentAccount,
+      reauthTargetAccountId,
+      t,
+      oauthLog,
+      setAddStatus,
+      setAddMessage,
+      setShowAddModal,
+      resetAddModalState,
+    ],
+  );
 
   const completeOauthError = useCallback(
     (e: unknown, allowTokenExchangeRetry = false) => {
@@ -4339,11 +4402,11 @@ export function CodexAccountsPage() {
         setAddMessage(t("codex.oauth.exchanging", "正在交换令牌..."));
         oauthCompletingRef.current = true;
         try {
-          await codexService.completeCodexOAuthLogin(
+          const account = await codexService.completeCodexOAuthLogin(
             loginId,
             reauthTargetAccountId || null,
           );
-          await completeOauthSuccess();
+          await completeOauthSuccess(account);
         } catch (e) {
           completeOauthError(e, true);
         } finally {
@@ -4608,11 +4671,11 @@ export function CodexAccountsPage() {
       setAddStatus("loading");
       setAddMessage(t("codex.oauth.exchanging", "正在交换令牌..."));
       tokenExchangeStarted = true;
-      await codexService.completeCodexOAuthLogin(
+      const account = await codexService.completeCodexOAuthLogin(
         loginId,
         reauthTargetAccountId || null,
       );
-      await completeOauthSuccess();
+      await completeOauthSuccess(account);
     } catch (e) {
       completeOauthError(e, tokenExchangeStarted);
       setOauthCallbackError(String(e).replace(/^Error:\s*/, ""));
@@ -4632,11 +4695,11 @@ export function CodexAccountsPage() {
     setAddMessage(t("codex.oauth.exchanging", "正在交换令牌..."));
     oauthCompletingRef.current = true;
     try {
-      await codexService.completeCodexOAuthLogin(
+      const account = await codexService.completeCodexOAuthLogin(
         loginId,
         reauthTargetAccountId || null,
       );
-      await completeOauthSuccess();
+      await completeOauthSuccess(account);
     } catch (e) {
       completeOauthError(e, true);
       setOauthCallbackError(String(e).replace(/^Error:\s*/, ""));
@@ -5330,6 +5393,7 @@ export function CodexAccountsPage() {
       await fetchAccounts();
       await new Promise((resolve) => setTimeout(resolve, 180));
       await fetchAccounts();
+      await assignCodexAccountsToTargetGroup([account]);
       await emitAccountsChanged({
         platformId: "codex",
         reason: "import",
@@ -5482,6 +5546,9 @@ export function CodexAccountsPage() {
       if (!selected || (Array.isArray(selected) && selected.length === 0))
         return;
       const paths = Array.isArray(selected) ? selected : [selected];
+      setBatchImportTargetGroupId(
+        resolveValidCodexGroupId(codexAddTargetGroupId),
+      );
       closeAddModal();
       await startBatchImportFromPaths(paths, false);
     } catch (e) {
@@ -5585,6 +5652,10 @@ export function CodexAccountsPage() {
       );
       setBatchImportResult(result);
       await fetchAccounts();
+      await assignCodexAccountsToTargetGroup(
+        result.imported,
+        batchImportTargetGroupId,
+      );
       if (result.imported.length > 0) {
         await emitAccountsChanged({
           platformId: "codex",
@@ -6113,6 +6184,7 @@ export function CodexAccountsPage() {
       );
       await fetchAccounts();
       await fetchCurrentAccount();
+      await assignCodexAccountsToTargetGroup([account]);
       await emitAccountsChanged({
         platformId: "codex",
         reason: "import",
@@ -6158,6 +6230,7 @@ export function CodexAccountsPage() {
     try {
       const imported = await codexService.importCodexFromJson(trimmed);
       await fetchAccounts();
+      await assignCodexAccountsToTargetGroup(imported);
       if (imported.length > 0) {
         await emitAccountsChanged({
           platformId: "codex",
@@ -7994,6 +8067,24 @@ export function CodexAccountsPage() {
   }, [codexGroups, groupQuickAddGroupId]);
 
   useEffect(() => {
+    if (
+      codexAddTargetGroupId &&
+      !codexGroups.some((group) => group.id === codexAddTargetGroupId)
+    ) {
+      setCodexAddTargetGroupId(null);
+    }
+  }, [codexAddTargetGroupId, codexGroups]);
+
+  useEffect(() => {
+    if (
+      batchImportTargetGroupId &&
+      !codexGroups.some((group) => group.id === batchImportTargetGroupId)
+    ) {
+      setBatchImportTargetGroupId(null);
+    }
+  }, [batchImportTargetGroupId, codexGroups]);
+
+  useEffect(() => {
     const existingAccountIds = new Set(accounts.map((account) => account.id));
     const hasStaleAccountIds = codexGroups.some((group) =>
       group.accountIds.some((accountId) => !existingAccountIds.has(accountId)),
@@ -8003,8 +8094,15 @@ export function CodexAccountsPage() {
     }
 
     void (async () => {
-      await cleanupDeletedCodexAccounts(existingAccountIds);
-      await reloadCodexGroups();
+      try {
+        await cleanupDeletedCodexAccounts(existingAccountIds);
+        await reloadCodexGroups();
+      } catch (error) {
+        console.error(
+          "Failed to clean up deleted Codex accounts from groups:",
+          error,
+        );
+      }
     })();
   }, [accounts, codexGroups, reloadCodexGroups]);
 
@@ -13350,6 +13448,17 @@ export function CodexAccountsPage() {
                   </button>
                 </div>
                 <div className="modal-body">
+                  {codexAddTargetGroup && !reauthTargetAccount && (
+                    <div className="codex-add-target-group-hint">
+                      <FolderPlus size={14} />
+                      <span>
+                        {t("codex.addModal.targetGroup", {
+                          defaultValue: "将添加到分组：{{group}}",
+                          group: codexAddTargetGroup.name,
+                        })}
+                      </span>
+                    </div>
+                  )}
                   {addTab !== "oauth" && <MfaQuickCodeSelect />}
                   {addTab === "oauth" && (
                     <div className="add-section">

--- a/src/services/accountGroupService.ts
+++ b/src/services/accountGroupService.ts
@@ -45,6 +45,7 @@ async function saveGroupsToDisk(groups: AccountGroup[]): Promise<void> {
     await invoke('save_account_groups', { data: JSON.stringify(groups, null, 2) });
   } catch (e) {
     console.error('[AccountGroups] Failed to save to disk:', e);
+    throw e;
   }
 }
 
@@ -85,8 +86,8 @@ async function loadGroups(): Promise<AccountGroup[]> {
 
 async function saveGroups(groups: AccountGroup[]): Promise<void> {
   const nextGroups = cloneGroups(groups);
-  cachedGroups = nextGroups;
   await saveGroupsToDisk(nextGroups);
+  cachedGroups = nextGroups;
 }
 
 // ─── 公开 API（全部改为 async） ───────────────────────

--- a/src/services/codexAccountGroupService.ts
+++ b/src/services/codexAccountGroupService.ts
@@ -47,6 +47,7 @@ async function saveGroupsToDisk(groups: CodexAccountGroup[]): Promise<void> {
     await invoke('save_codex_account_groups', { data: JSON.stringify(groups, null, 2) });
   } catch (e) {
     console.error('[CodexAccountGroups] Failed to save to disk:', e);
+    throw e;
   }
 }
 
@@ -58,8 +59,8 @@ async function loadGroups(): Promise<CodexAccountGroup[]> {
 
 async function saveGroups(groups: CodexAccountGroup[]): Promise<void> {
   const nextGroups = cloneGroups(groups);
-  cachedGroups = nextGroups;
   await saveGroupsToDisk(nextGroups);
+  cachedGroups = nextGroups;
 }
 
 // ─── 公开 API ───────────────────────────────────────

--- a/src/styles/pages/accounts-aurora.css
+++ b/src/styles/pages/accounts-aurora.css
@@ -1207,6 +1207,28 @@
   gap: 4px;
 }
 
+.accounts-add-target-group-hint {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 8px;
+  max-width: 100%;
+  padding: 7px 10px;
+  border: 1px solid color-mix(in srgb, var(--primary) 24%, var(--border));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary) 9%, var(--bg-secondary));
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.accounts-add-target-group-hint span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ---------- dark mode ---------- */
 [data-theme="dark"] .account-folder-card {
   background: rgba(30, 41, 59, 0.6);

--- a/src/styles/pages/codex.css
+++ b/src/styles/pages/codex.css
@@ -4772,6 +4772,28 @@
   gap: 16px;
 }
 
+.codex-add-modal .codex-add-target-group-hint {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 8px;
+  max-width: 100%;
+  padding: 7px 10px;
+  border: 1px solid color-mix(in srgb, var(--primary) 24%, var(--border));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary) 9%, var(--bg-secondary));
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.codex-add-modal .codex-add-target-group-hint span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .codex-reauth-note-summary {
   display: flex;
   align-items: center;


### PR DESCRIPTION
进入某个账号分组后，点击右上角“添加账号”，这次添加或导入成功的账号会自动加入当前分组。

不再需要先把账号导入到分组外，再到分组里点击“添加账号”手动挑选一次。

已覆盖：
- Codex：OAuth、待授权账号、API Key、Token / JSON、本地导入、文件批量导入。
- Antigravity：OAuth、Token、旧工具、本地、文件和扩展同步导入。

同时修正了分组保存失败时界面看起来已成功、重启后却丢失的问题。

验证：
- npm run build
- git diff --check