### PR TITLE
支持已有 Codex 账号直接加入 API 服务

### DIFF
--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -107,7 +107,10 @@ import {
   type CodexResetCredit,
   type CodexResetCreditsSnapshot,
 } from "../types/codex";
-import { filterCodexLocalAccessAccountIds } from "../utils/codexLocalAccessAccounts";
+import {
+  canAddCodexAccountToLocalAccess,
+  filterCodexLocalAccessAccountIds,
+} from "../utils/codexLocalAccessAccounts";
 import {
   extractCodexQuotaErrorCode,
   extractCodexQuotaErrorStatusCode,
@@ -1009,6 +1012,9 @@ export function CodexAccountsPage() {
     "panel" | "members"
   >("panel");
   const [localAccessSaving, setLocalAccessSaving] = useState(false);
+  const [addingLocalAccessAccountId, setAddingLocalAccessAccountId] = useState<
+    string | null
+  >(null);
   const [localAccessStarting, setLocalAccessStarting] = useState(false);
   const [syncImportedToApiService, setSyncImportedToApiService] = useState(
     readCodexImportSyncApiService,
@@ -8208,6 +8214,91 @@ export function CodexAccountsPage() {
     [localAccessCollection?.accountIds],
   );
 
+  const canDirectlyAddLocalAccessAccount = useCallback(
+    (account: CodexAccount) =>
+      localAccessState !== null &&
+      canAddCodexAccountToLocalAccess(
+        account,
+        localAccessAccountIdSet,
+        localAccessCollection?.restrictFreeAccounts ?? true,
+      ),
+    [
+      localAccessAccountIdSet,
+      localAccessCollection?.restrictFreeAccounts,
+      localAccessState,
+    ],
+  );
+
+  const handleAddLocalAccessAccount = useCallback(
+    async (accountId: string) => {
+      if (addingLocalAccessAccountId) return;
+      setAddingLocalAccessAccountId(accountId);
+      try {
+        const result =
+          await codexLocalAccessService.appendCodexLocalAccessAccounts([
+            accountId,
+          ]);
+        setLocalAccessState(result.state);
+        const accountAdded = Boolean(
+          result.state.collection?.accountIds.includes(accountId),
+        );
+        if (!accountAdded) {
+          throw new Error(
+            t(
+              "codex.localAccess.noEligibleAccountsSelected",
+              "所选账号不在当前环境中，或不符合 API 服务条件。请先在当前环境导入可用 Codex 账号后再添加。",
+            ),
+          );
+        }
+        await ensureLocalAccessEntryVisible();
+        window.dispatchEvent(new Event("codex-local-access-state-updated"));
+        setMessage({
+          text: t("codex.localAccess.saveSuccess", "API 服务集合已更新"),
+        });
+      } catch (error) {
+        console.error("Failed to add account to API service:", error);
+        setMessage({
+          text: t("messages.actionFailed", {
+            action: t("codex.localAccess.entryAction", "添加至 API 服务"),
+            error: String(error).replace(/^Error:\s*/, ""),
+          }),
+          tone: "error",
+        });
+      } finally {
+        setAddingLocalAccessAccountId(null);
+      }
+    },
+    [addingLocalAccessAccountId, ensureLocalAccessEntryVisible, setMessage, t],
+  );
+
+  const renderAddLocalAccessAccountButton = (
+    account: CodexAccount,
+    className: string,
+    iconSize = 14,
+  ) => {
+    if (!canDirectlyAddLocalAccessAccount(account)) return null;
+    const label = t(
+      "codex.localAccess.entryAction",
+      "添加至 API 服务",
+    );
+    return (
+      <button
+        type="button"
+        className={className}
+        onClick={() => void handleAddLocalAccessAccount(account.id)}
+        disabled={addingLocalAccessAccountId !== null}
+        title={label}
+        aria-label={label}
+      >
+        {addingLocalAccessAccountId === account.id ? (
+          <RefreshCw size={iconSize} className="loading-spinner" />
+        ) : (
+          <Link2 size={iconSize} />
+        )}
+      </button>
+    );
+  };
+
   const handleSaveLocalAccessAccounts = useCallback(
     async (
       accountIds: string[],
@@ -9813,6 +9904,11 @@ export function CodexAccountsPage() {
             )}
           </div>
           {renderAccountSpeedSelect(account, true)}
+          {renderAddLocalAccessAccountButton(
+            account,
+            "codex-compact-api-service-btn",
+            13,
+          )}
           {!isApiKeyAccount && (
             <button
               className={`codex-compact-note-btn ${hasCodexAccountNoteDetails(account) ? "has-note" : ""}`}
@@ -10246,6 +10342,10 @@ export function CodexAccountsPage() {
                     <Terminal size={14} />
                   )}
                 </button>
+                {renderAddLocalAccessAccountButton(
+                  account,
+                  "card-action-btn",
+                )}
                 {isNewApiAccount && (
                   <button
                     className="card-action-btn"
@@ -11575,6 +11675,7 @@ export function CodexAccountsPage() {
                   <Terminal size={14} />
                 )}
               </button>
+              {renderAddLocalAccessAccountButton(account, "action-btn")}
               {isNewApiAccount && (
                 <button
                   className="action-btn"

--- a/src/styles/pages/codex.css
+++ b/src/styles/pages/codex.css
@@ -4325,7 +4325,8 @@
   transition: all 0.15s ease;
 }
 
-.codex-accounts-page .codex-compact-note-btn {
+.codex-accounts-page .codex-compact-note-btn,
+.codex-accounts-page .codex-compact-api-service-btn {
   width: 22px;
   height: 22px;
   border-radius: var(--radius-md);
@@ -4341,10 +4342,16 @@
 }
 
 .codex-accounts-page .codex-compact-note-btn:hover,
-.codex-accounts-page .codex-compact-note-btn.has-note {
+.codex-accounts-page .codex-compact-note-btn.has-note,
+.codex-accounts-page .codex-compact-api-service-btn:hover:not(:disabled) {
   color: var(--primary);
   border-color: rgba(37, 99, 235, 0.22);
   background: rgba(37, 99, 235, 0.08);
+}
+
+.codex-accounts-page .codex-compact-api-service-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .codex-accounts-page .codex-compact-switch-btn:hover:not(:disabled) {

--- a/src/utils/codexLocalAccessAccounts.test.ts
+++ b/src/utils/codexLocalAccessAccounts.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  canAddCodexAccountToLocalAccess,
   getCodexLocalAccessAccountIneligibleReason,
   isCodexLocalAccessEligibleAccount,
 } from "./codexLocalAccessAccounts.ts";
@@ -43,4 +44,28 @@ test("authorized oauth accounts remain eligible", () => {
   });
   assert.equal(getCodexLocalAccessAccountIneligibleReason(ok, true), null);
   assert.equal(isCodexLocalAccessEligibleAccount(ok, true), true);
+});
+
+test("eligible accounts can be added when they are not API service members", () => {
+  const eligible = account({ plan_type: "plus" });
+
+  assert.equal(
+    canAddCodexAccountToLocalAccess(eligible, new Set(), true),
+    true,
+  );
+  assert.equal(
+    canAddCodexAccountToLocalAccess(
+      eligible,
+      new Set([eligible.id]),
+      true,
+    ),
+    false,
+  );
+});
+
+test("direct add follows the API service free-account restriction", () => {
+  const free = account({ plan_type: "free" });
+
+  assert.equal(canAddCodexAccountToLocalAccess(free, new Set(), true), false);
+  assert.equal(canAddCodexAccountToLocalAccess(free, new Set(), false), true);
 });

--- a/src/utils/codexLocalAccessAccounts.ts
+++ b/src/utils/codexLocalAccessAccounts.ts
@@ -99,6 +99,17 @@ export function isCodexLocalAccessEligibleAccount(
   ) === null;
 }
 
+export function canAddCodexAccountToLocalAccess(
+  account: CodexAccount,
+  currentAccountIds: ReadonlySet<string>,
+  restrictFreeAccounts: boolean,
+): boolean {
+  return (
+    !currentAccountIds.has(account.id) &&
+    isCodexLocalAccessEligibleAccount(account, restrictFreeAccounts)
+  );
+}
+
 export function filterCodexLocalAccessAccountIds(
   accountIds: string[],
   accounts: CodexAccount[],


### PR DESCRIPTION
### Code changes

- Added `canAddCodexAccountToLocalAccess()` with coverage for existing membership and Free-account restrictions.
- Added a one-click API service action to compact, card, and table account layouts.
- Reused the existing incremental append command and added loading, success, and failure feedback.

为已导入但尚未加入 API 服务的 Codex 账号增加了直接入口。符合现有规则的账号现在可以从账号列表一键加入，同时继续遵循 Free 账号、待授权账号和不兼容 API Key 的限制。

### Verification

- `node --test src/utils/codexLocalAccessAccounts.test.ts tests/codexLocalAccessAccounts.test.ts`
- `npm run typecheck`
- `npm run build`