### PR TITLE
feat(codex): show cached tokens in API stats

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1961,6 +1961,7 @@
         "requestsDetail": "نجاح {{success}} / فشل {{failed}} / إلغاء {{canceled}} / فشل المصدر {{upstreamFailed}} / غير مكتمل {{incomplete}}",
         "tokens": "الرموز",
         "tokensDetail": "إدخال {{input}} / إخراج {{output}}",
+        "cached": "الذاكرة",
         "specialTokens": "الذاكرة / التفكير",
         "specialTokensDetail": "الذاكرة {{cached}} / التفكير {{reasoning}}",
         "avgLatency": "متوسط التأخير",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "OK {{success}} / Chyba {{failed}} / Zruš. {{canceled}} / Zdroj {{upstreamFailed}} / Nedok. {{incomplete}}",
         "tokens": "Tokeny",
         "tokensDetail": "Vstup {{input}} / Výstup {{output}}",
+        "cached": "Mezipaměť",
         "specialTokens": "Cache / Přemýšlení",
         "specialTokensDetail": "Cache {{cached}} / Přemýšlení {{reasoning}}",
         "avgLatency": "Průměrná latence",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "OK {{success}} / Fehler {{failed}} / Abbr. {{canceled}} / Quelle {{upstreamFailed}} / Unvollst. {{incomplete}}",
         "tokens": "Token",
         "tokensDetail": "Eingabe {{input}} / Ausgabe {{output}}",
+        "cached": "Zwischenspeicher",
         "specialTokens": "Cache / Denken",
         "specialTokensDetail": "Cache {{cached}} / Denken {{reasoning}}",
         "avgLatency": "Durchschn. Latenz",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -2292,6 +2292,7 @@
         "requestsDetail": "OK {{success}} / Fail {{failed}} / Cancel {{canceled}} / Upstream {{upstreamFailed}} / Incomplete {{incomplete}}",
         "tokens": "Tokens",
         "tokensDetail": "Input {{input}} / Output {{output}}",
+        "cached": "Cache",
         "estimatedCost": "Estimated Value",
         "estimatedCostDetail": "Accumulated from each request's price snapshot",
         "specialTokens": "Cache / Reasoning",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2292,6 +2292,7 @@
         "requestsDetail": "OK {{success}} / Fail {{failed}} / Cancel {{canceled}} / Upstream {{upstreamFailed}} / Incomplete {{incomplete}}",
         "tokens": "Tokens",
         "tokensDetail": "Input {{input}} / Output {{output}}",
+        "cached": "Cache",
         "estimatedCost": "Estimated Value",
         "estimatedCostDetail": "Accumulated from each request's price snapshot",
         "specialTokens": "Cache / Reasoning",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "OK {{success}} / Fallo {{failed}} / Canc. {{canceled}} / Origen {{upstreamFailed}} / Incomp. {{incomplete}}",
         "tokens": "Tokens totales",
         "tokensDetail": "Entrada {{input}} / Salida {{output}}",
+        "cached": "Caché",
         "specialTokens": "Caché / Razonamiento",
         "specialTokensDetail": "Caché {{cached}} / Razonamiento {{reasoning}}",
         "avgLatency": "Latencia media",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "OK {{success}} / Échec {{failed}} / Annul. {{canceled}} / Amont {{upstreamFailed}} / Incomp. {{incomplete}}",
         "tokens": "Jetons",
         "tokensDetail": "Entrée {{input}} / Sortie {{output}}",
+        "cached": "Mémoire cache",
         "specialTokens": "Cache / Réflexion",
         "specialTokensDetail": "Cache {{cached}} / Réflexion {{reasoning}}",
         "avgLatency": "Latence moy.",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -1964,6 +1964,7 @@
         "requestsDetail": "OK {{success}} / Gagal {{failed}} / Batal {{canceled}} / Hulu {{upstreamFailed}} / Belum lengkap {{incomplete}}",
         "tokens": "Token",
         "tokensDetail": "Masuk {{input}} / Keluar {{output}}",
+        "cached": "Tembolok",
         "specialTokens": "Cache / Penalaran",
         "specialTokensDetail": "Cache {{cached}} / Penalaran {{reasoning}}",
         "avgLatency": "Latensi rata-rata",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "OK {{success}} / Errori {{failed}} / Annull. {{canceled}} / Monte {{upstreamFailed}} / Incompl. {{incomplete}}",
         "tokens": "Token",
         "tokensDetail": "Input {{input}} / Output {{output}}​",
+        "cached": "Memoria cache",
         "specialTokens": "Cache / Ragionamento",
         "specialTokensDetail": "Cache {{cached}} / Ragionamento {{reasoning}}",
         "avgLatency": "Latenza media",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "成功 {{success}} / 失敗 {{failed}} / 取消 {{canceled}} / 上流失敗 {{upstreamFailed}} / 未完了 {{incomplete}}",
         "tokens": "トークン",
         "tokensDetail": "入力 {{input}} / 出力 {{output}}",
+        "cached": "キャッシュ",
         "specialTokens": "キャッシュ / 思考",
         "specialTokensDetail": "キャッシュ {{cached}} / 思考 {{reasoning}}",
         "avgLatency": "平均遅延",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "성공 {{success}} / 실패 {{failed}} / 취소 {{canceled}} / 업스트림 {{upstreamFailed}} / 미완료 {{incomplete}}",
         "tokens": "토큰",
         "tokensDetail": "입력 {{input}} / 출력 {{output}}",
+        "cached": "캐시",
         "specialTokens": "캐시 / 추론",
         "specialTokensDetail": "캐시 {{cached}} / 추론 {{reasoning}}",
         "avgLatency": "평균 지연",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "OK {{success}} / Błąd {{failed}} / Anul. {{canceled}} / Źródło {{upstreamFailed}} / Niepeł. {{incomplete}}",
         "tokens": "Tokeny",
         "tokensDetail": "Wejście {{input}} / Wyjście {{output}}",
+        "cached": "Pamięć podręczna",
         "specialTokens": "Cache / Rozumowanie",
         "specialTokensDetail": "Cache {{cached}} / Rozumowanie {{reasoning}}",
         "avgLatency": "Śr. opóźnienie",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "OK {{success}} / Falha {{failed}} / Canc. {{canceled}} / Origem {{upstreamFailed}} / Incomp. {{incomplete}}",
         "tokens": "Tokens totais",
         "tokensDetail": "Entrada {{input}} / Saída {{output}}",
+        "cached": "Em cache",
         "specialTokens": "Cache / Raciocínio",
         "specialTokensDetail": "Cache {{cached}} / Raciocínio {{reasoning}}",
         "avgLatency": "Latência média",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "ОК {{success}} / Ошибка {{failed}} / Отмена {{canceled}} / Источник {{upstreamFailed}} / Неполн. {{incomplete}}",
         "tokens": "Токены",
         "tokensDetail": "Вход {{input}} / Выход {{output}}",
+        "cached": "Кэш",
         "specialTokens": "Кэш / Размышления",
         "specialTokensDetail": "Кэш {{cached}} / Размышления {{reasoning}}",
         "avgLatency": "Средняя задержка",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "OK {{success}} / Hata {{failed}} / İptal {{canceled}} / Kaynak {{upstreamFailed}} / Eksik {{incomplete}}",
         "tokens": "Tokenlar",
         "tokensDetail": "Girdi {{input}} / Çıktı {{output}}",
+        "cached": "Önbellek",
         "specialTokens": "Önbellek / Akıl yürütme",
         "specialTokensDetail": "Önbellek {{cached}} / Akıl yürütme {{reasoning}}",
         "avgLatency": "Ort. gecikme",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "OK {{success}} / Lỗi {{failed}} / Hủy {{canceled}} / Nguồn {{upstreamFailed}} / Chưa xong {{incomplete}}",
         "tokens": "Token",
         "tokensDetail": "Đầu vào {{input}} / Đầu ra {{output}}",
+        "cached": "Bộ đệm",
         "specialTokens": "Bộ đệm / Suy luận",
         "specialTokensDetail": "Bộ đệm {{cached}} / Suy luận {{reasoning}}",
         "avgLatency": "Độ trễ TB",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -2292,6 +2292,7 @@
         "requestsDetail": "成功 {{success}} / 失败 {{failed}} / 取消 {{canceled}} / 上游失败 {{upstreamFailed}} / 流未完成 {{incomplete}}",
         "tokens": "总 Token 数",
         "tokensDetail": "输入 {{input}} / 输出 {{output}}",
+        "cached": "缓存",
         "estimatedCost": "估算价值",
         "estimatedCostDetail": "按当前请求价格快照累计",
         "specialTokens": "缓存 / 思考",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -1914,6 +1914,7 @@
         "requestsDetail": "成功 {{success}} / 失敗 {{failed}} / 取消 {{canceled}} / 上游失敗 {{upstreamFailed}} / 未完成 {{incomplete}}",
         "tokens": "總 Token 數",
         "tokensDetail": "輸入 {{input}} / 輸出 {{output}}",
+        "cached": "快取",
         "specialTokens": "快取 / 思考",
         "specialTokensDetail": "快取 {{cached}} / 思考 {{reasoning}}",
         "avgLatency": "平均延遲",

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -3088,11 +3088,11 @@ export function CodexApiServicePage() {
       key: "tokens",
       label: t("codex.localAccess.stats.tokens", "总 Token 数"),
       value: formatCompactNumber(totals?.totalTokens ?? 0),
-      detail: t("codex.localAccess.stats.tokensDetail", {
+      detail: `${t("codex.localAccess.stats.tokensDetail", {
         input: formatCompactNumber(totals?.inputTokens ?? 0),
         output: formatCompactNumber(totals?.outputTokens ?? 0),
         defaultValue: "输入 {{input}} / 输出 {{output}}",
-      }),
+      })} / ${t("codex.localAccess.stats.cached", "缓存")} ${formatCompactNumber(totals?.cachedTokens ?? 0)}`,
     },
     {
       key: "cost",


### PR DESCRIPTION
## Summary

- show cached token usage alongside input and output in Codex API stats
- add the short Cache label across supported locales

## Checks

- npm run typecheck
- node scripts/check_locales.cjs
- git diff --check