### PR TITLE
feat(macOS): show live quota in menu bar

### DIFF
--- a/src-tauri/native/macos-native-menu/Sources/MacosNativeMenuSwift/NativeMenuBridge.swift
+++ b/src-tauri/native/macos-native-menu/Sources/MacosNativeMenuSwift/NativeMenuBridge.swift
@@ -83,3 +83,70 @@ public func macos_native_menu_update_snapshot(
         NativeMenuPopoverController.shared.update(snapshotJSON: snapshotJSON)
     }
 }
+
+@_cdecl("macos_native_menu_update_status_item")
+public func macos_native_menu_update_status_item(
+    accountPrefixPointer: UnsafePointer<CChar>?,
+    remainingPercent: Int32,
+    enabled: Int32,
+    statusItemPointer: UnsafeMutableRawPointer?
+) {
+    guard let statusItemPointer else { return }
+    let accountPrefix = accountPrefixPointer.map(String.init(cString:)) ?? ""
+
+    runNativeMenuController(label: "update_status_item") {
+        let statusItem = Unmanaged<NSStatusItem>
+            .fromOpaque(statusItemPointer)
+            .takeUnretainedValue()
+        guard let button = statusItem.button else { return }
+
+        statusItem.length = NSStatusItem.variableLength
+        guard enabled != 0 else {
+            button.attributedTitle = NSAttributedString(string: "")
+            button.title = ""
+            button.imagePosition = .imageOnly
+            return
+        }
+
+        let percentageText = remainingPercent >= 0 ? "\(remainingPercent)%" : "--"
+        let prefixText = accountPrefix.isEmpty ? "" : "\(accountPrefix) "
+        let fullText = prefixText + percentageText
+        let font = NSFont.monospacedDigitSystemFont(
+            ofSize: NSFont.systemFontSize,
+            weight: .medium
+        )
+        let attributedTitle = NSMutableAttributedString(
+            string: fullText,
+            attributes: [
+                .font: font,
+                .foregroundColor: NSColor.labelColor,
+            ]
+        )
+
+        if remainingPercent >= 0 {
+            let percentageColor: NSColor
+            if remainingPercent <= 30 {
+                percentageColor = .systemRed
+            } else if remainingPercent <= 60 {
+                percentageColor = .systemOrange
+            } else {
+                percentageColor = .systemGreen
+            }
+            attributedTitle.addAttribute(
+                .foregroundColor,
+                value: percentageColor,
+                range: NSRange(location: prefixText.utf16.count, length: percentageText.utf16.count)
+            )
+        } else {
+            attributedTitle.addAttribute(
+                .foregroundColor,
+                value: NSColor.secondaryLabelColor,
+                range: NSRange(location: prefixText.utf16.count, length: percentageText.utf16.count)
+            )
+        }
+
+        button.imagePosition = .imageLeading
+        button.attributedTitle = attributedTitle
+        button.needsDisplay = true
+    }
+}

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -129,6 +129,12 @@ pub struct GeneralConfig {
     pub hide_dock_icon: bool,
     /// 菜单栏图标样式（macOS）: "template", "color"
     pub tray_icon_style: String,
+    /// 是否在 macOS 菜单栏显示当前账号剩余额度
+    pub menu_bar_quota_enabled: bool,
+    /// 是否显示账号标识前 4 位
+    pub menu_bar_show_account_prefix: bool,
+    /// 菜单栏额度监控平台
+    pub menu_bar_quota_platform: String,
     /// 是否在启动时显示悬浮卡片
     pub floating_card_show_on_startup: bool,
     /// 是否在启动后自动最小化主窗口
@@ -1054,6 +1060,9 @@ fn is_general_config_patch_field(key: &str) -> bool {
             | "minimize_behavior"
             | "hide_dock_icon"
             | "tray_icon_style"
+            | "menu_bar_quota_enabled"
+            | "menu_bar_show_account_prefix"
+            | "menu_bar_quota_platform"
             | "floating_card_show_on_startup"
             | "startup_minimized"
             | "remember_main_window_state"
@@ -1209,6 +1218,12 @@ fn apply_general_config_updates(
     }
     if updates.contains_key("theme_color") {
         next.theme_color = config::normalize_theme_color(&next.theme_color);
+    }
+    if updates.contains_key("menu_bar_quota_platform") {
+        let platform = next.menu_bar_quota_platform.trim();
+        next.menu_bar_quota_platform = modules::tray::PlatformId::from_str(platform)
+            .map(|value| value.as_str().to_string())
+            .unwrap_or_else(|| "codex".to_string());
     }
     if updates.contains_key("webdav_allowed_domains") {
         next.webdav_allowed_domains = next
@@ -2526,6 +2541,9 @@ pub fn get_general_config(app: tauri::AppHandle) -> Result<GeneralConfig, String
         minimize_behavior: minimize_behavior_str.to_string(),
         hide_dock_icon: user_config.hide_dock_icon,
         tray_icon_style: user_config.tray_icon_style.as_str().to_string(),
+        menu_bar_quota_enabled: user_config.menu_bar_quota_enabled,
+        menu_bar_show_account_prefix: user_config.menu_bar_show_account_prefix,
+        menu_bar_quota_platform: user_config.menu_bar_quota_platform,
         floating_card_show_on_startup: user_config.floating_card_show_on_startup,
         startup_minimized: user_config.startup_minimized,
         remember_main_window_state: user_config.remember_main_window_state,
@@ -2740,6 +2758,8 @@ pub fn patch_general_config(
     let mut hide_dock_icon_changed = false;
     #[cfg(target_os = "macos")]
     let mut tray_icon_style_changed = false;
+    #[cfg(target_os = "macos")]
+    let mut menu_bar_quota_changed = false;
 
     let patch_result = config::patch_user_config(|current| {
         let previous_language = current.language.clone();
@@ -2750,6 +2770,12 @@ pub fn patch_general_config(
         let previous_hide_dock_icon = current.hide_dock_icon;
         #[cfg(target_os = "macos")]
         let previous_tray_icon_style = current.tray_icon_style;
+        #[cfg(target_os = "macos")]
+        let previous_menu_bar_quota = (
+            current.menu_bar_quota_enabled,
+            current.menu_bar_show_account_prefix,
+            current.menu_bar_quota_platform.clone(),
+        );
 
         apply_general_config_updates(current, &updates)?;
 
@@ -2764,6 +2790,12 @@ pub fn patch_general_config(
         {
             hide_dock_icon_changed = previous_hide_dock_icon != current.hide_dock_icon;
             tray_icon_style_changed = previous_tray_icon_style != current.tray_icon_style;
+            menu_bar_quota_changed = previous_menu_bar_quota
+                != (
+                    current.menu_bar_quota_enabled,
+                    current.menu_bar_show_account_prefix,
+                    current.menu_bar_quota_platform.clone(),
+                );
         }
         Ok(())
     });
@@ -2816,6 +2848,13 @@ pub fn patch_general_config(
     if tray_icon_style_changed {
         if let Err(err) = modules::tray::apply_tray_icon_style(&app) {
             modules::logger::log_warn(&format!("[Tray] 保存通用设置后应用图标样式失败: {}", err));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    if menu_bar_quota_changed {
+        if let Err(err) = modules::tray::update_tray_menu(&app) {
+            modules::logger::log_warn(&format!("[Tray] 保存菜单栏额度设置后刷新失败: {}", err));
         }
     }
 

--- a/src-tauri/src/modules/config.rs
+++ b/src-tauri/src/modules/config.rs
@@ -170,6 +170,15 @@ pub struct UserConfig {
     /// 菜单栏图标样式（macOS）
     #[serde(default = "default_tray_icon_style")]
     pub tray_icon_style: TrayIconStyle,
+    /// 是否在 macOS 菜单栏图标旁显示当前账号剩余额度
+    #[serde(default = "default_menu_bar_quota_enabled")]
+    pub menu_bar_quota_enabled: bool,
+    /// 是否在 macOS 菜单栏额度前显示账号标识前 4 位
+    #[serde(default = "default_menu_bar_show_account_prefix")]
+    pub menu_bar_show_account_prefix: bool,
+    /// macOS 菜单栏额度监控平台
+    #[serde(default = "default_menu_bar_quota_platform")]
+    pub menu_bar_quota_platform: String,
     /// 是否在启动后自动显示悬浮卡片
     #[serde(default = "default_floating_card_show_on_startup")]
     pub floating_card_show_on_startup: bool,
@@ -728,6 +737,15 @@ fn default_hide_dock_icon() -> bool {
 fn default_tray_icon_style() -> TrayIconStyle {
     TrayIconStyle::Template
 }
+fn default_menu_bar_quota_enabled() -> bool {
+    false
+}
+fn default_menu_bar_show_account_prefix() -> bool {
+    true
+}
+fn default_menu_bar_quota_platform() -> String {
+    "codex".to_string()
+}
 fn default_floating_card_show_on_startup() -> bool {
     false
 }
@@ -1138,6 +1156,9 @@ impl Default for UserConfig {
             minimize_behavior: default_minimize_behavior(),
             hide_dock_icon: default_hide_dock_icon(),
             tray_icon_style: default_tray_icon_style(),
+            menu_bar_quota_enabled: default_menu_bar_quota_enabled(),
+            menu_bar_show_account_prefix: default_menu_bar_show_account_prefix(),
+            menu_bar_quota_platform: default_menu_bar_quota_platform(),
             floating_card_show_on_startup: default_floating_card_show_on_startup(),
             startup_minimized: default_startup_minimized(),
             remember_main_window_state: default_remember_main_window_state(),
@@ -1597,6 +1618,27 @@ pub fn load_user_config() -> Result<UserConfig, String> {
             obj.insert(
                 "tray_icon_style".to_string(),
                 json!(default_tray_icon_style()),
+            );
+        }
+
+        if !obj.contains_key("menu_bar_quota_enabled") {
+            obj.insert(
+                "menu_bar_quota_enabled".to_string(),
+                json!(default_menu_bar_quota_enabled()),
+            );
+        }
+
+        if !obj.contains_key("menu_bar_show_account_prefix") {
+            obj.insert(
+                "menu_bar_show_account_prefix".to_string(),
+                json!(default_menu_bar_show_account_prefix()),
+            );
+        }
+
+        if !obj.contains_key("menu_bar_quota_platform") {
+            obj.insert(
+                "menu_bar_quota_platform".to_string(),
+                json!(default_menu_bar_quota_platform()),
             );
         }
 

--- a/src-tauri/src/modules/macos_native_menu.rs
+++ b/src-tauri/src/modules/macos_native_menu.rs
@@ -22,6 +22,12 @@ mod imp {
     unsafe extern "C" {
         fn macos_native_menu_toggle(snapshot_json: *const c_char, status_item_ptr: *mut c_void);
         fn macos_native_menu_update_snapshot(snapshot_json: *const c_char);
+        fn macos_native_menu_update_status_item(
+            account_prefix: *const c_char,
+            remaining_percent: i32,
+            enabled: i32,
+            status_item_ptr: *mut c_void,
+        );
     }
 
     #[derive(Debug, Clone, Serialize)]
@@ -65,6 +71,7 @@ mod imp {
         plan: Option<String>,
         updated_at: Option<i64>,
         quota_rows: Vec<QuotaRow>,
+        remaining_percent: Option<i32>,
     }
 
     #[derive(Debug, Clone, Serialize)]
@@ -188,6 +195,87 @@ mod imp {
         reset_at: Option<i64>,
         pay_as_you_go_open: Option<bool>,
         pay_as_you_go_usd: Option<f64>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct MenuBarStatus {
+        account_prefix: String,
+        remaining_percent: Option<i32>,
+    }
+
+    fn menu_bar_account_prefix(label: &str) -> String {
+        let local_part = label.trim().split('@').next().unwrap_or_default().trim();
+        local_part.chars().take(4).collect()
+    }
+
+    fn build_menu_bar_status() -> Option<MenuBarStatus> {
+        let config = modules::config::get_user_config();
+        if !config.menu_bar_quota_enabled {
+            return None;
+        }
+
+        let platform = PlatformId::from_str(config.menu_bar_quota_platform.trim())
+            .unwrap_or(PlatformId::Codex);
+        let lang = normalize_lang(&config.language);
+        let (cards, current_account_id, _) = build_platform_cards(platform, &lang);
+        let card = current_account_id
+            .as_deref()
+            .and_then(|id| cards.iter().find(|card| card.id == id))
+            .or_else(|| cards.first());
+
+        Some(MenuBarStatus {
+            account_prefix: if config.menu_bar_show_account_prefix {
+                card.map(|card| menu_bar_account_prefix(&card.title))
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            },
+            remaining_percent: card.and_then(|card| card.remaining_percent),
+        })
+    }
+
+    pub(crate) fn update_status_item<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+        let status = build_menu_bar_status();
+        let enabled = status.is_some();
+        let account_prefix = to_cstring(
+            status
+                .as_ref()
+                .map(|value| value.account_prefix.as_str())
+                .unwrap_or_default(),
+        );
+        let remaining_percent = status
+            .as_ref()
+            .and_then(|value| value.remaining_percent)
+            .unwrap_or(-1);
+        let app = app.clone();
+
+        app.clone()
+            .run_on_main_thread(move || {
+                let Some(tray) = app.tray_by_id(TRAY_ID) else {
+                    return;
+                };
+                let status_item_ptr = tray
+                    .with_inner_tray_icon(|tray_icon| {
+                        tray_icon
+                            .ns_status_item()
+                            .map(|status_item| Retained::as_ptr(&status_item) as usize)
+                    })
+                    .ok()
+                    .flatten();
+                let Some(status_item_ptr) = status_item_ptr else {
+                    return;
+                };
+
+                unsafe {
+                    macos_native_menu_update_status_item(
+                        account_prefix.as_ptr(),
+                        remaining_percent,
+                        i32::from(enabled),
+                        status_item_ptr as *mut c_void,
+                    );
+                }
+            })
+            .map_err(|error| error.to_string())
     }
 
     pub(crate) fn toggle_tray_menu<R: Runtime>(app: &AppHandle<R>, _rect: Rect) {
@@ -775,6 +863,19 @@ mod imp {
             progress_tone: None,
             subtext,
         }
+    }
+
+    fn min_quota_progress(rows: &[QuotaRow], progress_is_remaining: bool) -> Option<i32> {
+        rows.iter()
+            .filter_map(|row| row.progress)
+            .map(|value| {
+                if progress_is_remaining {
+                    value.clamp(0, 100)
+                } else {
+                    (100 - value).clamp(0, 100)
+                }
+            })
+            .min()
     }
 
     fn codex_api_key_provider_usage(
@@ -2859,6 +2960,7 @@ mod imp {
             .into_iter()
             .map(|account| {
                 let quota = account.quota.as_ref();
+                let quota_rows = build_antigravity_quota_rows(lang, quota);
                 AccountCard {
                     id: account.id,
                     title: account.email,
@@ -2868,7 +2970,8 @@ mod imp {
                         account.last_used,
                         account.created_at,
                     ),
-                    quota_rows: build_antigravity_quota_rows(lang, quota),
+                    remaining_percent: min_quota_progress(&quota_rows, true),
+                    quota_rows,
                 }
             })
             .collect();
@@ -2961,6 +3064,7 @@ mod imp {
                         rows.push(code_review);
                     }
                 }
+                let remaining_percent = min_quota_progress(&rows, !account.is_api_key_auth());
                 AccountCard {
                     id: account.id,
                     title: if matches!(
@@ -2984,6 +3088,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -3075,6 +3180,7 @@ mod imp {
                     ));
                 }
 
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id,
                     title: first_non_empty(&[
@@ -3094,6 +3200,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -3173,6 +3280,7 @@ mod imp {
                         None,
                     ),
                 ];
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id,
                     title: account
@@ -3187,6 +3295,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -3368,6 +3477,7 @@ mod imp {
                         rows
                     }
                 };
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id,
                     title: account
@@ -3382,6 +3492,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -3458,6 +3569,7 @@ mod imp {
                     }
                 }
                 let account_id = account.id.clone();
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account_id.clone(),
                     title: if account.email.trim().is_empty() {
@@ -3472,6 +3584,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -3558,6 +3671,7 @@ mod imp {
                     });
                 }
                 let account_id = account.id.clone();
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account_id.clone(),
                     title: if account.email.trim().is_empty() {
@@ -3572,6 +3686,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -3696,6 +3811,7 @@ mod imp {
                     }
                 }
 
+                let remaining_percent = min_quota_progress(&rows, true);
                 AccountCard {
                     id: account.id,
                     title: account.email,
@@ -3711,6 +3827,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -3806,7 +3923,7 @@ mod imp {
                                 ("total", total_text.as_str()),
                             ],
                         ),
-                        remaining_percent,
+                        (100 - remaining_percent).clamp(0, 100),
                         None,
                         cursor_usage_tone((100 - remaining_percent).clamp(0, 100)),
                     ));
@@ -3824,6 +3941,7 @@ mod imp {
                         None,
                     ));
                 }
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id.clone(),
                     title: account
@@ -3838,6 +3956,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -3927,6 +4046,7 @@ mod imp {
                 } else {
                     account.email.clone()
                 };
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id,
                     title,
@@ -3937,6 +4057,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -4013,6 +4134,7 @@ mod imp {
                         None,
                     ));
                 }
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id.clone(),
                     title: account
@@ -4027,6 +4149,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -4049,7 +4172,7 @@ mod imp {
                 if model.extra.total > 0.0 || model.extra.remain > 0.0 || model.extra.used > 0.0 {
                     resources.push(model.extra);
                 }
-                let rows = resources
+                let rows: Vec<QuotaRow> = resources
                     .into_iter()
                     .filter(|resource| resource.total > 0.0 || resource.remain > 0.0)
                     .map(|resource| {
@@ -4079,6 +4202,7 @@ mod imp {
                     .clone()
                     .filter(|text| !text.trim().is_empty())
                     .unwrap_or_else(|| account.email.clone());
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id.clone(),
                     title,
@@ -4089,6 +4213,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -4111,7 +4236,7 @@ mod imp {
                 if model.extra.total > 0.0 || model.extra.remain > 0.0 || model.extra.used > 0.0 {
                     resources.push(model.extra);
                 }
-                let rows = resources
+                let rows: Vec<QuotaRow> = resources
                     .into_iter()
                     .filter(|resource| resource.total > 0.0 || resource.remain > 0.0)
                     .map(|resource| {
@@ -4141,6 +4266,7 @@ mod imp {
                     .clone()
                     .filter(|text| !text.trim().is_empty())
                     .unwrap_or_else(|| account.email.clone());
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id.clone(),
                     title,
@@ -4151,6 +4277,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -4173,7 +4300,7 @@ mod imp {
                 if model.extra.total > 0.0 || model.extra.remain > 0.0 || model.extra.used > 0.0 {
                     resources.push(model.extra);
                 }
-                let rows = resources
+                let rows: Vec<QuotaRow> = resources
                     .into_iter()
                     .filter(|resource| resource.total > 0.0 || resource.remain > 0.0)
                     .map(|resource| {
@@ -4203,6 +4330,7 @@ mod imp {
                     .clone()
                     .filter(|text| !text.trim().is_empty())
                     .unwrap_or_else(|| account.email.clone());
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id.clone(),
                     title,
@@ -4213,6 +4341,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -4288,6 +4417,7 @@ mod imp {
                         None,
                     ));
                 }
+                let remaining_percent = min_quota_progress(&rows, false);
                 AccountCard {
                     id: account.id.clone(),
                     title: account
@@ -4306,6 +4436,7 @@ mod imp {
                         account.created_at,
                     ),
                     quota_rows: rows,
+                    remaining_percent,
                 }
             })
             .collect();
@@ -4669,6 +4800,9 @@ mod imp {
         unsafe {
             macos_native_menu_update_snapshot(snapshot_json.as_ptr());
         }
+        if let Some(app) = crate::get_app_handle() {
+            let _ = update_status_item(app);
+        }
     }
 
     fn spawn_switch_account(platform: PlatformId, account_id: String) {
@@ -4677,6 +4811,7 @@ mod imp {
         };
 
         tauri::async_runtime::spawn(async move {
+            let status_app = app.clone();
             let _ = match platform {
                 PlatformId::Antigravity => commands::account::switch_account(app, account_id, None)
                     .await
@@ -4741,6 +4876,7 @@ mod imp {
                     .await
                     .map(|_| ()),
             };
+            let _ = update_status_item(&status_app);
         });
     }
 
@@ -4758,4 +4894,4 @@ mod imp {
 }
 
 #[cfg(target_os = "macos")]
-pub(crate) use imp::toggle_tray_menu;
+pub(crate) use imp::{toggle_tray_menu, update_status_item};

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -3589,9 +3589,9 @@ fn handle_tray_event<R: Runtime>(tray: &TrayIcon<R>, event: TrayIconEvent) {
 pub fn update_tray_menu<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        let _ = app;
+        crate::modules::macos_native_menu::update_status_item(app)?;
         if !MACOS_TRAY_SKIP_LOGGED.swap(true, Ordering::Relaxed) {
-            logger::log_info("[Tray] macOS 原生菜单模式，跳过 Tauri 托盘菜单更新");
+            logger::log_info("[Tray] macOS 原生菜单模式，已更新菜单栏状态");
         }
     }
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -152,6 +152,9 @@ interface GeneralConfig {
   minimize_behavior?: 'dock_and_tray' | 'tray_only';
   hide_dock_icon?: boolean;
   tray_icon_style?: 'template' | 'color';
+  menu_bar_quota_enabled?: boolean;
+  menu_bar_show_account_prefix?: boolean;
+  menu_bar_quota_platform?: PlatformId;
   floating_card_show_on_startup?: boolean;
   startup_minimized?: boolean;
   remember_main_window_state?: boolean;
@@ -477,6 +480,27 @@ export function SettingsPage() {
     { value: 'ar', label: 'العربية' },
     { value: 'id', label: 'Bahasa Indonesia' },
   ];
+
+  const menuBarQuotaPlatformOptions: Array<{ value: PlatformId; label: string }> = [
+    { value: 'codex', label: 'Codex' },
+    { value: 'claude_manager', label: 'Claude' },
+    { value: 'antigravity', label: 'Antigravity' },
+    { value: 'github-copilot', label: 'GitHub Copilot' },
+    { value: 'windsurf', label: 'Windsurf' },
+    { value: 'kiro', label: 'Kiro' },
+    { value: 'cursor', label: 'Cursor' },
+    { value: 'grok', label: 'Grok' },
+    { value: 'codebuddy', label: 'CodeBuddy' },
+    { value: 'codebuddy_cn', label: 'CodeBuddy CN' },
+    { value: 'qoder', label: 'Qoder' },
+    { value: 'zcode', label: 'ZCode' },
+    { value: 'trae', label: 'Trae' },
+    { value: 'trae_solo', label: 'TRAE SOLO' },
+    { value: 'trae_cn', label: 'Trae CN' },
+    { value: 'trae_solo_cn', label: 'TRAE SOLO CN' },
+    { value: 'workbuddy', label: 'WorkBuddy' },
+    { value: 'zed', label: 'Zed' },
+  ];
   
   // General Settings States
   const [language, setLanguage] = useState(getCurrentLanguage());
@@ -507,6 +531,9 @@ export function SettingsPage() {
   const [minimizeBehavior, setMinimizeBehavior] = useState<'dock_and_tray' | 'tray_only'>('dock_and_tray');
   const [hideDockIcon, setHideDockIcon] = useState(false);
   const [trayIconStyle, setTrayIconStyle] = useState<'template' | 'color'>('template');
+  const [menuBarQuotaEnabled, setMenuBarQuotaEnabled] = useState(false);
+  const [menuBarShowAccountPrefix, setMenuBarShowAccountPrefix] = useState(true);
+  const [menuBarQuotaPlatform, setMenuBarQuotaPlatform] = useState<PlatformId>('codex');
   const [floatingCardShowOnStartup, setFloatingCardShowOnStartup] = useState(false);
   const [startupMinimized, setStartupMinimized] = useState(false);
   const [rememberMainWindowState, setRememberMainWindowState] = useState(false);
@@ -1050,6 +1077,9 @@ export function SettingsPage() {
       minimize_behavior: minimizeBehavior,
       hide_dock_icon: hideDockIcon,
       tray_icon_style: isMacOS ? trayIconStyle : undefined,
+      menu_bar_quota_enabled: isMacOS ? menuBarQuotaEnabled : undefined,
+      menu_bar_show_account_prefix: isMacOS ? menuBarShowAccountPrefix : undefined,
+      menu_bar_quota_platform: isMacOS ? menuBarQuotaPlatform : undefined,
       floating_card_show_on_startup: floatingCardShowOnStartup,
       startup_minimized: startupMinimized,
       remember_main_window_state: rememberMainWindowState,
@@ -1260,6 +1290,9 @@ export function SettingsPage() {
     minimizeBehavior,
     hideDockIcon,
     trayIconStyle,
+    menuBarQuotaEnabled,
+    menuBarShowAccountPrefix,
+    menuBarQuotaPlatform,
     isMacOS,
     floatingCardShowOnStartup,
     startupMinimized,
@@ -1611,6 +1644,9 @@ export function SettingsPage() {
       setMinimizeBehavior(config.minimize_behavior || 'dock_and_tray');
       setHideDockIcon(Boolean(config.hide_dock_icon));
       setTrayIconStyle(config.tray_icon_style === 'color' ? 'color' : 'template');
+      setMenuBarQuotaEnabled(config.menu_bar_quota_enabled ?? false);
+      setMenuBarShowAccountPrefix(config.menu_bar_show_account_prefix ?? true);
+      setMenuBarQuotaPlatform(config.menu_bar_quota_platform ?? 'codex');
       setFloatingCardShowOnStartup(config.floating_card_show_on_startup ?? false);
       setStartupMinimized(config.startup_minimized ?? false);
       setRememberMainWindowState(config.remember_main_window_state ?? false);
@@ -3409,6 +3445,87 @@ export function SettingsPage() {
                       </select>
                     </div>
                   </div>
+
+                  <div className="settings-row">
+                    <div className="row-label">
+                      <div className="row-title">
+                        {t('settings.general.menuBarQuota', '菜单栏显示实时额度')}
+                      </div>
+                      <div className="row-desc">
+                        {t(
+                          'settings.general.menuBarQuotaDesc',
+                          '在图标旁显示当前账号的剩余额度；低额度红色、中等橙色、充足绿色'
+                        )}
+                      </div>
+                    </div>
+                    <div className="row-control">
+                      <select
+                        className="settings-select"
+                        value={menuBarQuotaEnabled ? 'true' : 'false'}
+                        onChange={(e) => setMenuBarQuotaEnabled(e.target.value === 'true')}
+                      >
+                        <option value="false">{t('common.disable', '停用')}</option>
+                        <option value="true">{t('common.enable', '启用')}</option>
+                      </select>
+                    </div>
+                  </div>
+
+                  {menuBarQuotaEnabled && (
+                    <>
+                      <div className="settings-row">
+                        <div className="row-label">
+                          <div className="row-title">
+                            {t('settings.general.menuBarQuotaPlatform', '菜单栏额度账号平台')}
+                          </div>
+                          <div className="row-desc">
+                            {t(
+                              'settings.general.menuBarQuotaPlatformDesc',
+                              '跟随所选平台当前正在使用的账号，刷新或切换账号后自动更新'
+                            )}
+                          </div>
+                        </div>
+                        <div className="row-control">
+                          <select
+                            className="settings-select"
+                            value={menuBarQuotaPlatform}
+                            onChange={(e) => setMenuBarQuotaPlatform(e.target.value as PlatformId)}
+                          >
+                            {menuBarQuotaPlatformOptions.map((option) => (
+                              <option key={option.value} value={option.value}>
+                                {option.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+
+                      <div className="settings-row">
+                        <div className="row-label">
+                          <div className="row-title">
+                            {t('settings.general.menuBarAccountPrefix', '显示账号邮箱前 4 位')}
+                          </div>
+                          <div className="row-desc">
+                            {t(
+                              'settings.general.menuBarAccountPrefixDesc',
+                              '关闭后菜单栏只显示图标和百分比数字'
+                            )}
+                          </div>
+                        </div>
+                        <div className="row-control">
+                          <select
+                            className="settings-select"
+                            value={menuBarShowAccountPrefix ? 'true' : 'false'}
+                            onChange={(e) =>
+                              setMenuBarShowAccountPrefix(e.target.value === 'true')
+                            }
+                          >
+                            <option value="true">{t('common.enable', '启用')}</option>
+                            <option value="false">{t('common.disable', '停用')}</option>
+                          </select>
+                        </div>
+                      </div>
+                    </>
+                  )}
                 </>
               )}
 


### PR DESCRIPTION
## Summary

- add an optional macOS menu bar quota indicator next to the existing app icon
- show the current account prefix (first 4 characters) with a setting to hide it
- show the live remaining quota percentage and update it after quota refreshes or account switches
- support selecting which account platform the menu bar tracks
- use the lowest remaining percentage when a provider exposes multiple quota windows

## Color rules

- 0–30%: red
- 31–60%: orange
- 61–100%: green
- unavailable quota: gray `--`

## Verification

- `npm run typecheck`
- `npm run build`
- `swift build`
- `cargo check`
- `cargo test --lib` (698 passed, 2 ignored, 0 failed)
- macOS debug app and DMG bundles generated successfully; updater signing was skipped because the upstream private signing key is not available locally
