### PR TITLE
feat(codex): random routing and immediate SSE response

### DIFF
--- a/docs/CODEX_API_SERVICE_HANDOFF.md
+++ b/docs/CODEX_API_SERVICE_HANDOFF.md
@@ -1,0 +1,158 @@
+# Codex API Service Handoff
+
+## Scope
+
+This note describes the local service shown in the UI as **Codex API Service**.
+It is not a hosted Cockpit API. The desktop application creates a local,
+authenticated OpenAI-compatible gateway and can redirect Codex profiles to it.
+
+The repository was imported from `jlcodes99/cockpit-tools` at commit
+`9525a2b5fc519874d42213e6cac9cc90fd38ae82` on 2026-07-14.
+
+## Architecture
+
+```text
+Codex CLI / selected Codex profile
+  -> auth.json + config.toml injected by Cockpit
+  -> http://localhost:<configured-port>/v1
+  -> cockpit-cliproxy sidecar by default
+  -> selected Codex OAuth credentials or configured provider API key
+  -> OpenAI Codex upstream or provider upstream
+
+React page -> Tauri invoke -> Rust collection/runtime -> sidecar config + manifest
+```
+
+The implementation has two gateway modes:
+
+- `sidecar` is the default. Rust materializes config and credentials, then starts
+  the bundled Go executable `cockpit-cliproxy`.
+- `legacy` retains the Rust in-process HTTP proxy path. Do not change defaults or
+  route behavior in one mode without checking the other.
+
+## Source Ownership
+
+| Area | Primary files | Responsibility |
+| --- | --- | --- |
+| UI | `src/pages/CodexApiServicePage.tsx`, `src/components/CodexLocalAccessModal.tsx` | Service screen, account/key/routing controls, test panel and usage views. |
+| UI bridge | `src/services/codexLocalAccessService.ts` | Typed wrappers around the Tauri commands. Keep camelCase payload names aligned with Rust command arguments. |
+| Contract | `src/types/codexLocalAccess.ts`, `src-tauri/src/models/codex_local_access.rs` | Frontend/Rust state and configuration schema. Rust uses `serde(rename_all = "camelCase")`. |
+| Commands | `src-tauri/src/commands/codex.rs` | Tauri command boundary; commands are registered in `src-tauri/src/lib.rs`. |
+| Service coordinator | `src-tauri/src/modules/codex_local_access.rs` | Persistence, profile takeover, sidecar lifecycle, legacy proxy, routing, quotas, request logs and tests. |
+| Sidecar | `sidecars/cockpit-cliproxy/main.go` | Go HTTP gateway based on CLIProxyAPI SDK. Receives generated config and manifest. |
+
+## Runtime Flow
+
+1. The UI reads state through `codex_local_access_get_state` and changes it via
+   `codex_local_access_*` commands.
+2. Rust persists a `CodexLocalAccessCollection`, synchronizes `GatewayRuntime`,
+   and calls `ensure_gateway_matches_runtime` when a gateway-relevant setting
+   changes.
+3. In sidecar mode, `prepare_sidecar_launch_config` writes the sidecar `config.json`,
+   `manifest.json`, credentials below `auths/`, and quota-reserve state. A stable
+   fingerprint decides whether the process must be restarted.
+4. The sidecar authenticates the client key, applies model visibility/alias rules,
+   selects an account, and sends the upstream request. It reports diagnostics and
+   usage back to Rust.
+5. Activating the service backs up the target profile before writing a managed
+   Codex account bundle (`auth.json` and `config.toml`). Disabling restores saved
+   profile state.
+
+## HTTP Surface
+
+The Rust proxy recognizes these client paths; the sidecar is expected to preserve
+the same client contract:
+
+- `/v1/models`
+- `/v1/chat/completions`
+- `/v1/responses` and `/v1/responses/compact`
+- `/backend-api/codex/*`, including responses WebSocket traffic
+- `/v1/images/generations` and `/v1/images/edits`
+
+The default bind is loopback (`127.0.0.1`). The user can choose LAN scope
+(`0.0.0.0`), which expands exposure but still requires a generated API key. Client
+Base URL host can be `localhost` or `127.0.0.1`; preserve this when rewriting a
+profile, especially for WSL.
+
+## Routing And Safety Rules
+
+- Account pools support auto, random distribution, single-account, quota/plan/
+  expiry ordering, and custom priority/weight/backup routing. Random distribution
+  shuffles eligible accounts for each new request; a session-affinity binding still
+  wins for an existing conversation.
+- Session affinity is enabled by default. Routing also observes cooldown and
+  account-health state; retries are bounded by the configured credential count and
+  delay.
+- Named API keys can be disabled, limited by allowed/excluded models, and assigned
+  a model prefix. The primary collection key remains for backward compatibility.
+- Bound OAuth quota reserve can exclude an OAuth account when its fresh hourly or
+  weekly quota snapshot drops below the configured threshold. A failed refresh is
+  fail-closed for that reserve decision.
+- Model aliases and filters affect both model discovery and request rewriting.
+  Update both paths together and test an alias plus a rejected model.
+- Image behavior is separately configurable: enabled, images-only, or disabled.
+  Image requests and image tool injection have their own validation path.
+- `immediateSseResponse` is disabled by default. In sidecar mode it commits a
+  `200 OK` SSE response with an ignored `: accepted` comment before the upstream
+  stream opens. Once HTTP headers are committed, upstream-open failures are sent
+  as SSE error data and cannot change the HTTP status.
+
+## Persistent Artifacts And Logs
+
+Artifact paths are derived from the application data directory in
+`codex_local_access.rs`; do not hard-code an OS-specific profile path.
+
+- `codex_local_access.json`: durable collection and service configuration.
+- `codex_local_access_stats.json`: summarized counters/recent events.
+- `codex_local_access_logs.sqlite`: queryable request/usage records.
+- `codex_local_access_takeover_backups.json`: profile restoration data.
+- `codex_local_access_sidecar/`: generated sidecar `config.json`, `manifest.json`,
+  auth files, and quota-reserve state.
+- `codex_provider_gateway_sidecars/`: isolated generated gateways for direct
+  external model providers.
+
+Use `logger::log_codex_api_info`, `log_codex_api_warn`, and
+`log_codex_api_error` for Rust service messages. The sidecar emits request
+diagnostic and usage payloads; inspect its generated manifest only locally because
+it can contain credentials.
+
+## Debug Checklist
+
+1. Call `codex_local_access_get_state`: confirm `collection.enabled`, `running`,
+   `baseUrl`, `lastError`, selected account count, mode, and port.
+2. Verify the configured port is free or use `codex_local_access_kill_port` only
+   after identifying the owning process.
+3. In sidecar mode, inspect generated config/manifest for port, bind host, key
+   policy, account auth files, and a fresh fingerprint. Never paste their secrets
+   into issues, docs, or commits.
+4. Run the built-in `codex_local_access_test` or chat test, then query request logs
+   using `codex_local_access_query_request_logs`. Correlate request ID, account,
+   API key, status, error category, and upstream transport.
+5. If Codex itself does not use the gateway, inspect the target profile's managed
+   `auth.json` and `config.toml`, then check the saved takeover backup before any
+   manual reset. For WSL, verify the resolved WSL access plan and relay.
+6. For account rotation faults, check eligibility, quota reserve, cooldown/health,
+   account-model restrictions, and session affinity before changing retry limits.
+
+## Coding Conventions
+
+- TypeScript uses React function components, `async` service wrappers, camelCase
+  payloads, and explicit types from `src/types`.
+- Rust uses `Result<T, String>` at Tauri boundaries, `async` lifecycle functions,
+  serialized camelCase model fields, and structured helper functions in the module.
+- Keep persistence changes backward compatible: all new serialized fields need a
+  `serde(default)` migration story.
+- Keep secrets out of logs. Redact proxy URLs and API keys; generated runtime files
+  are local artifacts, not test fixtures.
+- Add focused tests next to the behavior. Existing coverage is concentrated in the
+  bottom `#[cfg(test)]` module of `codex_local_access.rs`, the Go sidecar tests,
+  and `tests/codexLocalAccessAccounts.test.ts`.
+
+## Completed And Next Work
+
+Completed: repository import, source map, service-flow review, and this handoff
+document.
+
+Before implementing a change, identify whether it belongs to the UI contract,
+Rust legacy proxy, generated sidecar contract, or all three. Test both the
+OpenAI-compatible request path and Codex profile takeover/restore whenever the
+change affects activation, keys, base URLs, models, routing, or credentials.

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math/rand"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -88,6 +89,7 @@ type manifest struct {
 	ExcludedModels     []string            `json:"excludedModels"`
 	RoutingStrategy    string              `json:"routingStrategy"`
 	CustomRoutingRules []customRoutingRule `json:"customRoutingRules"`
+	ImmediateSSEResponse bool              `json:"immediateSseResponse"`
 	DebugLogs          *bool               `json:"debugLogs,omitempty"`
 
 	apiKeyByValue     map[string]*apiKeySpec
@@ -1945,6 +1947,13 @@ func (s *cockpitSelector) orderAuths(auths []*coreauth.Auth, start int) []*corea
 		return auths
 	}
 	strategy := strings.TrimSpace(strings.ToLower(s.manifest.RoutingStrategy))
+	if strategy == "random" {
+		out := append([]*coreauth.Auth(nil), auths...)
+		rand.Shuffle(len(out), func(i, j int) {
+			out[i], out[j] = out[j], out[i]
+		})
+		return out
+	}
 	if strategy == "custom" {
 		return s.orderCustom(auths, start)
 	}
@@ -4449,6 +4458,20 @@ func (s *relayServer) handleStream(c *gin.Context, body []byte, model string, so
 	req, opts := buildExecutorRequest(c, body, model, sourceFormat, alt, true)
 	startedAt := time.Now()
 	timeouts := s.streamTimeoutsForRequest(c.Request, body, model)
+	immediateSSE := s.manifest != nil && s.manifest.ImmediateSSEResponse
+	var immediateFlusher http.Flusher
+	if immediateSSE {
+		flusher, ok := c.Writer.(http.Flusher)
+		if !ok {
+			writeAPIError(c, http.StatusInternalServerError, "streaming not supported", "streaming_not_supported")
+			return
+		}
+		setEventStreamHeaders(c.Writer.Header())
+		c.Status(http.StatusOK)
+		_, _ = c.Writer.Write([]byte(": accepted\n\n"))
+		flusher.Flush()
+		immediateFlusher = flusher
+	}
 	s.emitExecutorDiagnostic(c, "executor_started", model, "execute_stream", startedAt, "")
 	stopWaitLogger := s.startExecutorWaitLogger(c, model, "execute_stream", startedAt)
 	streamCtx, cancelStream := context.WithCancel(relayContext(c))
@@ -4457,12 +4480,22 @@ func (s *relayServer) handleStream(c *gin.Context, body []byte, model string, so
 	stopWaitLogger()
 	if err != nil {
 		s.emitExecutorDiagnostic(c, "executor_failed", model, "execute_stream", startedAt, err.Error())
+		if immediateSSE {
+			writeStreamTerminalError(c, err)
+			immediateFlusher.Flush()
+			return
+		}
 		s.writeExecutorError(c, err)
 		return
 	}
 	if result == nil || result.Chunks == nil {
 		s.emitExecutorDiagnostic(c, "executor_failed", model, "execute_stream", startedAt, "upstream stream is unavailable")
-		writeAPIError(c, http.StatusBadGateway, "upstream stream is unavailable", "bad_gateway")
+		if immediateSSE {
+			writeStreamTerminalError(c, relayStatusError{status: http.StatusBadGateway, message: "upstream stream is unavailable"})
+			immediateFlusher.Flush()
+		} else {
+			writeAPIError(c, http.StatusBadGateway, "upstream stream is unavailable", "bad_gateway")
+		}
 		return
 	}
 	s.emitExecutorDiagnostic(c, "stream_opened", model, "execute_stream", startedAt, "")
@@ -4472,9 +4505,11 @@ func (s *relayServer) handleStream(c *gin.Context, body []byte, model string, so
 		return
 	}
 
-	setEventStreamHeaders(c.Writer.Header())
-	writeUpstreamHeaders(c.Writer.Header(), result.Headers)
-	c.Status(http.StatusOK)
+	if !immediateSSE {
+		setEventStreamHeaders(c.Writer.Header())
+		writeUpstreamHeaders(c.Writer.Header(), result.Headers)
+		c.Status(http.StatusOK)
+	}
 
 	framer := newRelayStreamFramer(sourceFormat, requestPath(c.Request))
 	keepAlive := streamKeepAliveInterval(s.cfg)

--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -3173,6 +3173,7 @@ pub async fn codex_local_access_update_routing_options(
     max_retry_credentials: u16,
     max_retry_interval_ms: u64,
     disable_cooling: bool,
+    immediate_sse_response: bool,
 ) -> Result<CodexLocalAccessState, String> {
     codex_local_access::update_local_access_routing_options(
         session_affinity,
@@ -3180,6 +3181,7 @@ pub async fn codex_local_access_update_routing_options(
         max_retry_credentials,
         max_retry_interval_ms,
         disable_cooling,
+        immediate_sse_response,
     )
     .await
 }

--- a/src-tauri/src/models/codex_local_access.rs
+++ b/src-tauri/src/models/codex_local_access.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum CodexLocalAccessRoutingStrategy {
     Auto,
+    Random,
     SingleAccount,
     QuotaHighFirst,
     QuotaLowFirst,
@@ -482,6 +483,8 @@ pub struct CodexLocalAccessCollection {
     pub restrict_free_accounts: bool,
     #[serde(default = "default_true")]
     pub debug_logs: bool,
+    #[serde(default)]
+    pub immediate_sse_response: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bound_oauth_account_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -23,7 +23,7 @@ use crate::modules::{
 };
 use base64::{engine::general_purpose, Engine as _};
 use futures_util::{SinkExt, StreamExt};
-use rand::{distributions::Alphanumeric, Rng};
+use rand::{distributions::Alphanumeric, seq::SliceRandom, Rng};
 use reqwest::header::{HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use reqwest::{Client, Method, Proxy, StatusCode, Url};
 use rusqlite::{
@@ -4718,6 +4718,7 @@ fn compare_routing_candidates(
             compare_option_desc(left.plan_rank, right.plan_rank)
                 .then_with(|| compare_option_desc(left.remaining_quota, right.remaining_quota))
         }
+        CodexLocalAccessRoutingStrategy::Random => Ordering::Equal,
         CodexLocalAccessRoutingStrategy::SingleAccount => Ordering::Equal,
         CodexLocalAccessRoutingStrategy::QuotaHighFirst => {
             compare_option_desc(left.remaining_quota, right.remaining_quota)
@@ -4987,6 +4988,12 @@ fn apply_routing_strategy(
     custom_rules: &[CodexLocalAccessCustomRoutingRule],
     start: usize,
 ) -> Vec<String> {
+    if strategy == CodexLocalAccessRoutingStrategy::Random {
+        let mut shuffled = account_ids.to_vec();
+        shuffled.shuffle(&mut rand::thread_rng());
+        return shuffled;
+    }
+
     if strategy == CodexLocalAccessRoutingStrategy::SingleAccount {
         return account_ids.to_vec();
     }
@@ -8974,6 +8981,7 @@ fn sidecar_disable_image_generation_value(
 fn sidecar_routing_strategy_value(strategy: CodexLocalAccessRoutingStrategy) -> &'static str {
     match strategy {
         CodexLocalAccessRoutingStrategy::Auto => "auto",
+        CodexLocalAccessRoutingStrategy::Random => "random",
         CodexLocalAccessRoutingStrategy::SingleAccount => "single_account",
         CodexLocalAccessRoutingStrategy::QuotaHighFirst => "quota_high_first",
         CodexLocalAccessRoutingStrategy::QuotaLowFirst => "quota_low_first",
@@ -10007,6 +10015,7 @@ async fn prepare_sidecar_launch_config_in_dir(
             "excludedModels": rule.excluded_models.clone(),
         })).collect::<Vec<_>>(),
         "debugLogs": collection.debug_logs,
+        "immediateSseResponse": collection.immediate_sse_response,
     });
 
     let mut config = Map::new();
@@ -12835,6 +12844,7 @@ async fn ensure_runtime_loaded_without_start_with_profile_restore(
             disable_cooling: false,
             restrict_free_accounts: true,
             debug_logs: true,
+            immediate_sse_response: false,
             bound_oauth_account_id: None,
             bound_oauth_quota_reserve: None,
             account_ids: Vec::new(),
@@ -14106,6 +14116,7 @@ fn new_empty_local_access_collection() -> Result<CodexLocalAccessCollection, Str
         disable_cooling: false,
         restrict_free_accounts: true,
         debug_logs: true,
+        immediate_sse_response: false,
         bound_oauth_account_id: None,
         bound_oauth_quota_reserve: None,
         account_ids: Vec::new(),
@@ -16763,6 +16774,7 @@ fn new_local_access_collection() -> Result<CodexLocalAccessCollection, String> {
         disable_cooling: false,
         restrict_free_accounts: true,
         debug_logs: true,
+        immediate_sse_response: false,
         bound_oauth_account_id: None,
         bound_oauth_quota_reserve: None,
         account_ids: Vec::new(),
@@ -17201,6 +17213,7 @@ pub async fn update_local_access_routing_options(
     max_retry_credentials: u16,
     max_retry_interval_ms: u64,
     disable_cooling: bool,
+    immediate_sse_response: bool,
 ) -> Result<CodexLocalAccessState, String> {
     ensure_runtime_loaded().await?;
 
@@ -17222,6 +17235,7 @@ pub async fn update_local_access_routing_options(
     collection.max_retry_interval_ms =
         max_retry_interval_ms.clamp(MAX_RETRY_INTERVAL_MIN_MS, MAX_RETRY_INTERVAL_MAX_MS);
     collection.disable_cooling = disable_cooling;
+    collection.immediate_sse_response = immediate_sse_response;
     collection.updated_at = now_ms();
     save_collection_to_disk(&collection)?;
 
@@ -22924,6 +22938,7 @@ mod tests {
             disable_cooling: false,
             restrict_free_accounts: true,
             debug_logs: true,
+            immediate_sse_response: false,
             bound_oauth_account_id: None,
             bound_oauth_quota_reserve: None,
             account_ids,
@@ -25637,6 +25652,28 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
             sidecar_routing_strategy_value(CodexLocalAccessRoutingStrategy::SingleAccount),
             "single_account"
         );
+    }
+
+    #[test]
+    fn random_routing_serializes_and_keeps_all_candidates() {
+        let account_ids = vec![
+            "account-a".to_string(),
+            "account-b".to_string(),
+            "account-c".to_string(),
+        ];
+        let routed = apply_routing_strategy(
+            &account_ids,
+            CodexLocalAccessRoutingStrategy::Random,
+            &[],
+            0,
+        );
+
+        assert_eq!(
+            sidecar_routing_strategy_value(CodexLocalAccessRoutingStrategy::Random),
+            "random"
+        );
+        assert_eq!(routed.len(), account_ids.len());
+        assert!(account_ids.iter().all(|account_id| routed.contains(account_id)));
     }
 
     #[test]

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -2001,6 +2001,7 @@
         "planHighFirst": "الأعلى باقة أولاً",
         "planLowFirst": "الأقل باقة أولاً",
         "expirySoonFirst": "الأقرب انتهاءً أولاً",
+        "random": "عشوائي",
         "custom": "مخصص"
       },
       "statusUnconfigured": "غير مُعدّ",
@@ -3335,6 +3336,7 @@
         "maxRetryInterval": "انتظار retry",
         "disableCooling": "تعطيل cooldown",
         "saveOptions": "حفظ الخيارات",
+        "immediateSseResponse": "SSE فوري 200",
         "optionsSaved": "تم حفظ خيارات التوجيه"
       },
       "validation": {

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Nejvyšší tarif napřed",
         "planLowFirst": "Nejnižší tarif napřed",
         "expirySoonFirst": "Brzy končící první",
+        "random": "Náhodné",
         "custom": "Vlastní"
       },
       "statusUnconfigured": "Nenastaveno",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Čekání retry",
         "disableCooling": "Vypnout cooldown",
         "saveOptions": "Uložit volby",
+        "immediateSseResponse": "Okamžitá SSE 200",
         "optionsSaved": "Volby směrování uloženy"
       },
       "validation": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Hohes Abo zuerst",
         "planLowFirst": "Niedriges Abo zuerst",
         "expirySoonFirst": "Bald ablaufend zuerst",
+        "random": "Zufällig",
         "custom": "Benutzerdefiniert"
       },
       "statusUnconfigured": "Nicht konfiguriert",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Retry-Wartezeit",
         "disableCooling": "Cooldown deaktivieren",
         "saveOptions": "Optionen speichern",
+        "immediateSseResponse": "Sofortiges SSE 200",
         "optionsSaved": "Routingoptionen gespeichert"
       },
       "validation": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -2273,6 +2273,7 @@
         "planHighFirst": "High Plan First",
         "planLowFirst": "Low Plan First",
         "expirySoonFirst": "Expiry Soon First",
+        "random": "Random",
         "custom": "Custom"
       },
       "requestKind": {
@@ -3511,6 +3512,7 @@
         "maxRetryInterval": "Retry Wait",
         "disableCooling": "Disable Cooldown",
         "saveOptions": "Save Options",
+        "immediateSseResponse": "Immediate SSE 200",
         "optionsSaved": "Routing options saved"
       },
       "timeouts": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2273,6 +2273,7 @@
         "planHighFirst": "High Plan First",
         "planLowFirst": "Low Plan First",
         "expirySoonFirst": "Expiry Soon First",
+        "random": "Random",
         "custom": "Custom"
       },
       "requestKind": {
@@ -3511,6 +3512,7 @@
         "maxRetryInterval": "Retry Wait",
         "disableCooling": "Disable Cooldown",
         "saveOptions": "Save Options",
+        "immediateSseResponse": "Immediate SSE 200",
         "optionsSaved": "Routing options saved"
       },
       "timeouts": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Plan alto primero",
         "planLowFirst": "Plan bajo primero",
         "expirySoonFirst": "Vence antes primero",
+        "random": "Aleatorio",
         "custom": "Personalizado"
       },
       "statusUnconfigured": "Sin configurar",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Espera retry",
         "disableCooling": "Desactivar cooldown",
         "saveOptions": "Guardar opciones",
+        "immediateSseResponse": "SSE 200 inmediato",
         "optionsSaved": "Opciones de ruta guardadas"
       },
       "validation": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Forfait élevé d'abord",
         "planLowFirst": "Forfait faible d'abord",
         "expirySoonFirst": "Expiration proche d'abord",
+        "random": "Aléatoire",
         "custom": "Personnalisé"
       },
       "statusUnconfigured": "Non configuré",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Attente retry",
         "disableCooling": "Désactiver cooldown",
         "saveOptions": "Enregistrer",
+        "immediateSseResponse": "SSE 200 immédiat",
         "optionsSaved": "Options de routage enregistrées"
       },
       "validation": {

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -2004,6 +2004,7 @@
         "planHighFirst": "Paket Tinggi Dulu",
         "planLowFirst": "Paket Rendah Dulu",
         "expirySoonFirst": "Kedaluwarsa Cepat Dulu",
+        "random": "Acak",
         "custom": "Kustom"
       },
       "statusUnconfigured": "Belum dikonfigurasi",
@@ -3335,6 +3336,7 @@
         "maxRetryInterval": "Tunggu retry",
         "disableCooling": "Matikan cooldown",
         "saveOptions": "Simpan Opsi",
+        "immediateSseResponse": "SSE 200 langsung",
         "optionsSaved": "Opsi routing tersimpan"
       },
       "validation": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Piano alto prima",
         "planLowFirst": "Piano basso prima",
         "expirySoonFirst": "Scadenza vicina prima",
+        "random": "Casuale",
         "custom": "Personalizzato"
       },
       "statusUnconfigured": "Non configurato",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Attesa retry",
         "disableCooling": "Disattiva cooldown",
         "saveOptions": "Salva opzioni",
+        "immediateSseResponse": "SSE 200 immediato",
         "optionsSaved": "Opzioni routing salvate"
       },
       "validation": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "上位プラン優先",
         "planLowFirst": "下位プラン優先",
         "expirySoonFirst": "期限が近い順",
+        "random": "ランダム",
         "custom": "カスタム"
       },
       "statusUnconfigured": "未設定",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "再試行待ち",
         "disableCooling": "クールダウン無効",
         "saveOptions": "設定を保存",
+        "immediateSseResponse": "即時 SSE 200",
         "optionsSaved": "ルーティング設定を保存しました"
       },
       "validation": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "상위 요금제 우선",
         "planLowFirst": "하위 요금제 우선",
         "expirySoonFirst": "만료 임박 우선",
+        "random": "무작위",
         "custom": "사용자 지정"
       },
       "statusUnconfigured": "미설정",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "재시도 대기",
         "disableCooling": "쿨다운 끄기",
         "saveOptions": "옵션 저장",
+        "immediateSseResponse": "즉시 SSE 200",
         "optionsSaved": "라우팅 옵션 저장됨"
       },
       "validation": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Najpierw wyższy plan",
         "planLowFirst": "Najpierw niższy plan",
         "expirySoonFirst": "Najbliższe wygaśnięcie",
+        "random": "Losowo",
         "custom": "Niestandardowe"
       },
       "statusUnconfigured": "Nieskonfigurowane",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Czas retry",
         "disableCooling": "Wyłącz cooldown",
         "saveOptions": "Zapisz opcje",
+        "immediateSseResponse": "Natychmiastowe SSE 200",
         "optionsSaved": "Opcje routingu zapisane"
       },
       "validation": {

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Plano alto primeiro",
         "planLowFirst": "Plano baixo primeiro",
         "expirySoonFirst": "Vence antes primeiro",
+        "random": "Aleatório",
         "custom": "Personalizado"
       },
       "statusUnconfigured": "Não configurado",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Espera retry",
         "disableCooling": "Desativar cooldown",
         "saveOptions": "Salvar opções",
+        "immediateSseResponse": "SSE 200 imediato",
         "optionsSaved": "Opções de rota salvas"
       },
       "validation": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Сначала высокий тариф",
         "planLowFirst": "Сначала низкий тариф",
         "expirySoonFirst": "Скорое истечение сначала",
+        "random": "Случайно",
         "custom": "Настраиваемая"
       },
       "statusUnconfigured": "Не настроено",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Ожидание retry",
         "disableCooling": "Отключить cooldown",
         "saveOptions": "Сохранить параметры",
+        "immediateSseResponse": "Немедленный SSE 200",
         "optionsSaved": "Параметры маршрута сохранены"
       },
       "validation": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Önce yüksek plan",
         "planLowFirst": "Önce düşük plan",
         "expirySoonFirst": "Yakında Biten Önce",
+        "random": "Rastgele",
         "custom": "Özel"
       },
       "statusUnconfigured": "Yapılandırılmadı",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Retry bekleme",
         "disableCooling": "Cooldown kapat",
         "saveOptions": "Seçenekleri kaydet",
+        "immediateSseResponse": "Anında SSE 200",
         "optionsSaved": "Yönlendirme seçenekleri kaydedildi"
       },
       "validation": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "Ưu tiên gói cao",
         "planLowFirst": "Ưu tiên gói thấp",
         "expirySoonFirst": "Sắp hết hạn trước",
+        "random": "Phân tán ngẫu nhiên",
         "custom": "Tùy chỉnh"
       },
       "statusUnconfigured": "Chưa cấu hình",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "Chờ retry",
         "disableCooling": "Tắt cooldown",
         "saveOptions": "Lưu tùy chọn",
+        "immediateSseResponse": "SSE trả 200 ngay",
         "optionsSaved": "Đã lưu tùy chọn định tuyến"
       },
       "validation": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -2273,6 +2273,7 @@
         "planHighFirst": "优先高订阅",
         "planLowFirst": "优先低订阅",
         "expirySoonFirst": "优先近到期",
+        "random": "随机分散",
         "custom": "自定义"
       },
       "requestKind": {
@@ -3511,6 +3512,7 @@
         "maxRetryInterval": "重试等待",
         "disableCooling": "禁用冷却",
         "saveOptions": "保存选项",
+        "immediateSseResponse": "SSE 立即返回 200",
         "optionsSaved": "调度选项已保存"
       },
       "timeouts": {

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -1954,6 +1954,7 @@
         "planHighFirst": "優先高訂閱",
         "planLowFirst": "優先低訂閱",
         "expirySoonFirst": "優先近到期",
+        "random": "隨機分散",
         "custom": "自訂"
       },
       "statusUnconfigured": "未設定",
@@ -3288,6 +3289,7 @@
         "maxRetryInterval": "重試等待",
         "disableCooling": "停用冷卻",
         "saveOptions": "儲存選項",
+        "immediateSseResponse": "SSE 立即回傳 200",
         "optionsSaved": "調度選項已儲存"
       },
       "validation": {

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -663,6 +663,7 @@ export function CodexApiServicePage() {
   const [maxRetryCredentialsDraft, setMaxRetryCredentialsDraft] = useState("0");
   const [maxRetryIntervalDraft, setMaxRetryIntervalDraft] = useState("3");
   const [disableCoolingDraft, setDisableCoolingDraft] = useState(false);
+  const [immediateSseResponseDraft, setImmediateSseResponseDraft] = useState(false);
   const [requestLogPage, setRequestLogPage] = useState(1);
   const [requestLogPageSize, setRequestLogPageSize] = useState(() =>
     readStoredRequestLogPageSize(),
@@ -1293,6 +1294,7 @@ export function CodexApiServicePage() {
       formatSeconds(collection?.maxRetryIntervalMs ?? 3000),
     );
     setDisableCoolingDraft(collection?.disableCooling ?? false);
+    setImmediateSseResponseDraft(collection?.immediateSseResponse ?? false);
     setTimeoutDrafts(timeoutDraftsFromValue(collection?.timeouts));
     setSelectedTimeoutPresetId(
       collection?.activeTimeoutPresetId || "long_wait",
@@ -1306,6 +1308,7 @@ export function CodexApiServicePage() {
     collection?.maxRetryCredentials,
     collection?.maxRetryIntervalMs,
     collection?.disableCooling,
+    collection?.immediateSseResponse,
     collection?.timeouts,
     collection?.activeTimeoutPresetId,
   ]);
@@ -2268,6 +2271,7 @@ export function CodexApiServicePage() {
             maxRetryCredentials,
             maxRetryIntervalMs: maxRetryIntervalSeconds * 1000,
             disableCooling: disableCoolingDraft,
+            immediateSseResponse: immediateSseResponseDraft,
           });
         setState(next);
       },
@@ -2664,6 +2668,10 @@ export function CodexApiServicePage() {
     {
       value: "auto",
       label: t("codex.localAccess.routingStrategy.auto", "自动（推荐）"),
+    },
+    {
+      value: "random",
+      label: t("codex.localAccess.routingStrategy.random", "随机分散"),
     },
     {
       value: "single_account",
@@ -3833,6 +3841,22 @@ export function CodexApiServicePage() {
                       setDisableCoolingDraft(event.target.checked)
                     }
                     disabled={busy || !collection}
+                  />
+                </label>
+                <label>
+                  <span>
+                    {t(
+                      "codex.apiService.routing.immediateSseResponse",
+                      "SSE trả 200 ngay",
+                    )}
+                  </span>
+                  <input
+                    type="checkbox"
+                    checked={immediateSseResponseDraft}
+                    onChange={(event) =>
+                      setImmediateSseResponseDraft(event.target.checked)
+                    }
+                    disabled={busy || !collection || gatewayMode !== "sidecar"}
                   />
                 </label>
               </div>

--- a/src/services/codexLocalAccessService.ts
+++ b/src/services/codexLocalAccessService.ts
@@ -151,6 +151,7 @@ export async function updateCodexLocalAccessRoutingOptions(payload: {
   maxRetryCredentials: number;
   maxRetryIntervalMs: number;
   disableCooling: boolean;
+  immediateSseResponse: boolean;
 }): Promise<CodexLocalAccessState> {
   return await invoke("codex_local_access_update_routing_options", payload);
 }

--- a/src/types/codexLocalAccess.ts
+++ b/src/types/codexLocalAccess.ts
@@ -11,6 +11,7 @@ export type CodexLocalAccessImageGenerationStatus =
 
 export type CodexLocalAccessRoutingStrategy =
   | "auto"
+  | "random"
   | "single_account"
   | "quota_high_first"
   | "quota_low_first"
@@ -122,6 +123,7 @@ export interface CodexLocalAccessCollection {
   modelPricingVersion: number;
   modelPricings: CodexLocalAccessModelPricing[];
   debugLogs: boolean;
+  immediateSseResponse: boolean;
   excludedModels: string[];
   sessionAffinity: boolean;
   sessionAffinityTtlMs: number;


### PR DESCRIPTION
## Summary
- Add a random account-routing strategy for Codex API Service.
- Add an opt-in sidecar SSE mode that commits HTTP 200 immediately, then waits for and forwards upstream SSE events.
- Preserve session affinity, account health, cooldown, quota reserve, and model eligibility filters.
- Add localized UI labels and Codex API Service handoff documentation.

## Verification
- Passed: node scripts/check_locales.cjs
- Passed: git diff --check
- Not run: Go build/tests (Go toolchain is unavailable on this machine).
- Not run: Rust test target requires aws-lc-sys, which is not cached locally.