### PR TITLE
Fix Codex session visibility race before instance launch

### DIFF
--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -1,6 +1,8 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::process::Command;
+use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 use serde::Serialize;
@@ -12,6 +14,35 @@ use crate::models::{DefaultInstanceSettings, InstanceLaunchMode, InstanceProfile
 use crate::modules;
 
 const DEFAULT_INSTANCE_ID: &str = "__default__";
+static CODEX_INSTANCE_STARTS_IN_PROGRESS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+#[derive(Debug)]
+struct CodexInstanceStartGuard {
+    instance_id: String,
+}
+
+impl CodexInstanceStartGuard {
+    fn acquire(instance_id: &str) -> Result<Self, String> {
+        let starts = CODEX_INSTANCE_STARTS_IN_PROGRESS.get_or_init(|| Mutex::new(HashSet::new()));
+        let mut starts = starts.lock().unwrap_or_else(|error| error.into_inner());
+        if !starts.insert(instance_id.to_string()) {
+            return Err("该 Codex 实例正在启动，请稍候".to_string());
+        }
+        Ok(Self {
+            instance_id: instance_id.to_string(),
+        })
+    }
+}
+
+impl Drop for CodexInstanceStartGuard {
+    fn drop(&mut self) {
+        let starts = CODEX_INSTANCE_STARTS_IN_PROGRESS.get_or_init(|| Mutex::new(HashSet::new()));
+        starts
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(&self.instance_id);
+    }
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -64,14 +95,6 @@ impl CodexInstanceProfileView {
             auto_sync_threads: false,
             codex_launch_credential_change: None,
         }
-    }
-
-    fn with_launch_credential_change(
-        mut self,
-        change: Option<CodexLaunchCredentialChange>,
-    ) -> Self {
-        self.codex_launch_credential_change = change;
-        self
     }
 }
 
@@ -327,9 +350,9 @@ async fn apply_bound_account_to_initialized_profile(
     profile_dir: &Path,
     bind_account_id: Option<&str>,
     context: &str,
-) -> Result<Option<CodexLaunchCredentialChange>, String> {
+) -> Result<(), String> {
     if !is_profile_initialized(&profile_dir.to_string_lossy()) {
-        return Ok(None);
+        return Ok(());
     }
 
     let previous_kind = read_applied_launch_credential_kind_for_dir(profile_dir);
@@ -344,8 +367,8 @@ async fn apply_bound_account_to_initialized_profile(
         previous_kind,
         bind_account_id.and_then(launch_credential_kind_for_bind_account_id),
     );
-    log_session_visibility_repair_deferred_before_launch(context, &launch_credential_change);
-    Ok(launch_credential_change)
+    log_launch_credential_change(context, &launch_credential_change);
+    Ok(())
 }
 
 fn sanitize_codex_config_before_launch(data_dir: &Path) -> Result<(), String> {
@@ -370,7 +393,7 @@ fn build_launch_credential_change(
     Some(CodexLaunchCredentialChange { from, to })
 }
 
-fn log_session_visibility_repair_deferred_before_launch(
+fn log_launch_credential_change(
     context: &str,
     launch_provider_change: &Option<CodexLaunchCredentialChange>,
 ) {
@@ -378,16 +401,62 @@ fn log_session_visibility_repair_deferred_before_launch(
         return;
     };
     modules::logger::log_info(&format!(
-        "[Codex Session Visibility] {}: credential kind changed before launch, defer quick repair to frontend notice, from={}, to={}",
+        "[Codex Session Visibility] {}: credential kind changed; the selected instance will reconcile before its next launch, from={}, to={}",
         context,
         change.from,
         change.to
     ));
 }
 
+async fn repair_session_visibility_for_selected_instance(
+    instance_id: &str,
+    instance_name: &str,
+    data_dir: &Path,
+) -> Result<(), String> {
+    let instance_id = instance_id.to_string();
+    let instance_name = instance_name.to_string();
+    let data_dir = data_dir.to_path_buf();
+    tauri::async_runtime::spawn_blocking(move || {
+        modules::codex_session_visibility::repair_session_visibility_quick_for_instance(
+            &instance_id,
+            &instance_name,
+            &data_dir,
+        )
+        .map(|_| ())
+        .map_err(|error| {
+            format!(
+                "同步修复当前 Codex 实例的历史会话可见性失败 ({} / {}): {}",
+                instance_name,
+                data_dir.display(),
+                error
+            )
+        })
+    })
+    .await
+    .map_err(|error| format!("等待 Codex 会话可见性修复任务失败: {}", error))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn instance_start_guard_rejects_only_duplicate_instance_starts() {
+        let first = CodexInstanceStartGuard::acquire("guard-test-a")
+            .expect("first start should acquire the instance guard");
+        let duplicate = CodexInstanceStartGuard::acquire("guard-test-a");
+        let other = CodexInstanceStartGuard::acquire("guard-test-b")
+            .expect("different instances should start independently");
+
+        assert_eq!(
+            duplicate.expect_err("duplicate start should be rejected"),
+            "该 Codex 实例正在启动，请稍候"
+        );
+        drop(first);
+        CodexInstanceStartGuard::acquire("guard-test-a")
+            .expect("the guard should be released when the start finishes");
+        drop(other);
+    }
 
     #[test]
     fn build_launch_credential_change_detects_account_to_api_provider_change() {
@@ -933,16 +1002,14 @@ pub async fn codex_update_instance(
         let resolved_pid = modules::process::resolve_codex_pid(updated.last_pid, None);
         let running = resolved_pid.is_some();
         let default_bind_account_id = resolve_default_account_id(&updated);
-        let launch_credential_change = if should_apply_bind_account {
+        if should_apply_bind_account {
             apply_bound_account_to_initialized_profile(
                 &default_dir,
                 default_bind_account_id.as_deref(),
                 "update-default-bind-account",
             )
-            .await?
-        } else {
-            None
-        };
+            .await?;
+        }
         let _ = working_dir;
         return Ok(default_instance_view(
             &default_dir,
@@ -950,8 +1017,7 @@ pub async fn codex_update_instance(
             default_bind_account_id,
             running,
             resolved_pid,
-        )
-        .with_launch_credential_change(launch_credential_change));
+        ));
     }
 
     let wants_bind = bind_account_id
@@ -991,20 +1057,19 @@ pub async fn codex_update_instance(
         .map(modules::process::is_pid_running)
         .unwrap_or(false);
     let initialized = is_profile_initialized(&instance.user_data_dir);
-    let launch_credential_change = if should_apply_instance_bind_account {
+    if should_apply_instance_bind_account {
         apply_bound_account_to_initialized_profile(
             Path::new(&instance.user_data_dir),
             instance.bind_account_id.as_deref(),
             "update-instance-bind-account",
         )
-        .await?
-    } else {
-        None
-    };
-    Ok(
-        CodexInstanceProfileView::from_profile(instance, running, initialized)
-            .with_launch_credential_change(launch_credential_change),
-    )
+        .await?;
+    }
+    Ok(CodexInstanceProfileView::from_profile(
+        instance,
+        running,
+        initialized,
+    ))
 }
 
 #[tauri::command]
@@ -1019,6 +1084,7 @@ async fn codex_start_instance_internal(
     instance_id: String,
     skip_default_bind_account_injection: bool,
 ) -> Result<CodexInstanceProfileView, String> {
+    let _start_guard = CodexInstanceStartGuard::acquire(&instance_id)?;
     let flow_started = Instant::now();
     modules::logger::log_info(&format!(
         "[Codex Start] start_instance_internal started: instance_id={}, skip_default_bind_account_injection={}",
@@ -1104,10 +1170,7 @@ async fn codex_start_instance_internal(
                 .as_deref()
                 .and_then(launch_credential_kind_for_bind_account_id),
         );
-        log_session_visibility_repair_deferred_before_launch(
-            "before-start-default",
-            &launch_credential_change,
-        );
+        log_launch_credential_change("before-start-default", &launch_credential_change);
         if skip_default_bind_account_injection {
             modules::logger::log_info(
                 "[Codex Thread Sync] before-start-default: skipped on prepared-profile fast path",
@@ -1128,6 +1191,19 @@ async fn codex_start_instance_internal(
             sanitize_started.elapsed().as_millis(),
             flow_started.elapsed().as_millis()
         ));
+        let visibility_repair_started = Instant::now();
+        repair_session_visibility_for_selected_instance(
+            DEFAULT_INSTANCE_ID,
+            "默认实例",
+            &default_dir,
+        )
+        .await
+        .map_err(|error| format!("Codex 启动已取消: {}", error))?;
+        modules::logger::log_info(&format!(
+            "[Codex Start] default session visibility repair phase finished: elapsed_ms={}, total_ms={}",
+            visibility_repair_started.elapsed().as_millis(),
+            flow_started.elapsed().as_millis()
+        ));
 
         if default_settings.launch_mode == InstanceLaunchMode::Cli {
             let cli_prepare_started = Instant::now();
@@ -1145,8 +1221,7 @@ async fn codex_start_instance_internal(
                 default_bind_account_id,
                 false,
                 None,
-            )
-            .with_launch_credential_change(launch_credential_change));
+            ));
         }
 
         let extra_args = modules::process::parse_extra_args(&default_settings.extra_args);
@@ -1176,8 +1251,7 @@ async fn codex_start_instance_internal(
             default_bind_account_id,
             running,
             Some(pid),
-        )
-        .with_launch_credential_change(launch_credential_change));
+        ));
     }
 
     let prepare_started = Instant::now();
@@ -1253,10 +1327,7 @@ async fn codex_start_instance_internal(
             .as_deref()
             .and_then(launch_credential_kind_for_bind_account_id),
     );
-    log_session_visibility_repair_deferred_before_launch(
-        "before-start-instance",
-        &launch_credential_change,
-    );
+    log_launch_credential_change("before-start-instance", &launch_credential_change);
     let thread_sync_started = Instant::now();
     sync_codex_threads_across_idle_instances("before-start-instance");
     modules::logger::log_info(&format!(
@@ -1273,6 +1344,16 @@ async fn codex_start_instance_internal(
         sanitize_started.elapsed().as_millis(),
         flow_started.elapsed().as_millis()
     ));
+    let visibility_repair_started = Instant::now();
+    repair_session_visibility_for_selected_instance(&instance.id, &instance.name, instance_dir)
+        .await
+        .map_err(|error| format!("Codex 启动已取消: {}", error))?;
+    modules::logger::log_info(&format!(
+        "[Codex Start] instance session visibility repair phase finished: instance_id={}, elapsed_ms={}, total_ms={}",
+        instance.id,
+        visibility_repair_started.elapsed().as_millis(),
+        flow_started.elapsed().as_millis()
+    ));
 
     if instance.launch_mode == InstanceLaunchMode::Cli {
         let cli_prepare_started = Instant::now();
@@ -1286,10 +1367,11 @@ async fn codex_start_instance_internal(
             cli_prepare_started.elapsed().as_millis(),
             flow_started.elapsed().as_millis()
         ));
-        return Ok(
-            CodexInstanceProfileView::from_profile(updated, false, initialized)
-                .with_launch_credential_change(launch_credential_change),
-        );
+        return Ok(CodexInstanceProfileView::from_profile(
+            updated,
+            false,
+            initialized,
+        ));
     }
 
     modules::process::ensure_codex_launch_path_configured()?;
@@ -1313,10 +1395,11 @@ async fn codex_start_instance_internal(
         finalize_started.elapsed().as_millis(),
         flow_started.elapsed().as_millis()
     ));
-    Ok(
-        CodexInstanceProfileView::from_profile(updated, running, initialized)
-            .with_launch_credential_change(launch_credential_change),
-    )
+    Ok(CodexInstanceProfileView::from_profile(
+        updated,
+        running,
+        initialized,
+    ))
 }
 
 pub(crate) async fn codex_start_default_with_prepared_profile(

--- a/src-tauri/src/modules/codex_session_visibility.rs
+++ b/src-tauri/src/modules/codex_session_visibility.rs
@@ -382,6 +382,55 @@ pub fn repair_session_visibility_quick_across_instances(
     repair_session_visibility_auto_across_instances(CodexSessionVisibilityAutoRepairMode::Current)
 }
 
+/// Repairs the launch target only, using the same bounded quick-repair plan as the
+/// automatic multi-instance repair. The caller supplies the already-resolved data
+/// directory so this path never discovers or mutates another configured instance.
+pub fn repair_session_visibility_quick_for_instance(
+    instance_id: &str,
+    instance_name: &str,
+    data_dir: &Path,
+) -> Result<CodexSessionVisibilityRepairSummary, String> {
+    let started = std::time::Instant::now();
+    modules::logger::log_info(&format!(
+        "[Codex Session Visibility] launch-target quick repair started: instance_id={}, instance_name={}, data_dir={}",
+        instance_id,
+        instance_name,
+        data_dir.display()
+    ));
+    let result = repair_session_visibility_for_instances_with_options(
+        CodexSessionVisibilityRepairOptions::for_auto_repair_mode(
+            CodexSessionVisibilityAutoRepairMode::Current,
+        ),
+        None,
+        None,
+        RepairTargetSelection::default(),
+        vec![CodexSyncInstance {
+            id: instance_id.to_string(),
+            name: instance_name.to_string(),
+            data_dir: data_dir.to_path_buf(),
+            last_pid: None,
+        }],
+    );
+    match &result {
+        Ok(summary) => modules::logger::log_info(&format!(
+            "[Codex Session Visibility] launch-target quick repair finished: instance_id={}, mutated_instances={}, rollout_files={}, sqlite_rows={}, elapsed_ms={}",
+            instance_id,
+            summary.mutated_instance_count,
+            summary.changed_rollout_file_count,
+            summary.updated_sqlite_row_count,
+            started.elapsed().as_millis()
+        )),
+        Err(error) => modules::logger::log_warn(&format!(
+            "[Codex Session Visibility] launch-target quick repair failed: instance_id={}, data_dir={}, elapsed_ms={}, error={}",
+            instance_id,
+            data_dir.display(),
+            started.elapsed().as_millis(),
+            error
+        )),
+    }
+    result
+}
+
 pub fn repair_session_visibility_auto_across_instances(
     mode: CodexSessionVisibilityAutoRepairMode,
 ) -> Result<CodexSessionVisibilityRepairSummary, String> {
@@ -4400,5 +4449,139 @@ mod tests {
         assert_eq!(backup_count, 0);
 
         fs::remove_dir_all(&data_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn launch_target_quick_repair_is_bidirectional_idempotent_and_instance_scoped() {
+        fn write_fixture(
+            data_dir: &Path,
+            thread_id: &str,
+            configured_provider: &str,
+            history_provider: &str,
+        ) -> (PathBuf, PathBuf) {
+            fs::write(
+                data_dir.join(CONFIG_FILE_NAME),
+                format!("model_provider = \"{}\"\n", configured_provider),
+            )
+            .expect("write config");
+
+            let rollout_dir = data_dir.join("sessions").join("2026").join("07").join("14");
+            fs::create_dir_all(&rollout_dir).expect("create rollout dir");
+            let rollout_path = rollout_dir.join(format!("rollout-{}.jsonl", thread_id));
+            let rollout_relative = rollout_path
+                .strip_prefix(data_dir)
+                .expect("relative rollout")
+                .to_string_lossy()
+                .replace('\\', "/");
+            fs::write(
+                &rollout_path,
+                format!(
+                    "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\",\"model_provider\":\"{}\"}}}}\n",
+                    thread_id, history_provider
+                ),
+            )
+            .expect("write rollout");
+
+            let db_path = data_dir.join(STATE_DB_FILE);
+            let connection = Connection::open(&db_path).expect("open sqlite");
+            connection
+                .execute(
+                    "CREATE TABLE threads (
+                        id TEXT PRIMARY KEY,
+                        rollout_path TEXT,
+                        model_provider TEXT,
+                        has_user_event INTEGER,
+                        first_user_message TEXT,
+                        thread_source TEXT
+                    )",
+                    [],
+                )
+                .expect("create threads table");
+            connection
+                .execute(
+                    "INSERT INTO threads (id, rollout_path, model_provider, has_user_event, first_user_message, thread_source)
+                     VALUES (?1, ?2, ?3, 0, 'hello', '')",
+                    (thread_id, rollout_relative.as_str(), history_provider),
+                )
+                .expect("insert thread");
+            drop(connection);
+            (db_path, rollout_path)
+        }
+
+        fn read_provider(db_path: &Path, thread_id: &str) -> String {
+            Connection::open(db_path)
+                .expect("open sqlite for read")
+                .query_row(
+                    "SELECT model_provider FROM threads WHERE id = ?1",
+                    [thread_id],
+                    |row| row.get(0),
+                )
+                .expect("read provider")
+        }
+
+        let target_dir = make_temp_dir("codex-launch-target-repair-test");
+        let other_dir = make_temp_dir("codex-launch-other-instance-test");
+        let (target_db, target_rollout) =
+            write_fixture(&target_dir, "target-thread", "relay", "openai");
+        let (other_db, other_rollout) =
+            write_fixture(&other_dir, "other-thread", "openai", "other-provider");
+        let other_rollout_before = fs::read(&other_rollout).expect("read other rollout before");
+
+        let first = repair_session_visibility_quick_for_instance(
+            "target-instance",
+            "Target instance",
+            &target_dir,
+        )
+        .expect("repair target instance");
+        assert_eq!(first.instance_count, 1);
+        assert_eq!(first.mutated_instance_count, 1);
+        assert_eq!(first.items[0].instance_id, "target-instance");
+        assert_eq!(read_provider(&target_db, "target-thread"), "relay");
+        assert!(fs::read_to_string(&target_rollout)
+            .expect("read target rollout")
+            .contains("\"model_provider\":\"relay\""));
+
+        assert_eq!(read_provider(&other_db, "other-thread"), "other-provider");
+        assert_eq!(
+            fs::read(&other_rollout).expect("read other rollout after"),
+            other_rollout_before
+        );
+        assert!(fs::read_dir(&other_dir)
+            .expect("read other instance dir")
+            .filter_map(Result::ok)
+            .all(|entry| !entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(SESSION_VISIBILITY_REPAIR_BACKUP_PREFIX)));
+
+        let second = repair_session_visibility_quick_for_instance(
+            "target-instance",
+            "Target instance",
+            &target_dir,
+        )
+        .expect("repeat target repair");
+        assert_eq!(second.mutated_instance_count, 0);
+        assert_eq!(second.changed_rollout_file_count, 0);
+        assert_eq!(second.updated_sqlite_row_count, 0);
+
+        fs::write(
+            target_dir.join(CONFIG_FILE_NAME),
+            "model_provider = \"openai\"\n",
+        )
+        .expect("switch target back to account provider");
+        let switched_back = repair_session_visibility_quick_for_instance(
+            "target-instance",
+            "Target instance",
+            &target_dir,
+        )
+        .expect("repair target after provider switch");
+        assert_eq!(switched_back.mutated_instance_count, 1);
+        assert_eq!(read_provider(&target_db, "target-thread"), "openai");
+        assert!(fs::read_to_string(&target_rollout)
+            .expect("read switched-back rollout")
+            .contains("\"model_provider\":\"openai\""));
+
+        fs::remove_dir_all(&target_dir).expect("cleanup target dir");
+        fs::remove_dir_all(&other_dir).expect("cleanup other dir");
     }
 }

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -144,11 +144,6 @@ import {
   type CodexBatchImportQueueTaskStatus,
 } from "../utils/codexBatchImportQueue";
 import {
-  buildCodexSessionVisibilityInitialProgress,
-  CodexSessionVisibilityRepairProgressView,
-  createCodexSessionVisibilityRepairRunId,
-} from "../components/codex/CodexSessionVisibilityRepairModal";
-import {
   CodexWakeupContent,
   type CodexWakeupTestOpenRequest,
 } from "../components/codex/CodexWakeupContent";
@@ -170,7 +165,6 @@ import { SingleSelectDropdown } from "../components/SingleSelectDropdown";
 import type {
   CodexAccount,
   CodexAppSpeed,
-  CodexSessionVisibilityRepairProgress,
 } from "../types/codex";
 import type {
   CodexLocalAccessAddressKind,
@@ -184,7 +178,6 @@ import type {
 } from "../types/codexLocalAccess";
 import {
   CODEX_API_SERVICE_BIND_ID,
-  CODEX_PROVIDER_GATEWAY_BIND_PREFIX,
   type InstanceProfile,
 } from "../types/instance";
 import {
@@ -284,7 +277,6 @@ import {
   setCodexLocalAccessRiskNoticeDismissed,
   type CodexLocalAccessRiskNoticeAction,
 } from "../utils/codexLocalAccessRiskNotice";
-import { formatCodexSessionVisibilityRepairMessage } from "../utils/codexSessionVisibility";
 import {
   getMfaOtpToken,
   getMfaTimeRemaining,
@@ -593,16 +585,6 @@ function persistLocalAccessGatewayGuideDismissed(): void {
   }
 }
 
-type CodexLaunchCredentialKind = "api" | "api-key" | "api-service" | "account";
-type CodexLaunchCredentialType = "api" | "account";
-
-type CodexApiSwitchNoticeContext = {
-  from: CodexLaunchCredentialKind;
-  to: CodexLaunchCredentialKind;
-};
-
-const CODEX_SESSION_VISIBILITY_REPAIR_PROGRESS_EVENT =
-  "codex:session_visibility_repair_progress";
 const CODEX_BATCH_IMPORT_SESSION_STORAGE_KEY =
   "cockpit.codex.batchImport.sessionId";
 
@@ -626,26 +608,6 @@ function shouldAutoHideBatchDeleteJob(
   job: CodexBatchDeleteJobStatus | null,
 ): job is CodexBatchDeleteJobStatus {
   return job?.status === "completed" && job.failed === 0;
-}
-
-function getCodexLaunchCredentialKind(
-  account: CodexAccount,
-): CodexLaunchCredentialKind {
-  return isCodexApiKeyAccount(account) ? "api-key" : "account";
-}
-
-function getCodexLaunchCredentialType(
-  kind: CodexLaunchCredentialKind,
-): CodexLaunchCredentialType {
-  return kind === "account" ? "account" : "api";
-}
-
-function getCodexLaunchCredentialKindFromType(
-  type: string | null | undefined,
-): CodexLaunchCredentialKind | null {
-  if (type === "api") return "api";
-  if (type === "account") return "account";
-  return null;
 }
 
 type CockpitApiJsonRecord = Record<string, unknown>;
@@ -1076,19 +1038,6 @@ export function CodexAccountsPage() {
     useState<CodexLocalAccessRiskNoticeAction | null>(null);
   const [localAccessRiskNoticeRemember, setLocalAccessRiskNoticeRemember] =
     useState(false);
-  const [apiSwitchNoticeContext, setApiSwitchNoticeContext] =
-    useState<CodexApiSwitchNoticeContext | null>(null);
-  const [apiSwitchNoticeRepairRunId, setApiSwitchNoticeRepairRunId] =
-    useState<string | null>(null);
-  const [apiSwitchNoticeRepairProgress, setApiSwitchNoticeRepairProgress] =
-    useState<CodexSessionVisibilityRepairProgress | null>(null);
-  const [apiSwitchNoticeRepairResult, setApiSwitchNoticeRepairResult] =
-    useState<string | null>(null);
-  const {
-    message: apiSwitchNoticeError,
-    scrollKey: apiSwitchNoticeErrorScrollKey,
-    set: setApiSwitchNoticeError,
-  } = useModalErrorState();
   const [localAccessCopiedField, setLocalAccessCopiedField] = useState<
     "baseUrl" | "apiKey" | null
   >(null);
@@ -2236,51 +2185,6 @@ export function CodexAccountsPage() {
     }
   }, []);
 
-  const resolveCurrentCodexLaunchCredentialKind =
-    useCallback(async (): Promise<CodexLaunchCredentialKind | null> => {
-      try {
-        const activeAccount = await codexService.getCurrentCodexAccount();
-        if (activeAccount) {
-          return getCodexLaunchCredentialKind(activeAccount);
-        }
-
-        const instances = await codexInstanceService.listInstances();
-        const defaultInstance = instances.find(
-          (instance) => instance.isDefault,
-        );
-        const bindAccountId = defaultInstance?.bindAccountId ?? "";
-        if (bindAccountId === CODEX_API_SERVICE_BIND_ID) {
-          return "api-service";
-        }
-        if (bindAccountId.startsWith(CODEX_PROVIDER_GATEWAY_BIND_PREFIX)) {
-          return "api-key";
-        }
-        return null;
-      } catch (error) {
-        console.warn(
-          "Failed to resolve current Codex launch credential kind:",
-          error,
-        );
-        return null;
-      }
-    }, []);
-
-  const shouldShowApiSwitchVisibilityNotice = useCallback(
-    (
-      currentKind: CodexLaunchCredentialKind | null,
-      targetKind: CodexLaunchCredentialKind | null,
-    ) => {
-      if (!currentKind || !targetKind) {
-        return false;
-      }
-      return (
-        getCodexLaunchCredentialType(currentKind) !==
-        getCodexLaunchCredentialType(targetKind)
-      );
-    },
-    [],
-  );
-
   const exportFormatOptions = useMemo<SingleSelectFilterOption[]>(
     () => [
       {
@@ -2864,102 +2768,6 @@ export function CodexAccountsPage() {
   const clearFilterTypes = useCallback(() => {
     setFilterTypes([]);
   }, []);
-
-  const closeApiSwitchVisibilityNotice = useCallback(() => {
-    apiSwitchNoticeRepairSeqRef.current += 1;
-    if (apiSwitchNoticeAutoCloseTimerRef.current != null) {
-      window.clearTimeout(apiSwitchNoticeAutoCloseTimerRef.current);
-      apiSwitchNoticeAutoCloseTimerRef.current = null;
-    }
-    setApiSwitchNoticeContext(null);
-    setApiSwitchNoticeRepairRunId(null);
-    setApiSwitchNoticeRepairProgress(null);
-    setApiSwitchNoticeRepairResult(null);
-    setApiSwitchNoticeError(null);
-  }, [setApiSwitchNoticeError]);
-
-  const runApiSwitchVisibilityRepair = useCallback(async () => {
-    const repairSeq = apiSwitchNoticeRepairSeqRef.current + 1;
-    const runId = createCodexSessionVisibilityRepairRunId();
-    apiSwitchNoticeRepairSeqRef.current = repairSeq;
-    if (apiSwitchNoticeAutoCloseTimerRef.current != null) {
-      window.clearTimeout(apiSwitchNoticeAutoCloseTimerRef.current);
-      apiSwitchNoticeAutoCloseTimerRef.current = null;
-    }
-    setApiSwitchNoticeError(null);
-    setApiSwitchNoticeRepairResult(null);
-    setApiSwitchNoticeRepairRunId(runId);
-    setApiSwitchNoticeRepairProgress(
-      buildCodexSessionVisibilityInitialProgress(runId),
-    );
-    try {
-      const summary =
-        await codexInstanceService.repairSessionVisibilityAcrossInstances(
-          runId,
-        );
-      if (apiSwitchNoticeRepairSeqRef.current === repairSeq) {
-        setApiSwitchNoticeRepairResult(
-          formatCodexSessionVisibilityRepairMessage(summary, t),
-        );
-        setApiSwitchNoticeRepairProgress((current) =>
-          current
-            ? {
-                ...current,
-                stage: "done",
-                percent: 100,
-              }
-            : buildCodexSessionVisibilityInitialProgress(runId),
-        );
-        apiSwitchNoticeAutoCloseTimerRef.current = window.setTimeout(() => {
-          if (apiSwitchNoticeRepairSeqRef.current !== repairSeq) return;
-          apiSwitchNoticeRepairSeqRef.current += 1;
-          apiSwitchNoticeAutoCloseTimerRef.current = null;
-          setApiSwitchNoticeContext(null);
-          setApiSwitchNoticeRepairRunId(null);
-          setApiSwitchNoticeRepairProgress(null);
-          setApiSwitchNoticeRepairResult(null);
-          setApiSwitchNoticeError(null);
-        }, 1200);
-      }
-    } catch {
-      if (apiSwitchNoticeRepairSeqRef.current === repairSeq) {
-        setApiSwitchNoticeError(
-          t(
-            "codex.apiSwitchNotice.repairFailed",
-            "修复可见性失败。你仍可稍后在「会话管理」中重试。",
-          ),
-        );
-      }
-    }
-  }, [setApiSwitchNoticeError, t]);
-
-  const openApiSwitchVisibilityNotice = useCallback(
-    (context: CodexApiSwitchNoticeContext) => {
-      setApiSwitchNoticeContext(context);
-      setApiSwitchNoticeRepairResult(null);
-      setApiSwitchNoticeRepairRunId(null);
-      setApiSwitchNoticeRepairProgress(null);
-      setApiSwitchNoticeError(null);
-      void runApiSwitchVisibilityRepair();
-    },
-    [runApiSwitchVisibilityRepair, setApiSwitchNoticeError],
-  );
-
-  const formatCodexLaunchCredentialKindLabel = useCallback(
-    (kind: CodexLaunchCredentialKind) => {
-      if (kind === "api-service") {
-        return t("codex.apiSwitchNotice.type.apiService", "API 服务");
-      }
-      if (kind === "api-key") {
-        return t("codex.apiSwitchNotice.type.apiKey", "API Key");
-      }
-      if (kind === "api") {
-        return t("codex.apiSwitchNotice.type.api", "API 模式");
-      }
-      return t("codex.apiSwitchNotice.type.account", "账号");
-    },
-    [t],
-  );
 
   const validateApiKeyCredentialInputs = useCallback(
     (
@@ -3924,51 +3732,11 @@ export function CodexAccountsPage() {
   const oauthEventSeqRef = useRef(0);
   const oauthAttemptSeqRef = useRef(0);
   const inlineRenameDiscardRef = useRef(false);
-  const apiSwitchNoticeRepairSeqRef = useRef(0);
-  const apiSwitchNoticeAutoCloseTimerRef = useRef<number | null>(null);
   const skipManagedProviderApiKeyAutofillRef = useRef(false);
   const apiProviderPresetExplicitlySelectedRef = useRef(false);
   const apiKeyFunPrefillModelCatalogRef = useRef<string[] | null>(null);
   const pendingApiKeyFunCodexPrefillRef =
     useRef<ApiKeyFunPrefillPayload | null>(null);
-
-  useEffect(
-    () => () => {
-      if (apiSwitchNoticeAutoCloseTimerRef.current != null) {
-        window.clearTimeout(apiSwitchNoticeAutoCloseTimerRef.current);
-        apiSwitchNoticeAutoCloseTimerRef.current = null;
-      }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    if (!apiSwitchNoticeRepairRunId) return;
-
-    let disposed = false;
-    let unlisten: UnlistenFn | null = null;
-    void listen<CodexSessionVisibilityRepairProgress>(
-      CODEX_SESSION_VISIBILITY_REPAIR_PROGRESS_EVENT,
-      (event) => {
-        const payload = event.payload;
-        if (!payload || payload.runId !== apiSwitchNoticeRepairRunId) {
-          return;
-        }
-        setApiSwitchNoticeRepairProgress(payload);
-      },
-    ).then((nextUnlisten) => {
-      if (disposed) {
-        nextUnlisten();
-      } else {
-        unlisten = nextUnlisten;
-      }
-    });
-
-    return () => {
-      disposed = true;
-      unlisten?.();
-    };
-  }, [apiSwitchNoticeRepairRunId]);
 
   const selectedApiProviderPreset = useMemo(
     () => findCodexApiProviderPresetById(apiProviderPresetId),
@@ -5487,15 +5255,6 @@ export function CodexAccountsPage() {
         accountId,
       });
       const showSuccessMessage = options?.showSuccessMessage ?? true;
-      const currentKind = await resolveCurrentCodexLaunchCredentialKind();
-      const targetAccount = accounts.find((account) => account.id === accountId);
-      const targetKind = targetAccount
-        ? getCodexLaunchCredentialKind(targetAccount)
-        : null;
-      const shouldShowVisibilityNotice = shouldShowApiSwitchVisibilityNotice(
-        currentKind,
-        targetKind,
-      );
       setMessage(null);
       setSwitching(accountId);
       try {
@@ -5508,12 +5267,6 @@ export function CodexAccountsPage() {
             }),
           });
         }
-        if (shouldShowVisibilityNotice && currentKind && targetKind) {
-          openApiSwitchVisibilityNotice({
-            from: currentKind,
-            to: getCodexLaunchCredentialKind(account),
-          });
-        }
         return account;
       } finally {
         setSwitching(null);
@@ -5524,12 +5277,8 @@ export function CodexAccountsPage() {
       }
     },
     [
-      accounts,
       maskAccountText,
-      openApiSwitchVisibilityNotice,
-      resolveCurrentCodexLaunchCredentialKind,
       setMessage,
-      shouldShowApiSwitchVisibilityNotice,
       switchAccount,
       t,
     ],
@@ -5771,11 +5520,6 @@ export function CodexAccountsPage() {
         selected,
       );
       const prepared = await codexInstanceService.startInstance(instance.id);
-      if (prepared.codexLaunchCredentialChange) {
-        handleCodexInstanceLaunchCredentialChange(
-          prepared.codexLaunchCredentialChange,
-        );
-      }
       const result =
         await codexInstanceService.executeCodexInstanceLaunchCommand(
           prepared.id,
@@ -5820,11 +5564,6 @@ export function CodexAccountsPage() {
 
       const instance = await resolveCodexCliInstanceForApiService(selected);
       const prepared = await codexInstanceService.startInstance(instance.id);
-      if (prepared.codexLaunchCredentialChange) {
-        handleCodexInstanceLaunchCredentialChange(
-          prepared.codexLaunchCredentialChange,
-        );
-      }
       const result =
         await codexInstanceService.executeCodexInstanceLaunchCommand(
           prepared.id,
@@ -5845,18 +5584,6 @@ export function CodexAccountsPage() {
       setCliLaunchingAccountId(null);
     }
   };
-
-  const handleCodexInstanceLaunchCredentialChange = useCallback(
-    (change: { from: string; to: string }) => {
-      const from = getCodexLaunchCredentialKindFromType(change.from);
-      const to = getCodexLaunchCredentialKindFromType(change.to);
-      if (!shouldShowApiSwitchVisibilityNotice(from, to) || !from || !to) {
-        return;
-      }
-      openApiSwitchVisibilityNotice({ from, to });
-    },
-    [openApiSwitchVisibilityNotice, shouldShowApiSwitchVisibilityNotice],
-  );
 
   const handleImportFromLocal = async () => {
     page.setAddStatus("loading");
@@ -9293,11 +9020,6 @@ export function CodexAccountsPage() {
       const confirmed = await requestLocalAccessRiskNotice("service");
       if (!confirmed) return;
       const flowStartedAt = performance.now();
-      const currentKind = await resolveCurrentCodexLaunchCredentialKind();
-      const shouldShowVisibilityNotice = shouldShowApiSwitchVisibilityNotice(
-        currentKind,
-        "api-service",
-      );
       console.info("[Codex API Service Switch][UI] button loading started");
       setLocalAccessStarting(true);
       try {
@@ -9309,12 +9031,6 @@ export function CodexAccountsPage() {
         if (options?.showSuccessMessage ?? true) {
           setMessage({
             text: t("codex.localAccess.activateSuccess", "已切换到 API 服务"),
-          });
-        }
-        if (shouldShowVisibilityNotice && currentKind) {
-          openApiSwitchVisibilityNotice({
-            from: currentKind,
-            to: "api-service",
           });
         }
         return nextState;
@@ -9331,11 +9047,8 @@ export function CodexAccountsPage() {
     [
       fetchCurrentAccount,
       localAccessCollection,
-      openApiSwitchVisibilityNotice,
       requestLocalAccessRiskNotice,
-      resolveCurrentCodexLaunchCredentialKind,
       setMessage,
-      shouldShowApiSwitchVisibilityNotice,
       t,
     ],
   );
@@ -18002,7 +17715,6 @@ export function CodexAccountsPage() {
       {activeTab === "instances" && (
         <CodexInstancesContent
           accountsForSelect={sortedAccountsForInstances}
-          onLaunchCredentialChange={handleCodexInstanceLaunchCredentialChange}
         />
       )}
 
@@ -18041,65 +17753,6 @@ export function CodexAccountsPage() {
             await fetchCurrentAccount();
           }}
         />
-      )}
-
-      {apiSwitchNoticeContext && (
-        <div
-          className="modal-overlay codex-local-access-hide-confirm-overlay"
-        >
-          <div
-            className="modal codex-local-access-hide-confirm-modal codex-api-switch-notice-modal"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <div className="modal-header">
-              <h2>{t("codex.apiSwitchNotice.title", "Codex 会话不可见")}</h2>
-              <button
-                className="modal-close"
-                onClick={closeApiSwitchVisibilityNotice}
-                aria-label={t("common.close", "关闭")}
-              >
-                <X />
-              </button>
-            </div>
-            <div className="modal-body">
-              <ModalErrorMessage
-                message={apiSwitchNoticeError}
-                scrollKey={apiSwitchNoticeErrorScrollKey}
-              />
-              <p className="codex-local-access-hide-confirm-desc">
-                {t("codex.apiSwitchNotice.message", {
-                  defaultValue:
-                    "检测到 Codex 已从 {{from}} 切换到 {{to}}。由于官方机制，这类切换后原有会话可能不会自动显示。正在自动修复会话可见性，后续也可以在「会话管理」中手动修复。",
-                  from: formatCodexLaunchCredentialKindLabel(
-                    apiSwitchNoticeContext.from,
-                  ),
-                  to: formatCodexLaunchCredentialKindLabel(
-                    apiSwitchNoticeContext.to,
-                  ),
-                })}
-              </p>
-              {apiSwitchNoticeRepairProgress && (
-                <CodexSessionVisibilityRepairProgressView
-                  progress={apiSwitchNoticeRepairProgress}
-                />
-              )}
-              {apiSwitchNoticeRepairResult && (
-                <div className="codex-api-switch-notice-repair-status is-success">
-                  <Check size={14} />
-                  <span>{apiSwitchNoticeRepairResult}</span>
-                </div>
-              )}
-            </div>
-            <div className="modal-footer codex-api-switch-notice-footer">
-              <button
-                className="btn btn-primary"
-                onClick={closeApiSwitchVisibilityNotice}
-              >
-                {t("common.close", "关闭")}
-              </button>
-            </div>
-          </div>
-        </div>
       )}
     </div>
   );

--- a/src/pages/CodexInstancesPage.tsx
+++ b/src/pages/CodexInstancesPage.tsx
@@ -11,7 +11,6 @@ import { isCodexApiKeyAccount, type CodexAccount } from "../types/codex";
 import {
   CODEX_API_SERVICE_BIND_ID,
   CODEX_PROVIDER_GATEWAY_BIND_PREFIX,
-  type CodexLaunchCredentialChange,
   type InstanceProfile,
 } from "../types/instance";
 import { usePlatformRuntimeSupport } from "../hooks/usePlatformRuntimeSupport";
@@ -41,7 +40,6 @@ import { useEscClose } from "../hooks/useEscClose";
  */
 interface CodexInstancesContentProps {
   accountsForSelect?: CodexAccount[];
-  onLaunchCredentialChange?: (change: CodexLaunchCredentialChange) => void;
 }
 
 interface CodexLaunchModalState {
@@ -63,7 +61,6 @@ function normalizeCodexApiBaseUrl(rawValue?: string | null): string {
 
 export function CodexInstancesContent({
   accountsForSelect,
-  onLaunchCredentialChange,
 }: CodexInstancesContentProps = {}) {
   const { t } = useTranslation();
   const instanceStore = useCodexInstanceStore();
@@ -248,10 +245,6 @@ export function CodexInstancesContent({
   };
 
   const handleInstanceStarted = async (instance: InstanceProfile) => {
-    if (instance.codexLaunchCredentialChange) {
-      onLaunchCredentialChange?.(instance.codexLaunchCredentialChange);
-    }
-
     if ((instance.launchMode ?? "app") !== "cli") {
       return;
     }


### PR DESCRIPTION
## 问题

v1.3.1/main 已有 session visibility 修复引擎，但启动流程把修复延迟给前端；前端以 fire-and-forget 方式扫描所有实例，因此 Codex 可能先启动，非目标实例也可能被改写。这个 PR 是 #704 之后的窄范围补丁，不重新实现底层修复算法。

## 修改

- 复用现有 quick repair，引入只接收当前 instance_id/name/data_dir 的单实例入口。
- 关闭目标 Codex 进程并注入当前账号/API 配置后，同步等待修复完成，再启动 App 或准备 CLI；失败就取消启动。
- 删除账号页的异步跨实例自动修复链；Session Manager 的手动修复入口保留。
- 同一实例的重复启动采用 single-flight（单飞：同一时刻只允许一次），不同实例仍可并行。

当 codex_launch_on_switch=false 时，切换设置不会写正在运行的 rollout；下一次手动启动会在新进程出现前完成修复。

## 验证

- cargo test codex_session_visibility --lib：9 passed
- cargo test instance_start_guard_rejects_only_duplicate_instance_starts --lib：1 passed
- A/B fixture 覆盖 account ↔ API、幂等及非目标实例字节不变
- npm run typecheck：passed
- npm run build：passed
- cargo check --lib：passed
- release preflight：locale/typecheck/web build/cargo check passed；全量 lib 测试 554 passed，1 个上游未改动的 NVM 路径测试失败（codex_wakeup.rs 相对 upstream/main 无 diff）
- 本机两个真实实例 state_5.sqlite quick_check=ok，Thread ID 交集为 0
