### PR TITLE
feat: add MiniMax M3 provider presets

### DIFF
--- a/src-tauri/src/modules/claude_desktop_gateway.rs
+++ b/src-tauri/src/modules/claude_desktop_gateway.rs
@@ -516,3 +516,46 @@ fn empty_response(status: u16) -> Response<Cursor<Vec<u8>>> {
         None,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anthropic_base_url_appends_messages_path() {
+        let server = Server::http("127.0.0.1:0").expect("mock upstream should start");
+        let port = server
+            .server_addr()
+            .to_ip()
+            .expect("mock upstream should use an IP address")
+            .port();
+        let captured = thread::spawn(move || {
+            let request = server
+                .recv()
+                .expect("mock upstream should receive a request");
+            let path = request.url().to_string();
+            request
+                .respond(json_response(200, json!({ "type": "message" })))
+                .expect("mock upstream should send a response");
+            path
+        });
+
+        let base_url = format!("http://127.0.0.1:{}/anthropic", port);
+        let url = build_upstream_url(&base_url, "/v1/messages")
+            .expect("upstream messages URL should be valid");
+        let response = Client::builder()
+            .no_proxy()
+            .build()
+            .expect("HTTP client should build")
+            .post(url)
+            .body("{}")
+            .send()
+            .expect("captured request should succeed");
+
+        assert!(response.status().is_success());
+        assert_eq!(
+            captured.join().expect("capture thread should finish"),
+            "/anthropic/v1/messages"
+        );
+    }
+}

--- a/src/utils/claudeDesktopProviderPresets.ts
+++ b/src/utils/claudeDesktopProviderPresets.ts
@@ -337,9 +337,17 @@ export const CLAUDE_DESKTOP_GATEWAY_PROVIDER_PRESETS: readonly ClaudeDesktopGate
     baseUrls: ['https://api.minimaxi.com/anthropic'],
     authScheme: 'bearer',
     connectionMode: 'local_mapping',
-    website: 'https://platform.minimaxi.com',
+    website: 'https://platform.minimaxi.com/docs',
     apiKeyUrl: 'https://platform.minimaxi.com/subscribe/coding-plan',
-    modelMappings: repeatedMappedRoute('MiniMax-M2.7'),
+    modelMappings: [
+      createRoute('claude-sonnet-4-6', 'MiniMax-M3', {
+        labelOverride: 'MiniMax-M3',
+        supports1m: true,
+      }),
+      createRoute('claude-haiku-4-5', 'MiniMax-M2.7', {
+        labelOverride: 'MiniMax-M2.7',
+      }),
+    ],
   },
   {
     id: 'minimax_global',
@@ -347,9 +355,17 @@ export const CLAUDE_DESKTOP_GATEWAY_PROVIDER_PRESETS: readonly ClaudeDesktopGate
     baseUrls: ['https://api.minimax.io/anthropic'],
     authScheme: 'bearer',
     connectionMode: 'local_mapping',
-    website: 'https://platform.minimax.io',
+    website: 'https://platform.minimax.io/docs',
     apiKeyUrl: 'https://platform.minimax.io/subscribe/coding-plan',
-    modelMappings: repeatedMappedRoute('MiniMax-M2.7'),
+    modelMappings: [
+      createRoute('claude-sonnet-4-6', 'MiniMax-M3', {
+        labelOverride: 'MiniMax-M3',
+        supports1m: true,
+      }),
+      createRoute('claude-haiku-4-5', 'MiniMax-M2.7', {
+        labelOverride: 'MiniMax-M2.7',
+      }),
+    ],
   },
   {
     id: 'bailing',

--- a/src/utils/claudeProviderPresets.ts
+++ b/src/utils/claudeProviderPresets.ts
@@ -211,9 +211,10 @@ const CC_SWITCH_DIRECT_CLAUDE_PROVIDER_PRESETS: readonly ClaudeApiProviderPreset
     id: 'minimax',
     name: 'MiniMax',
     baseUrl: 'https://api.minimaxi.com/anthropic',
-    website: 'https://platform.minimaxi.com',
+    website: 'https://platform.minimaxi.com/docs',
     apiKeyUrl: 'https://platform.minimaxi.com/subscribe/coding-plan',
-    extraEnv: modelEnv('MiniMax-M2.7', {}, {
+    modelCatalog: ['MiniMax-M3', 'MiniMax-M2.7'],
+    extraEnv: modelEnv('MiniMax-M3', {}, {
       API_TIMEOUT_MS: '3000000',
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
     }),
@@ -222,9 +223,10 @@ const CC_SWITCH_DIRECT_CLAUDE_PROVIDER_PRESETS: readonly ClaudeApiProviderPreset
     id: 'minimax_global',
     name: 'MiniMax en',
     baseUrl: 'https://api.minimax.io/anthropic',
-    website: 'https://platform.minimax.io',
+    website: 'https://platform.minimax.io/docs',
     apiKeyUrl: 'https://platform.minimax.io/subscribe/coding-plan',
-    extraEnv: modelEnv('MiniMax-M2.7', {}, {
+    modelCatalog: ['MiniMax-M3', 'MiniMax-M2.7'],
+    extraEnv: modelEnv('MiniMax-M3', {}, {
       API_TIMEOUT_MS: '3000000',
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
     }),

--- a/src/utils/codexProviderPresets.ts
+++ b/src/utils/codexProviderPresets.ts
@@ -267,13 +267,15 @@ export const CODEX_API_PROVIDER_PRESETS: readonly CodexApiProviderPreset[] = [
     id: "minimax",
     name: "MiniMax",
     baseUrls: ["https://api.minimaxi.com/v1"],
-    website: "https://www.minimaxi.com/",
+    modelCatalog: ["MiniMax-M3", "MiniMax-M2.7"],
+    website: "https://platform.minimaxi.com/docs",
   },
   {
     id: "minimax_en",
     name: "MiniMax en",
     baseUrls: ["https://api.minimax.io/v1"],
-    website: "https://www.minimax.io/",
+    modelCatalog: ["MiniMax-M3", "MiniMax-M2.7"],
+    website: "https://platform.minimax.io/docs",
   },
   {
     id: "bailing",


### PR DESCRIPTION
Reason: add MiniMax M3 and preserve MiniMax M2.7 in the existing MiniMax provider presets.

## Summary

- Add both target models to the regional API preset catalogs.
- Make MiniMax-M3 the primary model while retaining MiniMax-M2.7 as an available model.
- Add desktop gateway mappings for both models and mark the MiniMax-M3 route as 1M-capable.
- Point the regional provider links to the API documentation.
- Add request-capture coverage for the configured messages path.

## Checks

- `npm ci`
- `npm run typecheck`
- `git diff --check`
- Modified Rust file formatting check passed.
- Focused gateway request-capture test passed.

`cargo fmt --all -- --check` still reports pre-existing formatting differences outside the modified Rust file.
