### PR TITLE
fix(kiro): resolve IDC client registration by clientIdHash

### DIFF
--- a/crates/cockpit-core/src/modules/kiro_account.rs
+++ b/crates/cockpit-core/src/modules/kiro_account.rs
@@ -2,7 +2,7 @@ use rusqlite::{Connection, OptionalExtension};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
@@ -12,6 +12,7 @@ use crate::modules::{account, kiro_oauth, logger};
 const ACCOUNTS_INDEX_FILE: &str = "kiro_accounts.json";
 const ACCOUNTS_DIR: &str = "kiro_accounts";
 const LOCAL_AUTH_TOKEN_FILE_NAME: &str = "kiro-auth-token.json";
+const AWS_SSO_CLIENT_ID_HASH_LENGTH: usize = 40;
 const LOCAL_USAGE_DB_KEY: &str = "kiro.kiroAgent";
 const KIRO_QUOTA_ALERT_COOLDOWN_SECONDS: i64 = 10 * 60;
 
@@ -1411,6 +1412,66 @@ pub fn get_default_kiro_auth_token_path() -> Result<PathBuf, String> {
         .join(LOCAL_AUTH_TOKEN_FILE_NAME))
 }
 
+fn idc_client_registration_path(cache_dir: &Path, client_id_hash: &str) -> Result<PathBuf, String> {
+    let hash = client_id_hash;
+    let is_lower_hex = hash
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+    if hash.len() != AWS_SSO_CLIENT_ID_HASH_LENGTH || !is_lower_hex {
+        return Err("Kiro 本地授权文件中的 clientIdHash 格式无效".to_string());
+    }
+
+    Ok(cache_dir.join(format!("{}.json", hash)))
+}
+
+pub(crate) fn read_idc_client_registration_from_cache_dir(
+    auth_token: &Value,
+    cache_dir: &Path,
+) -> Result<Option<Value>, String> {
+    let Some(client_id_hash) = auth_token.get("clientIdHash") else {
+        return Ok(None);
+    };
+    let client_id_hash = client_id_hash
+        .as_str()
+        .ok_or_else(|| "Kiro 本地授权文件中的 clientIdHash 必须是字符串".to_string())?;
+    let path = idc_client_registration_path(cache_dir, client_id_hash)?;
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(format!(
+                "读取 Kiro IdC 客户端注册文件失败({}): {}",
+                path.display(),
+                err
+            ));
+        }
+    };
+    let parsed = serde_json::from_str::<Value>(&raw).map_err(|err| {
+        format!(
+            "解析 Kiro IdC 客户端注册文件失败({}): {}",
+            path.display(),
+            err
+        )
+    })?;
+    if !parsed.is_object() {
+        return Err(format!(
+            "解析 Kiro IdC 客户端注册文件失败({}): 根节点必须是对象",
+            path.display()
+        ));
+    }
+    Ok(Some(parsed))
+}
+
+pub(crate) fn read_local_idc_client_registration(
+    auth_token: &Value,
+) -> Result<Option<Value>, String> {
+    let auth_token_path = get_default_kiro_auth_token_path()?;
+    let cache_dir = auth_token_path
+        .parent()
+        .ok_or_else(|| "无法解析 AWS SSO 缓存目录".to_string())?;
+    read_idc_client_registration_from_cache_dir(auth_token, cache_dir)
+}
+
 pub fn read_local_auth_token_json() -> Result<Option<Value>, String> {
     let path = get_default_kiro_auth_token_path()?;
     if !path.exists() {
@@ -1462,5 +1523,95 @@ pub fn read_local_usage_snapshot() -> Result<Option<Value>, String> {
             Ok(Some(parsed))
         }
         None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const CLIENT_ID_HASH: &str = "eb04fe0de39241e4fa17bec175f7540138ad1bd8";
+
+    fn create_cache_fixture(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "cockpit-tools-kiro-idc-{}-{}",
+            name,
+            std::process::id()
+        ));
+        if path.exists() {
+            fs::remove_dir_all(&path).expect("remove stale Kiro IdC fixture");
+        }
+        fs::create_dir_all(&path).expect("create Kiro IdC fixture");
+        path
+    }
+
+    #[test]
+    fn idc_registration_reads_only_the_file_named_by_client_id_hash() {
+        let cache_dir = create_cache_fixture("exact-hash");
+        fs::write(
+            cache_dir.join(format!("{}.json", CLIENT_ID_HASH)),
+            r#"{"clientId":"expected-client","clientSecret":"expected-secret"}"#,
+        )
+        .expect("write expected registration");
+        fs::write(
+            cache_dir.join("unrelated.json"),
+            r#"{"clientId":"wrong-client","clientSecret":"wrong-secret"}"#,
+        )
+        .expect("write decoy registration");
+
+        let registration = read_idc_client_registration_from_cache_dir(
+            &json!({"clientIdHash": CLIENT_ID_HASH}),
+            &cache_dir,
+        )
+        .expect("read registration")
+        .expect("registration should exist");
+
+        assert_eq!(
+            registration.get("clientId").and_then(Value::as_str),
+            Some("expected-client")
+        );
+        fs::remove_dir_all(cache_dir).expect("remove Kiro IdC fixture");
+    }
+
+    #[test]
+    fn idc_registration_does_not_scan_when_exact_hash_is_missing() {
+        let cache_dir = create_cache_fixture("no-scan");
+        fs::write(
+            cache_dir.join("unrelated.json"),
+            r#"{"clientId":"wrong-client","clientSecret":"wrong-secret"}"#,
+        )
+        .expect("write decoy registration");
+
+        let registration = read_idc_client_registration_from_cache_dir(
+            &json!({"clientIdHash": CLIENT_ID_HASH}),
+            &cache_dir,
+        )
+        .expect("missing exact registration is allowed");
+
+        assert!(registration.is_none());
+        fs::remove_dir_all(cache_dir).expect("remove Kiro IdC fixture");
+    }
+
+    #[test]
+    fn idc_registration_rejects_noncanonical_client_id_hashes() {
+        let cache_dir = create_cache_fixture("invalid-hash");
+        let invalid_hashes = [
+            "../eb04fe0de39241e4fa17bec175f7540138ad1bd8",
+            "EB04FE0DE39241E4FA17BEC175F7540138AD1BD8",
+            "eb04fe0de39241e4fa17bec175f7540138ad1bd8 ",
+            "eb04fe0de39241e4fa17bec175f7540138ad1bd",
+            "gb04fe0de39241e4fa17bec175f7540138ad1bd8",
+        ];
+
+        for hash in invalid_hashes {
+            let result = read_idc_client_registration_from_cache_dir(
+                &json!({"clientIdHash": hash}),
+                &cache_dir,
+            );
+            assert!(result.is_err(), "hash should be rejected: {}", hash);
+        }
+
+        fs::remove_dir_all(cache_dir).expect("remove Kiro IdC fixture");
     }
 }

--- a/crates/cockpit-core/src/modules/kiro_oauth.rs
+++ b/crates/cockpit-core/src/modules/kiro_oauth.rs
@@ -647,6 +647,40 @@ fn resolve_idc_client_secret(auth_token: &Value) -> Option<String> {
     .and_then(|value| normalize_non_empty(Some(value.as_str())))
 }
 
+fn resolve_idc_client_credentials(
+    auth_token: &Value,
+    account: &KiroAccount,
+    client_registration: Option<&Value>,
+) -> Result<(String, String), String> {
+    let client_id = resolve_idc_client_id(auth_token, account)
+        .or_else(|| {
+            pick_string(client_registration, &[&["clientId"]])
+                .and_then(|value| normalize_non_empty(Some(value.as_str())))
+        })
+        .ok_or_else(|| "缺少 client_id，无法执行 AWS IAM Identity Center 刷新".to_string())?;
+    let client_secret = resolve_idc_client_secret(auth_token)
+        .or_else(|| {
+            pick_string(client_registration, &[&["clientSecret"]])
+                .and_then(|value| normalize_non_empty(Some(value.as_str())))
+        })
+        .ok_or_else(|| "缺少 client_secret，无法执行 AWS IAM Identity Center 刷新".to_string())?;
+    Ok((client_id, client_secret))
+}
+
+fn resolve_idc_client_credentials_from_local_cache(
+    auth_token: &Value,
+    account: &KiroAccount,
+) -> Result<(String, String), String> {
+    if resolve_idc_client_id(auth_token, account).is_some()
+        && resolve_idc_client_secret(auth_token).is_some()
+    {
+        return resolve_idc_client_credentials(auth_token, account, None);
+    }
+
+    let client_registration = kiro_account::read_local_idc_client_registration(auth_token)?;
+    resolve_idc_client_credentials(auth_token, account, client_registration.as_ref())
+}
+
 fn should_prefer_idc_refresh(auth_token: &Value, account: &KiroAccount) -> bool {
     let auth_method_is_idc = normalize_ascii_lower(
         pick_string(Some(auth_token), &[&["authMethod"], &["auth_method"]]).as_deref(),
@@ -1514,10 +1548,8 @@ async fn refresh_token_via_idc_oidc(
 ) -> Result<Value, String> {
     let region = resolve_idc_region(auth_token, account)
         .ok_or_else(|| "缺少 idc_region，无法执行 AWS IAM Identity Center 刷新".to_string())?;
-    let client_id = resolve_idc_client_id(auth_token, account)
-        .ok_or_else(|| "缺少 client_id，无法执行 AWS IAM Identity Center 刷新".to_string())?;
-    let client_secret = resolve_idc_client_secret(auth_token)
-        .ok_or_else(|| "缺少 client_secret，无法执行 AWS IAM Identity Center 刷新".to_string())?;
+    let (client_id, client_secret) =
+        resolve_idc_client_credentials_from_local_cache(auth_token, account)?;
 
     let endpoint = KIRO_AWS_OIDC_TOKEN_ENDPOINT_FMT.replace("{region}", region.as_str());
     let response = reqwest::Client::new()
@@ -2526,6 +2558,47 @@ mod tests {
         assert!(
             chrono::DateTime::parse_from_rfc3339(expires_at).is_ok(),
             "expiresAt should be valid rfc3339"
+        );
+    }
+
+    #[test]
+    fn idc_client_credentials_preserve_inline_and_saved_account_precedence() {
+        let mut account: KiroAccount = serde_json::from_value(json!({
+            "id": "kiro_test",
+            "email": "tester@example.com",
+            "access_token": "access",
+            "created_at": 0,
+            "last_used": 0
+        }))
+        .expect("build test account");
+        account.client_id = Some("saved-client".to_string());
+        let registration = json!({
+            "clientId": "cache-client",
+            "clientSecret": "cache-secret"
+        });
+
+        let inline_auth = json!({
+            "clientId": "inline-client",
+            "clientSecret": "inline-secret",
+            "clientIdHash": "../ignored-because-inline-is-complete"
+        });
+        let inline_credentials =
+            resolve_idc_client_credentials_from_local_cache(&inline_auth, &account)
+                .expect("resolve inline credentials");
+        assert_eq!(
+            inline_credentials,
+            ("inline-client".to_string(), "inline-secret".to_string())
+        );
+
+        let hash_only_auth = json!({
+            "clientIdHash": "eb04fe0de39241e4fa17bec175f7540138ad1bd8"
+        });
+        let saved_credentials =
+            resolve_idc_client_credentials(&hash_only_auth, &account, Some(&registration))
+                .expect("resolve saved and cached credentials");
+        assert_eq!(
+            saved_credentials,
+            ("saved-client".to_string(), "cache-secret".to_string())
         );
     }
 

--- a/src-tauri/src/modules/kiro_account.rs
+++ b/src-tauri/src/modules/kiro_account.rs
@@ -2,7 +2,7 @@ use rusqlite::{Connection, OptionalExtension};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
@@ -12,6 +12,7 @@ use crate::modules::{account, kiro_oauth, logger};
 const ACCOUNTS_INDEX_FILE: &str = "kiro_accounts.json";
 const ACCOUNTS_DIR: &str = "kiro_accounts";
 const LOCAL_AUTH_TOKEN_FILE_NAME: &str = "kiro-auth-token.json";
+const AWS_SSO_CLIENT_ID_HASH_LENGTH: usize = 40;
 const LOCAL_USAGE_DB_KEY: &str = "kiro.kiroAgent";
 const KIRO_QUOTA_ALERT_COOLDOWN_SECONDS: i64 = 10 * 60;
 
@@ -1463,6 +1464,66 @@ pub fn get_default_kiro_auth_token_path() -> Result<PathBuf, String> {
         .join(LOCAL_AUTH_TOKEN_FILE_NAME))
 }
 
+fn idc_client_registration_path(cache_dir: &Path, client_id_hash: &str) -> Result<PathBuf, String> {
+    let hash = client_id_hash;
+    let is_lower_hex = hash
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+    if hash.len() != AWS_SSO_CLIENT_ID_HASH_LENGTH || !is_lower_hex {
+        return Err("Kiro 本地授权文件中的 clientIdHash 格式无效".to_string());
+    }
+
+    Ok(cache_dir.join(format!("{}.json", hash)))
+}
+
+pub(crate) fn read_idc_client_registration_from_cache_dir(
+    auth_token: &Value,
+    cache_dir: &Path,
+) -> Result<Option<Value>, String> {
+    let Some(client_id_hash) = auth_token.get("clientIdHash") else {
+        return Ok(None);
+    };
+    let client_id_hash = client_id_hash
+        .as_str()
+        .ok_or_else(|| "Kiro 本地授权文件中的 clientIdHash 必须是字符串".to_string())?;
+    let path = idc_client_registration_path(cache_dir, client_id_hash)?;
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(format!(
+                "读取 Kiro IdC 客户端注册文件失败({}): {}",
+                path.display(),
+                err
+            ));
+        }
+    };
+    let parsed = serde_json::from_str::<Value>(&raw).map_err(|err| {
+        format!(
+            "解析 Kiro IdC 客户端注册文件失败({}): {}",
+            path.display(),
+            err
+        )
+    })?;
+    if !parsed.is_object() {
+        return Err(format!(
+            "解析 Kiro IdC 客户端注册文件失败({}): 根节点必须是对象",
+            path.display()
+        ));
+    }
+    Ok(Some(parsed))
+}
+
+pub(crate) fn read_local_idc_client_registration(
+    auth_token: &Value,
+) -> Result<Option<Value>, String> {
+    let auth_token_path = get_default_kiro_auth_token_path()?;
+    let cache_dir = auth_token_path
+        .parent()
+        .ok_or_else(|| "无法解析 AWS SSO 缓存目录".to_string())?;
+    read_idc_client_registration_from_cache_dir(auth_token, cache_dir)
+}
+
 pub fn read_local_auth_token_json() -> Result<Option<Value>, String> {
     let path = get_default_kiro_auth_token_path()?;
     if !path.exists() {
@@ -1514,5 +1575,95 @@ pub fn read_local_usage_snapshot() -> Result<Option<Value>, String> {
             Ok(Some(parsed))
         }
         None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const CLIENT_ID_HASH: &str = "eb04fe0de39241e4fa17bec175f7540138ad1bd8";
+
+    fn create_cache_fixture(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "cockpit-tools-kiro-idc-{}-{}",
+            name,
+            std::process::id()
+        ));
+        if path.exists() {
+            fs::remove_dir_all(&path).expect("remove stale Kiro IdC fixture");
+        }
+        fs::create_dir_all(&path).expect("create Kiro IdC fixture");
+        path
+    }
+
+    #[test]
+    fn idc_registration_reads_only_the_file_named_by_client_id_hash() {
+        let cache_dir = create_cache_fixture("exact-hash");
+        fs::write(
+            cache_dir.join(format!("{}.json", CLIENT_ID_HASH)),
+            r#"{"clientId":"expected-client","clientSecret":"expected-secret"}"#,
+        )
+        .expect("write expected registration");
+        fs::write(
+            cache_dir.join("unrelated.json"),
+            r#"{"clientId":"wrong-client","clientSecret":"wrong-secret"}"#,
+        )
+        .expect("write decoy registration");
+
+        let registration = read_idc_client_registration_from_cache_dir(
+            &json!({"clientIdHash": CLIENT_ID_HASH}),
+            &cache_dir,
+        )
+        .expect("read registration")
+        .expect("registration should exist");
+
+        assert_eq!(
+            registration.get("clientId").and_then(Value::as_str),
+            Some("expected-client")
+        );
+        fs::remove_dir_all(cache_dir).expect("remove Kiro IdC fixture");
+    }
+
+    #[test]
+    fn idc_registration_does_not_scan_when_exact_hash_is_missing() {
+        let cache_dir = create_cache_fixture("no-scan");
+        fs::write(
+            cache_dir.join("unrelated.json"),
+            r#"{"clientId":"wrong-client","clientSecret":"wrong-secret"}"#,
+        )
+        .expect("write decoy registration");
+
+        let registration = read_idc_client_registration_from_cache_dir(
+            &json!({"clientIdHash": CLIENT_ID_HASH}),
+            &cache_dir,
+        )
+        .expect("missing exact registration is allowed");
+
+        assert!(registration.is_none());
+        fs::remove_dir_all(cache_dir).expect("remove Kiro IdC fixture");
+    }
+
+    #[test]
+    fn idc_registration_rejects_noncanonical_client_id_hashes() {
+        let cache_dir = create_cache_fixture("invalid-hash");
+        let invalid_hashes = [
+            "../eb04fe0de39241e4fa17bec175f7540138ad1bd8",
+            "EB04FE0DE39241E4FA17BEC175F7540138AD1BD8",
+            "eb04fe0de39241e4fa17bec175f7540138ad1bd8 ",
+            "eb04fe0de39241e4fa17bec175f7540138ad1bd",
+            "gb04fe0de39241e4fa17bec175f7540138ad1bd8",
+        ];
+
+        for hash in invalid_hashes {
+            let result = read_idc_client_registration_from_cache_dir(
+                &json!({"clientIdHash": hash}),
+                &cache_dir,
+            );
+            assert!(result.is_err(), "hash should be rejected: {}", hash);
+        }
+
+        fs::remove_dir_all(cache_dir).expect("remove Kiro IdC fixture");
     }
 }

--- a/src-tauri/src/modules/kiro_oauth.rs
+++ b/src-tauri/src/modules/kiro_oauth.rs
@@ -647,6 +647,40 @@ fn resolve_idc_client_secret(auth_token: &Value) -> Option<String> {
     .and_then(|value| normalize_non_empty(Some(value.as_str())))
 }
 
+fn resolve_idc_client_credentials(
+    auth_token: &Value,
+    account: &KiroAccount,
+    client_registration: Option<&Value>,
+) -> Result<(String, String), String> {
+    let client_id = resolve_idc_client_id(auth_token, account)
+        .or_else(|| {
+            pick_string(client_registration, &[&["clientId"]])
+                .and_then(|value| normalize_non_empty(Some(value.as_str())))
+        })
+        .ok_or_else(|| "缺少 client_id，无法执行 AWS IAM Identity Center 刷新".to_string())?;
+    let client_secret = resolve_idc_client_secret(auth_token)
+        .or_else(|| {
+            pick_string(client_registration, &[&["clientSecret"]])
+                .and_then(|value| normalize_non_empty(Some(value.as_str())))
+        })
+        .ok_or_else(|| "缺少 client_secret，无法执行 AWS IAM Identity Center 刷新".to_string())?;
+    Ok((client_id, client_secret))
+}
+
+fn resolve_idc_client_credentials_from_local_cache(
+    auth_token: &Value,
+    account: &KiroAccount,
+) -> Result<(String, String), String> {
+    if resolve_idc_client_id(auth_token, account).is_some()
+        && resolve_idc_client_secret(auth_token).is_some()
+    {
+        return resolve_idc_client_credentials(auth_token, account, None);
+    }
+
+    let client_registration = kiro_account::read_local_idc_client_registration(auth_token)?;
+    resolve_idc_client_credentials(auth_token, account, client_registration.as_ref())
+}
+
 fn should_prefer_idc_refresh(auth_token: &Value, account: &KiroAccount) -> bool {
     let auth_method_is_idc = normalize_ascii_lower(
         pick_string(Some(auth_token), &[&["authMethod"], &["auth_method"]]).as_deref(),
@@ -1514,10 +1548,8 @@ async fn refresh_token_via_idc_oidc(
 ) -> Result<Value, String> {
     let region = resolve_idc_region(auth_token, account)
         .ok_or_else(|| "缺少 idc_region，无法执行 AWS IAM Identity Center 刷新".to_string())?;
-    let client_id = resolve_idc_client_id(auth_token, account)
-        .ok_or_else(|| "缺少 client_id，无法执行 AWS IAM Identity Center 刷新".to_string())?;
-    let client_secret = resolve_idc_client_secret(auth_token)
-        .ok_or_else(|| "缺少 client_secret，无法执行 AWS IAM Identity Center 刷新".to_string())?;
+    let (client_id, client_secret) =
+        resolve_idc_client_credentials_from_local_cache(auth_token, account)?;
 
     let endpoint = KIRO_AWS_OIDC_TOKEN_ENDPOINT_FMT.replace("{region}", region.as_str());
     let response = reqwest::Client::new()
@@ -2526,6 +2558,47 @@ mod tests {
         assert!(
             chrono::DateTime::parse_from_rfc3339(expires_at).is_ok(),
             "expiresAt should be valid rfc3339"
+        );
+    }
+
+    #[test]
+    fn idc_client_credentials_preserve_inline_and_saved_account_precedence() {
+        let mut account: KiroAccount = serde_json::from_value(json!({
+            "id": "kiro_test",
+            "email": "tester@example.com",
+            "access_token": "access",
+            "created_at": 0,
+            "last_used": 0
+        }))
+        .expect("build test account");
+        account.client_id = Some("saved-client".to_string());
+        let registration = json!({
+            "clientId": "cache-client",
+            "clientSecret": "cache-secret"
+        });
+
+        let inline_auth = json!({
+            "clientId": "inline-client",
+            "clientSecret": "inline-secret",
+            "clientIdHash": "../ignored-because-inline-is-complete"
+        });
+        let inline_credentials =
+            resolve_idc_client_credentials_from_local_cache(&inline_auth, &account)
+                .expect("resolve inline credentials");
+        assert_eq!(
+            inline_credentials,
+            ("inline-client".to_string(), "inline-secret".to_string())
+        );
+
+        let hash_only_auth = json!({
+            "clientIdHash": "eb04fe0de39241e4fa17bec175f7540138ad1bd8"
+        });
+        let saved_credentials =
+            resolve_idc_client_credentials(&hash_only_auth, &account, Some(&registration))
+                .expect("resolve saved and cached credentials");
+        assert_eq!(
+            saved_credentials,
+            ("saved-client".to_string(), "cache-secret".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- follow the canonical `clientIdHash` pointer from Kiro's AWS SSO cache to the exact `{hash}.json` registration
- preserve inline auth and saved-account precedence, with strict lower-hex validation and no directory scanning
- apply the resolver in both the shared cockpit-core and Tauri Kiro OAuth paths with fixture tests

Fixes #1300

## Tests
- targeted Kiro IdC tests (5 passed)
- cockpit-core suite reached 88 passed; two unrelated pre-existing failures were reported separately
- `git diff --check`