### PR TITLE
fix(layout): contain custom icon storage quota errors

### DIFF
--- a/src/components/PlatformLayoutModal.tsx
+++ b/src/components/PlatformLayoutModal.tsx
@@ -42,8 +42,10 @@ import {
 import { CLASSIC_SIDEBAR_ENTRY_LIMIT, ORIGINAL_SIDEBAR_ENTRY_LIMIT, useSideNavLayoutStore } from '../stores/useSideNavLayoutStore';
 import { getPlatformLabel, renderPlatformIcon } from '../utils/platformMeta';
 import { useEscClose } from '../hooks/useEscClose';
-
-const PLATFORM_LAYOUT_ICON_STORAGE_KEY = 'agtools.platform_layout.custom_icons.v1';
+import {
+  PLATFORM_LAYOUT_ICON_STORAGE_KEY,
+  persistPlatformLayoutCustomIcons,
+} from '../utils/platformLayoutIconStorage';
 
 interface PlatformLayoutModalProps {
   open: boolean;
@@ -387,6 +389,7 @@ export function PlatformLayoutModal({
   const [dropChildTarget, setDropChildTarget] = useState<{ groupId: string; platformId: PlatformId } | null>(null);
 
   const [customIcons, setCustomIcons] = useState<PlatformLayoutCustomIcon[]>(() => loadCustomIcons());
+  const [customIconStorageFailed, setCustomIconStorageFailed] = useState(false);
 
   const [expandedGroupIds, setExpandedGroupIds] = useState<string[]>([]);
   const [addingChildGroupId, setAddingChildGroupId] = useState<string | null>(null);
@@ -522,7 +525,9 @@ export function PlatformLayoutModal({
     if (typeof window === 'undefined') {
       return;
     }
-    localStorage.setItem(PLATFORM_LAYOUT_ICON_STORAGE_KEY, JSON.stringify(customIcons));
+    setCustomIconStorageFailed(
+      !persistPlatformLayoutCustomIcons(localStorage, customIcons),
+    );
   }, [customIcons]);
 
   useEffect(() => {
@@ -1126,6 +1131,15 @@ export function PlatformLayoutModal({
               { max: sidebarSelectionLimit },
             )}
           </div>
+
+          {customIconStorageFailed && (
+            <div className="platform-layout-group-error" role="alert">
+              {t(
+                'platformLayout.customIconStorageFailed',
+                '自定义图标无法保存，本地存储空间可能已满。删除不再使用的自定义图标后重试。',
+              )}
+            </div>
+          )}
 
           <div className="platform-layout-bulk-header">
             <div className="platform-layout-bulk-header-left">

--- a/src/utils/platformLayoutIconStorage.test.ts
+++ b/src/utils/platformLayoutIconStorage.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PLATFORM_LAYOUT_ICON_STORAGE_KEY,
+  persistPlatformLayoutCustomIcons,
+} from "./platformLayoutIconStorage.ts";
+
+test("custom platform icons are serialized to the expected key", () => {
+  const writes: Array<[string, string]> = [];
+  const storage = {
+    setItem(key: string, value: string) {
+      writes.push([key, value]);
+    },
+  };
+  const icons = [{ id: "one", dataUrl: "data:image/png;base64,abc" }];
+
+  assert.equal(persistPlatformLayoutCustomIcons(storage, icons), true);
+  assert.deepEqual(writes, [
+    [PLATFORM_LAYOUT_ICON_STORAGE_KEY, JSON.stringify(icons)],
+  ]);
+});
+
+test("quota errors do not escape custom icon persistence", () => {
+  const storage = {
+    setItem() {
+      throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+    },
+  };
+
+  assert.doesNotThrow(() => persistPlatformLayoutCustomIcons(storage, []));
+  assert.equal(persistPlatformLayoutCustomIcons(storage, []), false);
+});

--- a/src/utils/platformLayoutIconStorage.ts
+++ b/src/utils/platformLayoutIconStorage.ts
@@ -1,0 +1,21 @@
+export const PLATFORM_LAYOUT_ICON_STORAGE_KEY =
+  "agtools.platform_layout.custom_icons.v1";
+
+interface StorageWriter {
+  setItem(key: string, value: string): void;
+}
+
+export function persistPlatformLayoutCustomIcons(
+  storage: StorageWriter,
+  customIcons: unknown,
+): boolean {
+  try {
+    storage.setItem(
+      PLATFORM_LAYOUT_ICON_STORAGE_KEY,
+      JSON.stringify(customIcons),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- catch custom-icon localStorage write failures
- keep the platform layout modal usable and show a bounded storage warning
- cover successful writes and quota errors with focused tests

Fixes #1446

## Tests

- `node --test src/utils/platformLayoutIconStorage.test.ts` (2 passed)
- `tsc --noEmit -p tsconfig.json`
- `git diff --check`