### PR TITLE
merge: PR #1503 auto-import local accounts

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -116,6 +116,8 @@ pub struct GeneralConfig {
     pub app_auto_launch_enabled: bool,
     /// 是否启用后台账号授权保活
     pub token_keeper_enabled: bool,
+    /// 是否启用本机账号变更后自动导入
+    pub auto_import_from_local_enabled: bool,
     /// 是否在应用启动后触发 Antigravity IDE 唤醒
     pub antigravity_startup_wakeup_enabled: bool,
     /// Antigravity IDE 启动后唤醒延时（秒）
@@ -1984,6 +1986,7 @@ pub fn save_network_config(
         floating_card_always_on_top: current.floating_card_always_on_top,
         app_auto_launch_enabled: current.app_auto_launch_enabled,
         token_keeper_enabled: current.token_keeper_enabled,
+        auto_import_from_local_enabled: current.auto_import_from_local_enabled,
         antigravity_startup_wakeup_enabled: current.antigravity_startup_wakeup_enabled,
         antigravity_startup_wakeup_delay_seconds: current.antigravity_startup_wakeup_delay_seconds,
         codex_startup_wakeup_enabled: current.codex_startup_wakeup_enabled,
@@ -2320,6 +2323,7 @@ pub fn get_general_config(app: tauri::AppHandle) -> Result<GeneralConfig, String
         floating_card_always_on_top: user_config.floating_card_always_on_top,
         app_auto_launch_enabled,
         token_keeper_enabled: user_config.token_keeper_enabled,
+        auto_import_from_local_enabled: user_config.auto_import_from_local_enabled,
         antigravity_startup_wakeup_enabled: user_config.antigravity_startup_wakeup_enabled,
         antigravity_startup_wakeup_delay_seconds: sanitize_startup_wakeup_delay_seconds(
             user_config.antigravity_startup_wakeup_delay_seconds,
@@ -2475,6 +2479,7 @@ pub fn save_general_config(
     floating_card_always_on_top: Option<bool>,
     app_auto_launch_enabled: Option<bool>,
     token_keeper_enabled: Option<bool>,
+    auto_import_from_local_enabled: Option<bool>,
     antigravity_startup_wakeup_enabled: Option<bool>,
     antigravity_startup_wakeup_delay_seconds: Option<i32>,
     codex_startup_wakeup_enabled: Option<bool>,
@@ -2661,6 +2666,10 @@ pub fn save_general_config(
         app_auto_launch_enabled.unwrap_or(current.app_auto_launch_enabled);
     let token_keeper_enabled_value = token_keeper_enabled.unwrap_or(current.token_keeper_enabled);
     let token_keeper_enabled_changed = current.token_keeper_enabled != token_keeper_enabled_value;
+    let auto_import_from_local_enabled_value = auto_import_from_local_enabled
+        .unwrap_or(current.auto_import_from_local_enabled);
+    let auto_import_from_local_enabled_changed =
+        current.auto_import_from_local_enabled != auto_import_from_local_enabled_value;
     let antigravity_startup_wakeup_enabled_value =
         antigravity_startup_wakeup_enabled.unwrap_or(current.antigravity_startup_wakeup_enabled);
     let antigravity_startup_wakeup_delay_seconds_value = sanitize_startup_wakeup_delay_seconds(
@@ -2757,6 +2766,7 @@ pub fn save_general_config(
         floating_card_always_on_top: floating_card_always_on_top_value,
         app_auto_launch_enabled: app_auto_launch_enabled_value,
         token_keeper_enabled: token_keeper_enabled_value,
+        auto_import_from_local_enabled: auto_import_from_local_enabled_value,
         antigravity_startup_wakeup_enabled: antigravity_startup_wakeup_enabled_value,
         antigravity_startup_wakeup_delay_seconds: antigravity_startup_wakeup_delay_seconds_value,
         codex_startup_wakeup_enabled: codex_startup_wakeup_enabled_value,
@@ -2935,6 +2945,10 @@ pub fn save_general_config(
             app.clone(),
             token_keeper_enabled_value,
         );
+    }
+
+    if auto_import_from_local_enabled_changed {
+        modules::auto_local_import::notify_config_changed(auto_import_from_local_enabled_value);
     }
 
     if current_app_auto_launch_enabled != app_auto_launch_enabled_value {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -333,6 +333,7 @@ pub fn run() {
             }
 
             modules::provider_token_keeper::ensure_started(app.handle().clone());
+            modules::auto_local_import::ensure_started(app.handle().clone());
             modules::wakeup_scheduler::restore_state_from_disk();
             modules::wakeup_scheduler::ensure_started(app.handle().clone());
             modules::codex_wakeup_scheduler::ensure_started(app.handle().clone());

--- a/src-tauri/src/modules/auto_local_import.rs
+++ b/src-tauri/src/modules/auto_local_import.rs
@@ -1,0 +1,709 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{LazyLock, Mutex};
+use std::time::Duration;
+
+use rusqlite::Connection;
+use serde_json::Value;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::Notify;
+
+use crate::models::codebuddy::CodebuddyOAuthCompletePayload;
+use crate::models::workbuddy::WorkbuddyOAuthCompletePayload;
+use crate::modules::{
+    claude_account, codebuddy_account, codebuddy_cn_account, codebuddy_cn_oauth, codebuddy_oauth,
+    codex_account, config, cursor_account, gemini_account, github_copilot_account,
+    github_copilot_instance, import, kiro_account, kiro_oauth, logger, qoder_account, trae_account,
+    windsurf_account, windsurf_oauth, workbuddy_account, workbuddy_oauth, zed_account,
+};
+
+const POLL_INTERVAL_SECONDS: u64 = 30;
+const STARTUP_DELAY_SECONDS: u64 = 10;
+
+static WATCHER_STARTED: AtomicBool = AtomicBool::new(false);
+static CONFIG_CHANGED: LazyLock<Notify> = LazyLock::new(Notify::new);
+static LAST_IDENTITIES: LazyLock<Mutex<HashMap<String, String>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+type ImportFuture = Pin<Box<dyn Future<Output = Result<bool, String>> + Send>>;
+
+struct PlatformWatcher {
+    platform: &'static str,
+    peek_identity: fn() -> Option<String>,
+    import_account: fn() -> ImportFuture,
+}
+
+pub fn ensure_started(app_handle: AppHandle) {
+    if WATCHER_STARTED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    logger::log_info("[AutoLocalImport] 本机账号自动导入监听已启动");
+    tauri::async_runtime::spawn(async move {
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_secs(STARTUP_DELAY_SECONDS)) => {}
+            _ = CONFIG_CHANGED.notified() => {}
+        }
+
+        loop {
+            run_watch_cycle(&app_handle).await;
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(POLL_INTERVAL_SECONDS)) => {}
+                _ = CONFIG_CHANGED.notified() => {}
+            }
+        }
+    });
+}
+
+pub fn notify_config_changed(enabled: bool) {
+    logger::log_info(&format!(
+        "[AutoLocalImport] 本机账号自动导入设置已{}",
+        if enabled { "启用" } else { "停用" }
+    ));
+    CONFIG_CHANGED.notify_one();
+}
+
+fn identity_key(parts: &[Option<String>]) -> Option<String> {
+    let values: Vec<String> = parts
+        .iter()
+        .filter_map(|part| {
+            part.as_ref()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .collect();
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join("|"))
+    }
+}
+
+fn read_vscdb_string_item(conn: &Connection, key: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT value FROM ItemTable WHERE key = ?1",
+        [key],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+    .map(|value| value.trim().to_string())
+    .filter(|value| !value.is_empty())
+}
+
+fn peek_antigravity_identity() -> Option<String> {
+    #[cfg(target_os = "windows")]
+    {
+        let credential = crate::modules::antigravity_credential::read_antigravity_system_credential()
+            .ok()
+            .flatten()?;
+        return identity_key(&[Some(
+            credential.refresh_token.chars().take(24).collect(),
+        )]);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        use base64::{engine::general_purpose, Engine as _};
+
+        let db_path = crate::modules::db::get_db_path().ok()?;
+        if !db_path.exists() {
+            return None;
+        }
+        let conn = Connection::open(&db_path).ok()?;
+        let state_data = read_vscdb_string_item(&conn, "antigravityUnifiedStateSync.oauthToken")?;
+        let blob = general_purpose::STANDARD.decode(&state_data).ok()?;
+        let refresh_token =
+            crate::utils::protobuf::extract_refresh_token_from_unified_oauth_token(&blob)?;
+        identity_key(&[Some(refresh_token.chars().take(24).collect())])
+    }
+}
+
+fn peek_codex_identity() -> Option<String> {
+    let auth_path = codex_account::get_auth_json_path();
+    if !auth_path.exists() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&auth_path).ok()?;
+    let auth_file: Value = serde_json::from_str(&content).ok()?;
+    let email = auth_file
+        .get("tokens")
+        .and_then(|tokens| tokens.get("email"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let auth_mode = auth_file
+        .get("auth_mode")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let api_key = auth_file
+        .get("OPENAI_API_KEY")
+        .and_then(Value::as_str)
+        .map(|value| value.chars().take(16).collect::<String>());
+    identity_key(&[email, auth_mode, api_key])
+}
+
+fn token_prefix(token: &str) -> Option<String> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.chars().take(16).collect())
+    }
+}
+
+fn peek_cursor_identity() -> Option<String> {
+    let payload = cursor_account::read_local_cursor_auth().ok().flatten()?;
+    identity_key(&[
+        Some(payload.email),
+        payload.auth_id,
+        token_prefix(&payload.access_token),
+    ])
+}
+
+fn peek_gemini_identity() -> Option<String> {
+    identity_key(&[gemini_account::get_local_active_email()])
+}
+
+fn peek_windsurf_identity() -> Option<String> {
+    let auth_status = windsurf_account::read_local_auth_status().ok().flatten()?;
+    let login = auth_status
+        .get("githubLogin")
+        .or_else(|| auth_status.get("login"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    identity_key(&[login.or_else(|| windsurf_account::read_local_login_hint())])
+}
+
+fn peek_github_copilot_identity() -> Option<String> {
+    let data_root = github_copilot_instance::get_default_vscode_user_data_dir().ok()?;
+    let db_path = crate::modules::vscode_paths::vscode_state_db_path(&data_root);
+    if !db_path.exists() {
+        return None;
+    }
+    let conn = Connection::open(&db_path).ok()?;
+    identity_key(&[read_vscdb_string_item(
+        &conn,
+        "github.copilot-github",
+    )])
+}
+
+fn peek_kiro_identity() -> Option<String> {
+    let profile = kiro_account::read_local_profile_json().ok().flatten()?;
+    let email = profile
+        .get("email")
+        .or_else(|| profile.get("userEmail"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let user_id = profile
+        .get("id")
+        .or_else(|| profile.get("userId"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    identity_key(&[email, user_id])
+}
+
+fn peek_codebuddy_identity() -> Option<String> {
+    let payload = codebuddy_account::import_payload_from_local().ok().flatten()?;
+    identity_key(&[
+        Some(payload.email),
+        payload.uid,
+        token_prefix(&payload.access_token),
+    ])
+}
+
+fn peek_codebuddy_cn_identity() -> Option<String> {
+    let payload = codebuddy_cn_account::import_payload_from_local().ok().flatten()?;
+    identity_key(&[
+        Some(payload.email),
+        payload.uid,
+        token_prefix(&payload.access_token),
+    ])
+}
+
+fn peek_workbuddy_identity() -> Option<String> {
+    let payload = workbuddy_account::import_payload_from_local().ok().flatten()?;
+    identity_key(&[
+        Some(payload.email),
+        payload.uid,
+        token_prefix(&payload.access_token),
+    ])
+}
+
+fn peek_qoder_identity() -> Option<String> {
+    let db_path = qoder_account::get_default_qoder_state_db_path()?;
+    if !db_path.exists() {
+        return None;
+    }
+    let user_info = crate::modules::vscode_inject::read_qoder_secret_storage_value_by_db_path(
+        &db_path,
+        "secret://aicoding.auth.userInfo",
+    )
+    .ok()
+    .flatten()?;
+    let parsed: Value = serde_json::from_str(&user_info).unwrap_or(Value::String(user_info));
+    let email = parsed
+        .get("email")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let user_id = parsed
+        .get("id")
+        .or_else(|| parsed.get("userId"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    identity_key(&[email, user_id])
+}
+
+fn peek_trae_identity(platform: trae_account::TraePlatformKind) -> Option<String> {
+    let payload = trae_account::read_local_trae_auth_for_platform(platform)
+        .ok()
+        .flatten()?;
+    identity_key(&[
+        Some(payload.email),
+        payload.user_id,
+        token_prefix(&payload.access_token),
+    ])
+}
+
+fn peek_zed_identity() -> Option<String> {
+    let credentials = zed_account::read_credentials_from_keychain().ok().flatten()?;
+    identity_key(&[Some(credentials.user_id)])
+}
+
+fn peek_claude_identity() -> Option<String> {
+    let config_dir = claude_account::get_default_claude_code_config_dir().ok()?;
+    let cred_path = config_dir.join(".credentials.json");
+    let cred_content = std::fs::read_to_string(&cred_path).ok()?;
+    let cred_json: Value = serde_json::from_str(&cred_content).ok()?;
+    let access_token = cred_json
+        .get("claudeAiOauth")
+        .or_else(|| cred_json.get("oauth"))
+        .and_then(|value| value.get("accessToken"))
+        .and_then(Value::as_str)
+        .map(|token| token.chars().take(16).collect::<String>());
+
+    let config_path = dirs::home_dir()?.join(".claude.json");
+    let config_content = std::fs::read_to_string(&config_path).ok()?;
+    let config_json: Value = serde_json::from_str(&config_content).ok()?;
+    let email = config_json
+        .get("oauthAccount")
+        .and_then(|value| value.get("emailAddress"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    identity_key(&[email, access_token])
+}
+
+async fn enrich_codebuddy_payload(
+    local_payload: CodebuddyOAuthCompletePayload,
+    oauth_build: impl std::future::Future<Output = Result<CodebuddyOAuthCompletePayload, String>>,
+    log_prefix: &str,
+) -> CodebuddyOAuthCompletePayload {
+    match oauth_build.await {
+        Ok(mut payload) => {
+            if payload.uid.is_none() {
+                payload.uid = local_payload.uid.clone();
+            }
+            if payload.nickname.is_none() {
+                payload.nickname = local_payload.nickname.clone();
+            }
+            if payload.refresh_token.is_none() {
+                payload.refresh_token = local_payload.refresh_token.clone();
+            }
+            if payload.domain.is_none() {
+                payload.domain = local_payload.domain.clone();
+            }
+            if payload.token_type.is_none() {
+                payload.token_type = local_payload.token_type.clone();
+            }
+            if payload.expires_at.is_none() {
+                payload.expires_at = local_payload.expires_at;
+            }
+            if payload.auth_raw.is_none() {
+                payload.auth_raw = local_payload.auth_raw.clone();
+            }
+            if payload.profile_raw.is_none() {
+                payload.profile_raw = local_payload.profile_raw.clone();
+            }
+            if payload.email.trim().is_empty() || payload.email == "unknown" {
+                payload.email = local_payload.email.clone();
+            }
+            payload
+        }
+        Err(err) => {
+            logger::log_warn(&format!(
+                "{log_prefix} 拉取账号资料失败，将保留本地导入结果: {err}"
+            ));
+            local_payload
+        }
+    }
+}
+
+fn import_antigravity() -> ImportFuture {
+    Box::pin(async {
+        import::import_from_local_logic()
+            .await
+            .map(|_| true)
+            .map_err(|error| error.to_string())
+    })
+}
+
+fn import_codex() -> ImportFuture {
+    Box::pin(async { codex_account::import_from_local().map(|_| true) })
+}
+
+fn import_cursor() -> ImportFuture {
+    Box::pin(async {
+        cursor_account::import_from_local()
+            .map(|account| account.is_some())
+            .map_err(|error| error.to_string())
+    })
+}
+
+fn import_gemini() -> ImportFuture {
+    Box::pin(async {
+        gemini_account::import_from_local()
+            .map(|account| account.is_some())
+            .map_err(|error| error.to_string())
+    })
+}
+
+fn import_windsurf() -> ImportFuture {
+    Box::pin(async {
+        let auth_status = windsurf_account::read_local_auth_status()?.ok_or_else(|| {
+            "未在本机 Windsurf 客户端中找到登录信息（windsurfAuthStatus）".to_string()
+        })?;
+        let mut payload = windsurf_oauth::build_payload_from_local_auth_status(auth_status).await?;
+        if payload.github_login.trim().is_empty() {
+            if let Some(hint) = windsurf_account::read_local_login_hint() {
+                payload.github_login = hint;
+            }
+        }
+        windsurf_account::upsert_account(payload).map(|_| true)
+    })
+}
+
+fn import_github_copilot() -> ImportFuture {
+    Box::pin(async {
+        github_copilot_account::import_from_local()
+            .await
+            .map(|account| account.is_some())
+            .map_err(|error| error.to_string())
+    })
+}
+
+fn import_kiro() -> ImportFuture {
+    Box::pin(async {
+        let payload = kiro_oauth::build_payload_from_local_files()?;
+        let payload = kiro_oauth::enrich_payload_with_runtime_usage(payload).await;
+        kiro_account::upsert_account(payload).map(|_| true)
+    })
+}
+
+fn import_codebuddy() -> ImportFuture {
+    Box::pin(async {
+        let local_payload = codebuddy_account::import_payload_from_local()?.ok_or_else(|| {
+            "未在本机 CodeBuddy 客户端中找到登录信息".to_string()
+        })?;
+        let access_token = local_payload.access_token.clone();
+        let payload = enrich_codebuddy_payload(
+            local_payload,
+            codebuddy_oauth::build_payload_from_token(&access_token),
+            "[AutoLocalImport][CodeBuddy]",
+        )
+        .await;
+        codebuddy_account::upsert_account(payload).map(|_| true)
+    })
+}
+
+fn import_codebuddy_cn() -> ImportFuture {
+    Box::pin(async {
+        let local_payload = codebuddy_cn_account::import_payload_from_local()?.ok_or_else(|| {
+            "未在本机 CodeBuddy CN 客户端中找到登录信息".to_string()
+        })?;
+        let access_token = local_payload.access_token.clone();
+        let payload = enrich_codebuddy_payload(
+            local_payload,
+            codebuddy_cn_oauth::build_payload_from_token(&access_token),
+            "[AutoLocalImport][CodeBuddyCN]",
+        )
+        .await;
+        codebuddy_cn_account::upsert_account(payload).map(|_| true)
+    })
+}
+
+async fn enrich_workbuddy_payload(
+    local_payload: WorkbuddyOAuthCompletePayload,
+    oauth_build: impl std::future::Future<Output = Result<WorkbuddyOAuthCompletePayload, String>>,
+    log_prefix: &str,
+) -> WorkbuddyOAuthCompletePayload {
+    match oauth_build.await {
+        Ok(mut payload) => {
+            if payload.uid.is_none() {
+                payload.uid = local_payload.uid.clone();
+            }
+            if payload.nickname.is_none() {
+                payload.nickname = local_payload.nickname.clone();
+            }
+            if payload.refresh_token.is_none() {
+                payload.refresh_token = local_payload.refresh_token.clone();
+            }
+            if payload.domain.is_none() {
+                payload.domain = local_payload.domain.clone();
+            }
+            if payload.token_type.is_none() {
+                payload.token_type = local_payload.token_type.clone();
+            }
+            if payload.expires_at.is_none() {
+                payload.expires_at = local_payload.expires_at;
+            }
+            if payload.auth_raw.is_none() {
+                payload.auth_raw = local_payload.auth_raw.clone();
+            }
+            if payload.profile_raw.is_none() {
+                payload.profile_raw = local_payload.profile_raw.clone();
+            }
+            if payload.email.trim().is_empty() || payload.email == "unknown" {
+                payload.email = local_payload.email.clone();
+            }
+            payload
+        }
+        Err(err) => {
+            logger::log_warn(&format!(
+                "{log_prefix} 拉取账号资料失败，将保留本地导入结果: {err}"
+            ));
+            local_payload
+        }
+    }
+}
+
+fn import_workbuddy() -> ImportFuture {
+    Box::pin(async {
+        let local_payload = workbuddy_account::import_payload_from_local()?.ok_or_else(|| {
+            "未在本机 WorkBuddy 客户端中找到登录信息".to_string()
+        })?;
+        let access_token = local_payload.access_token.clone();
+        let payload = enrich_workbuddy_payload(
+            local_payload,
+            workbuddy_oauth::build_payload_from_token(&access_token),
+            "[AutoLocalImport][WorkBuddy]",
+        )
+        .await;
+        workbuddy_account::upsert_account(payload).map(|_| true)
+    })
+}
+
+fn import_qoder() -> ImportFuture {
+    Box::pin(async {
+        qoder_account::import_from_local()
+            .map(|account| account.is_some())
+            .map_err(|error| error.to_string())
+    })
+}
+
+fn import_trae(platform: trae_account::TraePlatformKind) -> ImportFuture {
+    Box::pin(async move {
+        trae_account::import_from_local_for_platform(platform)
+            .map(|account| account.is_some())
+            .map_err(|error| error.to_string())
+    })
+}
+
+fn import_zed() -> ImportFuture {
+    Box::pin(async {
+        zed_account::import_from_local()
+            .await
+            .map(|_| true)
+            .map_err(|error| error.to_string())
+    })
+}
+
+fn import_claude() -> ImportFuture {
+    Box::pin(async { claude_account::import_cli_from_local().map(|_| true) })
+}
+
+fn platform_watchers() -> Vec<PlatformWatcher> {
+    vec![
+        PlatformWatcher {
+            platform: "antigravity",
+            peek_identity: peek_antigravity_identity,
+            import_account: import_antigravity,
+        },
+        PlatformWatcher {
+            platform: "codex",
+            peek_identity: peek_codex_identity,
+            import_account: import_codex,
+        },
+        PlatformWatcher {
+            platform: "cursor",
+            peek_identity: peek_cursor_identity,
+            import_account: import_cursor,
+        },
+        PlatformWatcher {
+            platform: "gemini",
+            peek_identity: peek_gemini_identity,
+            import_account: import_gemini,
+        },
+        PlatformWatcher {
+            platform: "windsurf",
+            peek_identity: peek_windsurf_identity,
+            import_account: import_windsurf,
+        },
+        PlatformWatcher {
+            platform: "github_copilot",
+            peek_identity: peek_github_copilot_identity,
+            import_account: import_github_copilot,
+        },
+        PlatformWatcher {
+            platform: "kiro",
+            peek_identity: peek_kiro_identity,
+            import_account: import_kiro,
+        },
+        PlatformWatcher {
+            platform: "codebuddy",
+            peek_identity: peek_codebuddy_identity,
+            import_account: import_codebuddy,
+        },
+        PlatformWatcher {
+            platform: "codebuddy_cn",
+            peek_identity: peek_codebuddy_cn_identity,
+            import_account: import_codebuddy_cn,
+        },
+        PlatformWatcher {
+            platform: "workbuddy",
+            peek_identity: peek_workbuddy_identity,
+            import_account: import_workbuddy,
+        },
+        PlatformWatcher {
+            platform: "qoder",
+            peek_identity: peek_qoder_identity,
+            import_account: import_qoder,
+        },
+        PlatformWatcher {
+            platform: "trae",
+            peek_identity: || peek_trae_identity(trae_account::TraePlatformKind::Trae),
+            import_account: || import_trae(trae_account::TraePlatformKind::Trae),
+        },
+        PlatformWatcher {
+            platform: "trae_solo",
+            peek_identity: || peek_trae_identity(trae_account::TraePlatformKind::TraeSolo),
+            import_account: || import_trae(trae_account::TraePlatformKind::TraeSolo),
+        },
+        PlatformWatcher {
+            platform: "trae_cn",
+            peek_identity: || peek_trae_identity(trae_account::TraePlatformKind::TraeCn),
+            import_account: || import_trae(trae_account::TraePlatformKind::TraeCn),
+        },
+        PlatformWatcher {
+            platform: "trae_solo_cn",
+            peek_identity: || peek_trae_identity(trae_account::TraePlatformKind::TraeSoloCn),
+            import_account: || import_trae(trae_account::TraePlatformKind::TraeSoloCn),
+        },
+        PlatformWatcher {
+            platform: "zed",
+            peek_identity: peek_zed_identity,
+            import_account: import_zed,
+        },
+        PlatformWatcher {
+            platform: "claude",
+            peek_identity: peek_claude_identity,
+            import_account: import_claude,
+        },
+    ]
+}
+
+async fn run_watch_cycle(app_handle: &AppHandle) {
+    if !config::get_user_config().auto_import_from_local_enabled {
+        return;
+    }
+
+    let mut imported_any = false;
+
+    for watcher in platform_watchers() {
+        let current_identity = (watcher.peek_identity)();
+        let Some(current_identity) = current_identity else {
+            if let Ok(mut state) = LAST_IDENTITIES.lock() {
+                state.remove(watcher.platform);
+            }
+            continue;
+        };
+
+        let should_import = {
+            let Ok(mut state) = LAST_IDENTITIES.lock() else {
+                continue;
+            };
+            match state.get(watcher.platform) {
+                None => {
+                    state.insert(watcher.platform.to_string(), current_identity.clone());
+                    false
+                }
+                Some(previous) if previous == &current_identity => false,
+                Some(_) => {
+                    state.insert(watcher.platform.to_string(), current_identity.clone());
+                    true
+                }
+            }
+        };
+
+        if !should_import {
+            continue;
+        }
+
+        match (watcher.import_account)().await {
+            Ok(true) => {
+                imported_any = true;
+                logger::log_info(&format!(
+                    "[AutoLocalImport] 已自动导入本机账号: platform={}, identity={}",
+                    watcher.platform, current_identity
+                ));
+                let _ = app_handle.emit(
+                    "auto_local_import:completed",
+                    serde_json::json!({
+                        "platform": watcher.platform,
+                        "identity": current_identity,
+                    }),
+                );
+                let _ = app_handle.emit(
+                    "accounts:changed",
+                    serde_json::json!({
+                        "platformId": watcher.platform,
+                        "reason": "auto_import_from_local",
+                    }),
+                );
+            }
+            Ok(false) => {}
+            Err(error) => {
+                logger::log_warn(&format!(
+                    "[AutoLocalImport] 自动导入失败: platform={}, error={}",
+                    watcher.platform, error
+                ));
+            }
+        }
+    }
+
+    if imported_any {
+        crate::modules::websocket::broadcast_data_changed("auto_import_from_local");
+        let _ = crate::modules::tray::update_tray_menu(app_handle);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::identity_key;
+
+    #[test]
+    fn identity_key_joins_non_empty_parts() {
+        assert_eq!(
+            identity_key(&[Some("a@example.com".to_string()), Some("id-1".to_string())]),
+            Some("a@example.com|id-1".to_string())
+        );
+    }
+
+    #[test]
+    fn identity_key_returns_none_for_empty_parts() {
+        assert_eq!(identity_key(&[None, Some("".to_string())]), None);
+    }
+}

--- a/src-tauri/src/modules/config.rs
+++ b/src-tauri/src/modules/config.rs
@@ -163,6 +163,9 @@ pub struct UserConfig {
     /// 是否启用后台账号授权保活
     #[serde(default = "default_token_keeper_enabled")]
     pub token_keeper_enabled: bool,
+    /// 是否启用本机账号变更后自动导入
+    #[serde(default = "default_auto_import_from_local_enabled")]
+    pub auto_import_from_local_enabled: bool,
     /// 是否在应用启动后触发 Antigravity IDE 唤醒
     #[serde(default = "default_antigravity_startup_wakeup_enabled")]
     pub antigravity_startup_wakeup_enabled: bool,
@@ -659,6 +662,9 @@ fn default_app_auto_launch_enabled() -> bool {
 fn default_token_keeper_enabled() -> bool {
     true
 }
+fn default_auto_import_from_local_enabled() -> bool {
+    false
+}
 fn default_antigravity_startup_wakeup_enabled() -> bool {
     false
 }
@@ -989,6 +995,7 @@ impl Default for UserConfig {
             floating_card_always_on_top: default_floating_card_always_on_top(),
             app_auto_launch_enabled: default_app_auto_launch_enabled(),
             token_keeper_enabled: default_token_keeper_enabled(),
+            auto_import_from_local_enabled: default_auto_import_from_local_enabled(),
             antigravity_startup_wakeup_enabled: default_antigravity_startup_wakeup_enabled(),
             antigravity_startup_wakeup_delay_seconds:
                 default_antigravity_startup_wakeup_delay_seconds(),
@@ -1526,6 +1533,12 @@ pub fn load_user_config() -> Result<UserConfig, String> {
             obj.insert(
                 "token_keeper_enabled".to_string(),
                 json!(default_token_keeper_enabled()),
+            );
+        }
+        if !obj.contains_key("auto_import_from_local_enabled") {
+            obj.insert(
+                "auto_import_from_local_enabled".to_string(),
+                json!(default_auto_import_from_local_enabled()),
             );
         }
 

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
+pub mod auto_local_import;
 pub mod account_index_repair;
 pub mod announcement;
 pub mod antigravity_credential;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1153,7 +1153,9 @@
       "antigravityLaunchOnSwitch": "Launch Antigravity on switch",
       "antigravityLaunchOnSwitchDesc": "When off, switching only writes the default Antigravity account data and will not close, launch, or restart the app.",
       "tokenKeeper": "Auth keep-alive",
-      "tokenKeeperDesc": "Refresh account tokens in small batches only when authorization is close to expiry, reducing background request pressure for large account sets."
+      "tokenKeeperDesc": "Refresh account tokens in small batches only when authorization is close to expiry, reducing background request pressure for large account sets.",
+      "autoImportFromLocal": "Auto-import local accounts",
+      "autoImportFromLocalDesc": "When enabled, Cockpit Tools automatically imports a new account into the matching platform list after you sign in with a different account in the official client."
     },
     "network": {
       "apiTitle": "Antigravity Cockpit API",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1153,7 +1153,9 @@
       "antigravityLaunchOnSwitch": "切换时启动 Antigravity",
       "antigravityLaunchOnSwitchDesc": "关闭后切号只写入 Antigravity 默认账号数据，不会关闭、启动或重启应用。",
       "tokenKeeper": "后台授权保活",
-      "tokenKeeperDesc": "仅在授权快过期时分批刷新账号 Token，降低大量账号场景下的后台请求压力。"
+      "tokenKeeperDesc": "仅在授权快过期时分批刷新账号 Token，降低大量账号场景下的后台请求压力。",
+      "autoImportFromLocal": "本机账号自动导入",
+      "autoImportFromLocalDesc": "开启后，当你在官方客户端更换登录账号时，Cockpit Tools 会自动将新账号导入到对应平台列表中。"
     },
     "network": {
       "apiTitle": "反重力驾驶舱 API",

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -135,6 +135,7 @@ interface GeneralConfig {
   floating_card_always_on_top?: boolean;
   app_auto_launch_enabled?: boolean;
   token_keeper_enabled?: boolean;
+  auto_import_from_local_enabled?: boolean;
   opencode_app_path: string;
   antigravity_app_path: string;
   codex_app_path: string;
@@ -437,6 +438,7 @@ export function SettingsPage() {
   const [floatingCardAlwaysOnTop, setFloatingCardAlwaysOnTop] = useState(false);
   const [appAutoLaunchEnabled, setAppAutoLaunchEnabled] = useState(false);
   const [tokenKeeperEnabled, setTokenKeeperEnabled] = useState(true);
+  const [autoImportFromLocalEnabled, setAutoImportFromLocalEnabled] = useState(false);
   const [errorReportingEnabled, setErrorReportingEnabled] = useState(true);
   const [errorReportingSaving, setErrorReportingSaving] = useState(false);
   const [opencodeAppPath, setOpencodeAppPath] = useState('');
@@ -936,6 +938,7 @@ export function SettingsPage() {
           floatingCardAlwaysOnTop,
           appAutoLaunchEnabled,
           tokenKeeperEnabled,
+          autoImportFromLocalEnabled,
           opencodeAppPath,
           antigravityAppPath,
           codexAppPath,
@@ -1085,6 +1088,7 @@ export function SettingsPage() {
     floatingCardAlwaysOnTop,
     appAutoLaunchEnabled,
     tokenKeeperEnabled,
+    autoImportFromLocalEnabled,
     generalLoaded,
     language,
     defaultTerminal,
@@ -1399,6 +1403,7 @@ export function SettingsPage() {
       setFloatingCardAlwaysOnTop(config.floating_card_always_on_top ?? false);
       setAppAutoLaunchEnabled(config.app_auto_launch_enabled ?? false);
       setTokenKeeperEnabled(config.token_keeper_enabled ?? true);
+      setAutoImportFromLocalEnabled(config.auto_import_from_local_enabled ?? false);
       setOpencodeAppPath(config.opencode_app_path || '');
       setAntigravityAppPath(config.antigravity_app_path || '');
       setCodexAppPath(config.codex_app_path || '');
@@ -3178,6 +3183,30 @@ export function SettingsPage() {
                       type="checkbox"
                       checked={tokenKeeperEnabled}
                       onChange={(e) => setTokenKeeperEnabled(e.target.checked)}
+                    />
+                    <span className="slider"></span>
+                  </label>
+                </div>
+              </div>
+
+              <div className="settings-row">
+                <div className="row-label">
+                  <div className="row-title">
+                    {t('settings.general.autoImportFromLocal', '本机账号自动导入')}
+                  </div>
+                  <div className="row-desc">
+                    {t(
+                      'settings.general.autoImportFromLocalDesc',
+                      '开启后，当你在官方客户端更换登录账号时，Cockpit Tools 会自动将新账号导入到对应平台列表中。',
+                    )}
+                  </div>
+                </div>
+                <div className="row-control">
+                  <label className="switch">
+                    <input
+                      type="checkbox"
+                      checked={autoImportFromLocalEnabled}
+                      onChange={(e) => setAutoImportFromLocalEnabled(e.target.checked)}
                     />
                     <span className="slider"></span>
                   </label>


### PR DESCRIPTION
## Summary
- Resolves and merges #1503 into current main (original PR was CONFLICTING).
- Keeps `patch_general_config` flow; adds `auto_import_from_local_enabled` (default off).
- Background watcher for local IDE login identity changes → auto import.

## Test plan
- [ ] Settings shows「本机账号自动导入」, default off
- [ ] Enable → local client account change imports into Cockpit
- [ ] Disable → no auto import

Closes #1503