### PR TITLE
解决Windows受限用户安装与无法自动更新问题

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,6 +53,11 @@
     "externalBin": [
       "../sidecars/cockpit-cliproxy/bin/cockpit-cliproxy"
     ],
+    "windows": {
+      "nsis": {
+        "installMode": "currentUser"
+      }
+    },
     "icon": [
       "icons/48x48.png",
       "icons/32x32.png",


### PR DESCRIPTION
### 📝 变更前因后果 / Background & Rationale

#### 1. 现存痛点 (Problem)
目前 Windows 下默认的 NSIS 打包配置未显式指定 `installMode`，因此采用了 Tauri 默认的 `perUserOrAllUsers` 模式。
在该模式下，生成的安装包（.exe）在双击运行时，即使最终选择“仅为当前用户安装”，**初始化时仍会默认向 Windows 系统申请管理员权限（触发 UAC 提权弹窗）**。
这导致了两个严重的问题：
- **企业/安全受限环境无法安装**：在许多企业、研发机构或学校电脑上，出于安全合规要求，管理员权限（UAC 密码）被统一收回。这部分无管理员权限的用户在安装时会被系统安全策略拦截，根本无法安装使用。
- **自动升级中断/失败**：应用在后台静默下载完更新包并拉起更新程序时，更新程序会因 UAC 提权弹窗受阻。对于普通用户，每次自动升级都会因为“缺少管理员权限”而弹出错误，导致无法顺利完成软件升级。

#### 2. 修改方案 (Solution)
本 PR 在 `tauri.conf.json` 的 `bundle.windows.nsis` 中将 `installMode` 显式配置为了 **`"currentUser"`**（当前用户模式）。
- **取消 UAC 提权**：修改后，生成的安装包运行期间完全不需要管理员权限（不再弹出提权申请），普通用户即可正常双击安装。
- **安装路径自适应**：安装包在运行时会自动且只能安装到当前用户的用户空间目录（即 `C:\Users\<Username>\AppData\Local\Cockpit Tools`）。
- **顺畅自动升级**：自动更新程序在写入该用户目录时具有完整读写权，无需任何额外系统提权即可静默覆盖，确保无管理员权限的用户也能够顺利地一键升级。

#### 3. 影响评估 (Impact)
- **无核心功能影响**：`Cockpit Tools` 作为桌面辅助及代理分流工具，其本身不需要写入任何系统级目录（如 `C:\Program Files`），亦无注册系统服务的需求。修改为 `currentUser` 能够完美满足应用运行所需的所有权限。
- **用户体验提升**：彻底解决了受控电脑用户安装困难和无法正常热更新的问题。

---

### 🛠️ 变更清单 / Changes
- 调整了 `src-tauri/tauri.conf.json`：
  - 在 `bundle` 下新增 `windows.nsis.installMode: "currentUser"`。