### PR TITLE
fix(codex): reconcile batch import preview after session start

### DIFF
--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -129,6 +129,7 @@ import {
   readCodexImportSyncApiService,
   writeCodexImportSyncApiService,
 } from "../utils/codexImportPreferences";
+import { recoverCodexBatchImportStartFromPreview } from "../utils/codexBatchImportQueue";
 import {
   CODEX_OPEN_ADD_ACCOUNT_EVENT,
   type CodexOpenAddAccountDetail,
@@ -5933,6 +5934,28 @@ export function CodexAccountsPage() {
         );
       } catch {
         // ignore storage failures
+      }
+      // The backend starts scanning before this invoke resolves. A fast scan can
+      // therefore emit its terminal event while the listener still filters on
+      // __pending__. Re-read the now-addressable session to recover that event.
+      try {
+        const recoveredPreview =
+          await codexService.getCodexBatchImportPreview(started.sessionId);
+        const recovery = recoverCodexBatchImportStartFromPreview(
+          batchImportSessionIdRef.current,
+          started.sessionId,
+          recoveredPreview,
+          batchImportSelectedIds,
+        );
+        if (recovery) {
+          setBatchImportPreview(recovery.preview);
+          setBatchImportCheckQuota(recovery.preview.checkQuota);
+          setBatchImportSelectedIds(recovery.selectedIds);
+          setBatchImportBusy(false);
+        }
+      } catch {
+        // If this read fails, only later listener events follow their normal path;
+        // it cannot recover terminal or error events that were already missed.
       }
     } catch (e) {
       cleanupBatchImportListeners();

--- a/src/utils/codexBatchImportQueue.ts
+++ b/src/utils/codexBatchImportQueue.ts
@@ -40,6 +40,13 @@ export interface CodexBatchImportPreviewLike {
   items: CodexBatchImportSelectableItemLike[];
 }
 
+export interface CodexBatchImportStartRecovery<
+  T extends CodexBatchImportPreviewLike = CodexBatchImportPreviewLike,
+> {
+  preview: T;
+  selectedIds: string[];
+}
+
 export interface CodexBatchImportApiServiceImportedAccountLike {
   id?: string | null;
 }
@@ -119,6 +126,31 @@ export function recoverCodexBatchImportStartedTaskFromPreview<
     preview,
     selectedIds: mergeCodexBatchImportDefaultSelection(
       task.selectedIds,
+      preview.items,
+    ),
+  };
+}
+
+export function recoverCodexBatchImportStartFromPreview<
+  T extends CodexBatchImportPreviewLike,
+>(
+  currentSessionId: string | null,
+  sessionId: string,
+  preview: T,
+  selectedIds: string[],
+): CodexBatchImportStartRecovery<T> | null {
+  if (
+    currentSessionId !== sessionId ||
+    preview.sessionId !== sessionId ||
+    (preview.status !== "ready" && preview.status !== "cancelled")
+  ) {
+    return null;
+  }
+
+  return {
+    preview,
+    selectedIds: mergeCodexBatchImportDefaultSelection(
+      selectedIds,
       preview.items,
     ),
   };

--- a/tests/codexBatchImportStartRecovery.test.ts
+++ b/tests/codexBatchImportStartRecovery.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { recoverCodexBatchImportStartFromPreview } from "../src/utils/codexBatchImportQueue.ts";
+
+describe("codex batch import start recovery", () => {
+  const readyPreview = {
+    sessionId: "session-fast",
+    status: "ready",
+    checkQuota: false,
+    total: 3,
+    items: [
+      {
+        itemId: "ready-default",
+        defaultSelected: true,
+        selectable: true,
+        status: "ready",
+      },
+      {
+        itemId: "existing-default",
+        defaultSelected: true,
+        selectable: true,
+        status: "existing",
+      },
+      {
+        itemId: "invalid-default",
+        defaultSelected: true,
+        selectable: false,
+        status: "invalid",
+      },
+    ],
+  };
+
+  it("recovers a terminal preview that completed before the start response", () => {
+    const recovery = recoverCodexBatchImportStartFromPreview(
+      "session-fast",
+      "session-fast",
+      readyPreview,
+      ["manual"],
+    );
+
+    assert.deepEqual(recovery, {
+      preview: readyPreview,
+      selectedIds: ["manual", "ready-default", "existing-default"],
+    });
+  });
+
+  it("recovers a cancelled terminal preview", () => {
+    const recovery = recoverCodexBatchImportStartFromPreview(
+      "session-fast",
+      "session-fast",
+      { ...readyPreview, status: "cancelled" },
+      [],
+    );
+
+    assert.equal(recovery?.preview.status, "cancelled");
+    assert.deepEqual(recovery?.selectedIds, [
+      "ready-default",
+      "existing-default",
+    ]);
+  });
+
+  it("does not clear the busy state from a running or stale session preview", () => {
+    assert.equal(
+      recoverCodexBatchImportStartFromPreview(
+        "session-fast",
+        "session-fast",
+        { ...readyPreview, status: "running" },
+        [],
+      ),
+      null,
+    );
+    assert.equal(
+      recoverCodexBatchImportStartFromPreview(
+        "replacement-session",
+        "session-fast",
+        readyPreview,
+        [],
+      ),
+      null,
+    );
+    assert.equal(
+      recoverCodexBatchImportStartFromPreview(
+        "session-fast",
+        "session-fast",
+        { ...readyPreview, sessionId: "unexpected-session" },
+        [],
+      ),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1714

## Summary

Reconcile the Codex batch import preview immediately after the start command returns the real session ID.

## Root cause

The backend starts scanning before the frontend invoke response is processed. A fast scan can emit its terminal event while the listeners held the `__pending__` sentinel rather than the real session ID. The event is filtered out, and the modal can remain in its busy/preparing state until reload.

## Fix

After storing the real session ID, the page reads that session's persisted preview once. If it is already in a `ready` or `cancelled` terminal state and still matches the active session, the page restores the preview and clears the busy state. Non-terminal sessions continue to use the existing listeners.

This is a frontend-only change: it does not change the Rust event protocol, persistence format, or credential format.

## Testing

- Node unit tests for terminal preview reconciliation and existing batch-import queue helpers
- `npm run typecheck`
- `npm run build`

A GUI Integration/E2E test was not run to avoid interfering with the actively used installation.
