### PR TITLE
阻止图片模型误用 Chat Completions

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -4808,6 +4808,11 @@ func (s *relayServer) handleExecutorBody(c *gin.Context, spec *apiKeySpec, body 
 		writeAPIError(c, http.StatusBadRequest, "model is required", "invalid_request")
 		return
 	}
+	canonicalModel := canonicalModelForClientModel(s.manifest, spec, model)
+	if sourceFormatEqual(sourceFormat, sdktranslator.FormatOpenAI) && isGPTImageGenerationModel(canonicalModel) {
+		writeAPIError(c, http.StatusBadRequest, "This model is not supported on the Chat Completions endpoint", "invalid_request")
+		return
+	}
 
 	if spec.ProviderGateway != nil {
 		s.handleProviderGatewayRequest(c, spec.ProviderGateway, body, model, sourceFormat, fixedAlt)
@@ -6633,6 +6638,10 @@ func modelBase(model string) string {
 		model = strings.TrimSpace(model[idx+1:])
 	}
 	return model
+}
+
+func isGPTImageGenerationModel(model string) bool {
+	return strings.HasPrefix(modelBase(model), "gpt-image-")
 }
 
 func jsonContainsImageGenerationTool(body []byte) bool {

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1767,6 +1768,63 @@ func TestRelayServerExecutesNonStreamingRequestThroughRuntime(t *testing.T) {
 	}
 	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
 		t.Fatalf("CORS header should match CPA server behavior")
+	}
+}
+
+func TestRelayServerRejectsGPTImageModelsOnChatCompletionsBeforeRuntime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	runtime := &fakeRuntime{}
+	apiKey := &apiKeySpec{
+		ID:          "key_1",
+		Label:       "Test key",
+		Key:         "client-key",
+		ModelPrefix: "team",
+		Enabled:     true,
+	}
+	m := &manifest{
+		APIKeys:  []apiKeySpec{*apiKey},
+		ModelIDs: []string{"gpt-5.5", "gpt-image-2"},
+		ModelAliases: []modelAliasSpec{{
+			SourceModel: "gpt-image-2",
+			Alias:       "image-latest",
+		}},
+		apiKeyByValue: map[string]*apiKeySpec{"client-key": apiKey},
+		aliasToSource: map[string]string{"image-latest": "gpt-image-2"},
+	}
+	router := (&relayServer{
+		runtime:  runtime,
+		cfg:      &config.Config{},
+		manifest: m,
+		policy:   &requestPolicy{manifest: m},
+	}).router()
+
+	for _, model := range []string{"team/gpt-image-2", "team/image-latest"} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":"draw"}]}`, model)))
+		req.Header.Set("Authorization", "Bearer client-key")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("model %q status = %d, want %d; body=%s", model, w.Code, http.StatusBadRequest, w.Body.String())
+		}
+		var payload struct {
+			Error struct {
+				Message string `json:"message"`
+				Type    string `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("model %q response should be JSON: %v", model, err)
+		}
+		if payload.Error.Type != "invalid_request_error" || !strings.Contains(payload.Error.Message, "Chat Completions") {
+			t.Fatalf("model %q unexpected error payload: %#v", model, payload.Error)
+		}
+	}
+
+	if runtime.executeCalls != 0 || runtime.streamCalls != 0 {
+		t.Fatalf("image-only models must be rejected before runtime scheduling: execute=%d stream=%d", runtime.executeCalls, runtime.streamCalls)
 	}
 }
 

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -2456,6 +2456,12 @@ fn normalize_image_model_base(model: &str) -> String {
     base_model.to_string()
 }
 
+fn is_gpt_image_generation_model(model: &str) -> bool {
+    normalize_image_model_base(model)
+        .to_ascii_lowercase()
+        .starts_with("gpt-image-")
+}
+
 fn normalize_image_response_format(value: Option<&Value>) -> String {
     value
         .and_then(Value::as_str)
@@ -3705,6 +3711,9 @@ fn build_responses_body_from_chat_completions(
         .filter(|value| !value.is_empty())
         .map(resolve_supported_model_alias)
         .ok_or("chat/completions 请求缺少 model".to_string())?;
+    if is_gpt_image_generation_model(&model) {
+        return Err("This model is not supported on the Chat Completions endpoint".to_string());
+    }
     let messages = request_obj
         .get("messages")
         .ok_or("chat/completions 请求缺少 messages".to_string())?;
@@ -27480,6 +27489,26 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
                 assert_eq!(requested_model, "gpt-5.4");
             }
             _ => panic!("expected chat completions adapter"),
+        }
+    }
+
+    #[test]
+    fn rejects_gpt_image_models_from_chat_completions() {
+        for model in ["gpt-image-1", "GPT-IMAGE-2", "team/gpt-image-2"] {
+            let request = ParsedRequest {
+                method: "POST".to_string(),
+                target: "/v1/chat/completions".to_string(),
+                headers: HashMap::new(),
+                body: format!(
+                    r#"{{"model":"{}","messages":[{{"role":"user","content":"draw"}}]}}"#,
+                    model
+                )
+                .into_bytes(),
+            };
+
+            let err = prepare_gateway_request(request)
+                .expect_err("image-only model should be rejected before proxying");
+            assert!(err.contains("Chat Completions"), "model={model}, err={err}");
         }
     }
 


### PR DESCRIPTION
### Code changes

- Added pre-dispatch gpt-image-* validation to the sidecar and legacy Codex API gateways.
- Covered API key model prefixes, aliases, and legacy request conversion.

在 /v1/chat/completions 调度前拒绝图片专用模型，并返回明确的 400 错误。这样可以避免占用账号并发后才由上游报错，同时保持 Responses 和图片专用端点的现有行为不变。