### PR TITLE
fix(codex,grok): limited concurrent batch quota refresh + remaining progress bar

### DIFF
--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -1134,6 +1134,22 @@ pub async fn refresh_all_codex_quotas(app: AppHandle) -> Result<i32, String> {
     Ok(success_count as i32)
 }
 
+/// 按账号 ID 列表限流并发刷新配额（分组刷新 / 本地访问批量等）
+/// 只在全部任务结束后做一次 tray / post-check，避免 N 次并发互踩。
+#[tauri::command]
+pub async fn refresh_codex_quotas_batch(
+    app: AppHandle,
+    account_ids: Vec<String>,
+) -> Result<i32, String> {
+    let results = codex_quota::refresh_quotas_for_account_ids(&account_ids).await?;
+    let success_count = results.iter().filter(|(_, r)| r.is_ok()).count();
+    if success_count > 0 {
+        run_codex_post_refresh_checks(&app).await;
+    }
+    let _ = crate::modules::tray::update_tray_menu(&app);
+    Ok(success_count as i32)
+}
+
 async fn save_codex_oauth_tokens(
     tokens: CodexTokens,
     reauth_account_id: Option<&str>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -714,6 +714,7 @@ pub fn run() {
             commands::codex::get_codex_batch_import_preview,
             commands::codex::confirm_codex_batch_import,
             commands::codex::refresh_codex_quota,
+            commands::codex::refresh_codex_quotas_batch,
             commands::codex::get_codex_reset_credits,
             commands::codex::consume_codex_reset_credit,
             commands::codex::refresh_codex_subscription_info,

--- a/src-tauri/src/modules/codex_quota.rs
+++ b/src-tauri/src/modules/codex_quota.rs
@@ -1601,23 +1601,39 @@ pub async fn refresh_account_subscription_info(
     }
 }
 
-/// 刷新所有账号配额
-pub async fn refresh_all_quotas() -> Result<Vec<(String, Result<CodexQuota, String>)>, String> {
+const CODEX_QUOTA_REFRESH_MAX_CONCURRENT: usize = 5;
+
+/// 按账号 ID 列表限流并发刷新配额（分组/勾选批量共用）。
+pub async fn refresh_quotas_for_account_ids(
+    account_ids: &[String],
+) -> Result<Vec<(String, Result<CodexQuota, String>)>, String> {
     use futures::future::join_all;
+    use std::collections::HashSet;
     use std::sync::Arc;
     use tokio::sync::Semaphore;
 
-    const MAX_CONCURRENT: usize = 5;
-    let accounts: Vec<_> = codex_account::list_accounts()
-        .into_iter()
-        .filter(|account| !account.is_api_key_auth() || is_new_api_account(account))
+    if account_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // 去重并保持输入顺序，避免重复刷新同一账号
+    let mut seen = HashSet::new();
+    let unique_ids: Vec<String> = account_ids
+        .iter()
+        .filter_map(|id| {
+            let trimmed = id.trim();
+            if trimmed.is_empty() || !seen.insert(trimmed.to_string()) {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
         .collect();
 
-    let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT));
-    let tasks: Vec<_> = accounts
+    let semaphore = Arc::new(Semaphore::new(CODEX_QUOTA_REFRESH_MAX_CONCURRENT));
+    let tasks: Vec<_> = unique_ids
         .into_iter()
-        .map(|account| {
-            let account_id = account.id;
+        .map(|account_id| {
             let semaphore = semaphore.clone();
             async move {
                 let _permit = semaphore
@@ -1637,8 +1653,17 @@ pub async fn refresh_all_quotas() -> Result<Vec<(String, Result<CodexQuota, Stri
             Err(err) => return Err(err),
         }
     }
-
     Ok(results)
+}
+
+/// 刷新所有账号配额
+pub async fn refresh_all_quotas() -> Result<Vec<(String, Result<CodexQuota, String>)>, String> {
+    let account_ids: Vec<String> = codex_account::list_accounts()
+        .into_iter()
+        .filter(|account| !account.is_api_key_auth() || is_new_api_account(account))
+        .map(|account| account.id)
+        .collect();
+    refresh_quotas_for_account_ids(&account_ids).await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/modules/grok_account.rs
+++ b/src-tauri/src/modules/grok_account.rs
@@ -24,7 +24,8 @@ const CLI_USER_URL: &str = "https://cli-chat-proxy.grok.com/v1/user?include=subs
 const SUBSCRIPTIONS_URL: &str = "https://grok.com/rest/subscriptions";
 const TASK_USAGE_URL: &str = "https://grok.com/rest/tasks/usage";
 const FALLBACK_GROK_CLIENT_VERSION: &str = "0.2.93";
-const TASK_USAGE_MAX_ATTEMPTS: usize = 3;
+/// billing / user / task_usage 传输层瞬时失败（SSL EOF、断连、超时）重试次数
+const TRANSPORT_MAX_ATTEMPTS: usize = 3;
 const FILE_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 
 static ACCOUNT_LOCK: std::sync::LazyLock<Mutex<()>> = std::sync::LazyLock::new(|| Mutex::new(()));
@@ -1610,15 +1611,47 @@ fn cli_proxy_get(
         .header(USER_AGENT, format!("grok-cli/{}", client_version))
 }
 
+/// 传输层瞬时错误（SSL EOF / 断连 / 超时）重试；RequestBuilder 不可复用，需每次重建。
+async fn send_with_transport_retry<F>(
+    label: &str,
+    max_attempts: usize,
+    mut build: F,
+) -> Result<reqwest::Response, String>
+where
+    F: FnMut() -> reqwest::RequestBuilder,
+{
+    let mut attempt = 0_usize;
+    loop {
+        attempt += 1;
+        match build().send().await {
+            Ok(response) => return Ok(response),
+            Err(error) if attempt < max_attempts => {
+                logger::log_warn(&format!(
+                    "[Grok Account] {} 传输失败，第 {}/{} 次: {}",
+                    label, attempt, max_attempts, error
+                ));
+                // 线性退避：0.5s / 1s / 1.5s…
+                tokio::time::sleep(Duration::from_millis(500 * attempt as u64)).await;
+            }
+            Err(error) => {
+                return Err(format!("{}失败: {}", label, error));
+            }
+        }
+    }
+}
+
 async fn cli_user_for(
     client: &reqwest::Client,
     account: &GrokAccount,
     client_version: &str,
 ) -> Option<Value> {
-    let response = cli_proxy_get(client, CLI_USER_URL, &account.access_token, client_version)
-        .send()
-        .await
-        .ok()?;
+    let access_token = account.access_token.clone();
+    let client_version = client_version.to_string();
+    let response = send_with_transport_retry("查询 Grok 用户信息", TRANSPORT_MAX_ATTEMPTS, || {
+        cli_proxy_get(client, CLI_USER_URL, &access_token, &client_version)
+    })
+    .await
+    .ok()?;
     if !response.status().is_success() {
         return None;
     }
@@ -1631,17 +1664,24 @@ async fn subscriptions_for(account: &GrokAccount, client_version: &str) -> Optio
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .ok()?;
-    let mut request = client
-        .get(SUBSCRIPTIONS_URL)
-        .header(AUTHORIZATION, format!("Bearer {}", account.access_token))
-        .header(ACCEPT, "application/json,text/plain,*/*")
-        .header("x-xai-token-auth", "xai-grok-cli")
-        .header("x-grok-client-version", client_version)
-        .header(USER_AGENT, format!("grok-cli/{}", client_version));
-    if let Some(user_id) = account.user_id.as_deref() {
-        request = request.header("x-userid", user_id);
-    }
-    let response = request.send().await.ok()?;
+    let access_token = account.access_token.clone();
+    let client_version = client_version.to_string();
+    let user_id = account.user_id.clone();
+    let response = send_with_transport_retry("查询 Grok 订阅", TRANSPORT_MAX_ATTEMPTS, || {
+        let mut request = client
+            .get(SUBSCRIPTIONS_URL)
+            .header(AUTHORIZATION, format!("Bearer {}", access_token))
+            .header(ACCEPT, "application/json,text/plain,*/*")
+            .header("x-xai-token-auth", "xai-grok-cli")
+            .header("x-grok-client-version", &client_version)
+            .header(USER_AGENT, format!("grok-cli/{}", client_version));
+        if let Some(user_id) = user_id.as_deref() {
+            request = request.header("x-userid", user_id);
+        }
+        request
+    })
+    .await
+    .ok()?;
     if !response.status().is_success() {
         return None;
     }
@@ -1654,29 +1694,17 @@ async fn task_usage_for(account: &GrokAccount) -> Result<Value, String> {
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|error| format!("创建 Grok 任务配额客户端失败: {}", error))?;
-    let mut attempt = 0_usize;
-    let response = loop {
-        attempt += 1;
-        match client
-            .get(TASK_USAGE_URL)
-            .header(AUTHORIZATION, format!("Bearer {}", account.access_token))
-            .header(ACCEPT, "application/json")
-            .header("x-xai-token-auth", "xai-grok-cli")
-            .header(USER_AGENT, "Grok Build")
-            .send()
-            .await
-        {
-            Ok(response) => break response,
-            Err(error) if attempt < TASK_USAGE_MAX_ATTEMPTS => {
-                logger::log_warn(&format!(
-                    "[Grok Account] 任务配额请求传输失败，第 {}/{} 次: {}",
-                    attempt, TASK_USAGE_MAX_ATTEMPTS, error
-                ));
-                tokio::time::sleep(Duration::from_millis(500 * attempt as u64)).await;
-            }
-            Err(error) => return Err(format!("查询 Grok 任务配额失败: {}", error)),
-        }
-    };
+    let access_token = account.access_token.clone();
+    let response =
+        send_with_transport_retry("查询 Grok 任务配额", TRANSPORT_MAX_ATTEMPTS, || {
+            client
+                .get(TASK_USAGE_URL)
+                .header(AUTHORIZATION, format!("Bearer {}", access_token))
+                .header(ACCEPT, "application/json")
+                .header("x-xai-token-auth", "xai-grok-cli")
+                .header(USER_AGENT, "Grok Build")
+        })
+        .await?;
     let status = response.status();
     let body = response
         .text()
@@ -1829,10 +1857,18 @@ async fn query_quota(account: &mut GrokAccount) -> Result<(), String> {
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|error| format!("创建 Grok 配额客户端失败: {}", error))?;
-    let response = cli_proxy_get(&client, BILLING_URL, &account.access_token, &client_version)
-        .send()
-        .await
-        .map_err(|error| format!("查询 Grok 配额失败: {}", error))?;
+    // billing 是主数据源：补上与 task_usage 相同的传输重试，降低 SSL EOF 等偶发失败
+    let access_token = account.access_token.clone();
+    let client_version_for_billing = client_version.clone();
+    let response = send_with_transport_retry("查询 Grok 配额", TRANSPORT_MAX_ATTEMPTS, || {
+        cli_proxy_get(
+            &client,
+            BILLING_URL,
+            &access_token,
+            &client_version_for_billing,
+        )
+    })
+    .await?;
     let status = response.status();
     let body = response
         .text()

--- a/src-tauri/src/modules/grok_account.rs
+++ b/src-tauri/src/modules/grok_account.rs
@@ -2081,15 +2081,44 @@ pub async fn force_refresh_account(account_id: &str) -> Result<GrokAccountView, 
 
 pub async fn refresh_all_accounts() -> Result<Vec<(String, Result<GrokAccountView, String>)>, String>
 {
+    use futures::future::join_all;
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+
+    // 多账号时全串行易拖垮 IPC/超时；过高并发会触发上游限流与 token 旋转压力。
+    // 每账号有独立 token 锁，跨账号限流并发是安全的。
+    const MAX_CONCURRENT: usize = 3;
     let ids: Vec<String> = load_index()?
         .accounts
         .into_iter()
         .map(|item| item.id)
         .collect();
-    let mut results = Vec::new();
-    for id in ids {
-        let result = refresh_account(&id).await;
-        results.push((id, result));
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT));
+    let tasks: Vec<_> = ids
+        .into_iter()
+        .map(|account_id| {
+            let semaphore = semaphore.clone();
+            async move {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .map_err(|error| format!("获取 Grok 刷新并发许可失败: {}", error))?;
+                let result = refresh_account(&account_id).await;
+                Ok::<(String, Result<GrokAccountView, String>), String>((account_id, result))
+            }
+        })
+        .collect();
+
+    let mut results = Vec::with_capacity(tasks.len());
+    for task in join_all(tasks).await {
+        match task {
+            Ok(item) => results.push(item),
+            Err(error) => return Err(error),
+        }
     }
     Ok(results)
 }

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -8660,9 +8660,13 @@ export function CodexAccountsPage() {
 
   const handleQuickRefreshLocalAccessQuota = useCallback(async () => {
     if (!localAccessCollection) return;
+    // 与分组/全量刷新一致：OAuth + New API 可刷，普通 API Key 跳过
     const targetIds = localAccessCollection.accountIds.filter((accountId) => {
       const account = accounts.find((item) => item.id === accountId);
-      return Boolean(account && !isCodexApiKeyAccount(account));
+      return Boolean(
+        account &&
+          (!isCodexApiKeyAccount(account) || isCodexNewApiAccount(account)),
+      );
     });
 
     if (targetIds.length === 0) {
@@ -8704,6 +8708,14 @@ export function CodexAccountsPage() {
       setMessage({
         text: t("codex.refreshFailed", {
           error: t("common.shared.quota.queryFailed", "配额查询失败"),
+        }),
+        tone: "error",
+      });
+    } catch (error) {
+      setMessage({
+        text: t("codex.refreshFailed", {
+          error: String(error ?? "").replace(/^Error:\s*/, "") ||
+            t("common.shared.quota.queryFailed", "配额查询失败"),
         }),
         tone: "error",
       });
@@ -9264,6 +9276,14 @@ export function CodexAccountsPage() {
         setMessage({
           text: t("codex.refreshFailed", {
             error: t("common.shared.quota.queryFailed", "配额查询失败"),
+          }),
+          tone: "error",
+        });
+      } catch (error) {
+        setMessage({
+          text: t("codex.refreshFailed", {
+            error: String(error ?? "").replace(/^Error:\s*/, "") ||
+              t("common.shared.quota.queryFailed", "配额查询失败"),
           }),
           tone: "error",
         });

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -8677,12 +8677,8 @@ export function CodexAccountsPage() {
 
     setLocalAccessRefreshing(true);
     try {
-      const results = await Promise.allSettled(
-        targetIds.map((accountId) => refreshQuota(accountId)),
-      );
-      const successCount = results.filter(
-        (result) => result.status === "fulfilled",
-      ).length;
+      // 后端限流并发（MAX=5），避免 N 路全开 + 每号 fetchAccounts thrash
+      const successCount = await codexService.refreshCodexQuotasBatch(targetIds);
 
       await fetchAccounts();
       await fetchCurrentAccount();
@@ -8705,13 +8701,9 @@ export function CodexAccountsPage() {
         return;
       }
 
-      const firstFailure = results.find(
-        (result): result is PromiseRejectedResult =>
-          result.status === "rejected",
-      );
       setMessage({
         text: t("codex.refreshFailed", {
-          error: String(firstFailure?.reason ?? "").replace(/^Error:\s*/, ""),
+          error: t("common.shared.quota.queryFailed", "配额查询失败"),
         }),
         tone: "error",
       });
@@ -8723,7 +8715,6 @@ export function CodexAccountsPage() {
     fetchAccounts,
     fetchCurrentAccount,
     localAccessCollection,
-    refreshQuota,
     setMessage,
     t,
   ]);
@@ -9245,14 +9236,9 @@ export function CodexAccountsPage() {
 
       setRefreshingGroupId(group.id);
       try {
-        const results = await Promise.allSettled(
-          targetIds.map((accountId) =>
-            codexService.refreshCodexQuota(accountId),
-          ),
-        );
-        const successCount = results.filter(
-          (result) => result.status === "fulfilled",
-        ).length;
+        // 与 refresh_all 同源限流；避免 Promise.allSettled 无上限并发导致部分账号失败
+        const successCount =
+          await codexService.refreshCodexQuotasBatch(targetIds);
 
         await fetchAccounts();
         await fetchCurrentAccount();
@@ -9275,13 +9261,9 @@ export function CodexAccountsPage() {
           return;
         }
 
-        const firstFailure = results.find(
-          (result): result is PromiseRejectedResult =>
-            result.status === "rejected",
-        );
         setMessage({
           text: t("codex.refreshFailed", {
-            error: String(firstFailure?.reason ?? "").replace(/^Error:\s*/, ""),
+            error: t("common.shared.quota.queryFailed", "配额查询失败"),
           }),
           tone: "error",
         });

--- a/src/pages/GrokAccountsPage.tsx
+++ b/src/pages/GrokAccountsPage.tsx
@@ -512,17 +512,18 @@ export function GrokAccountsPage() {
               </div>
             )}
             {items.map((item) => {
-              // item.percentage 为 used%；界面主文案展示剩余%，进度条仍按已用填充
+              // item.percentage 为 used%；文案与进度条均展示剩余%（与 Gemini 等平台一致：越用越短）
               const usedPercent = Math.max(
                 0,
                 Math.min(100, Math.round(item.percentage)),
               );
               const remainingPercent = Math.max(0, Math.min(100, 100 - usedPercent));
+              // 颜色按已用比例（越用越红），条长度按剩余
               const quotaClass = getGrokQuotaClass(usedPercent);
               const amountText = formatGrokQuotaUsedTotal(item.used, item.total);
               const remainingLabel = t(
                 "common.shared.quota.leftPercent",
-                "剩余 {{value}}%",
+                "{{value}}% left",
                 { value: remainingPercent },
               );
               const resetText = formatGrokQuotaResetTime(item.resetAtMs);
@@ -563,7 +564,7 @@ export function GrokAccountsPage() {
                     <div className="quota-bar-track">
                       <div
                         className={`quota-bar ${quotaClass}`}
-                        style={{ width: `${usedPercent}%` }}
+                        style={{ width: `${remainingPercent}%` }}
                       />
                     </div>
                     <span className="quota-reset">{resetDisplay}</span>
@@ -592,7 +593,7 @@ export function GrokAccountsPage() {
                   <div className="quota-progress-track">
                     <div
                       className={`quota-progress-bar ${quotaClass}`}
-                      style={{ width: `${usedPercent}%` }}
+                      style={{ width: `${remainingPercent}%` }}
                     />
                   </div>
                   <div className="quota-footer">

--- a/src/presentation/platformAccountPresentation.ts
+++ b/src/presentation/platformAccountPresentation.ts
@@ -1740,8 +1740,8 @@ export function buildGrokAccountPresentation(
         item.used != null && item.total != null
           ? Math.max(0, item.total - item.used)
           : null;
-      // 主文案展示剩余额度（非仅用量）；进度条仍按 used% 填充
-      const remainingText = t("common.shared.quota.leftPercent", "剩余 {{value}}%", {
+      // 与 Gemini 一致：文案与进度条均为剩余%（额度越少条越短）；颜色按已用比例
+      const remainingText = t("common.shared.quota.leftPercent", "{{value}}% left", {
         value: Math.round(remaining),
       });
       const valueText = amountText
@@ -1751,8 +1751,7 @@ export function buildGrokAccountPresentation(
         key: item.key,
         label: item.label,
         percentage: remaining,
-        progressPercent: usedPercent,
-        // Match overview card coloring (used% based), not remaining-only class.
+        progressPercent: remaining,
         quotaClass: getGrokQuotaClass(usedPercent),
         valueText,
         resetAt: item.resetAtMs,

--- a/src/services/codexService.ts
+++ b/src/services/codexService.ts
@@ -275,6 +275,11 @@ export async function refreshAllCodexQuotas(): Promise<number> {
   return await invoke('refresh_all_codex_quotas');
 }
 
+/** 按 ID 列表限流并发刷新配额（分组/本地访问批量）；后端统一限流并只做一次 tray 更新 */
+export async function refreshCodexQuotasBatch(accountIds: string[]): Promise<number> {
+  return await invoke('refresh_codex_quotas_batch', { accountIds });
+}
+
 /** 新 OAuth 流程：开始登录 */
 export async function startCodexOAuthLogin(): Promise<CodexOAuthLoginStartResponse> {
   return await invoke('codex_oauth_login_start');


### PR DESCRIPTION
## Summary

基于最新 `main` 的 **Codex / Grok** 修复（已子代理审查 + 本地静态核对 + `tsc`）。描述已脱敏，不含任何账号标识。

### Codex
- 分组 / 本地访问批量刷新：去掉无上限 `Promise.allSettled`，改走 `refresh_codex_quotas_batch`（后端限流 **max 5**，整批结束后只做一次 tray/post-check）
- 本地访问过滤与分组/全量对齐（OAuth + New API）
- invoke 失败时有 toast，避免静默

### Grok
- `refresh_all` 限流并发 **max 3**（每账号独立 token 锁，不互抢）
- billing / user / subscriptions / task_usage：**传输层最多 3 次**线性退避重试（缓解 SSL EOF）
- 仍失败：保留上次配额缓存
- 进度条：宽度=**剩余%**（越用越短，对齐 Gemini）；颜色仍按已用

## 验证
- 子代理结论：**可发 PR，无 P0**
- 本地：batch 注册、四端点重试、进度条 remaining、软缓存路径、`tsc --noEmit` 通过
- 本机多账号对照（脱敏）：Codex 限流全成功、全开部分断连；Grok 重试策略已落地

## 请维护者合并

@jlcodes99 最新 main 独立修复，**无冲突**。请帮忙 merge。谢谢！
