### PR TITLE
fix(sidecar): route collaboration tools through full Responses

### DIFF
--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_executor.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_executor.go
@@ -1797,13 +1797,16 @@ func normalizeCodexInstructions(body []byte) []byte {
 	return body
 }
 
-func normalizeCodexResponsesLiteRequest(body []byte, headers http.Header, auth *cliproxyauth.Auth, allowFullResponsesForImage bool) ([]byte, bool) {
+func normalizeCodexResponsesLiteRequest(body []byte, headers http.Header, auth *cliproxyauth.Auth, allowFullResponses bool) ([]byte, bool) {
 	if !codexResponsesLiteEnabled(headers) || codexAuthUsesAPIKey(auth) {
 		return body, false
 	}
 
+	if allowFullResponses && helps.PayloadDeclaresCollaborationNamespaceWithRoot(body, "") {
+		return body, true
+	}
 	body, _ = sjson.SetBytes(body, "parallel_tool_calls", false)
-	if allowFullResponsesForImage && codexRequestUsesImageGeneration(body) {
+	if allowFullResponses && codexRequestUsesImageGeneration(body) {
 		return body, true
 	}
 

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_executor_responses_lite_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/codex_executor_responses_lite_test.go
@@ -58,6 +58,35 @@ func TestNormalizeCodexResponsesLiteRequestFiltersUnsupportedTools(t *testing.T)
 	}
 }
 
+func TestNormalizeCodexResponsesLiteRequestUsesFullResponsesForCollaborationNamespace(t *testing.T) {
+	body := []byte(`{
+		"parallel_tool_calls":true,
+		"input":[{
+			"type":"additional_tools",
+			"role":"developer",
+			"tools":[{
+				"type":"namespace",
+				"name":"collaboration",
+				"tools":[{"type":"function","name":"spawn_agent"}]
+			}]
+		}]
+	}`)
+	headers := http.Header{codexResponsesLiteHeaderName: []string{"true"}}
+	oauth := &cliproxyauth.Auth{Metadata: map[string]any{"access_token": "oauth-token"}}
+
+	result, useFullResponses := normalizeCodexResponsesLiteRequest(body, headers, oauth, true)
+
+	if !useFullResponses {
+		t.Fatal("collaboration namespace should switch to full Responses")
+	}
+	if !gjson.GetBytes(result, "parallel_tool_calls").Bool() {
+		t.Fatalf("full Responses collaboration should preserve parallel tool calls: %s", result)
+	}
+	if got := gjson.GetBytes(result, "input.0.tools.0.name").String(); got != "collaboration" {
+		t.Fatalf("collaboration namespace was not preserved: %s", result)
+	}
+}
+
 func TestNormalizeCodexResponsesLiteRequestRemovesEmptyTools(t *testing.T) {
 	body := []byte(`{"tools":[{"type":"image_generation"}],"tool_choice":"image_generation"}`)
 	headers := http.Header{codexResponsesLiteHeaderName: []string{"true"}}

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/helps/payload_helpers.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/helps/payload_helpers.go
@@ -279,6 +279,10 @@ func applyFinalPayloadGuards(payload []byte, cfg *config.Config, root, model, re
 	// those tools survive until the executor decides. Hosted injection for Lite
 	// is blocked separately by ShouldInjectImageGenerationToolForModel.
 	if IsCodexResponsesLiteRequest(headers, model, requestedModel) {
+		compactRequest := strings.HasSuffix(strings.ToLower(strings.TrimRight(requestPath, "/")), "/responses/compact")
+		if !compactRequest && PayloadDeclaresCollaborationNamespaceWithRoot(out, root) {
+			return out
+		}
 		catalogLite := registry.CodexClientModelUsesResponsesLite(model) ||
 			registry.CodexClientModelUsesResponsesLite(requestedModel)
 		if catalogLite || !payloadDeclaresImageGenerationToolsWithRoot(out, root) {
@@ -286,6 +290,47 @@ func applyFinalPayloadGuards(payload []byte, cfg *config.Config, root, model, re
 		}
 	}
 	return out
+}
+
+// PayloadDeclaresCollaborationNamespaceWithRoot reports whether Codex declared
+// its client-side multi-agent tools in a collaboration namespace.
+func PayloadDeclaresCollaborationNamespaceWithRoot(payload []byte, root string) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	object := gjson.ParseBytes(payload)
+	if root = strings.TrimSpace(root); root != "" {
+		object = gjson.GetBytes(payload, root)
+	}
+	return objectDeclaresCollaborationNamespace(object)
+}
+
+func objectDeclaresCollaborationNamespace(object gjson.Result) bool {
+	if !object.IsObject() {
+		return false
+	}
+	if tools := object.Get("tools"); tools.IsArray() {
+		for _, tool := range tools.Array() {
+			if strings.EqualFold(strings.TrimSpace(tool.Get("type").String()), "namespace") &&
+				strings.EqualFold(strings.TrimSpace(tool.Get("name").String()), "collaboration") {
+				return true
+			}
+		}
+	}
+	if input := object.Get("input"); input.IsArray() {
+		for _, item := range input.Array() {
+			if strings.EqualFold(strings.TrimSpace(item.Get("type").String()), "additional_tools") &&
+				objectDeclaresCollaborationNamespace(item) {
+				return true
+			}
+		}
+	}
+	for _, field := range []string{"request", "response"} {
+		if objectDeclaresCollaborationNamespace(object.Get(field)) {
+			return true
+		}
+	}
+	return false
 }
 
 // payloadDeclaresImageGenerationToolsWithRoot reports whether the payload

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/helps/payload_helpers_responses_lite_test.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/runtime/executor/helps/payload_helpers_responses_lite_test.go
@@ -66,6 +66,39 @@ func TestApplyPayloadConfigWithRequestResponsesLiteRegistryModelFiltersWithoutHe
 	assertResponsesLiteToolTypes(t, out, "tools", []string{"function"})
 }
 
+func TestApplyPayloadConfigWithRequestKeepsCollaborationNamespaceForFullUpgrade(t *testing.T) {
+	payload := []byte(`{
+		"model":"gpt-5.6-sol",
+		"input":[{
+			"type":"additional_tools",
+			"role":"developer",
+			"tools":[{
+				"type":"namespace",
+				"name":"collaboration",
+				"tools":[{"type":"function","name":"spawn_agent"}]
+			}]
+		}]
+	}`)
+	headers := http.Header{CodexResponsesLiteHeader: {"true"}}
+
+	out := ApplyPayloadConfigWithRequest(nil, "gpt-5.6-sol", "codex", "openai-response", "", payload, nil, "gpt-5.6-sol", "/v1/responses", headers)
+
+	if got := gjson.GetBytes(out, "input.0.tools.0.name").String(); got != "collaboration" {
+		t.Fatalf("collaboration namespace was stripped before full Responses upgrade: %s", out)
+	}
+}
+
+func TestApplyPayloadConfigWithRequestFiltersCollaborationNamespaceForCompact(t *testing.T) {
+	payload := []byte(`{"input":[{"type":"additional_tools","tools":[{"type":"namespace","name":"collaboration"}]}]}`)
+	headers := http.Header{CodexResponsesLiteHeader: {"true"}}
+
+	out := ApplyPayloadConfigWithRequest(nil, "gpt-5.6-sol", "codex", "openai-response", "", payload, nil, "gpt-5.6-sol", "/v1/responses/compact", headers)
+
+	if got := gjson.GetBytes(out, "input.#").Int(); got != 0 {
+		t.Fatalf("compact request kept unsupported collaboration namespace: %s", out)
+	}
+}
+
 func TestApplyPayloadConfigWithRequestResponsesLiteFiltersAllToolDeclarations(t *testing.T) {
 	cfg := &config.Config{
 		Payload: config.PayloadConfig{


### PR DESCRIPTION
## Summary

- detect Codex multi-agent tools in `input[].type = additional_tools` under the `collaboration` namespace before the Responses Lite allowlist removes them
- upgrade regular `/responses` requests containing collaboration tools to full Responses and preserve `parallel_tool_calls`
- keep explicit `/responses/compact` requests on the existing filtered path
- add regression coverage at both the shared payload guard and Codex executor boundaries

This uses the existing full Responses upgrade path instead of adding another namespace-flattening layer. The OpenAI chat translator already handles namespace flattening for providers that need it.

Thanks to @a90091343 for the A/B protocol report that identified the real `additional_tools -> namespace` wire shape.

## Verification

- `go test ./internal/runtime/executor/... -count=1`
- `git diff --check`

A full `go test ./... -count=1` also reached all packages, but the existing `internal/translator/antigravity/claude` suite has six unrelated signature-cache expectation failures; the changed executor packages pass.

Closes #1647
