### PR TITLE
[codex] 修复 Spark 模型专属配额开关不生效

### DIFF
--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -691,21 +691,6 @@ function normalizeAdditionalRateLimitWindow(
   };
 }
 
-function isCodexSparkAdditionalLimit(
-  limitName: string,
-  meteredFeature: string,
-  limitLabel: string,
-): boolean {
-  const haystack = [limitName, meteredFeature, limitLabel]
-    .join(" ")
-    .toLowerCase();
-  return (
-    haystack.includes("spark") ||
-    haystack.includes("codex-spark") ||
-    haystack.includes("gpt-5.3-codex-spark")
-  );
-}
-
 export function getCodexAdditionalQuotaWindows(
   quota: CodexQuota | undefined,
 ): CodexAdditionalQuotaWindow[] {
@@ -724,11 +709,6 @@ export function getCodexAdditionalQuotaWindows(
       limitName,
       meteredFeature,
     );
-    // Official payloads may include Spark-only rate windows that clutter the
-    // main quota card; hide them from the default account presentation.
-    if (isCodexSparkAdditionalLimit(limitName, meteredFeature, limitLabel)) {
-      return [];
-    }
     const allowed = toBoolValue(rateLimit.allowed);
     const limitReached = toBoolValue(rateLimit.limit_reached);
     const result: CodexAdditionalQuotaWindow[] = [];


### PR DESCRIPTION
## 问题现象

OpenAI 的 Codex usage 响应已经在 `additional_rate_limits` 中返回 `GPT-5.3-Codex-Spark` 专属配额，Cockpit Tools 也会把原始数据保存到账号缓存中。但是，即使用户在快捷设置中打开“显示模型专属配额”，Codex 账号卡片和实例预览仍然不会显示 Spark 配额。

## 前因后果

- #1405 增加了 Codex additional rate limits 的解析和展示能力。
- #1424 增加了“显示模型专属配额”开关。页面层会根据 `additional:*` key 决定是否隐藏模型专属配额，开关状态也会保存到 `localStorage`。
- v1.3.0 为处理 #1523 中 Spark 行默认展示过于嘈杂的问题，又在 `getCodexAdditionalQuotaWindows` 解析阶段加入了 Spark 特判，并直接 `return []`。
- 这使 Spark 数据在到达页面开关之前就被无条件丢弃。开关关闭时可以隐藏其他模型专属配额，但打开时无法恢复已经被解析层删除的 Spark 数据，因此开关表现为对 Spark 不生效。

## 修复内容

- 删除 `isCodexSparkAdditionalLimit` 特判。
- 删除解析阶段对 Spark additional rate limit 的提前过滤。
- 保留现有页面层开关作为模型专属配额显示与隐藏的唯一控制点。

修复后：

- 打开“显示模型专属配额”时，正常显示 GPT-5.3-Codex-Spark 配额。
- 关闭该开关时，仍会通过现有 `additional:*` 过滤逻辑隐藏 Spark 及其他模型专属配额。
- 不改变额度请求、缓存结构、百分比计算和重置时间解析逻辑。

## 验证

- `npm run typecheck`
- `git diff --check`

Closes #1523