### PR TITLE
fix(codex): clear stale API service catalog

### DIFF
--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -44,6 +44,7 @@ const CODEX_CONFIG_HTTP_HEADERS_KEY: &str = "http_headers";
 const CODEX_CONFIG_MODEL_CONTEXT_WINDOW_KEY: &str = "model_context_window";
 const CODEX_CONFIG_MODEL_AUTO_COMPACT_TOKEN_LIMIT_KEY: &str = "model_auto_compact_token_limit";
 const CODEX_MANAGED_MODEL_CATALOG_FILE: &str = "cockpit-provider-model-catalog.json";
+const CODEX_LOCAL_ACCESS_MODEL_CATALOG_FILE: &str = "cockpit-local-access-model-catalog.json";
 const CODEX_AUTO_REVIEW_MODEL_ID: &str = "codex-auto-review";
 const CODEX_IMAGE_MODEL_ID: &str = "gpt-image-2";
 const CODEX_IMAGEGEN_ACTOR_HEADER: &str = "x-openai-actor-authorization";
@@ -1128,11 +1129,14 @@ fn write_api_provider_to_config_toml(
 }
 
 fn remove_managed_model_catalog_from_doc(doc: &mut Document) -> bool {
-    let uses_managed_catalog = doc
+    let managed_catalog = doc
         .get(CODEX_CONFIG_MODEL_CATALOG_JSON_KEY)
         .and_then(|item| item.as_str())
-        .map(str::trim)
-        == Some(CODEX_MANAGED_MODEL_CATALOG_FILE);
+        .map(str::trim);
+    let uses_managed_catalog = matches!(
+        managed_catalog,
+        Some(CODEX_MANAGED_MODEL_CATALOG_FILE) | Some(CODEX_LOCAL_ACCESS_MODEL_CATALOG_FILE)
+    );
     if uses_managed_catalog {
         let _ = doc.remove(CODEX_CONFIG_MODEL_CATALOG_JSON_KEY);
         return true;
@@ -1175,7 +1179,9 @@ fn sync_api_key_model_catalog_to_dir(
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
-        if configured_catalog != CODEX_MANAGED_MODEL_CATALOG_FILE {
+        if configured_catalog != CODEX_MANAGED_MODEL_CATALOG_FILE
+            && configured_catalog != CODEX_LOCAL_ACCESS_MODEL_CATALOG_FILE
+        {
             return Ok(false);
         }
     }
@@ -11643,6 +11649,35 @@ requires_openai_auth = false
     }
 
     #[test]
+    fn config_toml_removes_local_access_catalog_when_switching_to_builtin_openai() {
+        let base_dir = make_temp_dir("codex-config-clean-local-access-catalog-test");
+        let config_path = base_dir.join("config.toml");
+        fs::write(
+            &config_path,
+            r#"model_provider = "openai"
+model_catalog_json = "cockpit-local-access-model-catalog.json"
+model_context_window = 1000000
+"#,
+        )
+        .expect("write stale local access config");
+        let provider_config = resolve_api_provider_config(
+            None,
+            Some(CodexApiProviderMode::OpenaiBuiltin),
+            None,
+            None,
+        )
+        .expect("resolve provider config");
+
+        write_api_provider_to_config_toml(&base_dir, &provider_config).expect("write config");
+
+        let content = fs::read_to_string(&config_path).expect("read config");
+        assert!(!content.contains("model_catalog_json"));
+        assert!(content.contains("model_context_window = 1000000"));
+
+        fs::remove_dir_all(&base_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
     fn config_toml_preserves_user_model_catalog_when_switching_to_builtin_openai() {
         let base_dir = make_temp_dir("codex-config-preserve-user-catalog-builtin-test");
         let config_path = base_dir.join("config.toml");
@@ -12520,6 +12555,40 @@ supports_websockets = false
                     == Some("custom-b")
                 && model.get("visibility").and_then(serde_json::Value::as_str) == Some("list")
         }));
+
+        fs::remove_dir_all(&base_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn responses_api_key_bundle_replaces_stale_local_access_catalog() {
+        let base_dir = make_temp_dir("codex-api-key-replace-local-access-catalog-test");
+        fs::write(
+            base_dir.join("config.toml"),
+            r#"model_catalog_json = "cockpit-local-access-model-catalog.json"
+"#,
+        )
+        .expect("write stale local access catalog config");
+        let mut account = CodexAccount::new_api_key(
+            "custom-api-key".to_string(),
+            "custom@example.com".to_string(),
+            "sk-custom".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://relay.example.com/v1".to_string()),
+            Some("relay".to_string()),
+            Some("Relay".to_string()),
+            vec!["custom-a".to_string()],
+        );
+        account.api_wire_api = Some("responses".to_string());
+        account.api_sync_model_catalog_to_codex = true;
+
+        write_account_bundle_to_dir(&base_dir, &account).expect("write account bundle");
+
+        let config = fs::read_to_string(base_dir.join("config.toml")).expect("read config");
+        assert!(config.contains("model_catalog_json = \"cockpit-provider-model-catalog.json\""));
+        assert!(!config.contains("cockpit-local-access-model-catalog.json"));
+        assert!(base_dir
+            .join(super::CODEX_MANAGED_MODEL_CATALOG_FILE)
+            .exists());
 
         fs::remove_dir_all(&base_dir).expect("cleanup temp dir");
     }

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -9220,13 +9220,24 @@ fn restore_config_toml_from_takeover_backup(
         crate::modules::codex_config_format::read_codex_config_doc_from_str(current_config)
             .map_err(|e| format!("解析当前 Codex config.toml 失败: {}", e))?
     };
-    let backup_doc = match backup_config.filter(|content| !content.trim().is_empty()) {
+    let mut backup_doc = match backup_config.filter(|content| !content.trim().is_empty()) {
         Some(content) => Some(
             crate::modules::codex_config_format::read_codex_config_doc_from_str(content)
                 .map_err(|e| format!("解析 Codex API 服务接管备份 config.toml 失败: {}", e))?,
         ),
         None => None,
     };
+    if backup_doc
+        .as_ref()
+        .and_then(|doc| doc.get("model_catalog_json"))
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        == Some(CODEX_LOCAL_ACCESS_MODEL_CATALOG_FILE)
+    {
+        if let Some(doc) = backup_doc.as_mut() {
+            let _ = doc.remove("model_catalog_json");
+        }
+    }
 
     let current_selected_local_access = current_doc
         .get("model_provider")
@@ -28407,6 +28418,37 @@ wire_api = "responses"
                 .and_then(|value| value.as_str()),
             Some("keep-current")
         );
+    }
+
+    #[test]
+    fn takeover_backup_restore_drops_stale_local_access_catalog() {
+        let current = r#"model_provider = "codex_local_access"
+model_catalog_json = "cockpit-local-access-model-catalog.json"
+
+[model_providers.codex_local_access]
+name = "Codex API Service"
+base_url = "http://localhost:14998/v1"
+wire_api = "responses"
+requires_openai_auth = false
+experimental_bearer_token = "agt_codex_test"
+"#;
+        let stale_backup = r#"model_provider = "openai"
+model_catalog_json = "cockpit-local-access-model-catalog.json"
+model_context_window = 1000000
+"#;
+
+        let output = restore_config_toml_from_takeover_backup(Some(current), Some(stale_backup))
+            .expect("restore config")
+            .expect("restored content");
+        let parsed = output
+            .parse::<toml_edit::Document>()
+            .expect("parse restored toml");
+
+        assert_eq!(
+            parsed.get("model_provider").and_then(|item| item.as_str()),
+            Some("openai")
+        );
+        assert!(parsed.get("model_catalog_json").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat `cockpit-local-access-model-catalog.json` as a Cockpit-managed catalog during account projection
- remove the stale catalog when switching back to built-in OpenAI mode and allow API-key catalog sync to replace it
- discard the reserved local-access catalog from legacy takeover backups while preserving arbitrary user catalogs

Addresses #1675 problem 1 and hardens the restore path discussed in #1671.

## Tests

- `cargo test --manifest-path src-tauri/Cargo.toml local_access_catalog --lib` (3 passed)
- takeover tests (10 passed)
- sidecar lifecycle test (1 passed)
- no-backup cleanup test (1 passed)
- user-catalog safeguard tests (2 passed)
- focused `rustfmt --check`
- `git diff --check`