### PR TITLE
补全缺失工具调用 ID 的 Responses 事件链

### DIFF
--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -619,7 +619,13 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						existingCallID := st.FuncCallIDs[key]
 						effectiveCallID := existingCallID
 						shouldEmitItem := false
-						if existingCallID == "" && newCallID != "" {
+						if existingCallID == "" {
+							if newCallID == "" {
+								// Some OpenAI-compatible providers omit tool_call ids in
+								// streaming deltas; synthesize one so the Responses event
+								// chain (output_item.added/done) still fires for Codex.
+								newCallID = fmt.Sprintf("call_%s_%d_%d", st.ResponseID, idx, toolIndex)
+							}
 							effectiveCallID = newCallID
 							st.FuncCallIDs[key] = newCallID
 							st.FuncOutputIx[key] = allocOutputIndex()
@@ -933,8 +939,13 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 
 				// Function/tool calls
 				if tcs := msg.Get("tool_calls"); tcs.Exists() && tcs.IsArray() {
-					tcs.ForEach(func(_, tc gjson.Result) bool {
+					tcs.ForEach(func(tcIndex, tc gjson.Result) bool {
 						callID := tc.Get("id").String()
+						if callID == "" {
+							// Providers may omit tool_call ids; synthesize one so the
+							// function_call item stays usable for Codex round-trips.
+							callID = fmt.Sprintf("call_%s_%d_%d", id, choice.Get("index").Int(), tcIndex.Int())
+						}
 						name := tc.Get("function.name").String()
 						args := tc.Get("function.arguments").String()
 						item := responseToolCallItem(callID, name, args, "completed", toolSpecs[name])

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -301,6 +301,58 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_Restores
 	}
 }
 
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_SynthesizesMissingToolCallID(t *testing.T) {
+	request := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"lookup"}]}`)
+	in := []string{
+		`data: {"id":"resp_missing_id","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"lookup","arguments":""}}]},"finish_reason":null}]}`,
+		`data: {"id":"resp_missing_id","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"query\":\"weather\"}"}}]},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	}
+
+	var param any
+	events := map[string]gjson.Result{}
+	for _, line := range in {
+		for _, chunk := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "model", request, request, []byte(line), &param) {
+			event, data := parseOpenAIResponsesSSEEvent(t, chunk)
+			events[event] = data
+		}
+	}
+
+	const wantCallID = "call_resp_missing_id_0_0"
+	if got := events["response.output_item.added"].Get("item.call_id").String(); got != wantCallID {
+		t.Fatalf("added call_id = %q, want %q", got, wantCallID)
+	}
+	if got := events["response.output_item.done"].Get("item.call_id").String(); got != wantCallID {
+		t.Fatalf("done call_id = %q, want %q", got, wantCallID)
+	}
+	if got := events["response.completed"].Get("response.output.0.call_id").String(); got != wantCallID {
+		t.Fatalf("completed call_id = %q, want %q", got, wantCallID)
+	}
+}
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_SynthesizesMissingToolCallID(t *testing.T) {
+	request := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"lookup"}]}`)
+	raw := []byte(`{
+		"id":"chatcmpl_missing_id",
+		"object":"chat.completion",
+		"created":1773896263,
+		"model":"model",
+		"choices":[{"index":2,"message":{"role":"assistant","tool_calls":[
+			{"type":"function","function":{"name":"lookup","arguments":"{\"query\":\"weather\"}"}}
+		]},"finish_reason":"tool_calls"}]
+	}`)
+
+	out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "model", request, request, raw, nil)
+
+	const wantCallID = "call_chatcmpl_missing_id_2_0"
+	if got := gjson.GetBytes(out, "output.0.call_id").String(); got != wantCallID {
+		t.Fatalf("call_id = %q, want %q; out=%s", got, wantCallID, out)
+	}
+	if got := gjson.GetBytes(out, "output.0.id").String(); got != "fc_"+wantCallID {
+		t.Fatalf("item id = %q, want %q; out=%s", got, "fc_"+wantCallID, out)
+	}
+}
+
 func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_MultipleToolCallsRemainSeparate(t *testing.T) {
 	in := []string{
 		`data: {"id":"resp_test","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":"assistant","content":null,"reasoning_content":null,"tool_calls":[{"index":0,"id":"call_read","type":"function","function":{"name":"read","arguments":""}}]},"finish_reason":null}]}`,


### PR DESCRIPTION
### Code changes

- Strategy and data flow: derive a deterministic fallback ID from response, choice, and tool indexes when the first tool-call delta omits `tool_calls[].id`, then store it in the existing per-stream conversion state.
- State isolation: key synthesized IDs by choice and tool index so parallel calls remain independent, and reuse each ID across added, argument, done, and completed events.
- Boundary and compatibility: never replace an upstream-provided ID, apply the same fallback to non-streaming conversion, and preserve the existing event shape for conforming providers.

部分 OpenAI 兼容上游会返回完整工具名称和参数，却漏掉调用 ID，导致 Codex 收不到可执行的工具事件。本次修复让这类上游仍能正常调用工具和回传结果，同时完全保留规范响应的原有行为。