### PR TITLE
fix(codex): remove stale local access catalog on OAuth restore

### DIFF
--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -42,6 +42,8 @@ const CODEX_CONFIG_HTTP_HEADERS_KEY: &str = "http_headers";
 const CODEX_CONFIG_MODEL_CONTEXT_WINDOW_KEY: &str = "model_context_window";
 const CODEX_CONFIG_MODEL_AUTO_COMPACT_TOKEN_LIMIT_KEY: &str = "model_auto_compact_token_limit";
 const CODEX_MANAGED_MODEL_CATALOG_FILE: &str = "cockpit-provider-model-catalog.json";
+const CODEX_LOCAL_ACCESS_MODEL_CATALOG_FILE: &str =
+    "cockpit-local-access-model-catalog.json";
 const CODEX_AUTO_REVIEW_MODEL_ID: &str = "codex-auto-review";
 const CODEX_IMAGE_MODEL_ID: &str = "gpt-image-2";
 const CODEX_IMAGEGEN_ACTOR_HEADER: &str = "x-openai-actor-authorization";
@@ -1000,11 +1002,15 @@ fn write_api_provider_to_config_toml(
 }
 
 fn remove_managed_model_catalog_from_doc(doc: &mut Document) -> bool {
-    let uses_managed_catalog = doc
+    let managed_catalog = doc
         .get(CODEX_CONFIG_MODEL_CATALOG_JSON_KEY)
         .and_then(|item| item.as_str())
-        .map(str::trim)
-        == Some(CODEX_MANAGED_MODEL_CATALOG_FILE);
+        .map(str::trim);
+    let uses_managed_catalog = matches!(
+        managed_catalog,
+        Some(CODEX_MANAGED_MODEL_CATALOG_FILE)
+            | Some(CODEX_LOCAL_ACCESS_MODEL_CATALOG_FILE)
+    );
     if uses_managed_catalog {
         let _ = doc.remove(CODEX_CONFIG_MODEL_CATALOG_JSON_KEY);
         return true;
@@ -10626,6 +10632,35 @@ multi_agent = true
         assert!(content.contains("[model_providers.user_manual_provider]"));
         assert!(content.contains("model_context_window = 1000000"));
         assert!(content.contains("[features]"));
+
+        fs::remove_dir_all(&base_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn config_toml_removes_local_access_catalog_when_switching_to_builtin_openai() {
+        let base_dir = make_temp_dir("codex-config-clean-local-access-catalog-test");
+        let config_path = base_dir.join("config.toml");
+        fs::write(
+            &config_path,
+            format!(
+                "model_provider = \"openai\"\nmodel_catalog_json = \"{}\"\n",
+                super::CODEX_LOCAL_ACCESS_MODEL_CATALOG_FILE
+            ),
+        )
+        .expect("write stale local access config");
+        let provider_config = resolve_api_provider_config(
+            None,
+            Some(CodexApiProviderMode::OpenaiBuiltin),
+            None,
+            None,
+        )
+        .expect("resolve provider config");
+
+        write_api_provider_to_config_toml(&base_dir, &provider_config).expect("write config");
+
+        let content = fs::read_to_string(&config_path).expect("read config");
+        assert!(!content.contains("model_catalog_json"));
+        assert!(!content.contains("model_provider = "));
 
         fs::remove_dir_all(&base_dir).expect("cleanup temp dir");
     }

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -8749,6 +8749,15 @@ fn restore_config_toml_from_takeover_backup(
         crate::modules::codex_config_format::read_codex_config_doc_from_str(backup_config)
             .map_err(|e| format!("解析 Codex API 服务接管备份 config.toml 失败: {}", e))?;
 
+    let backup_uses_local_access_catalog = backup_doc
+        .get("model_catalog_json")
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        == Some(CODEX_LOCAL_ACCESS_MODEL_CATALOG_FILE);
+    if backup_uses_local_access_catalog {
+        backup_doc.remove("model_catalog_json");
+    }
+
     if let Some(current_config) = current_config.filter(|content| !content.trim().is_empty()) {
         let current_without_takeover = remove_codex_local_access_config(current_config)?;
         if !current_without_takeover.trim().is_empty() {
@@ -26708,6 +26717,7 @@ requires_openai_auth = true
 experimental_bearer_token = "agt_codex_test"
 "#;
         let backup = r#"model = "gpt-5"
+model_catalog_json = "cockpit-local-access-model-catalog.json"
 
 [plugins."browser@openai-bundled"]
 enabled = true
@@ -26725,6 +26735,7 @@ enabled = true
             .expect("plugins should remain");
 
         assert!(parsed.get("model_provider").is_none());
+        assert!(parsed.get("model_catalog_json").is_none());
         assert!(plugins.get("browser@openai-bundled").is_some());
         assert!(plugins.get("chrome@openai-bundled").is_some());
         assert!(plugins.get("hyperframes@openai-curated").is_some());


### PR DESCRIPTION
## What changed

- Remove `cockpit-local-access-model-catalog.json` when switching back to built-in OpenAI OAuth.
- Sanitize the same stale catalog reference when restoring a local-access takeover backup.
- Add regression coverage for both restore paths.

## Root cause

Cockpit could delete the local-access catalog file while leaving `model_catalog_json` in `config.toml`. Codex then fails to initialize its local app server because the configured catalog path no longer exists.

## Validation

- `git diff --check` passes.
- Added focused Rust unit coverage.
- Rust/Cargo is not installed on the reporting machine, so the test suite was not executed locally.