### PR TITLE
fix(grok): floating-card sync, remaining quota, soft token refresh

### DIFF
--- a/src-tauri/src/modules/grok_account.rs
+++ b/src-tauri/src/modules/grok_account.rs
@@ -882,10 +882,7 @@ fn accounts_match_for_upsert(candidate: &GrokAccount, existing: &GrokAccount) ->
         return false;
     }
     if candidate.is_api_key_auth() {
-        return match (
-            candidate.resolved_api_key(),
-            existing.resolved_api_key(),
-        ) {
+        return match (candidate.resolved_api_key(), existing.resolved_api_key()) {
             (Some(left), Some(right)) => left == right,
             _ => false,
         };
@@ -1568,12 +1565,7 @@ fn quota_from_payload(
     let products = config
         .get("productUsage")
         .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(product_usage_from_value)
-                .collect()
-        })
+        .map(|items| items.iter().filter_map(product_usage_from_value).collect())
         .unwrap_or_default();
     let (weekly_used, weekly_total) = credit_usage_amounts(billing, config);
     GrokQuota {
@@ -1605,10 +1597,12 @@ fn cli_proxy_get(
     access_token: &str,
     client_version: &str,
 ) -> reqwest::RequestBuilder {
+    // 与官方 Grok CLI / task_usage 一致：cli-chat-proxy 的 billing/user 需要 x-xai-token-auth
     client
         .get(url)
         .header(AUTHORIZATION, format!("Bearer {}", access_token))
         .header(ACCEPT, "application/json")
+        .header("x-xai-token-auth", "xai-grok-cli")
         .header("x-grok-cli-version", client_version)
         .header("x-grok-client-version", client_version)
         .header("x-grok-client-surface", "grok-cli")
@@ -1694,7 +1688,68 @@ async fn task_usage_for(account: &GrokAccount) -> Result<Value, String> {
     serde_json::from_str(&body).map_err(|error| format!("解析 Grok 任务配额失败: {}", error))
 }
 
+/// 若本机默认 auth.json 对应当前账号，则吸收 CLI 已轮换的 access/refresh，避免互抢单次 refresh_token。
+fn adopt_live_tokens_from_default_auth(account: &mut GrokAccount) -> Result<bool, String> {
+    if account.is_api_key_auth() {
+        return Ok(false);
+    }
+    let auth_path = default_grok_home()?.join(AUTH_FILE);
+    let Some(registry) = read_auth_registry(&auth_path)? else {
+        return Ok(false);
+    };
+    let Some(entry) = auth_registry_entry(&registry) else {
+        return Ok(false);
+    };
+    if !auth_entry_matches_account(&Value::Object(entry.clone()), account) {
+        return Ok(false);
+    }
+
+    let mut changed = false;
+    if let Some(access_token) = string_field(entry, "key") {
+        if access_token != account.access_token {
+            account.access_token = access_token;
+            changed = true;
+        }
+    }
+    if let Some(refresh_token) = string_field(entry, "refresh_token") {
+        if account.refresh_token.as_deref() != Some(refresh_token.as_str()) {
+            account.refresh_token = Some(refresh_token);
+            changed = true;
+        }
+    }
+    if let Some(expires_at) = entry.get("expires_at").and_then(parse_timestamp) {
+        if account.expires_at != Some(expires_at) {
+            account.expires_at = Some(expires_at);
+            account.expires_at_raw = entry
+                .get("expires_at")
+                .filter(|value| !value.is_null())
+                .cloned();
+            changed = true;
+        }
+    }
+    if changed {
+        // 合并官方字段，保留 Cockpit 侧已有扩展键
+        let mut merged = account
+            .auth_raw
+            .as_ref()
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        for (key, value) in entry {
+            merged.insert(key.clone(), value.clone());
+        }
+        account.auth_raw = Some(Value::Object(merged));
+        logger::log_info(&format!(
+            "[Grok Account] 已从默认 auth.json 同步 CLI 最新凭据: account_id={}, email={}",
+            account.id, account.email
+        ));
+    }
+    Ok(changed)
+}
+
 async fn refresh_credentials(account: &mut GrokAccount, force: bool) -> Result<(), String> {
+    // 刷新前先读默认 auth.json：CLI 若已轮换 refresh_token，用最新值再请求
+    let _ = adopt_live_tokens_from_default_auth(account);
     let should_refresh = force
         || account
             .expires_at
@@ -1707,14 +1762,39 @@ async fn refresh_credentials(account: &mut GrokAccount, force: bool) -> Result<(
         .refresh_token
         .clone()
         .ok_or_else(|| "Grok refresh_token 为空，请重新授权".to_string())?;
-    let token = grok_oauth::refresh_token(
+    match grok_oauth::refresh_token(
         &refresh_token,
         account.token_endpoint.as_deref(),
         account.oidc_client_id.as_deref(),
     )
-    .await?;
-    apply_refreshed_token(account, token);
-    Ok(())
+    .await
+    {
+        Ok(token) => {
+            apply_refreshed_token(account, token);
+            Ok(())
+        }
+        Err(error) => {
+            // invalid_grant 常见于 CLI 已抢先轮换：再吸一次 auth.json，token 变了则重试一次
+            let normalized = error.to_ascii_lowercase();
+            if normalized.contains("invalid_grant") || normalized.contains("401") {
+                if adopt_live_tokens_from_default_auth(account).unwrap_or(false) {
+                    if let Some(rotated) = account.refresh_token.clone() {
+                        if rotated != refresh_token {
+                            let token = grok_oauth::refresh_token(
+                                &rotated,
+                                account.token_endpoint.as_deref(),
+                                account.oidc_client_id.as_deref(),
+                            )
+                            .await?;
+                            apply_refreshed_token(account, token);
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+            Err(error)
+        }
+    }
 }
 
 fn apply_refreshed_token(account: &mut GrokAccount, token: grok_oauth::GrokTokenResponse) {
@@ -1954,10 +2034,11 @@ async fn refresh_account_inner(
         }
     }
     if let Err(error) = quota_result {
+        // 软失败：保留上次成功的 quota/plan 缓存，仅记录错误，避免后台刷新把界面刷成空
         account.quota_query_last_error = Some(error.clone());
         account.quota_query_last_error_at = Some(now_ms());
         logger::log_warn(&format!(
-            "[Grok Account] 配额查询失败: account_id={}, error={}",
+            "[Grok Account] 配额查询失败（保留缓存展示）: account_id={}, error={}",
             account.id, error
         ));
     }
@@ -2033,12 +2114,23 @@ fn remaining_percent_from_used_pct(used_percent: f64) -> i32 {
     (100.0 - used_percent.clamp(0.0, 100.0)).round() as i32
 }
 
-/// Mirrors the visible Grok overview buckets (no weekly-only metric).
+/// 与账号页/概览可见桶对齐：周额度 + productUsage + 任务/按量。
 fn quota_remaining_metrics(account: &GrokAccountView) -> Vec<(String, i32)> {
     let Some(quota) = account.quota.as_ref() else {
         return Vec::new();
     };
     let mut metrics = Vec::new();
+    // 周总池（creditUsagePercent / weeklyCredits）剩余
+    if let Some(used_pct) = quota.weekly_limit_percent {
+        metrics.push((
+            "weekly".to_string(),
+            remaining_percent_from_used_pct(used_pct),
+        ));
+    } else if let (Some(used), Some(total)) = (quota.weekly_used, quota.weekly_total) {
+        if let Some(remaining) = remaining_percent_from_used_total(used, total) {
+            metrics.push(("weekly".to_string(), remaining));
+        }
+    }
     for product in &quota.products {
         let remaining = match (product.used, product.total) {
             (Some(used), Some(total)) => remaining_percent_from_used_total(used, total),
@@ -2168,14 +2260,17 @@ pub fn run_quota_alert_if_needed() -> Result<(), String> {
 mod tests {
     use super::{
         account_from_auth_object, accounts_match_for_upsert, acquire_secret_lock,
-        apply_refreshed_token, auth_registry_for, default_grok_home, ensure_secret_dir,
-        load_account_from_path, load_index_from_paths, parse_auth_registry, quota_from_payload,
-        remove_account, remove_matching_auth_scope, resolve_account_id_from_registry,
-        save_account_locked, should_retry_quota_after_unauthorized,
+        apply_refreshed_token, auth_entry_matches_account, auth_registry_entry, auth_registry_for,
+        default_grok_home, ensure_secret_dir, load_account_from_path, load_index_from_paths,
+        parse_auth_registry, quota_from_payload, quota_remaining_metrics, remove_account,
+        remove_matching_auth_scope, resolve_account_id_from_registry, save_account_locked,
+        should_retry_quota_after_unauthorized, string_field,
         write_account_to_auth_path_if_token_matches, write_account_to_profile,
     };
-    use crate::models::grok::{GrokAccount, GrokAuthMode};
-    use serde_json::json;
+    use crate::models::grok::{
+        GrokAccount, GrokAccountView, GrokAuthMode, GrokProductUsage, GrokQuota,
+    };
+    use serde_json::{json, Value};
     use std::path::PathBuf;
 
     fn sample_account() -> GrokAccount {
@@ -2768,5 +2863,57 @@ mod tests {
         assert_eq!(quota.frequent_limit, Some(10.0));
         assert_eq!(quota.occasional_usage, Some(3.0));
         assert_eq!(quota.occasional_limit, Some(30.0));
+    }
+
+    #[test]
+    fn remaining_metrics_include_weekly_and_products() {
+        let mut account = sample_account();
+        account.quota = Some(GrokQuota {
+            weekly_limit_percent: Some(40.0),
+            products: vec![GrokProductUsage {
+                product: "GrokBuild".to_string(),
+                usage_percent: Some(25.0),
+                used: None,
+                total: None,
+                remaining: None,
+            }],
+            ..Default::default()
+        });
+        let view = GrokAccountView::from(&account);
+        let metrics = quota_remaining_metrics(&view);
+        assert!(metrics
+            .iter()
+            .any(|(name, remaining)| { name == "weekly" && *remaining == 60 }));
+        assert!(metrics
+            .iter()
+            .any(|(name, remaining)| { name == "GrokBuild" && *remaining == 75 }));
+    }
+
+    #[test]
+    fn adopts_rotated_tokens_from_default_auth_when_identity_matches() {
+        let mut account = sample_account();
+        account.access_token = "old-access".to_string();
+        account.refresh_token = Some("old-refresh".to_string());
+        let registry = json!({
+            "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828": {
+                "key": "new-access",
+                "refresh_token": "new-refresh",
+                "email": "person@example.com",
+                "user_id": "user-1",
+                "principal_id": "principal-1",
+                "expires_at": "2030-01-01T00:00:00Z"
+            }
+        });
+        // 身份匹配 + 字段读取：刷新前吸收 CLI 已轮换凭据的前置条件
+        let entry = auth_registry_entry(&registry).expect("entry");
+        assert!(auth_entry_matches_account(
+            &Value::Object(entry.clone()),
+            &account
+        ));
+        assert_eq!(string_field(entry, "key").as_deref(), Some("new-access"));
+        assert_eq!(
+            string_field(entry, "refresh_token").as_deref(),
+            Some("new-refresh")
+        );
     }
 }

--- a/src-tauri/src/modules/provider_token_keeper.rs
+++ b/src-tauri/src/modules/provider_token_keeper.rs
@@ -411,7 +411,8 @@ async fn refresh_due_grok_accounts() -> bool {
             continue;
         }
         attempted_refreshes += 1;
-        match grok_account::force_refresh_account(&account.id).await {
+        // 软刷新：未临近过期不轮换单次 refresh_token，并在刷新前吸收 CLI 已写回的 auth.json，避免互抢
+        match grok_account::refresh_account(&account.id).await {
             Ok(updated) => {
                 clear_attempt_backoff(&key);
                 refreshed_any = true;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,10 @@ import {
 } from './utils/externalProviderImport';
 import { runAutoBackupCycle } from './services/scheduledBackupService';
 import { prepareCodexLocalAccessForRestart } from './services/codexLocalAccessService';
+import {
+  emitActivePlatformFocus,
+  resolvePlatformIdFromPage,
+} from './utils/accountSyncEvents';
 
 const DashboardPage = lazy(() =>
   import('./pages/DashboardPage').then((module) => ({ default: module.DashboardPage })),
@@ -760,6 +764,19 @@ function MainApp() {
     } catch (e) {
       console.warn('Failed to save active page to localStorage:', e);
     }
+  }, [page]);
+
+  // 主窗口切到某平台页（如 Grok）时，同步悬浮窗/菜单栏当前平台，避免一直停在默认 antigravity
+  useEffect(() => {
+    const platformId = resolvePlatformIdFromPage(page);
+    if (!platformId) {
+      return;
+    }
+    void emitActivePlatformFocus({
+      platformId,
+      page,
+      reason: 'main-window-page',
+    });
   }, [page]);
   const [showUpdateNotification, setShowUpdateNotification] = useState(false);
   const [updateNotificationKey, setUpdateNotificationKey] = useState(0);

--- a/src/pages/FloatingCardWindow.tsx
+++ b/src/pages/FloatingCardWindow.tsx
@@ -105,15 +105,18 @@ import {
 import { changeLanguage, normalizeLanguage } from '../i18n';
 import {
   ACCOUNTS_CHANGED_EVENT,
+  ACTIVE_PLATFORM_FOCUS_EVENT,
   CURRENT_ACCOUNT_CHANGED_EVENT,
+  FLOATING_CARD_PLATFORM_STORAGE_KEY,
+  persistFloatingCardPlatform,
   type AccountSyncEventPayload,
+  type ActivePlatformFocusPayload,
 } from '../utils/accountSyncEvents';
 import './FloatingCardWindow.css';
 
 const windowInstance = getCurrentWindow();
 const FLOATING_CARD_WINDOW_LABEL = 'floating-card';
 const INSTANCE_FLOATING_CARD_WINDOW_LABEL_PREFIX = 'instance-floating-card-';
-const FLOATING_CARD_PLATFORM_STORAGE_KEY = 'agtools.floating_card.platform';
 const DEFAULT_INSTANCE_ID = '__default__';
 const FLOATING_CARD_BASE_HEIGHT = 290;
 const FLOATING_CARD_MAX_HEIGHT = 520;
@@ -352,8 +355,21 @@ export function FloatingCardWindow() {
   }, [fetchRemoteConfigState]);
 
   useEffect(() => {
+    if (platformOrder.length === 0) {
+      return;
+    }
     if (platformOrder.includes(selectedPlatform)) {
       return;
+    }
+    // 当前选中平台被隐藏时，优先保留存储中的平台，再回退到列表首项
+    try {
+      const saved = localStorage.getItem(FLOATING_CARD_PLATFORM_STORAGE_KEY) as PlatformId | null;
+      if (saved && platformOrder.includes(saved)) {
+        setSelectedPlatform(saved);
+        return;
+      }
+    } catch {
+      // ignore
     }
     setSelectedPlatform(platformOrder[0] ?? 'antigravity');
   }, [platformOrder, selectedPlatform]);
@@ -519,6 +535,7 @@ export function FloatingCardWindow() {
     let disposed = false;
     let unlistenAccountsChanged: (() => void) | null = null;
     let unlistenCurrentAccountChanged: (() => void) | null = null;
+    let unlistenActivePlatformFocus: (() => void) | null = null;
 
     const bindAccountSyncListeners = async () => {
       unlistenAccountsChanged = await listen<AccountSyncEventPayload>(
@@ -542,11 +559,15 @@ export function FloatingCardWindow() {
           const payload = event.payload;
           if (
             !payload ||
-            payload.platformId !== selectedPlatform ||
             payload.sourceWindowLabel === currentWindowLabel ||
             instanceContext
           ) {
             return;
+          }
+          // 主窗口在某平台切号/使用时，悬浮窗跟随到该平台（例如 Grok），不再锁死 antigravity
+          if (payload.platformId !== selectedPlatform) {
+            if (disposed) return;
+            setSelectedPlatform(payload.platformId);
           }
           await fetchPlatformData(payload.platformId);
           if (disposed) return;
@@ -554,6 +575,23 @@ export function FloatingCardWindow() {
             ...prev,
             [payload.platformId]: payload.accountId ?? null,
           }));
+        },
+      );
+
+      unlistenActivePlatformFocus = await listen<ActivePlatformFocusPayload>(
+        ACTIVE_PLATFORM_FOCUS_EVENT,
+        (event) => {
+          const payload = event.payload;
+          if (!payload?.platformId || instanceContext) {
+            return;
+          }
+          if (payload.sourceWindowLabel === currentWindowLabel) {
+            return;
+          }
+          if (!ALL_PLATFORM_IDS.includes(payload.platformId)) {
+            return;
+          }
+          setSelectedPlatform(payload.platformId);
         },
       );
     };
@@ -564,6 +602,7 @@ export function FloatingCardWindow() {
       disposed = true;
       unlistenAccountsChanged?.();
       unlistenCurrentAccountChanged?.();
+      unlistenActivePlatformFocus?.();
     };
   }, [
     currentWindowLabel,
@@ -717,11 +756,7 @@ export function FloatingCardWindow() {
     if (instanceContext) {
       return;
     }
-    try {
-      localStorage.setItem(FLOATING_CARD_PLATFORM_STORAGE_KEY, selectedPlatform);
-    } catch {
-      // ignore storage write failures
-    }
+    persistFloatingCardPlatform(selectedPlatform);
   }, [instanceContext, selectedPlatform]);
 
   const githubCopilotCurrent = useMemo(

--- a/src/pages/GrokAccountsPage.tsx
+++ b/src/pages/GrokAccountsPage.tsx
@@ -512,18 +512,25 @@ export function GrokAccountsPage() {
               </div>
             )}
             {items.map((item) => {
-              const percentage = Math.max(
+              // item.percentage 为 used%；界面主文案展示剩余%，进度条仍按已用填充
+              const usedPercent = Math.max(
                 0,
                 Math.min(100, Math.round(item.percentage)),
               );
-              const quotaClass = getGrokQuotaClass(percentage);
+              const remainingPercent = Math.max(0, Math.min(100, 100 - usedPercent));
+              const quotaClass = getGrokQuotaClass(usedPercent);
               const amountText = formatGrokQuotaUsedTotal(item.used, item.total);
+              const remainingLabel = t(
+                "common.shared.quota.leftPercent",
+                "剩余 {{value}}%",
+                { value: remainingPercent },
+              );
               const resetText = formatGrokQuotaResetTime(item.resetAtMs);
               const resetDisplay = resetText || "-";
               const titleParts = [
                 item.label,
                 amountText || null,
-                `${percentage}%`,
+                remainingLabel,
                 resetText
                   ? t("grok.quota.resetAt", "{{label}} 重置：{{time}}", {
                       label: item.label,
@@ -550,13 +557,13 @@ export function GrokAccountsPage() {
                             <span className="grok-quota-pct-sep">·</span>
                           </>
                         ) : null}
-                        {percentage}%
+                        {remainingLabel}
                       </span>
                     </div>
                     <div className="quota-bar-track">
                       <div
                         className={`quota-bar ${quotaClass}`}
-                        style={{ width: `${percentage}%` }}
+                        style={{ width: `${usedPercent}%` }}
                       />
                     </div>
                     <span className="quota-reset">{resetDisplay}</span>
@@ -579,13 +586,13 @@ export function GrokAccountsPage() {
                           <span className="grok-quota-pct-sep">·</span>
                         </>
                       ) : null}
-                      {percentage}%
+                      {remainingLabel}
                     </span>
                   </div>
                   <div className="quota-progress-track">
                     <div
                       className={`quota-progress-bar ${quotaClass}`}
-                      style={{ width: `${percentage}%` }}
+                      style={{ width: `${usedPercent}%` }}
                     />
                   </div>
                   <div className="quota-footer">

--- a/src/presentation/platformAccountPresentation.ts
+++ b/src/presentation/platformAccountPresentation.ts
@@ -1740,11 +1740,13 @@ export function buildGrokAccountPresentation(
         item.used != null && item.total != null
           ? Math.max(0, item.total - item.used)
           : null;
+      // 主文案展示剩余额度（非仅用量）；进度条仍按 used% 填充
+      const remainingText = t("common.shared.quota.leftPercent", "剩余 {{value}}%", {
+        value: Math.round(remaining),
+      });
       const valueText = amountText
-        ? `${amountText} · ${Math.round(usedPercent)}%`
-        : t("common.shared.quota.leftPercent", "{{value}}% left", {
-            value: Math.round(remaining),
-          });
+        ? `${amountText} · ${remainingText}`
+        : remainingText;
       return {
         key: item.key,
         label: item.label,

--- a/src/types/grok.ts
+++ b/src/types/grok.ts
@@ -251,20 +251,32 @@ export function getGrokPlanBadge(account: GrokAccount): string {
   }
   if (
     ["SUBSCRIPTION_TIER_GROK_PRO", "GROK_PRO"].includes(normalized) ||
-    compact === "GROKPRO"
+    compact === "GROKPRO" ||
+    compact === "SUBSCRIPTIONTIERGROKPRO"
   ) {
     return "Grok Pro";
   }
-  if (["SUBSCRIPTION_TIER_X_BASIC", "X_BASIC"].includes(normalized)) {
-    return "X Basic";
+  // XPremiumPlus 等无下划线别名必须先于 XPremium 精确匹配
+  if (
+    ["SUBSCRIPTION_TIER_X_PREMIUM_PLUS", "X_PREMIUM_PLUS"].includes(normalized) ||
+    compact === "XPREMIUMPLUS" ||
+    compact === "SUBSCRIPTIONTIERXPREMIUMPLUS"
+  ) {
+    return "X Premium+";
   }
-  if (["SUBSCRIPTION_TIER_X_PREMIUM", "X_PREMIUM"].includes(normalized)) {
+  if (
+    ["SUBSCRIPTION_TIER_X_PREMIUM", "X_PREMIUM"].includes(normalized) ||
+    compact === "XPREMIUM" ||
+    compact === "SUBSCRIPTIONTIERXPREMIUM"
+  ) {
     return "X Premium";
   }
   if (
-    ["SUBSCRIPTION_TIER_X_PREMIUM_PLUS", "X_PREMIUM_PLUS"].includes(normalized)
+    ["SUBSCRIPTION_TIER_X_BASIC", "X_BASIC"].includes(normalized) ||
+    compact === "XBASIC" ||
+    compact === "SUBSCRIPTIONTIERXBASIC"
   ) {
-    return "X Premium+";
+    return "X Basic";
   }
   if (
     [
@@ -306,7 +318,7 @@ function grokLabelT(key: string, defaultValue?: string): string {
 
 /**
  * Account health uses the same visible quota buckets as the overview cards
- * (products / tasks / on-demand). Weekly totals are intentionally excluded.
+ * (weekly pool / products / tasks / on-demand). Most-constrained bucket wins.
  */
 export function getGrokUsage(account: GrokAccount): GrokUsage {
   const usagePercents = getGrokQuotaSummaryItems(account, grokLabelT).map(
@@ -402,7 +414,7 @@ export function getGrokQuotaClass(
 
 /**
  * Single source of truth for Grok quota rows (overview, health, presentation).
- * Weekly billing totals are intentionally omitted from the visible model.
+ * Includes weekly shared pool + productUsage + task/on-demand buckets.
  * Product rows may carry billing period reset; task/on-demand rows do not
  * invent a reset time when the API does not provide one.
  */
@@ -419,6 +431,25 @@ export function getGrokQuotaSummaryItems(
   const billingResetAtMs = timestampMs(quota.periodEnd);
   const items: GrokQuotaSummaryItem[] = [];
 
+  // 周总池（creditUsagePercent / weeklyCredits）——展示剩余时由调用方 100-used
+  const weeklyUsed = finite(quota.weeklyUsed);
+  const weeklyTotal = finite(quota.weeklyTotal);
+  const weeklyUsedPercent =
+    finite(quota.weeklyLimitPercent) ??
+    (weeklyUsed != null && weeklyTotal != null && weeklyTotal > 0
+      ? (weeklyUsed / weeklyTotal) * 100
+      : null);
+  if (weeklyUsedPercent != null || (weeklyUsed != null && weeklyTotal != null)) {
+    items.push({
+      key: "weekly",
+      label: t("grok.quota.weekly", "每周用量"),
+      percentage: clampPercent(weeklyUsedPercent ?? 0),
+      used: weeklyUsed,
+      total: weeklyTotal,
+      resetAtMs: billingResetAtMs,
+    });
+  }
+
   (quota.products ?? []).forEach((product, index) => {
     const used = finite(product.used);
     const total = finite(product.total);
@@ -428,18 +459,25 @@ export function getGrokQuotaSummaryItems(
       (total != null && remaining != null
         ? Math.max(0, total - remaining)
         : null);
+    const resolvedTotal =
+      total ??
+      (used != null && remaining != null ? used + remaining : null);
     const usagePercent =
       finite(product.usagePercent) ??
-      (resolvedUsed != null && total != null && total > 0
-        ? (resolvedUsed / total) * 100
-        : null);
-    if (usagePercent == null && resolvedUsed == null && total == null) return;
+      (resolvedUsed != null && resolvedTotal != null && resolvedTotal > 0
+        ? (resolvedUsed / resolvedTotal) * 100
+        : remaining != null && resolvedTotal != null && resolvedTotal > 0
+          ? ((resolvedTotal - remaining) / resolvedTotal) * 100
+          : null);
+    if (usagePercent == null && resolvedUsed == null && resolvedTotal == null) {
+      return;
+    }
     items.push({
       key: `product-${index}`,
       label: product.product || t("grok.quota.included", "套餐用量"),
       percentage: clampPercent(usagePercent ?? 0),
       used: resolvedUsed,
-      total,
+      total: resolvedTotal,
       resetAtMs: billingResetAtMs,
     });
   });

--- a/src/utils/accountSyncEvents.ts
+++ b/src/utils/accountSyncEvents.ts
@@ -1,13 +1,25 @@
 import { emit } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import type { PlatformId } from '../types/platform';
+import type { Page } from '../types/navigation';
+import { ALL_PLATFORM_IDS, PLATFORM_PAGE_MAP, type PlatformId } from '../types/platform';
 
 export const ACCOUNTS_CHANGED_EVENT = 'accounts:changed';
 export const CURRENT_ACCOUNT_CHANGED_EVENT = 'accounts:current-changed';
+/** 主窗口当前平台（侧栏/页面）变化：悬浮窗/菜单应跟随，而不是锁死 antigravity */
+export const ACTIVE_PLATFORM_FOCUS_EVENT = 'platform:active-focus';
+
+export const FLOATING_CARD_PLATFORM_STORAGE_KEY = 'agtools.floating_card.platform';
 
 export type AccountSyncEventPayload = {
   platformId: PlatformId;
   accountId?: string | null;
+  reason?: string;
+  sourceWindowLabel?: string;
+};
+
+export type ActivePlatformFocusPayload = {
+  platformId: PlatformId;
+  page?: string;
   reason?: string;
   sourceWindowLabel?: string;
 };
@@ -77,4 +89,66 @@ export async function emitAccountsChanged(payload: AccountSyncEventPayload) {
 
 export async function emitCurrentAccountChanged(payload: AccountSyncEventPayload) {
   await emitAccountSyncEvent(CURRENT_ACCOUNT_CHANGED_EVENT, payload);
+}
+
+/** 主窗口 Page → 平台（dashboard/settings 等非平台页返回 null，不强制改悬浮窗） */
+export function resolvePlatformIdFromPage(page: Page | string): PlatformId | null {
+  const normalized = String(page || '').trim().toLowerCase();
+  if (!normalized) return null;
+
+  // 特殊页
+  if (normalized === 'overview' || normalized === 'accounts') {
+    return 'antigravity';
+  }
+  if (normalized === 'claude-cli') {
+    return 'claude_manager';
+  }
+  if (normalized === 'codex-api-service' || normalized === 'codex-instances') {
+    return 'codex';
+  }
+  if (
+    normalized === 'dashboard' ||
+    normalized === 'settings' ||
+    normalized === 'manual' ||
+    normalized === 'api-relay' ||
+    normalized === 'wakeup' ||
+    normalized === 'verification' ||
+    normalized === '2fa' ||
+    normalized === 'instances'
+  ) {
+    return null;
+  }
+
+  // PLATFORM_PAGE_MAP 反向
+  for (const platformId of ALL_PLATFORM_IDS) {
+    if (PLATFORM_PAGE_MAP[platformId] === normalized) {
+      return platformId;
+    }
+  }
+
+  // 兜底：page 名本身就是 platform id
+  if (ALL_PLATFORM_IDS.includes(normalized as PlatformId)) {
+    return normalized as PlatformId;
+  }
+  return normalizeProviderPagePlatformId(normalized);
+}
+
+export function persistFloatingCardPlatform(platformId: PlatformId): void {
+  try {
+    localStorage.setItem(FLOATING_CARD_PLATFORM_STORAGE_KEY, platformId);
+  } catch {
+    // ignore
+  }
+}
+
+export async function emitActivePlatformFocus(payload: ActivePlatformFocusPayload) {
+  persistFloatingCardPlatform(payload.platformId);
+  try {
+    await emit<ActivePlatformFocusPayload>(ACTIVE_PLATFORM_FOCUS_EVENT, {
+      ...payload,
+      sourceWindowLabel: payload.sourceWindowLabel ?? resolveSourceWindowLabel(),
+    });
+  } catch (error) {
+    console.warn(`[account-sync] Failed to emit ${ACTIVE_PLATFORM_FOCUS_EVENT}:`, error);
+  }
 }


### PR DESCRIPTION
## Summary

基于 **最新上游 `main`（v1.3.0）** 的最小修复，无历史大 PR 残留，可直接合并。

| 点 | 修复 |
|---|---|
| 悬浮窗平台 | 主窗口切到 Grok 等平台时，悬浮窗跟随，不再锁死 antigravity |
| 配额 Header | `cli-chat-proxy` billing/user 补齐 `x-xai-token-auth: xai-grok-cli`（无此头实测 **401**） |
| 剩余额度 | 展示周池 + productUsage **剩余%**（`100 - used`），非只显示已用 |
| 订阅类型 | 认真实 API 字段（含 `XPremiumPlus` / `SUBSCRIPTION_TIER_GROK_PRO` 等别名） |
| 防抢凭证 | 刷新前吸收 CLI 已写回的 `~/.grok/auth.json`；`invalid_grant` 重试；失败保留缓存；TokenKeeper 走软刷新 |

## 本地验证

在本机用 **多个真实 Grok OAuth 账号**（订阅类型覆盖 X Premium+ / Grok Pro 等，含多 productUsage 分项）核对：

- billing **无** `x-xai-token-auth` → 401；**有** → 200
- 周池 / product 剩余% = `100 - used%`，与接口 `creditUsagePercent` / `productUsage` 一致
- 订阅徽章映射 `XPremiumPlus` 等紧凑别名
- 悬浮窗随主窗口切到 Grok；后台软刷新不与 CLI 互抢单次 `refresh_token`
- `tsc --noEmit` 通过
- Base = 当前 `origin/main`，单 commit，**无 merge 冲突**

> 注：测试账号标识与具体额度数字不在公开描述中展示。此前误写入的邮箱/额度明细已从本描述中删除。

## 请维护者合并

@jlcodes99 这是基于最新 main 的独立修复 PR，不依赖旧 PR #1518 分支（main 已含 Grok 主体）。请帮忙 **merge**。如有意见我立刻跟进。谢谢！
