### PR TITLE
fix(updater): 修复 Windows 用户级安装升级误触发管理员权限

### DIFF
--- a/src-tauri/src/modules/linux_updater.rs
+++ b/src-tauri/src/modules/linux_updater.rs
@@ -63,9 +63,34 @@ pub struct UpdateRuntimeInfo {
     pub updater_target: Option<String>,
 }
 
-/// Map Windows arch + detected installer kind to updater target key.
-/// Unknown/None bundle prefers MSI so MSI installs are not forced onto NSIS packages.
-pub fn windows_updater_target_for_bundle(arch: &str, bundle: Option<&str>) -> String {
+#[cfg(target_os = "windows")]
+fn is_current_exe_dir_writable() -> bool {
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(parent) = current_exe.parent() {
+            let temp_file = parent.join(format!(
+                ".tauri-updater-write-test-{}-{}",
+                std::process::id(),
+                uuid::Uuid::new_v4()
+            ));
+            if std::fs::write(&temp_file, b"").is_ok() {
+                return std::fs::remove_file(temp_file).is_ok();
+            }
+        }
+    }
+    false
+}
+
+/// Map Windows arch and install state to an updater target key.
+///
+/// The bundle metadata is authoritative when available. Older or unbundled executables can lack
+/// that metadata, so a writable executable directory is used as a fallback signal for a per-user
+/// NSIS installation. Protected directories keep the conservative MSI fallback.
+#[cfg(any(target_os = "windows", test))]
+fn windows_updater_target_for_bundle(
+    arch: &str,
+    bundle: Option<&str>,
+    current_exe_dir_writable: bool,
+) -> String {
     let arch = match arch {
         "x86_64" | "aarch64" => arch,
         _ => "x86_64",
@@ -73,6 +98,7 @@ pub fn windows_updater_target_for_bundle(arch: &str, bundle: Option<&str>) -> St
     let suffix = match bundle {
         Some("nsis") => "nsis",
         Some("msi") => "msi",
+        _ if current_exe_dir_writable => "nsis",
         _ => "msi",
     };
     format!("windows-{}-{}", arch, suffix)
@@ -659,7 +685,28 @@ mod imp {
             Some(BundleType::Msi) => Some("msi"),
             _ => None,
         };
-        Some(super::windows_updater_target_for_bundle(arch, bundle))
+        let current_exe_dir_writable = bundle
+            .is_none()
+            .then(super::is_current_exe_dir_writable)
+            .unwrap_or(false);
+        let target =
+            super::windows_updater_target_for_bundle(arch, bundle, current_exe_dir_writable);
+
+        tracing::info!(
+            "[Updater] Windows updater target resolved: arch={}, bundle={}, exe_dir_writable={}, target={}",
+            arch,
+            bundle.unwrap_or("unknown"),
+            if bundle.is_some() {
+                "not_checked"
+            } else if current_exe_dir_writable {
+                "true"
+            } else {
+                "false"
+            },
+            target
+        );
+
+        Some(target)
     }
 
     #[cfg(target_os = "macos")]
@@ -711,19 +758,23 @@ mod tests {
     };
 
     #[test]
-    fn windows_unknown_bundle_prefers_msi_target() {
-        assert_eq!(
-            windows_updater_target_for_bundle("x86_64", None),
-            "windows-x86_64-msi"
-        );
-        assert_eq!(
-            windows_updater_target_for_bundle("x86_64", Some("nsis")),
-            "windows-x86_64-nsis"
-        );
-        assert_eq!(
-            windows_updater_target_for_bundle("x86_64", Some("msi")),
-            "windows-x86_64-msi"
-        );
+    fn windows_updater_target_uses_bundle_then_directory_writability() {
+        let cases = [
+            ("x86_64", Some("nsis"), false, "windows-x86_64-nsis"),
+            ("x86_64", Some("nsis"), true, "windows-x86_64-nsis"),
+            ("x86_64", Some("msi"), false, "windows-x86_64-msi"),
+            ("x86_64", Some("msi"), true, "windows-x86_64-msi"),
+            ("x86_64", None, true, "windows-x86_64-nsis"),
+            ("x86_64", None, false, "windows-x86_64-msi"),
+            ("x86", None, true, "windows-x86_64-nsis"),
+        ];
+
+        for (arch, bundle, writable, expected) in cases {
+            assert_eq!(
+                windows_updater_target_for_bundle(arch, bundle, writable),
+                expected
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 问题背景

Windows 的 NSIS 安装包已经配置为 `currentUser`，因此普通用户首次安装时不需要管理员权限。但在部分现有安装中，Tauri 运行时无法识别 bundle 类型；旧逻辑在这种情况下固定回退到 MSI 更新包。

这会造成一个比较严重且隐蔽的问题：用户可以正常完成首次安装，但升级时却突然弹出 UAC 管理员授权。对于公司、学校等已收回本机管理员权限的受管设备，用户无法确认该弹窗，应用会被永久卡在旧版本，后续缺陷修复和安全更新也无法送达。

## 根因

当 `bundle_type()` 返回 `None` 时，更新目标无条件选择 `windows-*-msi`。这会把原本安装在用户目录、具备自更新条件的 NSIS 安装误判成系统级 MSI 安装，最终通过 `msiexec` 触发提权。

## 修复内容

- 已识别出 NSIS 或 MSI 时，继续以 Tauri bundle 元数据为权威依据。
- 仅在 bundle 类型未知时探测当前可执行文件目录是否可写：
  - 目录可写时选择 NSIS 更新包，保持用户级无管理员权限升级；
  - 目录不可写时保守回退 MSI，避免破坏真正的系统级安装。
- 探测文件使用 PID 与 UUID 生成唯一名称，并在探测后立即清理。
- 增加 updater 目标选择日志，记录架构、bundle 类型、目录可写性和最终 target，便于定位受管设备上的实际更新路径。
- 补充表驱动单元测试，覆盖 NSIS、MSI、未知类型下目录可写/不可写以及未知架构回退。

## 用户影响

对于通过 current-user NSIS 安装、但运行时 bundle 元数据缺失的 Windows 用户，升级将继续选择 NSIS，不再因为误走 MSI 而请求管理员权限。这使没有管理员权限的公司和学校设备也能正常接收应用更新。

## 兼容性边界

如果应用确实通过 MSI 安装在 `Program Files` 等受保护目录，则 Windows 本身要求管理员权限才能原地更新。本修复不会绕过系统权限，也不会把明确识别出的 MSI 安装强制迁移为 NSIS。

## 验证

- `rustfmt --edition 2021 --check src-tauri/src/modules/linux_updater.rs`
- `cargo test windows_updater_target_uses_bundle_then_directory_writability --lib`
- `git diff --check`

目标单元测试通过；构建过程中仅存在仓库原有的 warning。