### PR TITLE
fix(codex): move reused API keys between providers

### DIFF
--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -4115,6 +4115,23 @@ export function CodexAccountsPage() {
     [managedProviders, sponsorApiProviderTemplates],
   );
 
+  const resolveManagedProviderIdForAccount = useCallback(
+    (account: CodexAccount | null | undefined): string | null => {
+      if (!account || !isCodexApiKeyAccount(account)) return null;
+      return (
+        findCodexModelProviderById(
+          managedProviders,
+          account.api_provider_id,
+        ) ??
+        findCodexModelProviderByBaseUrl(
+          managedProviders,
+          account.api_base_url ?? "",
+        )
+      )?.id ?? null;
+    },
+    [managedProviders],
+  );
+
   useEffect(() => {
     showAddModalRef.current = showAddModal;
     addTabRef.current = addTab;
@@ -6478,6 +6495,11 @@ export function CodexAccountsPage() {
       return;
     }
     setApiModelCatalogError(null);
+    const existingApiKeyAccount = accounts.find(
+      (account) =>
+        isCodexApiKeyAccount(account) &&
+        account.openai_api_key?.trim() === validation.apiKey,
+    );
     const providerPayload = {
       ...buildApiProviderPayload(
         apiBaseUrlInput,
@@ -6504,6 +6526,9 @@ export function CodexAccountsPage() {
             )
               ? null
               : (providerPayload.apiProviderId ?? null),
+            previousProviderId: resolveManagedProviderIdForAccount(
+              existingApiKeyAccount,
+            ),
             providerName: providerPayload.apiProviderName ?? null,
             apiBaseUrl: validation.apiBaseUrl,
             apiKey: validation.apiKey,
@@ -7677,6 +7702,7 @@ export function CodexAccountsPage() {
       return;
     }
     setEditingApiModelCatalogError(null);
+    const editingAccount = accounts.find((account) => account.id === accountId);
     const providerPayload = {
       ...buildApiProviderPayload(
         editingApiBaseUrlCredentialsValue,
@@ -7716,6 +7742,8 @@ export function CodexAccountsPage() {
             )
               ? null
               : (providerPayload.apiProviderId ?? null),
+            previousProviderId:
+              resolveManagedProviderIdForAccount(editingAccount),
             providerName: providerPayload.apiProviderName ?? null,
             apiBaseUrl: validation.apiBaseUrl,
             apiKey: validation.apiKey,
@@ -7792,6 +7820,7 @@ export function CodexAccountsPage() {
     editingManagedProviderId,
     editingNewManagedProviderNameInput,
     reloadManagedProviders,
+    resolveManagedProviderIdForAccount,
     setMessage,
     t,
     upsertCodexModelProviderFromCredential,

--- a/src/services/codexModelProviderService.ts
+++ b/src/services/codexModelProviderService.ts
@@ -17,6 +17,7 @@ import {
   queryModelProviderUsage,
   type ModelProviderUsageSummary,
 } from './modelProviderUsageService';
+import { moveCodexProviderApiKey } from '../utils/codexModelProviderApiKeyMove';
 
 export interface CodexModelProviderApiKey {
   id: string;
@@ -52,6 +53,7 @@ export type CodexModelProviderUsageSummary = ModelProviderUsageSummary;
 
 interface UpsertFromCredentialInput {
   providerId?: string | null;
+  previousProviderId?: string | null;
   providerName?: string | null;
   apiBaseUrl: string;
   apiKey: string;
@@ -817,7 +819,15 @@ export async function upsertCodexModelProviderFromCredential(
     provider.sourceTag = sanitizeName(input.sourceTag ?? '') || undefined;
   }
 
-  ensureApiKeyOnProvider(provider, apiKey, input.apiKeyName);
+  const moveResult = moveCodexProviderApiKey(
+    providers,
+    input.previousProviderId,
+    provider.id,
+    apiKey,
+  );
+  if (moveResult === 'not_moved' || moveResult === 'name_conflict') {
+    ensureApiKeyOnProvider(provider, apiKey, input.apiKeyName);
+  }
   provider.baseUrl = apiBaseUrl;
   provider.modelCatalog =
     normalizeModelCatalog(input.modelCatalog) ??

--- a/src/utils/codexModelProviderApiKeyMove.test.ts
+++ b/src/utils/codexModelProviderApiKeyMove.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  moveCodexProviderApiKey,
+  type CodexProviderApiKeyOwner,
+} from "./codexModelProviderApiKeyMove.ts";
+
+function provider(
+  id: string,
+  apiKeys: CodexProviderApiKeyOwner["apiKeys"],
+): CodexProviderApiKeyOwner {
+  return { id, apiKeys, updatedAt: 1 };
+}
+
+test("moves a reused API key to the newly selected provider", () => {
+  const savedKey = {
+    id: "key-1",
+    name: "Personal relay key",
+    apiKey: "sk-shared",
+    createdAt: 10,
+    updatedAt: 20,
+  };
+  const providers = [provider("old", [savedKey]), provider("new", [])];
+
+  const result = moveCodexProviderApiKey(
+    providers,
+    "old",
+    "new",
+    " sk-shared ",
+    30,
+  );
+
+  assert.equal(result, "moved");
+  assert.deepEqual(providers[0].apiKeys, []);
+  assert.deepEqual(providers[1].apiKeys, [
+    {
+      ...savedKey,
+      apiKey: "sk-shared",
+      updatedAt: 30,
+    },
+  ]);
+});
+
+test("deduplicates matching labels without losing the saved name", () => {
+  const providers = [
+    provider("old", [
+      {
+        id: "key-old",
+        name: "Saved label",
+        apiKey: "sk-shared",
+        createdAt: 10,
+        updatedAt: 20,
+      },
+    ]),
+    provider("new", [
+      {
+        id: "key-new",
+        name: "",
+        apiKey: "sk-shared",
+        createdAt: 15,
+        updatedAt: 25,
+      },
+    ]),
+  ];
+
+  const result = moveCodexProviderApiKey(
+    providers,
+    "old",
+    "new",
+    "sk-shared",
+    30,
+  );
+
+  assert.equal(result, "deduplicated");
+  assert.deepEqual(providers[0].apiKeys, []);
+  assert.equal(providers[1].apiKeys[0].name, "Saved label");
+});
+
+test("does not guess when the same key has conflicting saved names", () => {
+  const providers = [
+    provider("old", [
+      {
+        id: "key-old",
+        name: "Old saved label",
+        apiKey: "sk-shared",
+        createdAt: 10,
+        updatedAt: 20,
+      },
+    ]),
+    provider("new", [
+      {
+        id: "key-new",
+        name: "New saved label",
+        apiKey: "sk-shared",
+        createdAt: 15,
+        updatedAt: 25,
+      },
+    ]),
+  ];
+
+  const before = structuredClone(providers);
+  const result = moveCodexProviderApiKey(
+    providers,
+    "old",
+    "new",
+    "sk-shared",
+    30,
+  );
+
+  assert.equal(result, "name_conflict");
+  assert.deepEqual(providers, before);
+});

--- a/src/utils/codexModelProviderApiKeyMove.ts
+++ b/src/utils/codexModelProviderApiKeyMove.ts
@@ -1,0 +1,73 @@
+export interface MovableCodexProviderApiKey {
+  id: string;
+  name: string;
+  apiKey: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CodexProviderApiKeyOwner {
+  id: string;
+  apiKeys: MovableCodexProviderApiKey[];
+  updatedAt: number;
+}
+
+export type CodexProviderApiKeyMoveResult =
+  | "not_moved"
+  | "moved"
+  | "deduplicated"
+  | "name_conflict";
+
+export function moveCodexProviderApiKey(
+  providers: CodexProviderApiKeyOwner[],
+  previousProviderId: string | null | undefined,
+  targetProviderId: string,
+  apiKey: string,
+  now = Date.now(),
+): CodexProviderApiKeyMoveResult {
+  const sourceId = previousProviderId?.trim();
+  const targetId = targetProviderId.trim();
+  const normalizedApiKey = apiKey.trim();
+  if (!sourceId || !targetId || sourceId === targetId || !normalizedApiKey) {
+    return "not_moved";
+  }
+
+  const source = providers.find((provider) => provider.id === sourceId);
+  const target = providers.find((provider) => provider.id === targetId);
+  if (!source || !target) return "not_moved";
+
+  const sourceIndex = source.apiKeys.findIndex(
+    (item) => item.apiKey.trim() === normalizedApiKey,
+  );
+  if (sourceIndex < 0) return "not_moved";
+
+  const sourceApiKey = source.apiKeys[sourceIndex];
+  const targetApiKey = target.apiKeys.find(
+    (item) => item.apiKey.trim() === normalizedApiKey,
+  );
+  if (targetApiKey) {
+    const sourceName = sourceApiKey.name.trim();
+    const targetName = targetApiKey.name.trim();
+    if (sourceName && targetName && sourceName !== targetName) {
+      return "name_conflict";
+    }
+    if (!targetName && sourceName) {
+      targetApiKey.name = sourceName;
+    }
+    targetApiKey.updatedAt = now;
+    source.apiKeys.splice(sourceIndex, 1);
+    source.updatedAt = now;
+    target.updatedAt = now;
+    return "deduplicated";
+  }
+
+  source.apiKeys.splice(sourceIndex, 1);
+  target.apiKeys.push({
+    ...sourceApiKey,
+    apiKey: normalizedApiKey,
+    updatedAt: now,
+  });
+  source.updatedAt = now;
+  target.updatedAt = now;
+  return "moved";
+}


### PR DESCRIPTION
## Summary

- carry the explicitly previous managed-provider identity through API-key account add and edit flows
- move a reused key from its previous provider to the newly selected provider instead of leaving duplicate ownership
- preserve stored key identity, timestamps, and compatible user labels while avoiding destructive label overwrites

Fixes #1597

## Validation

- `node --test src/utils/codexApiKeyAccountScope.test.ts src/utils/codexModelProviderApiKeyMove.test.ts` (8 passed)
- `npm run typecheck`
- `git diff --check origin/main..HEAD`