### PR TITLE
修复 reasoning 历史回放 404 并优化清洗复杂度

### DIFF
--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/openai_responses_signature.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/openai_responses_signature.go
@@ -12,8 +12,8 @@ import (
 )
 
 func sanitizeOpenAIResponsesReasoningEncryptedContent(ctx context.Context, provider string, body []byte) []byte {
-	input := gjson.GetBytes(body, "input")
-	if !input.Exists() || !input.IsArray() {
+	inputResult := gjson.GetBytes(body, "input")
+	if !inputResult.Exists() || !inputResult.IsArray() {
 		return body
 	}
 	provider = strings.TrimSpace(provider)
@@ -21,15 +21,35 @@ func sanitizeOpenAIResponsesReasoningEncryptedContent(ctx context.Context, provi
 		provider = "openai responses upstream"
 	}
 
-	updated := body
-	for index, item := range input.Array() {
+	items := inputResult.Array()
+
+	// rebuilt accumulates the edited "input" array as JSON array bytes. It
+	// stays nil while no item needs editing so the common case (nothing to
+	// sanitize) does no allocation or rebuilding. Edits are applied directly
+	// to each item's own raw JSON rather than re-parsing the whole body,
+	// keeping the cost proportional to the item being edited.
+	var rebuilt []byte
+	itemsWritten := 0
+	keep := func(raw string) {
+		if rebuilt == nil {
+			return
+		}
+		if itemsWritten > 0 {
+			rebuilt = append(rebuilt, ',')
+		}
+		rebuilt = append(rebuilt, raw...)
+		itemsWritten++
+	}
+
+	for index, item := range items {
 		if strings.TrimSpace(item.Get("type").String()) != "reasoning" {
+			keep(item.Raw)
 			continue
 		}
 
-		encryptedContentPath := fmt.Sprintf("input.%d.encrypted_content", index)
-		encryptedContent := gjson.GetBytes(updated, encryptedContentPath)
+		encryptedContent := item.Get("encrypted_content")
 		if !encryptedContent.Exists() {
+			keep(item.Raw)
 			continue
 		}
 
@@ -48,21 +68,44 @@ func sanitizeOpenAIResponsesReasoningEncryptedContent(ctx context.Context, provi
 			reason = fmt.Sprintf("encrypted_content must be a string, got %s", encryptedContent.Type.String())
 		}
 		if reason == "" {
+			keep(item.Raw)
 			continue
 		}
 
-		next, err := sjson.DeleteBytes(updated, encryptedContentPath)
+		nextItem, err := sjson.Delete(item.Raw, "encrypted_content")
 		if err != nil {
 			helps.LogWithRequestID(ctx).Debugf("%s: failed to drop invalid reasoning encrypted_content at input[%d]: %v", provider, index, err)
+			keep(item.Raw)
 			continue
 		}
-		updated = next
 
-		itemID := strings.TrimSpace(gjson.GetBytes(updated, fmt.Sprintf("input.%d.id", index)).String())
+		if rebuilt == nil {
+			// First item that needs editing: start the buffer and backfill
+			// it with the raw JSON of every preceding item.
+			rebuilt = make([]byte, 0, len(inputResult.Raw))
+			rebuilt = append(rebuilt, '[')
+			for i := range index {
+				keep(items[i].Raw)
+			}
+		}
+		keep(nextItem)
+
+		itemID := strings.TrimSpace(item.Get("id").String())
 		if itemID == "" {
 			itemID = fmt.Sprintf("input[%d]", index)
 		}
 		helps.LogWithRequestID(ctx).Debugf("%s: dropped invalid reasoning encrypted_content at input[%d] item_id=%q reason=%s", provider, index, itemID, reason)
+	}
+
+	if rebuilt == nil {
+		return body
+	}
+	rebuilt = append(rebuilt, ']')
+
+	updated, err := sjson.SetRawBytes(body, "input", rebuilt)
+	if err != nil {
+		helps.LogWithRequestID(ctx).Debugf("%s: failed to rebuild input array while sanitizing reasoning encrypted_content: %v", provider, err)
+		return body
 	}
 	return updated
 }

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/openai_responses_signature.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/openai_responses_signature.go
@@ -21,6 +21,13 @@ func sanitizeOpenAIResponsesReasoningEncryptedContent(ctx context.Context, provi
 		provider = "openai responses upstream"
 	}
 
+	// Codex backend rejects store=true and does not persist items when store=false.
+	// A reasoning item that still carries an id without usable encrypted_content is
+	// treated as a store lookup and returns:
+	//   Item with id '...' not found. Items are not persisted when `store` is set to false.
+	// Strip those orphan ids unless the request explicitly opts into store=true.
+	stripOrphanReasoningIDs := !gjson.GetBytes(body, "store").Bool()
+
 	items := inputResult.Array()
 
 	// rebuilt accumulates the edited "input" array as JSON array bytes. It
@@ -40,6 +47,18 @@ func sanitizeOpenAIResponsesReasoningEncryptedContent(ctx context.Context, provi
 		rebuilt = append(rebuilt, raw...)
 		itemsWritten++
 	}
+	startRebuild := func(index int) {
+		if rebuilt != nil {
+			return
+		}
+		// First item that needs editing: start the buffer and backfill
+		// it with the raw JSON of every preceding item.
+		rebuilt = make([]byte, 0, len(inputResult.Raw))
+		rebuilt = append(rebuilt, '[')
+		for i := range index {
+			keep(items[i].Raw)
+		}
+	}
 
 	for index, item := range items {
 		if strings.TrimSpace(item.Get("type").String()) != "reasoning" {
@@ -48,7 +67,24 @@ func sanitizeOpenAIResponsesReasoningEncryptedContent(ctx context.Context, provi
 		}
 
 		encryptedContent := item.Get("encrypted_content")
+		itemID := strings.TrimSpace(item.Get("id").String())
+		if itemID == "" {
+			itemID = fmt.Sprintf("input[%d]", index)
+		}
+
 		if !encryptedContent.Exists() {
+			if stripOrphanReasoningIDs && item.Get("id").Exists() {
+				nextItem, err := sjson.Delete(item.Raw, "id")
+				if err != nil {
+					helps.LogWithRequestID(ctx).Debugf("%s: failed to drop orphan reasoning id at input[%d]: %v", provider, index, err)
+					keep(item.Raw)
+					continue
+				}
+				startRebuild(index)
+				keep(nextItem)
+				helps.LogWithRequestID(ctx).Debugf("%s: dropped orphan reasoning id at input[%d] item_id=%q reason=missing encrypted_content with store disabled", provider, index, itemID)
+				continue
+			}
 			keep(item.Raw)
 			continue
 		}
@@ -79,21 +115,17 @@ func sanitizeOpenAIResponsesReasoningEncryptedContent(ctx context.Context, provi
 			continue
 		}
 
-		if rebuilt == nil {
-			// First item that needs editing: start the buffer and backfill
-			// it with the raw JSON of every preceding item.
-			rebuilt = make([]byte, 0, len(inputResult.Raw))
-			rebuilt = append(rebuilt, '[')
-			for i := range index {
-				keep(items[i].Raw)
+		if stripOrphanReasoningIDs && item.Get("id").Exists() {
+			if nextID, errID := sjson.Delete(nextItem, "id"); errID != nil {
+				helps.LogWithRequestID(ctx).Debugf("%s: failed to drop reasoning id after invalid encrypted_content at input[%d]: %v", provider, index, errID)
+			} else {
+				nextItem = nextID
 			}
 		}
+
+		startRebuild(index)
 		keep(nextItem)
 
-		itemID := strings.TrimSpace(item.Get("id").String())
-		if itemID == "" {
-			itemID = fmt.Sprintf("input[%d]", index)
-		}
 		helps.LogWithRequestID(ctx).Debugf("%s: dropped invalid reasoning encrypted_content at input[%d] item_id=%q reason=%s", provider, index, itemID, reason)
 	}
 

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/openai_responses_signature_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/openai_responses_signature_test.go
@@ -1,0 +1,55 @@
+package executor
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func validOpenAIResponsesReasoningEncryptedContentForTest() string {
+	payload := make([]byte, 1+8+16+16+32)
+	payload[0] = 0x80
+	for i := 9; i < len(payload); i++ {
+		payload[i] = byte(i)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func TestSanitizeOpenAIResponsesReasoningEncryptedContent_RebuildsMultipleInvalidItems(t *testing.T) {
+	valid := validOpenAIResponsesReasoningEncryptedContentForTest()
+	body := []byte(`{"input":[` +
+		`{"id":"rs_bad","type":"reasoning","encrypted_content":"bad","summary":[]},` +
+		`{"id":"msg_1","type":"message","role":"user","content":"hi"},` +
+		`{"id":"rs_null","type":"reasoning","encrypted_content":null,"summary":[]},` +
+		`{"id":"rs_good","type":"reasoning","encrypted_content":"` + valid + `","summary":[]}` +
+		`]}`)
+
+	got := sanitizeOpenAIResponsesReasoningEncryptedContent(context.Background(), "test", body)
+
+	if gjson.GetBytes(got, "input.0.encrypted_content").Exists() {
+		t.Fatalf("invalid encrypted_content still present: %s", got)
+	}
+	if gotID := gjson.GetBytes(got, "input.1.id").String(); gotID != "msg_1" {
+		t.Fatalf("middle item id = %q, want msg_1; body=%s", gotID, got)
+	}
+	if gjson.GetBytes(got, "input.2.encrypted_content").Exists() {
+		t.Fatalf("null encrypted_content still present: %s", got)
+	}
+	if gotEC := gjson.GetBytes(got, "input.3.encrypted_content").String(); gotEC != valid {
+		t.Fatalf("valid encrypted_content not preserved: %s", got)
+	}
+}
+
+func TestSanitizeOpenAIResponsesReasoningEncryptedContent_NoopReturnsOriginalBody(t *testing.T) {
+	valid := validOpenAIResponsesReasoningEncryptedContentForTest()
+	body := []byte(`{"input":[{"id":"rs_good","type":"reasoning","encrypted_content":"` + valid + `","summary":[]},{"role":"user","content":"hi"}]}`)
+	got := sanitizeOpenAIResponsesReasoningEncryptedContent(context.Background(), "test", body)
+	if string(got) != string(body) {
+		t.Fatalf("noop path should return original body unchanged\ngot=%s\nwant=%s", got, body)
+	}
+	if len(got) > 0 && len(body) > 0 && &got[0] != &body[0] {
+		t.Fatalf("noop path should return the original body slice")
+	}
+}

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/openai_responses_signature_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/openai_responses_signature_test.go
@@ -42,6 +42,53 @@ func TestSanitizeOpenAIResponsesReasoningEncryptedContent_RebuildsMultipleInvali
 	}
 }
 
+func TestSanitizeOpenAIResponsesReasoningEncryptedContent_StripsOrphanIDsWhenStoreDisabled(t *testing.T) {
+	valid := validOpenAIResponsesReasoningEncryptedContentForTest()
+	body := []byte(`{"store":false,"input":[` +
+		`{"id":"rs_bad","type":"reasoning","encrypted_content":"bad","summary":[]},` +
+		`{"id":"rs_orphan","type":"reasoning","summary":[]},` +
+		`{"id":"rs_good","type":"reasoning","encrypted_content":"` + valid + `","summary":[]},` +
+		`{"id":"msg_1","type":"message","role":"user","content":"hi"}` +
+		`]}`)
+
+	got := sanitizeOpenAIResponsesReasoningEncryptedContent(context.Background(), "test", body)
+
+	if gjson.GetBytes(got, "input.0.encrypted_content").Exists() {
+		t.Fatalf("invalid encrypted_content still present: %s", got)
+	}
+	if gjson.GetBytes(got, "input.0.id").Exists() {
+		t.Fatalf("invalid reasoning id should be stripped when store=false: %s", got)
+	}
+	if gjson.GetBytes(got, "input.1.id").Exists() {
+		t.Fatalf("orphan reasoning id should be stripped when store=false: %s", got)
+	}
+	if gotID := gjson.GetBytes(got, "input.2.id").String(); gotID != "rs_good" {
+		t.Fatalf("valid reasoning id = %q, want rs_good; body=%s", gotID, got)
+	}
+	if gotID := gjson.GetBytes(got, "input.3.id").String(); gotID != "msg_1" {
+		t.Fatalf("non-reasoning id = %q, want msg_1; body=%s", gotID, got)
+	}
+}
+
+func TestSanitizeOpenAIResponsesReasoningEncryptedContent_KeepsIDsWhenStoreEnabled(t *testing.T) {
+	body := []byte(`{"store":true,"input":[` +
+		`{"id":"rs_bad","type":"reasoning","encrypted_content":"bad","summary":[]},` +
+		`{"id":"rs_orphan","type":"reasoning","summary":[]}` +
+		`]}`)
+
+	got := sanitizeOpenAIResponsesReasoningEncryptedContent(context.Background(), "test", body)
+
+	if gjson.GetBytes(got, "input.0.encrypted_content").Exists() {
+		t.Fatalf("invalid encrypted_content still present: %s", got)
+	}
+	if gotID := gjson.GetBytes(got, "input.0.id").String(); gotID != "rs_bad" {
+		t.Fatalf("store=true should keep reasoning id after dropping invalid encrypted_content, got %q body=%s", gotID, got)
+	}
+	if gotID := gjson.GetBytes(got, "input.1.id").String(); gotID != "rs_orphan" {
+		t.Fatalf("store=true should keep orphan reasoning id, got %q body=%s", gotID, got)
+	}
+}
+
 func TestSanitizeOpenAIResponsesReasoningEncryptedContent_NoopReturnsOriginalBody(t *testing.T) {
 	valid := validOpenAIResponsesReasoningEncryptedContentForTest()
 	body := []byte(`{"input":[{"id":"rs_good","type":"reasoning","encrypted_content":"` + valid + `","summary":[]},{"role":"user","content":"hi"}]}`)


### PR DESCRIPTION
### Code changes

- Strategy and data flow: walk the Responses `input` array once, start a lazy rebuild only at the first invalid reasoning item, and splice the rebuilt array back into the request once.
- State isolation: remove an ID only from reasoning items whose `encrypted_content` is missing or unusable under effective `store=false`; valid signatures, non-reasoning items, and explicit `store=true` requests remain unchanged.
- Boundary and compatibility: keep the no-op path allocation-free by returning the original body slice, and cover mixed histories, multiple invalid items, orphan IDs, and storage opt-in.

Codex 不会在 `store=false` 下保存 reasoning item，孤立 ID 会导致历史回放请求被上游以 `Item with id not found` 拒绝。本次修复避免这类长对话突然失败，同时减少大型历史清洗的重复工作，不影响有效 reasoning 内容或主动开启存储的请求。