### PR TITLE
fix(sidecar): honor per-account excluded_models during account selection

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -3507,6 +3507,9 @@ func readManifestCodexTokenAuth(account *accountSpec, authDir, path string) (*co
 	if proxyURL := firstMetadataString(metadata, "proxy_url", "proxy-url"); proxyURL != "" {
 		auth.ProxyURL = proxyURL
 	}
+	if excluded := authExcludedModelRules(auth); len(excluded) > 0 {
+		auth.Attributes["excluded_models"] = strings.Join(excluded, ",")
+	}
 	coreauth.ApplyCustomHeadersFromMetadata(auth)
 	return auth, nil
 }
@@ -3556,6 +3559,37 @@ func metadataString(metadata map[string]any, key string) string {
 		return strings.TrimSpace(raw)
 	}
 	return ""
+}
+
+func authExcludedModelRules(auth *coreauth.Auth) []string {
+	if auth == nil {
+		return nil
+	}
+	rules := make([]string, 0)
+	if auth.Attributes != nil {
+		if raw := strings.TrimSpace(auth.Attributes["excluded_models"]); raw != "" {
+			rules = append(rules, strings.Split(raw, ",")...)
+		}
+	}
+	for _, key := range []string{"excluded_models", "excluded-models"} {
+		raw, ok := auth.Metadata[key]
+		if !ok || raw == nil {
+			continue
+		}
+		switch value := raw.(type) {
+		case string:
+			rules = append(rules, strings.Split(value, ",")...)
+		case []string:
+			rules = append(rules, value...)
+		case []any:
+			for _, item := range value {
+				if rule, ok := item.(string); ok {
+					rules = append(rules, rule)
+				}
+			}
+		}
+	}
+	return normalizeStringList(rules)
 }
 
 func firstMetadataString(metadata map[string]any, keys ...string) string {
@@ -3707,6 +3741,16 @@ func registerManifestModelsForAuth(manager *coreauth.Manager, m *manifest, auth 
 		return
 	}
 	models := manifestRegistryModels(m)
+	if excluded := authExcludedModelRules(auth); len(excluded) > 0 {
+		filtered := make([]*cliproxy.ModelInfo, 0, len(models))
+		for _, model := range models {
+			if model == nil || modelMatchesAnyRule(model.ID, excluded) {
+				continue
+			}
+			filtered = append(filtered, model)
+		}
+		models = filtered
+	}
 	if len(models) == 0 {
 		cliproxy.GlobalModelRegistry().UnregisterClient(auth.ID)
 		manager.RefreshSchedulerEntry(auth.ID)

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -1560,8 +1560,9 @@ func TestSidecarRuntimeRegistersConfigCodexAPIKeyAuths(t *testing.T) {
 	cfg := &config.Config{
 		AuthDir: authDir,
 		CodexKey: []config.CodexKey{{
-			APIKey:  "sk-upstream",
-			BaseURL: "http://127.0.0.1:1",
+			APIKey:         "sk-upstream",
+			BaseURL:        "http://127.0.0.1:1",
+			ExcludedModels: []string{"gpt-5.6-luna"},
 		}},
 	}
 	account := &accountSpec{ID: "api-account", Email: "api@example.com", UpstreamAPIKey: "sk-upstream"}
@@ -1570,7 +1571,7 @@ func TestSidecarRuntimeRegistersConfigCodexAPIKeyAuths(t *testing.T) {
 		accountByID:     map[string]*accountSpec{"api-account": account},
 		accountByAuthID: map[string]*accountSpec{},
 		accountByAPIKey: map[string]*accountSpec{"sk-upstream": account},
-		ModelIDs:        []string{"gpt-5.4"},
+		ModelIDs:        []string{"gpt-5.4", "gpt-5.6-luna"},
 	}
 	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
 
@@ -1596,6 +1597,18 @@ func TestSidecarRuntimeRegistersConfigCodexAPIKeyAuths(t *testing.T) {
 	if got := m.accountByAuthID[strings.ToLower(codexAPIKeyAuth.ID)]; got == nil || got.ID != "api-account" {
 		t.Fatalf("expected auth to be linked to manifest account, got %#v", got)
 	}
+	if info := findModelInfoForTest(
+		registry.GetGlobalRegistry().GetModelsForClient(codexAPIKeyAuth.ID),
+		"gpt-5.6-luna",
+	); info != nil {
+		t.Fatalf("excluded API key model was restored by manifest registration: %#v", info)
+	}
+	if info := findModelInfoForTest(
+		registry.GetGlobalRegistry().GetModelsForClient(codexAPIKeyAuth.ID),
+		"gpt-5.4",
+	); info == nil {
+		t.Fatal("non-excluded API key model was removed")
+	}
 }
 
 func TestSidecarRuntimeRegistersManifestCodexAccessTokenAuths(t *testing.T) {
@@ -1617,7 +1630,8 @@ func TestSidecarRuntimeRegistersManifestCodexAccessTokenAuths(t *testing.T) {
 		"at_token":"at-runtime-token",
 		"account_id":"acct-token",
 		"openai_auth_mode":"personal_access_token",
-		"proxy_url":"http://127.0.0.1:9"
+		"proxy_url":"http://127.0.0.1:9",
+		"excluded_models":["gpt-5.6-luna"]
 	}`), 0o600); err != nil {
 		t.Fatalf("write auth file: %v", err)
 	}
@@ -1638,7 +1652,7 @@ func TestSidecarRuntimeRegistersManifestCodexAccessTokenAuths(t *testing.T) {
 		accountByAPIKey:  map[string]*accountSpec{},
 		accountByChatGPT: map[string]*accountSpec{"acct-token": account},
 		accountByEmail:   map[string]*accountSpec{"token@example.com": account},
-		ModelIDs:         []string{"gpt-5.4"},
+		ModelIDs:         []string{"gpt-5.4", "gpt-5.6-luna"},
 	}
 	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
 
@@ -1664,6 +1678,9 @@ func TestSidecarRuntimeRegistersManifestCodexAccessTokenAuths(t *testing.T) {
 	if tokenAuth.ProxyURL != "http://127.0.0.1:9" {
 		t.Fatalf("expected proxy url from auth metadata, got %q", tokenAuth.ProxyURL)
 	}
+	if got := tokenAuth.Attributes["excluded_models"]; got != "gpt-5.6-luna" {
+		t.Fatalf("excluded_models attribute = %q, want gpt-5.6-luna", got)
+	}
 	if got := m.accountByAuthID[strings.ToLower(tokenAuth.ID)]; got == nil || got.ID != "token-account" {
 		t.Fatalf("expected token auth to be linked to manifest account, got %#v", got)
 	}
@@ -1672,6 +1689,96 @@ func TestSidecarRuntimeRegistersManifestCodexAccessTokenAuths(t *testing.T) {
 		"gpt-5.4",
 	); info == nil {
 		t.Fatalf("expected manifest models to be registered for token auth")
+	}
+	if info := findModelInfoForTest(
+		registry.GetGlobalRegistry().GetModelsForClient(tokenAuth.ID),
+		"gpt-5.6-luna",
+	); info != nil {
+		t.Fatalf("excluded token model was restored by manifest registration: %#v", info)
+	}
+}
+
+func TestSidecarRuntimeDoesNotSelectAccountWithExcludedModel(t *testing.T) {
+	tempDir := t.TempDir()
+	authDir := filepath.Join(tempDir, "auths")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	configPath := filepath.Join(tempDir, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write config path: %v", err)
+	}
+
+	blockedFile := "blocked-luna.json"
+	allowedFile := "allowed-luna.json"
+	if err := os.WriteFile(filepath.Join(authDir, blockedFile), []byte(`{
+		"type":"codex",
+		"email":"blocked@example.com",
+		"access_token":"blocked-token",
+		"account_id":"acct-blocked",
+		"excluded_models":["GPT-5.6-LUNA", "gpt-5.7-*"]
+	}`), 0o600); err != nil {
+		t.Fatalf("write blocked auth: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, allowedFile), []byte(`{
+		"type":"codex",
+		"email":"allowed@example.com",
+		"access_token":"allowed-token",
+		"account_id":"acct-allowed"
+	}`), 0o600); err != nil {
+		t.Fatalf("write allowed auth: %v", err)
+	}
+
+	m := &manifest{
+		Accounts: []accountSpec{
+			{ID: "blocked-account", Email: "blocked@example.com", AuthID: blockedFile, AuthKind: "oauth"},
+			{ID: "allowed-account", Email: "allowed@example.com", AuthID: allowedFile, AuthKind: "oauth"},
+		},
+		ModelIDs:         []string{"gpt-5.6-luna", "gpt-5.7-preview", "gpt-5.4"},
+		accountByID:      make(map[string]*accountSpec),
+		accountByAuthID:  make(map[string]*accountSpec),
+		accountByAPIKey:  make(map[string]*accountSpec),
+		accountByChatGPT: make(map[string]*accountSpec),
+		accountByEmail:   make(map[string]*accountSpec),
+	}
+	for index := range m.Accounts {
+		account := &m.Accounts[index]
+		m.accountByID[account.ID] = account
+		m.accountByAuthID[strings.ToLower(account.AuthID)] = account
+		m.accountByEmail[strings.ToLower(account.Email)] = account
+	}
+
+	cfg := &config.Config{AuthDir: authDir}
+	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
+	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager)
+	if err != nil {
+		t.Fatalf("newSidecarRuntime: %v", err)
+	}
+	defer runtime.Stop()
+
+	for attempt := 0; attempt < 8; attempt++ {
+		selected, errSelect := manager.SelectAuth(context.Background(), "codex", "gpt-5.6-luna", cliproxyexecutor.Options{})
+		if errSelect != nil {
+			t.Fatalf("SelectAuth attempt %d: %v", attempt, errSelect)
+		}
+		if account := accountForAuthInManifest(m, selected); account == nil || account.ID != "allowed-account" {
+			t.Fatalf("SelectAuth attempt %d selected blocked account: auth=%#v account=%#v", attempt, selected, account)
+		}
+	}
+
+	blockedAuth, ok := manager.GetByID(blockedFile)
+	if !ok || blockedAuth == nil {
+		t.Fatalf("blocked auth %q was not registered", blockedFile)
+	}
+	blockedModels := registry.GetGlobalRegistry().GetModelsForClient(blockedAuth.ID)
+	if info := findModelInfoForTest(blockedModels, "gpt-5.6-luna"); info != nil {
+		t.Fatalf("blocked auth still advertises exact excluded model: %#v", info)
+	}
+	if info := findModelInfoForTest(blockedModels, "gpt-5.7-preview"); info != nil {
+		t.Fatalf("blocked auth still advertises wildcard-excluded model: %#v", info)
+	}
+	if info := findModelInfoForTest(blockedModels, "gpt-5.4"); info == nil {
+		t.Fatal("blocked auth lost a non-excluded model")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1736 by preserving per-account model exclusions through the actual API Service-New sidecar runtime path.

Accounts whose merged model rules exclude `gpt-5.6-luna` are no longer registered as supporting that model and therefore cannot be selected for Luna requests. Exact, case-insensitive, and wildcard exclusions are supported for both OAuth/token and API-key credentials.

## Root Cause

API Service-New runs the embedded service through `StartRuntime` with Cockpit selector wrappers. This path does not start the normal auth-file watcher, and the wrapped custom selector means the built-in `authScheduler` fast path is not used.

Cockpit instead loads token auth files manually through `readManifestCodexTokenAuth`. The merged `excluded_models` value remained only in mutable auth metadata rather than being copied into `Auth.Attributes`, unlike auths produced by the standard synthesizer.

After auth registration, `registerManifestModelsForAuth` registered the same unfiltered manifest model catalog for every credential. That restored `gpt-5.6-luna` as a supported model for blocked accounts, so registry-based candidate filtering continued to pass those accounts to the custom selector.

## Changes

- Normalize `excluded_models` and `excluded-models` from manual auth metadata into `Auth.Attributes["excluded_models"]`.
- Accept array and comma-separated representations while trimming and case-insensitively deduplicating rules.
- Filter manifest registry models separately for each auth before calling `RegisterClient`.
- Reuse the existing wildcard matcher so exact, case-insensitive, and `*` rules behave consistently.
- Unregister credentials when exclusions leave them with no supported manifest models.
- Keep registry reconciliation and scheduler refresh after the filtered registration.

## Tests

- Extended the config-generated Codex API-key runtime test to verify manifest registration does not restore an excluded model.
- Extended the manually loaded token-auth runtime test to verify exclusion metadata is normalized and respected.
- Added a real sidecar runtime regression with blocked and allowed accounts, repeated Luna selections, case-insensitive exact matching, wildcard matching, and retention of non-excluded models.

```text
go test ./...
```

All sidecar wrapper tests pass.