### PR TITLE
fix(codex): show billing quota for new_api accounts

### DIFF
--- a/src/components/codex/CodexModelProviderManager.tsx
+++ b/src/components/codex/CodexModelProviderManager.tsx
@@ -99,6 +99,9 @@ import {
   CODEX_API_KEY_USAGE_REFRESHED_EVENT,
   readCodexApiKeyUsageCache,
 } from "../../services/codexApiKeyUsageRefreshService";
+import {
+  resolveNewApiQuotaSnapshot,
+} from "../../services/modelProviderUsageService";
 import { useSponsorStore } from "../../stores/useSponsorStore";
 import type { Sponsor } from "../../types/sponsor";
 import {
@@ -3342,32 +3345,11 @@ export function CodexModelProviderManager({
               usageSummary?.mode === "new_api" || usageSummary?.mode === "sub2api"
                 ? usageSummary.mode
                 : provider.integrationType ?? null;
-            const detailMap = new Map(
-              (usageSummary?.details ?? []).map((item) => [item.key, item.value]),
-            );
-            const totalGrantedValue = detailMap.get("totalGranted");
-            const totalAvailableValue = detailMap.get("totalAvailable");
-            const expiresAtValue = detailMap.get("expiresAt");
-            const totalGranted =
-              typeof totalGrantedValue === "number"
-                ? totalGrantedValue
-                : typeof totalGrantedValue === "string"
-                  ? Number(totalGrantedValue)
-                  : null;
-            const totalAvailable =
-              typeof totalAvailableValue === "number"
-                ? totalAvailableValue
-                : typeof totalAvailableValue === "string"
-                  ? Number(totalAvailableValue)
-                : typeof usageSummary?.quotaRemaining === "number"
-                  ? usageSummary.quotaRemaining
-                  : null;
-            const expiresAt =
-              typeof expiresAtValue === "number"
-                ? expiresAtValue
-                : typeof expiresAtValue === "string"
-                  ? Number(expiresAtValue)
-                  : null;
+            const {
+              granted: totalGranted,
+              available: totalAvailable,
+              expiresAt,
+            } = resolveNewApiQuotaSnapshot(usageSummary);
             const progressPercent =
               usageMode === "new_api" &&
               totalGranted != null &&
@@ -5510,6 +5492,7 @@ export function CodexModelProviderManager({
             })) as CodexServicePanelMetricItem[]),
         ];
 
+        const newApiQuota = resolveNewApiQuotaSnapshot(usageSummary);
         const coreMetrics: CodexServicePanelMetricItem[] =
           usageMode === "new_api"
             ? [
@@ -5519,11 +5502,7 @@ export function CodexModelProviderManager({
                   value: formatUsageDetailValue(
                     {
                       key: "totalGranted",
-                      value:
-                        String(
-                          usageSummary?.details?.find((item) => item.key === "totalGranted")
-                            ?.value ?? "-",
-                        ),
+                      value: String(newApiQuota.granted ?? "-"),
                     },
                     usageSummary?.unit,
                   ),
@@ -5534,11 +5513,7 @@ export function CodexModelProviderManager({
                   value: formatUsageDetailValue(
                     {
                       key: "totalAvailable",
-                      value:
-                        String(
-                          usageSummary?.details?.find((item) => item.key === "totalAvailable")
-                            ?.value ?? "-",
-                        ),
+                      value: String(newApiQuota.available ?? "-"),
                     },
                     usageSummary?.unit,
                   ),
@@ -5549,11 +5524,7 @@ export function CodexModelProviderManager({
                   value: formatUsageDetailValue(
                     {
                       key: "expiresAt",
-                      value:
-                        String(
-                          usageSummary?.details?.find((item) => item.key === "expiresAt")
-                            ?.value ?? "-",
-                        ),
+                      value: String(newApiQuota.expiresAt ?? "-"),
                     },
                     usageSummary?.unit,
                   ),

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -268,6 +268,7 @@ import {
 import {
   isModelProviderUsageUnavailableError,
   listModelProviderModels,
+  resolveNewApiQuotaSnapshot,
 } from "../services/modelProviderUsageService";
 import { useSponsorStore } from "../stores/useSponsorStore";
 import type { Sponsor } from "../types/sponsor";
@@ -7490,17 +7491,8 @@ export function CodexAccountsPage() {
   const formatApiKeyUsagePercent = useCallback(
     (summary?: CodexModelProviderUsageSummary): number => {
       if (summary?.mode === "new_api") {
-        const granted = Number(
-          summary.details?.find((item) => item.key === "totalGranted")?.value,
-        );
-        const available = Number(
-          summary.details?.find((item) => item.key === "totalAvailable")?.value,
-        );
-        if (
-          Number.isFinite(granted) &&
-          Number.isFinite(available) &&
-          granted > 0
-        ) {
+        const { granted, available } = resolveNewApiQuotaSnapshot(summary);
+        if (granted != null && available != null && granted > 0) {
           return Math.max(
             0,
             Math.min(100, Math.round(((granted - available) / granted) * 100)),
@@ -7690,19 +7682,19 @@ export function CodexAccountsPage() {
       const isSub2ApiUsage = usageMode === "sub2api";
       const usedPercent = formatApiKeyUsagePercent(summary);
       if (variant === "card" && summary && isNewApiUsage) {
-        const grantedRaw = Number(
-          findApiKeyUsageDetail(summary, "totalGranted")?.value ?? NaN,
+        const quota = resolveNewApiQuotaSnapshot(summary);
+        const grantedText = formatApiKeyUsageMoney(quota.granted, summary.unit);
+        const availableText = formatApiKeyUsageMoney(
+          quota.available,
+          summary.unit,
         );
-        const availableRaw = Number(
-          findApiKeyUsageDetail(summary, "totalAvailable")?.value ?? NaN,
-        );
-        const grantedText = Number.isFinite(grantedRaw)
-          ? formatApiKeyUsageMoney(grantedRaw, summary.unit)
-          : formatApiKeyUsageDetailByKey(summary, "totalGranted");
-        const availableText = Number.isFinite(availableRaw)
-          ? formatApiKeyUsageMoney(availableRaw, summary.unit)
-          : formatApiKeyUsageDetailByKey(summary, "totalAvailable");
-        const expiresText = formatApiKeyUsageDetailByKey(summary, "expiresAt");
+        const expiresText =
+          quota.expiresAt != null
+            ? formatApiKeyUsageDetailValue({
+                key: "expiresAt",
+                value: String(quota.expiresAt),
+              })
+            : "-";
         const unlimitedText = t("codex.newApi.quota.unlimited", "不限量");
         const quotaValueText =
           summary.quotaUnlimited === true
@@ -12711,6 +12703,7 @@ export function CodexAccountsPage() {
     const baseUrl =
       provider?.baseUrl.trim() || (account.api_base_url || "").trim() || "-";
     const usedPercent = formatApiKeyUsagePercent(summary);
+    const newApiQuota = resolveNewApiQuotaSnapshot(summary);
     const summaryDetails =
       usageMode === "new_api"
         ? [
@@ -12720,14 +12713,10 @@ export function CodexAccountsPage() {
                 "codex.modelProviders.usage.fields.totalGranted",
                 "授予额度",
               ),
-              value: (() => {
-                const raw = Number(
-                  findApiKeyUsageDetail(summary, "totalGranted")?.value ?? NaN,
-                );
-                return Number.isFinite(raw)
-                  ? formatApiKeyUsageMoney(raw, summary?.unit)
-                  : formatApiKeyUsageDetailByKey(summary, "totalGranted");
-              })(),
+              value: formatApiKeyUsageMoney(
+                newApiQuota.granted,
+                summary?.unit,
+              ),
             },
             {
               key: "totalAvailable",
@@ -12735,15 +12724,10 @@ export function CodexAccountsPage() {
                 "codex.modelProviders.usage.fields.totalAvailable",
                 "可用额度",
               ),
-              value: (() => {
-                const raw = Number(
-                  findApiKeyUsageDetail(summary, "totalAvailable")?.value ??
-                    NaN,
-                );
-                return Number.isFinite(raw)
-                  ? formatApiKeyUsageMoney(raw, summary?.unit)
-                  : formatApiKeyUsageDetailByKey(summary, "totalAvailable");
-              })(),
+              value: formatApiKeyUsageMoney(
+                newApiQuota.available,
+                summary?.unit,
+              ),
             },
             {
               key: "expiresAt",
@@ -12751,7 +12735,13 @@ export function CodexAccountsPage() {
                 "codex.modelProviders.usage.fields.expiresAt",
                 "过期时间",
               ),
-              value: formatApiKeyUsageDetailByKey(summary, "expiresAt"),
+              value:
+                newApiQuota.expiresAt != null
+                  ? formatApiKeyUsageDetailValue({
+                      key: "expiresAt",
+                      value: String(newApiQuota.expiresAt),
+                    })
+                  : "-",
             },
           ]
         : usageMode === "sub2api"

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -117,6 +117,7 @@ import {
 } from '../services/codexApiKeyUsageRefreshService';
 import {
   isModelProviderUsageUnavailableError,
+  resolveNewApiQuotaSnapshot,
   type ModelProviderUsageSummary,
 } from '../services/modelProviderUsageService';
 import * as traeService from '../services/traeService';
@@ -2283,18 +2284,13 @@ export function DashboardPage({
       const usageState = codexApiUsageMap[account.id];
       const usageSummary = usageState?.summary;
       const usageMode = resolveDashboardCodexApiUsageMode(usageSummary);
-      const newApiGranted = Number(
-        usageSummary?.details?.find((item) => item.key === 'totalGranted')?.value ?? NaN,
-      );
-      const newApiAvailable = Number(
-        usageSummary?.details?.find((item) => item.key === 'totalAvailable')?.value ?? NaN,
-      );
-      const newApiExpiresAt = Number(
-        usageSummary?.details?.find((item) => item.key === 'expiresAt')?.value ?? NaN,
-      );
+      const newApiQuota = resolveNewApiQuotaSnapshot(usageSummary);
+      const newApiGranted = newApiQuota.granted;
+      const newApiAvailable = newApiQuota.available;
+      const newApiExpiresAt = newApiQuota.expiresAt;
       const isUnlimited = usageSummary?.quotaUnlimited === true;
       const progressPercent =
-        usageMode === 'new_api' && Number.isFinite(newApiGranted) && Number.isFinite(newApiAvailable) && newApiGranted > 0
+        usageMode === 'new_api' && newApiGranted != null && newApiAvailable != null && newApiGranted > 0
           ? Math.max(0, Math.min(100, Math.round(((newApiGranted - newApiAvailable) / newApiGranted) * 100)))
           : isUnlimited
             ? 100
@@ -2322,7 +2318,7 @@ export function DashboardPage({
                     <span className="model-pct high">
                       {isUnlimited
                         ? t('codex.newApi.quota.unlimited', '不限量')
-                        : Number.isFinite(newApiAvailable) && Number.isFinite(newApiGranted)
+                        : newApiAvailable != null && newApiGranted != null
                           ? `$${newApiAvailable.toFixed(2)} / $${newApiGranted.toFixed(2)}`
                           : '-'}
                     </span>
@@ -2334,7 +2330,7 @@ export function DashboardPage({
                     />
                   </div>
                   <div className="mini-reset-time">
-                    {Number.isFinite(newApiExpiresAt) && newApiExpiresAt > 0
+                    {newApiExpiresAt != null && newApiExpiresAt > 0
                       ? `${t('codex.modelProviders.usage.fields.expiresAt', '过期时间')} ${new Date(newApiExpiresAt * 1000).toLocaleDateString()}`
                       : t('dashboard.noData', '暂无数据')}
                   </div>

--- a/src/services/modelProviderUsageService.test.ts
+++ b/src/services/modelProviderUsageService.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resolveNewApiQuotaSnapshot,
+  type ModelProviderUsageSummary,
+} from "./modelProviderUsageService.ts";
+
+function summary(
+  partial: Partial<ModelProviderUsageSummary>,
+): ModelProviderUsageSummary {
+  return {
+    modelStatsCount: 0,
+    latencyMs: 0,
+    ...partial,
+  };
+}
+
+test("new_api quota uses token allocation details when available", () => {
+  const snapshot = resolveNewApiQuotaSnapshot(
+    summary({
+      mode: "new_api",
+      quotaLimit: 100,
+      quotaRemaining: 80,
+      details: [
+        { key: "totalGranted", label: "Granted", value: "250" },
+        { key: "totalAvailable", label: "Available", value: "175.5" },
+        { key: "expiresAt", label: "Expires", value: "1800000000" },
+      ],
+    }),
+  );
+
+  assert.deepEqual(snapshot, {
+    granted: 250,
+    available: 175.5,
+    expiresAt: 1800000000,
+  });
+});
+
+test("new_api quota falls back to billing limits when token allocation is absent", () => {
+  const snapshot = resolveNewApiQuotaSnapshot(
+    summary({
+      mode: "new_api",
+      quotaLimit: 1849,
+      quotaRemaining: 1610,
+      details: [
+        { key: "hardLimitUsd", label: "Hard Limit", value: "1849" },
+        { key: "accessUntil", label: "Access Until", value: "1815609561" },
+        { key: "totalUsage", label: "Total Usage", value: "23900" },
+      ],
+    }),
+  );
+
+  assert.deepEqual(snapshot, {
+    granted: 1849,
+    available: 1610,
+    expiresAt: 1815609561,
+  });
+});
+
+test("new_api quota ignores malformed numeric details", () => {
+  const snapshot = resolveNewApiQuotaSnapshot(
+    summary({
+      mode: "new_api",
+      quotaLimit: 75,
+      quotaRemaining: 25,
+      details: [
+        { key: "totalGranted", label: "Granted", value: "unlimited" },
+        { key: "totalAvailable", label: "Available", value: "" },
+        { key: "expiresAt", label: "Expires", value: "never" },
+      ],
+    }),
+  );
+
+  assert.deepEqual(snapshot, {
+    granted: 75,
+    available: 25,
+    expiresAt: null,
+  });
+});

--- a/src/services/modelProviderUsageService.ts
+++ b/src/services/modelProviderUsageService.ts
@@ -40,6 +40,53 @@ export interface ModelProviderUsageSummary {
   }>;
 }
 
+export interface NewApiQuotaSnapshot {
+  granted: number | null;
+  available: number | null;
+  expiresAt: number | null;
+}
+
+function finiteUsageNumber(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function usageDetailNumber(
+  summary: ModelProviderUsageSummary | undefined,
+  key: string,
+): number | null {
+  return finiteUsageNumber(summary?.details?.find((item) => item.key === key)?.value);
+}
+
+export function resolveNewApiQuotaSnapshot(
+  summary?: ModelProviderUsageSummary,
+): NewApiQuotaSnapshot {
+  const used =
+    finiteUsageNumber(summary?.quotaUsed) ??
+    finiteUsageNumber(summary?.totalCost);
+  const granted =
+    usageDetailNumber(summary, 'totalGranted') ??
+    finiteUsageNumber(summary?.quotaLimit) ??
+    usageDetailNumber(summary, 'hardLimitUsd') ??
+    usageDetailNumber(summary, 'softLimitUsd') ??
+    usageDetailNumber(summary, 'systemHardLimitUsd');
+  const available =
+    usageDetailNumber(summary, 'totalAvailable') ??
+    finiteUsageNumber(summary?.quotaRemaining) ??
+    (granted != null && used != null
+      ? Math.max(0, granted - used)
+      : null);
+  const expiresAt =
+    usageDetailNumber(summary, 'expiresAt') ??
+    usageDetailNumber(summary, 'accessUntil');
+
+  return { granted, available, expiresAt };
+}
+
 function buildUsageBaseUrlCandidates(baseUrl: string): string[] {
   const trimmed = baseUrl.trim();
   if (!trimmed) return [];


### PR DESCRIPTION
## Summary

- normalize token-allocation and billing-only New API quota responses
- fall back to `quotaLimit`, `quotaRemaining`, and `accessUntil`
- reuse the normalized snapshot across account, dashboard, and provider views

Fixes #1573

## Tests

- `node --test src/services/modelProviderUsageService.test.ts` (3 passed)
- `tsc --noEmit -p tsconfig.json`
- `git diff --check`