### PR TITLE
fix(window): restore main WebView after close-to-tray on Windows

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -3841,9 +3841,14 @@ pub fn save_floating_card_position(x: i32, y: i32) -> Result<(), String> {
     Ok(())
 }
 
+/// Must run window recreate on the UI/main thread. Sync invoke handlers run on a
+/// worker pool; building a WebView there hangs on Windows after tray destroy.
 #[tauri::command]
-pub fn show_main_window_and_navigate(app: tauri::AppHandle, page: String) -> Result<(), String> {
-    modules::floating_card_window::show_main_window_and_navigate(&app, &page)
+pub async fn show_main_window_and_navigate(
+    app: tauri::AppHandle,
+    page: String,
+) -> Result<(), String> {
+    modules::floating_card_window::show_main_window_and_navigate_async(app, page).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/modules/floating_card_window.rs
+++ b/src-tauri/src/modules/floating_card_window.rs
@@ -461,16 +461,55 @@ fn clone_main_window_config(
     Ok(config)
 }
 
+/// After close-to-tray destroy (#686), a stale `main` label can still resolve on
+/// Windows/WebView2. Treat `destroyed_to_tray` as authoritative and force recreate.
+fn must_recreate_main_window(window_present: bool, destroyed_to_tray: bool) -> bool {
+    destroyed_to_tray || !window_present
+}
+
+fn wait_until_main_window_gone<R: Runtime>(app: &AppHandle<R>, attempts: u32) {
+    for _ in 0..attempts {
+        if app.get_webview_window(MAIN_WINDOW_LABEL).is_none() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
 fn ensure_main_window<R: Runtime>(app: &AppHandle<R>) -> Result<(WebviewWindow<R>, bool), String> {
+    let destroyed_to_tray = MAIN_WINDOW_DESTROYED_TO_TRAY.load(Ordering::SeqCst);
+
     if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-        return Ok((window, false));
+        if !must_recreate_main_window(true, destroyed_to_tray) {
+            return Ok((window, false));
+        }
+
+        logger::log_info(
+            "[Window] 托盘销毁后检测到残留主窗口句柄，强制销毁并重建",
+        );
+        if let Err(err) = window.destroy() {
+            logger::log_warn(&format!(
+                "[Window] 清理残留主窗口失败（仍将尝试重建）: {}",
+                err
+            ));
+        }
+        wait_until_main_window_gone(app, 50);
     }
 
+    logger::log_info(&format!(
+        "[Window] 开始重建主窗口 WebView (destroyed_to_tray={})",
+        destroyed_to_tray
+    ));
     let window_config = clone_main_window_config(app)?;
     let window = WebviewWindowBuilder::from_config(app, &window_config)
         .map_err(|err| err.to_string())?
         .build()
-        .map_err(|err| err.to_string())?;
+        .map_err(|err| {
+            format!(
+                "重建主窗口失败（destroyed_to_tray={}）: {}",
+                destroyed_to_tray, err
+            )
+        })?;
 
     logger::log_info("[Window] WebView 主窗口已重新创建");
     Ok((window, true))
@@ -508,7 +547,11 @@ pub fn destroy_main_window_to_tray<R: Runtime>(window: &Window<R>) -> Result<(),
         MAIN_WINDOW_DESTROYED_TO_TRAY.store(false, Ordering::SeqCst);
         return Err(err.to_string());
     }
-    process_memory::trim_idle_process_memory();
+    // Defer working-set trim so WebView2 can finish teardown before a later recreate.
+    std::thread::spawn(|| {
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        process_memory::trim_idle_process_memory();
+    });
     logger::log_info("[Window] 主窗口 WebView 已销毁并保留托盘进程");
     Ok(())
 }
@@ -517,9 +560,16 @@ pub fn show_main_window_and_navigate<R: Runtime>(
     app: &AppHandle<R>,
     page: &str,
 ) -> Result<(), String> {
-    let should_defer_navigation = app.get_webview_window(MAIN_WINDOW_LABEL).is_none();
+    let window_present = app.get_webview_window(MAIN_WINDOW_LABEL).is_some();
+    let destroyed_to_tray = MAIN_WINDOW_DESTROYED_TO_TRAY.load(Ordering::SeqCst);
+    // Recreate (or first create) means the frontend is not ready for tray:navigate yet.
+    let should_defer_navigation = must_recreate_main_window(window_present, destroyed_to_tray);
     if should_defer_navigation {
         set_pending_main_window_navigation(page)?;
+        logger::log_info(&format!(
+            "[Window] 主窗口将重建，延迟导航到: {}",
+            page
+        ));
     }
     if let Err(err) = show_main_window_internal(app) {
         if should_defer_navigation {
@@ -527,13 +577,30 @@ pub fn show_main_window_and_navigate<R: Runtime>(
         }
         return Err(err);
     }
+    if should_defer_navigation {
+        // Pending navigation is consumed on main-window mount; emit would race load.
+        return Ok(());
+    }
     if let Err(err) = app.emit("tray:navigate", page.to_string()) {
-        if should_defer_navigation {
-            let _ = take_pending_main_window_navigation();
-        }
         return Err(err.to_string());
     }
     Ok(())
+}
+
+/// Invoke from async Tauri commands so WebView recreate runs on the UI thread.
+pub async fn show_main_window_and_navigate_async<R: Runtime>(
+    app: AppHandle<R>,
+    page: String,
+) -> Result<(), String> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let app_for_task = app.clone();
+    app.run_on_main_thread(move || {
+        let result = show_main_window_and_navigate(&app_for_task, &page);
+        let _ = tx.send(result);
+    })
+    .map_err(|err| format!("调度主线程重建主窗口失败: {}", err))?;
+    rx.await
+        .map_err(|_| "主线程重建主窗口任务已取消".to_string())?
 }
 
 pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
@@ -543,7 +610,10 @@ pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
 fn show_main_window_internal<R: Runtime>(app: &AppHandle<R>) -> Result<bool, String> {
     let (window, created) = ensure_main_window(app)?;
 
-    logger::log_info("[Window] 尝试恢复主窗口");
+    logger::log_info(&format!(
+        "[Window] 尝试恢复主窗口 (recreated={})",
+        created
+    ));
     #[cfg(target_os = "macos")]
     show_macos_application(app);
 
@@ -558,8 +628,37 @@ fn show_main_window_internal<R: Runtime>(app: &AppHandle<R>) -> Result<bool, Str
     activate_macos_application(app);
 
     #[cfg(target_os = "windows")]
-    if let Err(err) = crate::modules::process::focus_current_process_main_window() {
-        logger::log_warn(&format!("[Window] Windows 原生前置主窗口失败: {}", err));
+    {
+        // Prefer the Tauri main window HWND. Process MainWindowHandle often points at
+        // the floating card after the main WebView was destroyed to tray.
+        // Never block the UI thread on PowerShell focus.
+        match window.hwnd() {
+            Ok(hwnd) => {
+                let raw = hwnd.0 as isize;
+                std::thread::spawn(move || {
+                    if let Err(err) = crate::modules::process::focus_window_by_hwnd(raw) {
+                        logger::log_warn(&format!(
+                            "[Window] Windows 按 HWND 前置主窗口失败: {}",
+                            err
+                        ));
+                    }
+                });
+            }
+            Err(err) => {
+                logger::log_warn(&format!(
+                    "[Window] 获取主窗口 HWND 失败，回退进程主句柄: {}",
+                    err
+                ));
+                std::thread::spawn(|| {
+                    if let Err(err) = crate::modules::process::focus_current_process_main_window() {
+                        logger::log_warn(&format!(
+                            "[Window] Windows 原生前置主窗口失败: {}",
+                            err
+                        ));
+                    }
+                });
+            }
+        }
     }
 
     if created {
@@ -630,4 +729,26 @@ fn send_hidden_notification<R: Runtime>(app: &AppHandle<R>) {
             logger::log_warn(&format!("[FloatingCard] 发送关闭引导通知失败: {}", err));
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::must_recreate_main_window;
+
+    #[test]
+    fn recreates_when_window_missing() {
+        assert!(must_recreate_main_window(false, false));
+        assert!(must_recreate_main_window(false, true));
+    }
+
+    #[test]
+    fn reuses_live_window_when_not_destroyed_to_tray() {
+        assert!(!must_recreate_main_window(true, false));
+    }
+
+    #[test]
+    fn force_recreates_stale_handle_after_tray_destroy() {
+        // Windows/WebView2 may still resolve `main` after destroy; flag wins.
+        assert!(must_recreate_main_window(true, true));
+    }
 }

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -5985,6 +5985,40 @@ pub fn focus_current_process_main_window() -> Result<(), String> {
     focus_window_by_pid(std::process::id())
 }
 
+/// Focus a specific HWND (e.g. Tauri `main` window), not the process MainWindowHandle.
+/// After tray destroy, MainWindowHandle often points at the floating card.
+#[cfg(target_os = "windows")]
+pub fn focus_window_by_hwnd(hwnd: isize) -> Result<(), String> {
+    if hwnd == 0 {
+        return Err("HWND_EMPTY".to_string());
+    }
+    let command = format!(
+        r#"Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public class Win32FocusHwnd {{
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+}}
+'@; $h = [IntPtr]{hwnd}; [Win32FocusHwnd]::ShowWindowAsync($h, 9) | Out-Null; [Win32FocusHwnd]::SetForegroundWindow($h) | Out-Null;"#
+    );
+    crate::modules::logger::log_info(&format!(
+        "[Focus] Windows PowerShell focus hwnd={}",
+        hwnd
+    ));
+    let output = powershell_output(&["-NoProfile", "-Command", &command])
+        .map_err(|e| format!("调用 PowerShell 失败: {}", e))?;
+    if output.status.success() {
+        crate::modules::logger::log_info(&format!(
+            "[Focus] Windows PowerShell hwnd success hwnd={}",
+            hwnd
+        ));
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(format!("窗口聚焦失败: {}", stderr.trim()))
+}
+
 #[cfg(target_os = "linux")]
 fn focus_window_by_pid(pid: u32) -> Result<(), String> {
     if let Ok(output) = Command::new("wmctrl").arg("-lp").output() {

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -3481,6 +3481,7 @@ fn handle_menu_event<R: Runtime>(app: &tauri::AppHandle<R>, event: tauri::menu::
         }
         menu_ids::QUIT => {
             info!("[Tray] 用户选择退出应用");
+            crate::modules::floating_card_window::request_app_exit();
             app.exit(0);
         }
         _ => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import { AnnouncementHost } from './components/AnnouncementCenter';
 import { CodexBatchImportGlobalTask } from './components/CodexBatchImportGlobalTask';
 import { TopCenterPromoBanner } from './components/TopCenterPromoBanner';
 import type { QuickSettingsType } from './components/QuickSettingsPopover';
-import type { Page } from './types/navigation';
+import { isMainWindowNavigablePage, type Page } from './types/navigation';
 import type { TopRightAd } from './types/topRightAd';
 import { useAutoRefresh } from './hooks/useAutoRefresh';
 import { useEasterEggTrigger } from './hooks/useEasterEggTrigger';
@@ -3377,15 +3377,8 @@ function MainApp() {
       .then((target) => {
         if (!target) return;
         const page = String(target);
-        if (
-          page === 'overview' ||
-          page === 'codex' ||
-          page === 'codex-api-service' ||
-          page === 'settings' ||
-          page === 'dashboard' ||
-          page === 'manual'
-        ) {
-          setPage(page as Page);
+        if (isMainWindowNavigablePage(page)) {
+          setPage(page);
         }
       })
       .catch(() => {
@@ -3398,33 +3391,8 @@ function MainApp() {
 
         listen<string>('tray:navigate', (event) => {
           const target = String(event.payload || '');
-          switch (target) {
-            case 'overview':
-            case 'api-relay':
-            case 'codex':
-            case 'codex-api-service':
-            case 'claude':
-            case 'claude-cli':
-            case 'github-copilot':
-            case 'windsurf':
-            case 'kiro':
-            case 'cursor':
-            case 'grok':
-            case 'codebuddy':
-            case 'codebuddy-cn':
-            case 'qoder':
-            case 'trae':
-            case 'trae-solo':
-            case 'trae-cn':
-            case 'trae-solo-cn':
-            case 'workbuddy':
-            case 'zed':
-            case 'manual':
-            case 'settings':
-              setPage(target as Page);
-              break;
-            default:
-              break;
+          if (isMainWindowNavigablePage(target)) {
+            setPage(target);
           }
         }).then((fn) => { unlisten = fn; });
 

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -29,3 +29,35 @@ export type Page =
   | 'verification'
   | '2fa'
   | 'settings';
+
+/** Pages that tray / floating-card restore may navigate to after main-window recreate. */
+export const MAIN_WINDOW_NAVIGABLE_PAGES: readonly Page[] = [
+  'dashboard',
+  'manual',
+  'api-relay',
+  'overview',
+  'codex',
+  'claude',
+  'claude-cli',
+  'codex-api-service',
+  'zed',
+  'github-copilot',
+  'windsurf',
+  'kiro',
+  'cursor',
+  'grok',
+  'codebuddy',
+  'codebuddy-cn',
+  'qoder',
+  'zcode',
+  'trae',
+  'trae-solo',
+  'trae-cn',
+  'trae-solo-cn',
+  'workbuddy',
+  'settings',
+] as const;
+
+export function isMainWindowNavigablePage(page: string): page is Page {
+  return (MAIN_WINDOW_NAVIGABLE_PAGES as readonly string[]).includes(page);
+}


### PR DESCRIPTION
## Summary

Fixes close-to-tray (#686) regression on Windows: after closing the main window to the tray, opening details from the floating card only worked once; subsequent clicks appeared to do nothing.

### Root causes

1. **Stale `main` handle after destroy** — `ensure_main_window` only recreated when `get_webview_window("main")` was `None`. After destroy, Windows/WebView2 could still resolve the label, so restore reused a dead window and never rebuilt.
2. **WebView rebuild off the UI thread** — the sync Tauri command ran on a worker pool; `WebviewWindowBuilder::build()` hung there after tray destroy.

### Changes

- Force recreate when `MAIN_WINDOW_DESTROYED_TO_TRAY` is set (destroy residual handle first, wait for release).
- Make `show_main_window_and_navigate` async and rebuild via `run_on_main_thread`.
- Defer `tray:navigate` across recreate; rely on pending navigation on remount.
- Align pending navigation page whitelist with tray navigable pages.
- Focus Tauri main HWND on Windows (not process `MainWindowHandle`); do not block UI thread.
- Defer `EmptyWorkingSet` after destroy; call `request_app_exit` on tray Quit.

## Test plan

- [x] `cargo test --lib floating_card_window` (3 unit tests)
- [x] Manual Windows: close to tray → floating card open details → close to tray again → open details again (works every time)
- [ ] Taskbar minimize still works (unchanged path)

## Related

- #686 tray destroy main WebView for idle memory

