### PR TITLE
fix(floating-card): limit platform list to menu-bar-visible platforms

### DIFF
--- a/src/pages/FloatingCardWindow.tsx
+++ b/src/pages/FloatingCardWindow.tsx
@@ -242,6 +242,8 @@ export function FloatingCardWindow() {
     INSTANCE_FLOATING_CARD_WINDOW_LABEL_PREFIX,
   );
   const orderedPlatformIds = usePlatformLayoutStore((state) => state.orderedPlatformIds);
+  // 与平台布局「菜单栏显示」勾选一致（trayPlatformIds）
+  const trayPlatformIds = usePlatformLayoutStore((state) => state.trayPlatformIds);
   const remoteHiddenPlatformIds = useRemoteConfigStore((state) => state.hiddenPlatformIds);
   const fetchRemoteConfigState = useRemoteConfigStore((state) => state.fetchState);
   const { accounts: agAccounts, currentAccountsByTarget: agCurrentAccountsByTarget } = useAccountStore();
@@ -323,23 +325,27 @@ export function FloatingCardWindow() {
   const platformOrder = useMemo(() => {
     const seen = new Set<PlatformId>();
     const ordered: PlatformId[] = [];
+    const trayEnabled = new Set(trayPlatformIds);
 
+    // Prefer layout order, but only platforms enabled for menu bar (菜单栏显示).
     for (const platformId of orderedPlatformIds) {
+      if (!ALL_PLATFORM_IDS.includes(platformId) || seen.has(platformId)) continue;
+      if (remoteHiddenPlatformSet.has(platformId)) continue;
+      if (!trayEnabled.has(platformId)) continue;
+      ordered.push(platformId);
+      seen.add(platformId);
+    }
+
+    // Keep tray-enabled platforms that are not yet in orderedPlatformIds.
+    for (const platformId of trayPlatformIds) {
       if (!ALL_PLATFORM_IDS.includes(platformId) || seen.has(platformId)) continue;
       if (remoteHiddenPlatformSet.has(platformId)) continue;
       ordered.push(platformId);
       seen.add(platformId);
     }
 
-    for (const platformId of ALL_PLATFORM_IDS) {
-      if (seen.has(platformId)) continue;
-      if (remoteHiddenPlatformSet.has(platformId)) continue;
-      ordered.push(platformId);
-      seen.add(platformId);
-    }
-
     return ordered;
-  }, [orderedPlatformIds, remoteHiddenPlatformSet]);
+  }, [orderedPlatformIds, remoteHiddenPlatformSet, trayPlatformIds]);
 
   useEffect(() => {
     void fetchRemoteConfigState(false);


### PR DESCRIPTION
## Summary

悬浮卡平台下拉原先会列出全部平台。应与「平台布局」中勾选了 **菜单栏显示** 的平台一致（`trayPlatformIds`），并保持布局顺序。

### Changes

- `FloatingCardWindow.tsx`：`platformOrder` 仅保留 `trayPlatformIds` 中的平台

## Test plan

- [ ] 打开平台布局，取消部分平台的「菜单栏显示」
- [ ] 悬浮卡平台下拉只显示仍勾选的平台
- [ ] 勾选状态变更后，重新打开悬浮卡列表正确

## Related

- Separated from #1595 (window restore after close-to-tray)
