### PR TITLE
修复 Responses 流式分片与 JSON 事件边界错位

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -7160,7 +7160,41 @@ func responsesSSECanEmitWithoutDelimiter(chunk []byte) bool {
 	if responsesSSENeedsMoreData(trimmed) {
 		return false
 	}
-	return isSSEFieldChunk(trimmed) || bytes.HasPrefix(trimmed, []byte("{")) || bytes.HasPrefix(trimmed, []byte("["))
+	if payload, ok := responsesSSEDataPayload(trimmed); ok {
+		if bytes.Equal(bytes.TrimSpace(payload), []byte("[DONE]")) {
+			return true
+		}
+		return json.Valid(payload)
+	}
+	return isSSEFieldChunk(trimmed)
+}
+
+func responsesSSEDataPayload(chunk []byte) ([]byte, bool) {
+	trimmed := bytes.TrimSpace(chunk)
+	if len(trimmed) == 0 {
+		return nil, false
+	}
+	if bytes.HasPrefix(trimmed, []byte("{")) || bytes.HasPrefix(trimmed, []byte("[")) {
+		return trimmed, true
+	}
+
+	lines := bytes.Split(bytes.ReplaceAll(trimmed, []byte("\r\n"), []byte("\n")), []byte("\n"))
+	dataLines := make([][]byte, 0, 1)
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		value := line[len("data:"):]
+		if len(value) > 0 && value[0] == ' ' {
+			value = value[1:]
+		}
+		dataLines = append(dataLines, value)
+	}
+	if len(dataLines) == 0 {
+		return nil, false
+	}
+	return bytes.Join(dataLines, []byte("\n")), true
 }
 
 func responsesSSENeedsMoreData(chunk []byte) bool {

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -7058,7 +7058,7 @@ func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) error {
 		if frameLen == 0 {
 			break
 		}
-		if err := writeResponsesSSEChunk(w, f.pending[:frameLen]); err != nil {
+		if err := writeResponsesSSEFrame(w, f.pending[:frameLen]); err != nil {
 			return err
 		}
 		copy(f.pending, f.pending[frameLen:])
@@ -7071,7 +7071,7 @@ func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) error {
 	if !responsesSSECanEmitWithoutDelimiter(f.pending) {
 		return nil
 	}
-	if err := writeResponsesSSEChunk(w, f.pending); err != nil {
+	if err := writeResponsesSSEFrame(w, f.pending); err != nil {
 		return err
 	}
 	f.pending = f.pending[:0]
@@ -7090,10 +7090,82 @@ func (f *responsesSSEFramer) Flush(w io.Writer) error {
 		f.pending = f.pending[:0]
 		return nil
 	}
-	if err := writeResponsesSSEChunk(w, f.pending); err != nil {
+	if err := writeResponsesSSEFrame(w, f.pending); err != nil {
 		return err
 	}
 	f.pending = f.pending[:0]
+	return nil
+}
+
+const (
+	maxResponsesConcatenatedJSONDocuments = 16
+	maxResponsesConcatenatedJSONBytes     = 16 * 1024 * 1024
+)
+
+func splitResponsesConcatenatedJSONDocuments(payload []byte) ([][]byte, bool) {
+	payload = bytes.TrimSpace(payload)
+	if len(payload) == 0 || len(payload) > maxResponsesConcatenatedJSONBytes || json.Valid(payload) {
+		return nil, false
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	documents := make([][]byte, 0, 2)
+	for {
+		var raw json.RawMessage
+		err := decoder.Decode(&raw)
+		if err != nil {
+			if errors.Is(err, io.EOF) && len(documents) > 1 {
+				return documents, true
+			}
+			return nil, false
+		}
+
+		raw = bytes.TrimSpace(raw)
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			return nil, false
+		}
+		eventType := strings.TrimSpace(envelope.Type)
+		if eventType == "" || strings.ContainsAny(eventType, "\r\n") {
+			return nil, false
+		}
+		if len(documents) == maxResponsesConcatenatedJSONDocuments {
+			return nil, false
+		}
+		documents = append(documents, bytes.Clone(raw))
+	}
+}
+
+func writeResponsesSSEFrame(w io.Writer, chunk []byte) error {
+	payload, ok := responsesSSEDataPayload(chunk)
+	if !ok {
+		return writeResponsesSSEChunk(w, chunk)
+	}
+	documents, repaired := splitResponsesConcatenatedJSONDocuments(payload)
+	if !repaired {
+		return writeResponsesSSEChunk(w, chunk)
+	}
+
+	for _, document := range documents {
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(document, &envelope); err != nil {
+			return err
+		}
+		frame := make([]byte, 0, len(document)+len(envelope.Type)+17)
+		frame = append(frame, "event: "...)
+		frame = append(frame, strings.TrimSpace(envelope.Type)...)
+		frame = append(frame, '\n')
+		frame = append(frame, "data: "...)
+		frame = append(frame, document...)
+		frame = append(frame, '\n', '\n')
+		if err := writeResponsesSSEChunk(w, frame); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -7164,7 +7236,11 @@ func responsesSSECanEmitWithoutDelimiter(chunk []byte) bool {
 		if bytes.Equal(bytes.TrimSpace(payload), []byte("[DONE]")) {
 			return true
 		}
-		return json.Valid(payload)
+		if json.Valid(payload) {
+			return true
+		}
+		_, repaired := splitResponsesConcatenatedJSONDocuments(payload)
+		return repaired
 	}
 	return isSSEFieldChunk(trimmed)
 }

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -25,6 +25,32 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
 
+func TestResponsesSSEFramerBuffersPartialJSONAcrossChunks(t *testing.T) {
+	framer := newRelayStreamFramer(sdktranslator.FormatOpenAIResponse, "/v1/responses")
+	var output strings.Builder
+
+	first := []byte("event: response.completed\ndata: {\"type\":\"response.comp")
+	if err := framer.Write(&output, first); err != nil {
+		t.Fatalf("write first chunk: %v", err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("partial JSON should remain buffered, got %q", output.String())
+	}
+
+	second := []byte("leted\",\"response\":{\"id\":\"resp_1\"}}")
+	if err := framer.Write(&output, second); err != nil {
+		t.Fatalf("write second chunk: %v", err)
+	}
+	if err := framer.Close(&output); err != nil {
+		t.Fatalf("close framer: %v", err)
+	}
+
+	want := "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\"}}\n\n"
+	if got := output.String(); got != want {
+		t.Fatalf("framed output = %q, want %q", got, want)
+	}
+}
+
 func TestCodexClientModelsResponseShape(t *testing.T) {
 	response := buildCodexClientModelsResponse([]string{"gpt-5.4", "gpt-image-2", codexAutoReviewModel}, &apiKeySpec{})
 	models, ok := response["models"].([]map[string]any)

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -51,6 +51,73 @@ func TestResponsesSSEFramerBuffersPartialJSONAcrossChunks(t *testing.T) {
 	}
 }
 
+func TestResponsesSSEFramerRepairsConcatenatedJSONDocuments(t *testing.T) {
+	first := `{"type":"response.in_progress","response":{"id":"resp_1"}}`
+	second := `{"type":"response.output_item.added","output_index":0,"item":{"type":"message"}}`
+
+	tests := []struct {
+		name  string
+		chunk string
+	}{
+		{
+			name:  "plain JSON chunk",
+			chunk: first + second,
+		},
+		{
+			name:  "SSE data line",
+			chunk: "event: response.in_progress\ndata: " + first + second + "\n\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			framer := newRelayStreamFramer(sdktranslator.FormatOpenAIResponse, "/v1/responses")
+			var output strings.Builder
+			if err := framer.Write(&output, []byte(tc.chunk)); err != nil {
+				t.Fatalf("write concatenated chunk: %v", err)
+			}
+			if err := framer.Close(&output); err != nil {
+				t.Fatalf("close framer: %v", err)
+			}
+
+			frames := strings.Split(strings.TrimSpace(output.String()), "\n\n")
+			wantTypes := []string{"response.in_progress", "response.output_item.added"}
+			if len(frames) != len(wantTypes) {
+				t.Fatalf("frame count = %d, want %d; output=%q", len(frames), len(wantTypes), output.String())
+			}
+			for i, frame := range frames {
+				lines := strings.Split(frame, "\n")
+				if len(lines) != 2 {
+					t.Fatalf("frame %d lines = %d, want 2; frame=%q", i, len(lines), frame)
+				}
+				if got := strings.TrimSpace(strings.TrimPrefix(lines[0], "event:")); got != wantTypes[i] {
+					t.Fatalf("frame %d event = %q, want %q", i, got, wantTypes[i])
+				}
+				data := strings.TrimSpace(strings.TrimPrefix(lines[1], "data:"))
+				if !json.Valid([]byte(data)) {
+					t.Fatalf("frame %d data is invalid JSON: %q", i, data)
+				}
+				var envelope struct {
+					Type string `json:"type"`
+				}
+				if err := json.Unmarshal([]byte(data), &envelope); err != nil {
+					t.Fatalf("decode frame %d: %v", i, err)
+				}
+				if envelope.Type != wantTypes[i] {
+					t.Fatalf("frame %d payload type = %q, want %q", i, envelope.Type, wantTypes[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitResponsesConcatenatedJSONDocumentsRejectsMalformedPayload(t *testing.T) {
+	payload := []byte(`{"type":"response.in_progress"}{"missing_type":true}`)
+	if documents, repaired := splitResponsesConcatenatedJSONDocuments(payload); repaired || documents != nil {
+		t.Fatalf("malformed payload should not be repaired: %#v", documents)
+	}
+}
+
 func TestCodexClientModelsResponseShape(t *testing.T) {
 	response := buildCodexClientModelsResponse([]string{"gpt-5.4", "gpt-image-2", codexAutoReviewModel}, &apiKeySpec{})
 	models, ok := response["models"].([]map[string]any)


### PR DESCRIPTION
### Code changes

- Strategy and data flow: retain transport fragments in the request-local framer until their SSE data forms `[DONE]`, one valid JSON document, or a narrowly repairable sequence of complete documents.
- State isolation: keep pending bytes inside each `responsesSSEFramer` instance, so partial data and repair state cannot leak across requests or streams.
- Boundary and compatibility: split at most 16 documents within 16 MiB, require every repaired document to expose a valid event type, preserve valid single-document frames as-is, and leave ambiguous malformed payloads on the existing error path.

Responses 的网络分片并不保证与 JSON 事件边界一致，原逻辑可能提前输出半段 JSON，或把多个事件合成一个非法 `data`。本次修复避免客户端解析失败和后续事件丢失，同时通过严格修复范围保证正常流式响应不受影响。