### PR TITLE
fix(codex): honor sidecar bootstrap retry setting

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -2895,7 +2895,7 @@ func buildCoreAuthSelector(cfg *config.Config, selector coreauth.Selector, m *ma
 		})
 		selector = &imageRequestSelector{
 			imageFallback: imageFallback,
-			fallback:      &cockpitSessionAffinitySelector{inner: selector},
+			fallback:      &cockpitSessionAffinitySelector{inner: affinitySelector},
 		}
 	}
 	if m != nil {

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -10581,7 +10581,7 @@ async fn prepare_sidecar_launch_config_in_dir(
         "streaming".to_string(),
         json!({
             "keepalive-seconds": timeouts.sidecar_stream_keepalive_seconds,
-            "bootstrap-retries": timeouts.single_account_status_retry_attempts,
+            "bootstrap-retries": timeouts.sidecar_streaming_bootstrap_retries,
             "bootstrap-retry-base-delay-ms": timeouts.single_account_status_retry_base_delay_ms,
             "bootstrap-retry-max-delay-ms": timeouts.single_account_status_retry_max_delay_ms,
             "stream-open-timeout-ms": timeouts.sidecar_stream_open_timeout_ms,
@@ -29314,6 +29314,46 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
             &fs::read_to_string(&launch_config.config_path).expect("read sidecar config"),
         )
         .expect("parse sidecar config");
+
+        fs::remove_dir_all(&dir).expect("cleanup temp dir");
+    }
+
+    #[tokio::test]
+    async fn sidecar_config_uses_streaming_bootstrap_retry_setting() {
+        let dir = make_temp_dir("codex-sidecar-streaming-bootstrap-retries");
+        let account = CodexAccount::new(
+            "oauth-streaming-retries-1".to_string(),
+            "oauth@example.com".to_string(),
+            CodexTokens {
+                id_token: String::new(),
+                access_token: "access-token".to_string(),
+                refresh_token: Some("refresh-token".to_string()),
+            },
+        );
+        let mut collection = test_local_access_collection(vec![account.id.clone()]);
+        collection.timeouts.single_account_status_retry_attempts = 4;
+        collection.timeouts.sidecar_streaming_bootstrap_retries = 2;
+
+        let launch_config = prepare_sidecar_launch_config_in_dir(
+            &collection,
+            dir.clone(),
+            HashMap::new(),
+            None,
+            HashMap::from([(account.id.clone(), account)]),
+        )
+        .await
+        .expect("sidecar config should build");
+        let config: Value = serde_json::from_str(
+            &fs::read_to_string(&launch_config.config_path).expect("read sidecar config"),
+        )
+        .expect("parse sidecar config");
+
+        assert_eq!(
+            config
+                .get("streaming")
+                .and_then(|streaming| streaming.get("bootstrap-retries")),
+            Some(&json!(2))
+        );
 
         fs::remove_dir_all(&dir).expect("cleanup temp dir");
     }


### PR DESCRIPTION
## Summary
- use the dedicated new-API startup retry setting for sidecar `streaming.bootstrap-retries`
- keep the legacy single-account retry setting scoped to the embedded gateway
- fix the upstream sidecar selector merge so `affinitySelector` is used and Go builds succeed while API-key session affinity remains active
- add a Rust regression test for the retry setting

Fixes #1572

## Tests
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -q sidecar_config_uses_streaming_bootstrap_retry_setting --lib` (1 passed)
- `go test ./...` in `sidecars/cockpit-cliproxy`
- `git diff --check`

The original build matrix failure was reproduced from run 29472393051: all platform jobs failed at `main.go:2892` with `declared and not used: affinitySelector`. The follow-up fix is commit `4891d1d0`.