### PR TITLE
fix(codex): distribute concurrent image streams

### DIFF
--- a/docs/CODEX_API_SERVICE_HANDOFF.md
+++ b/docs/CODEX_API_SERVICE_HANDOFF.md
@@ -90,11 +90,17 @@ profile, especially for WSL.
 - Model aliases and filters affect both model discovery and request rewriting.
   Update both paths together and test an alias plus a rejected model.
 - Image behavior is separately configurable: enabled, images-only, or disabled.
-  Image requests and image tool injection have their own validation path.
+  Image requests and image tool injection have their own validation path. The
+  sidecar tracks in-flight image jobs by selected auth and gives each auth one
+  job slot. It selects an eligible free account with the fewest jobs and queues
+  later image requests locally until a slot is released when a request ends.
+  Image requests bypass session-affinity cache so a prior text/image request
+  cannot pin new image jobs to an already busy account.
 - `immediateSseResponse` is disabled by default. In sidecar mode it commits a
   `200 OK` SSE response with an ignored `: accepted` comment before the upstream
-  stream opens. Once HTTP headers are committed, upstream-open failures are sent
-  as SSE error data and cannot change the HTTP status.
+  stream opens. This also applies to streaming image generation and edits. Once
+  HTTP headers are committed, upstream-open failures are sent as SSE `error`
+  events and cannot change the HTTP status.
 
 ## Persistent Artifacts And Logs
 

--- a/docs/CODEX_API_SERVICE_HANDOFF.md
+++ b/docs/CODEX_API_SERVICE_HANDOFF.md
@@ -91,9 +91,10 @@ profile, especially for WSL.
   Update both paths together and test an alias plus a rejected model.
 - Image behavior is separately configurable: enabled, images-only, or disabled.
   Image requests and image tool injection have their own validation path. The
-  sidecar tracks in-flight image jobs by selected auth and gives each auth one
-  job slot. It selects an eligible free account with the fewest jobs and queues
-  later image requests locally until a slot is released when a request ends.
+  sidecar tracks in-flight image jobs by selected auth. `maxConcurrentImageRequests`
+  configures the number of job slots per account (default `1`, range `1-16`).
+  It selects an eligible account with the fewest jobs and queues later image
+  requests locally until a slot is released when a request ends.
   Image requests bypass session-affinity cache so a prior text/image request
   cannot pin new image jobs to an already busy account.
 - `immediateSseResponse` is disabled by default. In sidecar mode it commits a

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -299,13 +299,94 @@ type requestUsageTracker struct {
 	mu               sync.Mutex
 	records          map[string][]usagePayload
 	selectedAccounts map[string]selectedAccountRecord
+	imageJobs        map[string]map[string]struct{}
+	imageInFlight    map[string]int
+	imageJobsChanged chan struct{}
 }
 
 func newRequestUsageTracker() *requestUsageTracker {
 	return &requestUsageTracker{
 		records:          make(map[string][]usagePayload),
 		selectedAccounts: make(map[string]selectedAccountRecord),
+		imageJobs:        make(map[string]map[string]struct{}),
+		imageInFlight:    make(map[string]int),
+		imageJobsChanged: make(chan struct{}),
 	}
+}
+
+func (t *requestUsageTracker) imageInFlightCount(authID string) int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.imageInFlight[strings.TrimSpace(authID)]
+}
+
+func (t *requestUsageTracker) tryReserveImageJob(requestID, authID string) bool {
+	if t == nil {
+		return true
+	}
+	requestID = strings.TrimSpace(requestID)
+	authID = strings.TrimSpace(authID)
+	if requestID == "" || authID == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	jobs := t.imageJobs[requestID]
+	if jobs == nil {
+		jobs = make(map[string]struct{})
+		t.imageJobs[requestID] = jobs
+	}
+	if _, alreadyReserved := jobs[authID]; alreadyReserved {
+		return true
+	}
+	if t.imageInFlight[authID] > 0 {
+		return false
+	}
+	jobs[authID] = struct{}{}
+	t.imageInFlight[authID]++
+	return true
+}
+
+func (t *requestUsageTracker) imageJobChangeSignal() <-chan struct{} {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	changed := t.imageJobsChanged
+	t.mu.Unlock()
+	return changed
+}
+
+func (t *requestUsageTracker) notifyImageJobChangeLocked() {
+	if t == nil || t.imageJobsChanged == nil {
+		return
+	}
+	close(t.imageJobsChanged)
+	t.imageJobsChanged = make(chan struct{})
+}
+
+func (t *requestUsageTracker) releaseImageJobs(requestID string) {
+	if t == nil {
+		return
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for authID := range t.imageJobs[requestID] {
+		if t.imageInFlight[authID] <= 1 {
+			delete(t.imageInFlight, authID)
+		} else {
+			t.imageInFlight[authID]--
+		}
+	}
+	delete(t.imageJobs, requestID)
+	t.notifyImageJobChangeLocked()
 }
 
 func (t *requestUsageTracker) record(payload usagePayload) {
@@ -829,6 +910,7 @@ func (p *requestPolicy) emitRequestCompleted(c *gin.Context, requestID string, s
 	if p.tracker == nil || !shouldEmitRequestDiagnostic(c.Request) {
 		return
 	}
+	p.tracker.releaseImageJobs(requestID)
 	if payload, ok := p.tracker.finalize(requestID, usageFinalizeInput{
 		spec:          spec,
 		requestKind:   requestKind,
@@ -1497,6 +1579,7 @@ type cockpitSelector struct {
 	manifest *manifest
 	emitter  *eventEmitter
 	quota    *quotaReserveStateStore
+	tracker  *requestUsageTracker
 	mu       sync.Mutex
 	cursor   int
 }
@@ -1505,6 +1588,28 @@ type recordingSelector struct {
 	inner    coreauth.Selector
 	manifest *manifest
 	tracker  *requestUsageTracker
+}
+
+type imageRequestSelector struct {
+	imageFallback coreauth.Selector
+	fallback      coreauth.Selector
+}
+
+func (s *imageRequestSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
+	requestKind, _ := ctx.Value(requestKindContextKey).(string)
+	if isImageRequestKind(requestKind) && s.imageFallback != nil {
+		return s.imageFallback.Pick(ctx, provider, model, opts, auths)
+	}
+	if s.fallback == nil {
+		return nil, fmt.Errorf("image request selector fallback is not initialized")
+	}
+	return s.fallback.Pick(ctx, provider, model, opts, auths)
+}
+
+func (s *imageRequestSelector) Stop() {
+	if stoppable, ok := s.fallback.(coreauth.StoppableSelector); ok {
+		stoppable.Stop()
+	}
 }
 
 func (s *recordingSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
@@ -1771,13 +1876,59 @@ func (s *cockpitSelector) Pick(ctx context.Context, provider, model string, opts
 	s.cursor++
 	s.mu.Unlock()
 
+	requestKind, _ := ctx.Value(requestKindContextKey).(string)
 	ordered := s.orderAuths(available, start)
+	if isImageRequestKind(requestKind) {
+		ordered = s.orderImageAuths(available, start)
+	}
 	if len(ordered) == 0 {
 		return nil, noAuthAvailableError(quotaReserveReasons)
+	}
+	if isImageRequestKind(requestKind) && s.tracker != nil {
+		requestID := internallogging.GetRequestID(ctx)
+		for {
+			changed := s.tracker.imageJobChangeSignal()
+			for _, candidate := range s.orderImageAuths(available, start) {
+				if s.tracker.tryReserveImageJob(requestID, candidate.ID) {
+					s.emitAuthSelected(ctx, candidate, provider, model, len(auths), len(available))
+					return candidate, nil
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-changed:
+			}
+		}
 	}
 	selected := ordered[0]
 	s.emitAuthSelected(ctx, selected, provider, model, len(auths), len(available))
 	return selected, nil
+}
+
+func isImageRequestKind(requestKind string) bool {
+	switch strings.TrimSpace(requestKind) {
+	case "image_generation", "image_edit":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *cockpitSelector) orderImageAuths(auths []*coreauth.Auth, start int) []*coreauth.Auth {
+	if len(auths) <= 1 || s == nil || s.tracker == nil {
+		return s.orderAuths(auths, start)
+	}
+	out := append([]*coreauth.Auth(nil), auths...)
+	sort.SliceStable(out, func(i, j int) bool {
+		leftJobs := s.tracker.imageInFlightCount(out[i].ID)
+		rightJobs := s.tracker.imageInFlightCount(out[j].ID)
+		if leftJobs != rightJobs {
+			return leftJobs < rightJobs
+		}
+		return s.rotatedIndex(s.accountForAuth(out[i]), start) < s.rotatedIndex(s.accountForAuth(out[j]), start)
+	})
+	return out
 }
 
 func quotaReserveBlockReason(account *accountSpec, now time.Time) string {
@@ -2463,14 +2614,16 @@ func buildCoreAuthSelector(cfg *config.Config, selector coreauth.Selector, m *ma
 		selector = &coreauth.RoundRobinSelector{}
 	}
 	if cfg != nil && cfg.Routing.SessionAffinity {
+		imageFallback := selector
 		ttl := time.Hour
 		if parsed, err := time.ParseDuration(strings.TrimSpace(cfg.Routing.SessionAffinityTTL)); err == nil && parsed > 0 {
 			ttl = parsed
 		}
-		selector = coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
+		affinitySelector := coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
 			Fallback: selector,
 			TTL:      ttl,
 		})
+		selector = &imageRequestSelector{imageFallback: imageFallback, fallback: affinitySelector}
 	}
 	if m != nil {
 		selector = &backupAccountSelector{manifest: m, fallback: selector}
@@ -3447,19 +3600,41 @@ func (s *relayServer) handleImagesRelayRequest(c *gin.Context, imageReq imageRel
 	req, opts := buildExecutorRequest(c, imageReq.body, model, sdktranslator.FormatOpenAIResponse, "", true)
 	startedAt := time.Now()
 	timeouts := s.streamTimeoutsForRequest(c.Request, imageReq.body, defaultImagesToolModel)
+	immediateSSE := imageReq.stream && s.manifest != nil && s.manifest.ImmediateSSEResponse
+	var immediateFlusher http.Flusher
+	if immediateSSE {
+		flusher, ok := c.Writer.(http.Flusher)
+		if !ok {
+			writeAPIError(c, http.StatusInternalServerError, "streaming not supported", "streaming_not_supported")
+			return
+		}
+		setEventStreamHeaders(c.Writer.Header())
+		c.Status(http.StatusOK)
+		_, _ = c.Writer.Write([]byte(": accepted\n\n"))
+		flusher.Flush()
+		immediateFlusher = flusher
+	}
 	streamCtx, cancelStream := context.WithCancel(relayContext(c))
 	defer cancelStream()
 	result, err := s.executeStreamWithOpenTimeout(c, streamCtx, []string{"codex"}, req, opts, model, startedAt, timeouts.open)
 	if err != nil {
+		if immediateSSE {
+			writeImagesStreamError(c, immediateFlusher, err)
+			return
+		}
 		s.writeExecutorError(c, err)
 		return
 	}
 	if result == nil || result.Chunks == nil {
+		if immediateSSE {
+			writeImagesStreamError(c, immediateFlusher, relayStatusError{status: http.StatusBadGateway, message: "upstream stream is unavailable"})
+			return
+		}
 		writeAPIError(c, http.StatusBadGateway, "upstream stream is unavailable", "bad_gateway")
 		return
 	}
 	if imageReq.stream {
-		s.forwardImagesStream(c, streamCtx, result, imageReq, timeouts.idle)
+		s.forwardImagesStream(c, streamCtx, result, imageReq, timeouts.idle, immediateSSE)
 		return
 	}
 	out, err := collectImagesResponse(streamCtx, result.Chunks, imageReq.responseFormat, timeouts.idle)
@@ -3471,15 +3646,17 @@ func (s *relayServer) handleImagesRelayRequest(c *gin.Context, imageReq imageRel
 	c.Data(http.StatusOK, "application/json", out)
 }
 
-func (s *relayServer) forwardImagesStream(c *gin.Context, ctx context.Context, result *cliproxyexecutor.StreamResult, imageReq imageRelayRequest, idleTimeout time.Duration) {
+func (s *relayServer) forwardImagesStream(c *gin.Context, ctx context.Context, result *cliproxyexecutor.StreamResult, imageReq imageRelayRequest, idleTimeout time.Duration, headersCommitted bool) {
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
 		writeAPIError(c, http.StatusInternalServerError, "streaming not supported", "streaming_not_supported")
 		return
 	}
-	setEventStreamHeaders(c.Writer.Header())
-	writeUpstreamHeaders(c.Writer.Header(), result.Headers)
-	c.Status(http.StatusOK)
+	if !headersCommitted {
+		setEventStreamHeaders(c.Writer.Header())
+		writeUpstreamHeaders(c.Writer.Header(), result.Headers)
+		c.Status(http.StatusOK)
+	}
 
 	writeEvent := func(eventName string, payload []byte) {
 		if strings.TrimSpace(eventName) != "" {
@@ -3489,15 +3666,7 @@ func (s *relayServer) forwardImagesStream(c *gin.Context, ctx context.Context, r
 		flusher.Flush()
 	}
 	writeErr := func(err error) {
-		status := statusCodeFromError(err)
-		payload, _ := json.Marshal(map[string]any{
-			"error": map[string]any{
-				"message": errorMessage(err),
-				"type":    "upstream_error",
-				"code":    status,
-			},
-		})
-		writeEvent("error", payload)
+		writeImagesStreamError(c, flusher, err)
 	}
 
 	acc := &imageSSEAccumulator{}
@@ -3543,6 +3712,21 @@ func (s *relayServer) forwardImagesStream(c *gin.Context, ctx context.Context, r
 			}
 		}
 	}
+}
+
+func writeImagesStreamError(c *gin.Context, flusher http.Flusher, err error) {
+	if c == nil || flusher == nil {
+		return
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"message": errorMessage(err),
+			"type":    "upstream_error",
+			"code":    statusCodeFromError(err),
+		},
+	})
+	_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", string(payload))
+	flusher.Flush()
 }
 
 func forwardImageResponseFrame(frame []byte, imageReq imageRelayRequest, writeEvent func(string, []byte), writeErr func(error)) bool {
@@ -6452,7 +6636,7 @@ func main() {
 	usageTracker := newRequestUsageTracker()
 	policy := &requestPolicy{manifest: m, emitter: emitter, tracker: usageTracker}
 	hook := &authHook{manifest: m, emitter: emitter}
-	selector := &cockpitSelector{manifest: m, emitter: emitter, quota: quotaState}
+	selector := &cockpitSelector{manifest: m, emitter: emitter, quota: quotaState, tracker: usageTracker}
 	coreManager := buildCoreAuthManager(cfg, selector, hook, m, quotaState, usageTracker)
 
 	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -89,8 +89,9 @@ type manifest struct {
 	ExcludedModels     []string            `json:"excludedModels"`
 	RoutingStrategy    string              `json:"routingStrategy"`
 	CustomRoutingRules []customRoutingRule `json:"customRoutingRules"`
-	ImmediateSSEResponse bool              `json:"immediateSseResponse"`
-	DebugLogs          *bool               `json:"debugLogs,omitempty"`
+	ImmediateSSEResponse       bool              `json:"immediateSseResponse"`
+	MaxConcurrentImageRequests int               `json:"maxConcurrentImageRequests"`
+	DebugLogs                  *bool               `json:"debugLogs,omitempty"`
 
 	apiKeyByValue     map[string]*apiKeySpec
 	accountByID       map[string]*accountSpec
@@ -323,7 +324,7 @@ func (t *requestUsageTracker) imageInFlightCount(authID string) int {
 	return t.imageInFlight[strings.TrimSpace(authID)]
 }
 
-func (t *requestUsageTracker) tryReserveImageJob(requestID, authID string) bool {
+func (t *requestUsageTracker) tryReserveImageJob(requestID, authID string, maxConcurrent int) bool {
 	if t == nil {
 		return true
 	}
@@ -331,6 +332,9 @@ func (t *requestUsageTracker) tryReserveImageJob(requestID, authID string) bool 
 	authID = strings.TrimSpace(authID)
 	if requestID == "" || authID == "" {
 		return false
+	}
+	if maxConcurrent < 1 {
+		maxConcurrent = 1
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -342,7 +346,7 @@ func (t *requestUsageTracker) tryReserveImageJob(requestID, authID string) bool 
 	if _, alreadyReserved := jobs[authID]; alreadyReserved {
 		return true
 	}
-	if t.imageInFlight[authID] > 0 {
+	if t.imageInFlight[authID] >= maxConcurrent {
 		return false
 	}
 	jobs[authID] = struct{}{}
@@ -1889,7 +1893,7 @@ func (s *cockpitSelector) Pick(ctx context.Context, provider, model string, opts
 		for {
 			changed := s.tracker.imageJobChangeSignal()
 			for _, candidate := range s.orderImageAuths(available, start) {
-				if s.tracker.tryReserveImageJob(requestID, candidate.ID) {
+				if s.tracker.tryReserveImageJob(requestID, candidate.ID, s.maxConcurrentImageRequests()) {
 					s.emitAuthSelected(ctx, candidate, provider, model, len(auths), len(available))
 					return candidate, nil
 				}
@@ -1904,6 +1908,13 @@ func (s *cockpitSelector) Pick(ctx context.Context, provider, model string, opts
 	selected := ordered[0]
 	s.emitAuthSelected(ctx, selected, provider, model, len(auths), len(available))
 	return selected, nil
+}
+
+func (s *cockpitSelector) maxConcurrentImageRequests() int {
+	if s == nil || s.manifest == nil || s.manifest.MaxConcurrentImageRequests < 1 {
+		return 1
+	}
+	return s.manifest.MaxConcurrentImageRequests
 }
 
 func isImageRequestKind(requestKind string) bool {

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -273,6 +273,75 @@ func TestCockpitSelectorPickSkipsBoundOAuthAtEitherQuotaReserve(t *testing.T) {
 	}
 }
 
+func TestCockpitSelectorPrefersAccountWithFewerImageJobs(t *testing.T) {
+	busyAccount := &accountSpec{ID: "busy", AuthID: "busy.json"}
+	idleAccount := &accountSpec{ID: "idle", AuthID: "idle.json"}
+	tracker := newRequestUsageTracker()
+	if !tracker.tryReserveImageJob("existing-image", "busy.json") {
+		t.Fatal("expected initial busy image reservation")
+	}
+	if tracker.tryReserveImageJob("competing-image", "busy.json") {
+		t.Fatal("expected busy image auth to reject a second concurrent reservation")
+	}
+	selector := &cockpitSelector{
+		manifest: &manifest{accountByAuthID: map[string]*accountSpec{
+			"busy.json": busyAccount,
+			"idle.json": idleAccount,
+		}},
+		tracker: tracker,
+	}
+	ctx := internallogging.WithRequestID(context.Background(), "new-image")
+	ctx = context.WithValue(ctx, requestKindContextKey, "image_generation")
+
+	selected, err := selector.Pick(
+		ctx,
+		"codex",
+		"gpt-5.4-mini",
+		cliproxyexecutor.Options{},
+		[]*coreauth.Auth{{ID: "busy.json"}, {ID: "idle.json"}},
+	)
+	if err != nil {
+		t.Fatalf("Pick: %v", err)
+	}
+	if selected == nil || selected.ID != "idle.json" {
+		t.Fatalf("expected idle auth, got %#v", selected)
+	}
+	if got := tracker.imageInFlightCount("idle.json"); got != 1 {
+		t.Fatalf("idle auth in-flight count = %d, want 1", got)
+	}
+
+	changed := tracker.imageJobChangeSignal()
+	tracker.releaseImageJobs("new-image")
+	select {
+	case <-changed:
+	default:
+		t.Fatal("expected image slot release notification")
+	}
+	if got := tracker.imageInFlightCount("idle.json"); got != 0 {
+		t.Fatalf("idle auth in-flight count after release = %d, want 0", got)
+	}
+}
+
+func TestImageRequestSelectorBypassesSessionAffinityFallback(t *testing.T) {
+	imageAuth := &coreauth.Auth{ID: "image.json"}
+	affinityAuth := &coreauth.Auth{ID: "affinity.json"}
+	imageFallback := &countingSelector{auth: imageAuth}
+	affinityFallback := &countingSelector{auth: affinityAuth}
+	selector := &imageRequestSelector{
+		imageFallback: imageFallback,
+		fallback:      affinityFallback,
+	}
+	ctx := context.WithValue(context.Background(), requestKindContextKey, "image_generation")
+
+	selected, err := selector.Pick(ctx, "codex", "gpt-5.4-mini", cliproxyexecutor.Options{}, []*coreauth.Auth{imageAuth, affinityAuth})
+	if err != nil {
+		t.Fatalf("Pick: %v", err)
+	}
+	if selected != imageAuth || imageFallback.count != 1 || affinityFallback.count != 0 {
+		t.Fatalf("image request should use image fallback, selected=%#v image=%d affinity=%d", selected, imageFallback.count, affinityFallback.count)
+	}
+}
+
 func TestCockpitSelectorPickIgnoresExplicitlyMissingQuotaWindow(t *testing.T) {
 	hourlyThreshold := 10
 	weeklyThreshold := 20

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -277,10 +277,10 @@ func TestCockpitSelectorPrefersAccountWithFewerImageJobs(t *testing.T) {
 	busyAccount := &accountSpec{ID: "busy", AuthID: "busy.json"}
 	idleAccount := &accountSpec{ID: "idle", AuthID: "idle.json"}
 	tracker := newRequestUsageTracker()
-	if !tracker.tryReserveImageJob("existing-image", "busy.json") {
+	if !tracker.tryReserveImageJob("existing-image", "busy.json", 1) {
 		t.Fatal("expected initial busy image reservation")
 	}
-	if tracker.tryReserveImageJob("competing-image", "busy.json") {
+	if tracker.tryReserveImageJob("competing-image", "busy.json", 1) {
 		t.Fatal("expected busy image auth to reject a second concurrent reservation")
 	}
 	selector := &cockpitSelector{
@@ -319,6 +319,22 @@ func TestCockpitSelectorPrefersAccountWithFewerImageJobs(t *testing.T) {
 	}
 	if got := tracker.imageInFlightCount("idle.json"); got != 0 {
 		t.Fatalf("idle auth in-flight count after release = %d, want 0", got)
+	}
+}
+
+func TestRequestUsageTrackerHonorsConfiguredImageJobLimit(t *testing.T) {
+	tracker := newRequestUsageTracker()
+	if !tracker.tryReserveImageJob("first-image", "shared.json", 2) {
+		t.Fatal("expected first image reservation")
+	}
+	if !tracker.tryReserveImageJob("second-image", "shared.json", 2) {
+		t.Fatal("expected second image reservation within configured limit")
+	}
+	if tracker.tryReserveImageJob("third-image", "shared.json", 2) {
+		t.Fatal("expected image reservation above configured limit to be rejected")
+	}
+	if got := tracker.imageInFlightCount("shared.json"); got != 2 {
+		t.Fatalf("shared auth in-flight count = %d, want 2", got)
 	}
 }
 

--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -3174,6 +3174,7 @@ pub async fn codex_local_access_update_routing_options(
     max_retry_interval_ms: u64,
     disable_cooling: bool,
     immediate_sse_response: bool,
+    max_concurrent_image_requests: u16,
 ) -> Result<CodexLocalAccessState, String> {
     codex_local_access::update_local_access_routing_options(
         session_affinity,
@@ -3182,6 +3183,7 @@ pub async fn codex_local_access_update_routing_options(
         max_retry_interval_ms,
         disable_cooling,
         immediate_sse_response,
+        max_concurrent_image_requests,
     )
     .await
 }

--- a/src-tauri/src/models/codex_local_access.rs
+++ b/src-tauri/src/models/codex_local_access.rs
@@ -183,6 +183,10 @@ fn default_max_retry_interval_ms() -> u64 {
     3 * 1000
 }
 
+fn default_max_concurrent_image_requests() -> u16 {
+    1
+}
+
 fn default_legacy_request_read_timeout_ms() -> u64 {
     60 * 1000
 }
@@ -485,6 +489,8 @@ pub struct CodexLocalAccessCollection {
     pub debug_logs: bool,
     #[serde(default)]
     pub immediate_sse_response: bool,
+    #[serde(default = "default_max_concurrent_image_requests")]
+    pub max_concurrent_image_requests: u16,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bound_oauth_account_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -107,6 +107,7 @@ const DEFAULT_SESSION_AFFINITY_TTL_MS: i64 = 60 * 60 * 1000;
 const MAX_RETRY_INTERVAL_MIN_MS: u64 = 0;
 const MAX_RETRY_INTERVAL_MAX_MS: u64 = 30 * 1000;
 const DEFAULT_MAX_RETRY_INTERVAL_MS: u64 = 3 * 1000;
+const MAX_CONCURRENT_IMAGE_REQUESTS_PER_ACCOUNT: u16 = 16;
 const LOCAL_ACCESS_TIMEOUT_MIN_MS: u64 = 1_000;
 const LOCAL_ACCESS_TIMEOUT_MAX_MS: u64 = 600_000;
 const LEGACY_STREAM_TOTAL_TIMEOUT_MAX_MS: u64 = 30 * 60 * 1000;
@@ -10016,6 +10017,7 @@ async fn prepare_sidecar_launch_config_in_dir(
         })).collect::<Vec<_>>(),
         "debugLogs": collection.debug_logs,
         "immediateSseResponse": collection.immediate_sse_response,
+        "maxConcurrentImageRequests": collection.max_concurrent_image_requests,
     });
 
     let mut config = Map::new();
@@ -12845,6 +12847,7 @@ async fn ensure_runtime_loaded_without_start_with_profile_restore(
             restrict_free_accounts: true,
             debug_logs: true,
             immediate_sse_response: false,
+            max_concurrent_image_requests: 1,
             bound_oauth_account_id: None,
             bound_oauth_quota_reserve: None,
             account_ids: Vec::new(),
@@ -14117,6 +14120,7 @@ fn new_empty_local_access_collection() -> Result<CodexLocalAccessCollection, Str
         restrict_free_accounts: true,
         debug_logs: true,
         immediate_sse_response: false,
+        max_concurrent_image_requests: 1,
         bound_oauth_account_id: None,
         bound_oauth_quota_reserve: None,
         account_ids: Vec::new(),
@@ -16775,6 +16779,7 @@ fn new_local_access_collection() -> Result<CodexLocalAccessCollection, String> {
         restrict_free_accounts: true,
         debug_logs: true,
         immediate_sse_response: false,
+        max_concurrent_image_requests: 1,
         bound_oauth_account_id: None,
         bound_oauth_quota_reserve: None,
         account_ids: Vec::new(),
@@ -17214,6 +17219,7 @@ pub async fn update_local_access_routing_options(
     max_retry_interval_ms: u64,
     disable_cooling: bool,
     immediate_sse_response: bool,
+    max_concurrent_image_requests: u16,
 ) -> Result<CodexLocalAccessState, String> {
     ensure_runtime_loaded().await?;
 
@@ -17236,6 +17242,8 @@ pub async fn update_local_access_routing_options(
         max_retry_interval_ms.clamp(MAX_RETRY_INTERVAL_MIN_MS, MAX_RETRY_INTERVAL_MAX_MS);
     collection.disable_cooling = disable_cooling;
     collection.immediate_sse_response = immediate_sse_response;
+    collection.max_concurrent_image_requests = max_concurrent_image_requests
+        .clamp(1, MAX_CONCURRENT_IMAGE_REQUESTS_PER_ACCOUNT);
     collection.updated_at = now_ms();
     save_collection_to_disk(&collection)?;
 
@@ -22939,6 +22947,7 @@ mod tests {
             restrict_free_accounts: true,
             debug_logs: true,
             immediate_sse_response: false,
+            max_concurrent_image_requests: 1,
             bound_oauth_account_id: None,
             bound_oauth_quota_reserve: None,
             account_ids,

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -3337,6 +3337,7 @@
         "disableCooling": "تعطيل cooldown",
         "saveOptions": "حفظ الخيارات",
         "immediateSseResponse": "SSE فوري 200",
+        "maxConcurrentImageRequests": "طلبات الصور لكل حساب",
         "optionsSaved": "تم حفظ خيارات التوجيه"
       },
       "validation": {

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Vypnout cooldown",
         "saveOptions": "Uložit volby",
         "immediateSseResponse": "Okamžitá SSE 200",
+        "maxConcurrentImageRequests": "Požadavky na obrázky na účet",
         "optionsSaved": "Volby směrování uloženy"
       },
       "validation": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Cooldown deaktivieren",
         "saveOptions": "Optionen speichern",
         "immediateSseResponse": "Sofortiges SSE 200",
+        "maxConcurrentImageRequests": "Bildanfragen pro Konto",
         "optionsSaved": "Routingoptionen gespeichert"
       },
       "validation": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -3513,6 +3513,7 @@
         "disableCooling": "Disable Cooldown",
         "saveOptions": "Save Options",
         "immediateSseResponse": "Immediate SSE 200",
+        "maxConcurrentImageRequests": "Image requests per account",
         "optionsSaved": "Routing options saved"
       },
       "timeouts": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3513,6 +3513,7 @@
         "disableCooling": "Disable Cooldown",
         "saveOptions": "Save Options",
         "immediateSseResponse": "Immediate SSE 200",
+        "maxConcurrentImageRequests": "Image requests per account",
         "optionsSaved": "Routing options saved"
       },
       "timeouts": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Desactivar cooldown",
         "saveOptions": "Guardar opciones",
         "immediateSseResponse": "SSE 200 inmediato",
+        "maxConcurrentImageRequests": "Solicitudes de imagen por cuenta",
         "optionsSaved": "Opciones de ruta guardadas"
       },
       "validation": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Désactiver cooldown",
         "saveOptions": "Enregistrer",
         "immediateSseResponse": "SSE 200 immédiat",
+        "maxConcurrentImageRequests": "Requêtes d'images par compte",
         "optionsSaved": "Options de routage enregistrées"
       },
       "validation": {

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -3337,6 +3337,7 @@
         "disableCooling": "Matikan cooldown",
         "saveOptions": "Simpan Opsi",
         "immediateSseResponse": "SSE 200 langsung",
+        "maxConcurrentImageRequests": "Permintaan gambar per akun",
         "optionsSaved": "Opsi routing tersimpan"
       },
       "validation": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Disattiva cooldown",
         "saveOptions": "Salva opzioni",
         "immediateSseResponse": "SSE 200 immediato",
+        "maxConcurrentImageRequests": "Richieste di immagini per account",
         "optionsSaved": "Opzioni routing salvate"
       },
       "validation": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "クールダウン無効",
         "saveOptions": "設定を保存",
         "immediateSseResponse": "即時 SSE 200",
+        "maxConcurrentImageRequests": "アカウントごとの画像リクエスト",
         "optionsSaved": "ルーティング設定を保存しました"
       },
       "validation": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "쿨다운 끄기",
         "saveOptions": "옵션 저장",
         "immediateSseResponse": "즉시 SSE 200",
+        "maxConcurrentImageRequests": "계정당 이미지 요청",
         "optionsSaved": "라우팅 옵션 저장됨"
       },
       "validation": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Wyłącz cooldown",
         "saveOptions": "Zapisz opcje",
         "immediateSseResponse": "Natychmiastowe SSE 200",
+        "maxConcurrentImageRequests": "Żądania obrazów na konto",
         "optionsSaved": "Opcje routingu zapisane"
       },
       "validation": {

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Desativar cooldown",
         "saveOptions": "Salvar opções",
         "immediateSseResponse": "SSE 200 imediato",
+        "maxConcurrentImageRequests": "Solicitações de imagem por conta",
         "optionsSaved": "Opções de rota salvas"
       },
       "validation": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Отключить cooldown",
         "saveOptions": "Сохранить параметры",
         "immediateSseResponse": "Немедленный SSE 200",
+        "maxConcurrentImageRequests": "Запросы изображений на аккаунт",
         "optionsSaved": "Параметры маршрута сохранены"
       },
       "validation": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Cooldown kapat",
         "saveOptions": "Seçenekleri kaydet",
         "immediateSseResponse": "Anında SSE 200",
+        "maxConcurrentImageRequests": "Hesap başına görsel isteği",
         "optionsSaved": "Yönlendirme seçenekleri kaydedildi"
       },
       "validation": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "Tắt cooldown",
         "saveOptions": "Lưu tùy chọn",
         "immediateSseResponse": "SSE trả 200 ngay",
+        "maxConcurrentImageRequests": "Yêu cầu ảnh mỗi tài khoản",
         "optionsSaved": "Đã lưu tùy chọn định tuyến"
       },
       "validation": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -3513,6 +3513,7 @@
         "disableCooling": "禁用冷却",
         "saveOptions": "保存选项",
         "immediateSseResponse": "SSE 立即返回 200",
+        "maxConcurrentImageRequests": "每个账户的图片请求数",
         "optionsSaved": "调度选项已保存"
       },
       "timeouts": {

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -3290,6 +3290,7 @@
         "disableCooling": "停用冷卻",
         "saveOptions": "儲存選項",
         "immediateSseResponse": "SSE 立即回傳 200",
+        "maxConcurrentImageRequests": "每個帳戶的圖片請求數",
         "optionsSaved": "調度選項已儲存"
       },
       "validation": {

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -664,6 +664,8 @@ export function CodexApiServicePage() {
   const [maxRetryIntervalDraft, setMaxRetryIntervalDraft] = useState("3");
   const [disableCoolingDraft, setDisableCoolingDraft] = useState(false);
   const [immediateSseResponseDraft, setImmediateSseResponseDraft] = useState(false);
+  const [maxConcurrentImageRequestsDraft, setMaxConcurrentImageRequestsDraft] =
+    useState("1");
   const [requestLogPage, setRequestLogPage] = useState(1);
   const [requestLogPageSize, setRequestLogPageSize] = useState(() =>
     readStoredRequestLogPageSize(),
@@ -1295,6 +1297,9 @@ export function CodexApiServicePage() {
     );
     setDisableCoolingDraft(collection?.disableCooling ?? false);
     setImmediateSseResponseDraft(collection?.immediateSseResponse ?? false);
+    setMaxConcurrentImageRequestsDraft(
+      String(collection?.maxConcurrentImageRequests ?? 1),
+    );
     setTimeoutDrafts(timeoutDraftsFromValue(collection?.timeouts));
     setSelectedTimeoutPresetId(
       collection?.activeTimeoutPresetId || "long_wait",
@@ -1309,6 +1314,7 @@ export function CodexApiServicePage() {
     collection?.maxRetryIntervalMs,
     collection?.disableCooling,
     collection?.immediateSseResponse,
+    collection?.maxConcurrentImageRequests,
     collection?.timeouts,
     collection?.activeTimeoutPresetId,
   ]);
@@ -2262,6 +2268,21 @@ export function CodexApiServicePage() {
       );
       return;
     }
+    const maxConcurrentImageRequests = parseIntegerDraft(
+      maxConcurrentImageRequestsDraft,
+      1,
+      16,
+    );
+    if (maxConcurrentImageRequests === null) {
+      setError(
+        t("codex.apiService.validation.numberRange", {
+          min: 1,
+          max: 16,
+          defaultValue: "Please enter a number between {{min}} and {{max}}",
+        }),
+      );
+      return;
+    }
     await runAction(
       async () => {
         const next =
@@ -2272,6 +2293,7 @@ export function CodexApiServicePage() {
             maxRetryIntervalMs: maxRetryIntervalSeconds * 1000,
             disableCooling: disableCoolingDraft,
             immediateSseResponse: immediateSseResponseDraft,
+            maxConcurrentImageRequests,
           });
         setState(next);
       },
@@ -3855,6 +3877,24 @@ export function CodexApiServicePage() {
                     checked={immediateSseResponseDraft}
                     onChange={(event) =>
                       setImmediateSseResponseDraft(event.target.checked)
+                    }
+                    disabled={busy || !collection || gatewayMode !== "sidecar"}
+                  />
+                </label>
+                <label>
+                  <span>
+                    {t(
+                      "codex.apiService.routing.maxConcurrentImageRequests",
+                      "Image requests per account",
+                    )}
+                  </span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={16}
+                    value={maxConcurrentImageRequestsDraft}
+                    onChange={(event) =>
+                      setMaxConcurrentImageRequestsDraft(event.target.value)
                     }
                     disabled={busy || !collection || gatewayMode !== "sidecar"}
                   />

--- a/src/services/codexLocalAccessService.ts
+++ b/src/services/codexLocalAccessService.ts
@@ -152,6 +152,7 @@ export async function updateCodexLocalAccessRoutingOptions(payload: {
   maxRetryIntervalMs: number;
   disableCooling: boolean;
   immediateSseResponse: boolean;
+  maxConcurrentImageRequests: number;
 }): Promise<CodexLocalAccessState> {
   return await invoke("codex_local_access_update_routing_options", payload);
 }

--- a/src/types/codexLocalAccess.ts
+++ b/src/types/codexLocalAccess.ts
@@ -124,6 +124,7 @@ export interface CodexLocalAccessCollection {
   modelPricings: CodexLocalAccessModelPricing[];
   debugLogs: boolean;
   immediateSseResponse: boolean;
+  maxConcurrentImageRequests: number;
   excludedModels: string[];
   sessionAffinity: boolean;
   sessionAffinityTtlMs: number;


### PR DESCRIPTION
## Summary
- Limit each Codex auth to one in-flight image generation or edit job.
- Prefer idle eligible accounts and queue excess image requests locally instead of allowing opaque upstream queues.
- Bypass session affinity for image requests so a cached account cannot receive overlapping image jobs.
- Apply immediate SSE acceptance to streaming image endpoints and report upstream-open failures as SSE error events.

## Verification
- Passed: node scripts/check_locales.cjs
- Passed: git diff --check
- Added sidecar unit tests for image job reservation, release notification, idle-account preference, and affinity bypass.
- Not run locally: Go toolchain is unavailable on this machine.