### PR TITLE
fix(i18n): fix hardcoded Chinese fallback strings on Codex API Service page

### DIFF
--- a/src/components/OverviewTabsHeader.tsx
+++ b/src/components/OverviewTabsHeader.tsx
@@ -96,7 +96,7 @@ export function OverviewTabsHeader({
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">
-            {t('settings.general.account', '账号')}
+            {t('settings.general.account', 'Accounts')}
           </span>
           <ManualHelpIconButton className="platform-header-help" onClick={onOpenManual} />
         </div>

--- a/src/components/platform/PlatformOverviewTabsHeader.tsx
+++ b/src/components/platform/PlatformOverviewTabsHeader.tsx
@@ -227,7 +227,7 @@ export function PlatformOverviewTabsHeader({
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">
-            {t('settings.general.account', '账号')}
+            {t('settings.general.account', 'Accounts')}
           </span>
           <ManualHelpIconButton className="platform-header-help" />
         </div>

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -772,6 +772,9 @@
   "settings": {
     "title": "Settings",
     "subtitle": "Customize your Cockpit Tools experience.",
+    "general": {
+      "account": "Accounts"
+    },
     "tabs": {
       "general": "General",
       "network": "Network",
@@ -2367,6 +2370,7 @@
         "imagesDetail": "Generate {{generate}} / Edit {{edit}} / Capability {{blocked}}",
         "avgLatency": "Avg Latency",
         "successRate": "Success Rate {{rate}}%",
+        "successRateLabel": "Success Rate",
         "accountRequests": "{{count}} requests",
         "accountTokens": "{{count}} tokens",
         "accountTokensCompact": "{{value}}",
@@ -3489,6 +3493,10 @@
         "thisWeek": "This week",
         "thisMonth": "This month"
       },
+      "usage": {
+        "title": "Usage Stats",
+        "lastRecorded": "Last recorded"
+      },
       "healthTitle": "Service Health",
       "compat": {
         "title": "Protocol Compat",
@@ -3578,6 +3586,8 @@
         "pricingRepriceSaveBlocked": "Historical estimate update in progress; save after it finishes"
       },
       "keys": {
+        "lastUsed": "Last used",
+        "routingAccounts": "Routing Accounts",
         "policyTitle": "Account Pool & Model Policy",
         "advancedPolicyTitle": "Account Pool & Model Policy",
         "accountScope": "Account Rotation Scope",
@@ -3675,6 +3685,9 @@
         "allKinds": "All Types",
         "allStatuses": "All Statuses",
         "allGatewayModes": "All Modes",
+        "allInstances": "All Instances",
+        "instanceFilter": "Instance",
+        "instanceUnknown": "Instance -",
         "modelFilter": "Model",
         "modelPlaceholder": "Model ID",
         "accountFilter": "Account",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -772,6 +772,9 @@
   "settings": {
     "title": "Settings",
     "subtitle": "Customize your Cockpit Tools experience.",
+    "general": {
+      "account": "Accounts"
+    },
     "tabs": {
       "general": "General",
       "network": "Network",
@@ -2367,6 +2370,7 @@
         "imagesDetail": "Generate {{generate}} / Edit {{edit}} / Capability {{blocked}}",
         "avgLatency": "Avg Latency",
         "successRate": "Success Rate {{rate}}%",
+        "successRateLabel": "Success Rate",
         "accountRequests": "{{count}} requests",
         "accountTokens": "{{count}} tokens",
         "accountTokensCompact": "{{value}}",
@@ -3489,6 +3493,10 @@
         "thisWeek": "This week",
         "thisMonth": "This month"
       },
+      "usage": {
+        "title": "Usage Stats",
+        "lastRecorded": "Last recorded"
+      },
       "healthTitle": "Service Health",
       "compat": {
         "title": "Protocol Compat",
@@ -3578,6 +3586,8 @@
         "pricingRepriceSaveBlocked": "Historical estimate update in progress; save after it finishes"
       },
       "keys": {
+        "lastUsed": "Last used",
+        "routingAccounts": "Routing Accounts",
         "policyTitle": "Account Pool & Model Policy",
         "advancedPolicyTitle": "Account Pool & Model Policy",
         "accountScope": "Account Rotation Scope",
@@ -3675,6 +3685,9 @@
         "allKinds": "All Types",
         "allStatuses": "All Statuses",
         "allGatewayModes": "All Modes",
+        "allInstances": "All Instances",
+        "instanceFilter": "Instance",
+        "instanceUnknown": "Instance -",
         "modelFilter": "Model",
         "modelPlaceholder": "Model ID",
         "accountFilter": "Account",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -772,6 +772,9 @@
   "settings": {
     "title": "应用设置",
     "subtitle": "个性化您的 Cockpit Tools 体验。",
+    "general": {
+      "account": "账号"
+    },
     "tabs": {
       "general": "通用",
       "network": "网络服务",
@@ -2367,6 +2370,7 @@
         "imagesDetail": "生成 {{generate}} / 编辑 {{edit}} / 权限 {{blocked}}",
         "avgLatency": "平均延迟",
         "successRate": "成功率 {{rate}}%",
+        "successRateLabel": "成功率",
         "accountRequests": "{{count}} 次请求",
         "accountTokens": "{{count}} Tokens",
         "accountTokensCompact": "{{value}}",
@@ -3489,6 +3493,10 @@
         "thisWeek": "本周",
         "thisMonth": "本月"
       },
+      "usage": {
+        "title": "用量统计",
+        "lastRecorded": "最近入账"
+      },
       "healthTitle": "服务健康",
       "compat": {
         "title": "协议兼容",
@@ -3578,6 +3586,8 @@
         "pricingRepriceSaveBlocked": "历史估算价值更新中，完成后再保存"
       },
       "keys": {
+        "lastUsed": "最近使用",
+        "routingAccounts": "分流账号",
         "policyTitle": "账号池与模型策略",
         "advancedPolicyTitle": "账号池与模型策略",
         "accountScope": "账号轮转范围",
@@ -3675,6 +3685,9 @@
         "allKinds": "全部类型",
         "allStatuses": "全部状态",
         "allGatewayModes": "全部模式",
+        "allInstances": "全部实例",
+        "instanceFilter": "实例",
+        "instanceUnknown": "实例 -",
         "modelFilter": "模型",
         "modelPlaceholder": "模型 ID",
         "accountFilter": "账号",

--- a/src/pages/ClaudeAccountsPage.tsx
+++ b/src/pages/ClaudeAccountsPage.tsx
@@ -2800,7 +2800,7 @@ export function ClaudeAccountsPage({ subPlatform = 'desktop' }: ClaudeAccountsPa
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">
-            {t('settings.general.account', '账号')}
+            {t('settings.general.account', 'Accounts')}
           </span>
           <ManualHelpIconButton className="platform-header-help" />
         </div>

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -688,7 +688,7 @@ function instanceDisplayName(
   t: ReturnType<typeof useTranslation>["t"],
 ): string {
   if (instance.isDefault) {
-    return t("instances.defaultName", "默认实例");
+    return t("instances.defaultName", "Default Instance");
   }
   const name = instance.name?.trim();
   return name || instance.id;
@@ -701,7 +701,7 @@ function resolveClientInstanceLabel(
 ): string {
   const id = clientInstanceId?.trim() ?? "";
   if (!id) {
-    return t("codex.apiService.logs.instanceUnknown", "实例 -");
+    return t("codex.apiService.logs.instanceUnknown", "Instance -");
   }
   const matched = instances.find((instance) => {
     const dirId = clientInstanceIdFromUserDataDir(instance.userDataDir || "");
@@ -3106,34 +3106,34 @@ export function CodexApiServicePage() {
     value: RequestLogKindFilter;
     label: string;
   }> = [
-    { value: "all", label: t("codex.apiService.logs.allKinds", "全部类型") },
-    { value: "text", label: t("codex.localAccess.requestKind.text", "文本") },
+    { value: "all", label: t("codex.apiService.logs.allKinds", "All Types") },
+    { value: "text", label: t("codex.localAccess.requestKind.text", "Text") },
     {
       value: "image_generation",
-      label: t("codex.localAccess.requestKind.imageGeneration", "生图"),
+      label: t("codex.localAccess.requestKind.imageGeneration", "Image Gen"),
     },
     {
       value: "image_edit",
-      label: t("codex.localAccess.requestKind.imageEdit", "改图"),
+      label: t("codex.localAccess.requestKind.imageEdit", "Image Edit"),
     },
-    { value: "other", label: t("codex.localAccess.requestKind.other", "其他") },
+    { value: "other", label: t("codex.localAccess.requestKind.other", "Other") },
   ];
   const requestLogStatusOptions: Array<{
     value: RequestLogStatusFilter;
     label: string;
   }> = [
-    { value: "all", label: t("codex.apiService.logs.allStatuses", "全部状态") },
+    { value: "all", label: t("codex.apiService.logs.allStatuses", "All Statuses") },
     {
       value: "success",
-      label: t("codex.localAccess.requestLogSuccess", "成功"),
+      label: t("codex.localAccess.requestLogSuccess", "Success"),
     },
-    { value: "failed", label: t("codex.localAccess.requestLogFailed", "失败") },
+    { value: "failed", label: t("codex.localAccess.requestLogFailed", "Failed") },
   ];
   const requestLogInstanceOptions = useMemo(() => {
     const options: Array<{ value: string; label: string }> = [
       {
         value: "all",
-        label: t("codex.apiService.logs.allInstances", "全部实例"),
+        label: t("codex.apiService.logs.allInstances", "All Instances"),
       },
     ];
     const seen = new Set<string>(["all"]);
@@ -3156,15 +3156,15 @@ export function CodexApiServicePage() {
   }> = [
     {
       value: "all",
-      label: t("codex.apiService.logs.allGatewayModes", "全部模式"),
+      label: t("codex.apiService.logs.allGatewayModes", "All Modes"),
     },
     {
       value: "sidecar",
-      label: t("codex.localAccess.gatewayModeNewLabel", "API 服务-新"),
+      label: t("codex.localAccess.gatewayModeNewLabel", "API Service-New"),
     },
     {
       value: "legacy",
-      label: t("codex.localAccess.gatewayModeOldLabel", "API 服务-旧"),
+      label: t("codex.localAccess.gatewayModeOldLabel", "API Service-Old"),
     },
   ];
   const gatewayModeOptions: Array<{
@@ -3314,7 +3314,7 @@ export function CodexApiServicePage() {
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">
-            {t("settings.general.account", "账号")}
+            {t("settings.general.account", "Accounts")}
           </span>
           <ManualHelpIconButton className="platform-header-help" />
         </div>
@@ -3549,12 +3549,12 @@ export function CodexApiServicePage() {
             <Activity size={16} />
             <div>
               <strong>
-                {t("codex.apiService.usage.title", "用量统计")}
+                {t("codex.apiService.usage.title", "Usage Stats")}
               </strong>
               <span>
                 {selectedStatsRangeTitle}
                 {stats?.updatedAt
-                  ? ` · ${t("codex.apiService.usage.lastRecorded", "最近入账")} ${formatDateTime(stats.updatedAt)}`
+                  ? ` · ${t("codex.apiService.usage.lastRecorded", "Last recorded")} ${formatDateTime(stats.updatedAt)}`
                   : ""}
               </span>
             </div>
@@ -3961,12 +3961,12 @@ export function CodexApiServicePage() {
                         className={`codex-api-service-pill ${apiKey.enabled ? "success" : "muted"}`}
                       >
                         {apiKey.enabled
-                          ? t("common.enabled", "已启用")
-                          : t("common.disabled", "已停用")}
+                          ? t("common.enabled", "Enabled")
+                          : t("common.disabled", "Disabled")}
                       </span>
                       <span className="codex-api-service-key-last-used">
                         <small>
-                          {t("codex.apiService.keys.lastUsed", "最近使用")}
+                          {t("codex.apiService.keys.lastUsed", "Last used")}
                         </small>
                         <strong>{formatDateTime(apiKey.lastUsedAt)}</strong>
                       </span>
@@ -3977,7 +3977,7 @@ export function CodexApiServicePage() {
                           onClick={() =>
                             void handleCopy(`apiKey:${apiKey.id}`, apiKey.key)
                           }
-                          title={t("common.copy", "复制")}
+                          title={t("common.copy", "Copy")}
                         >
                           {copiedField === `apiKey:${apiKey.id}` ? (
                             <Check size={14} />
@@ -3994,8 +3994,8 @@ export function CodexApiServicePage() {
                           disabled={busy}
                           title={
                             apiKey.enabled
-                              ? t("common.disable", "停用")
-                              : t("common.enable", "启用")
+                              ? t("common.disable", "Disable")
+                              : t("common.enable", "Enable")
                           }
                         >
                           <Power size={14} />
@@ -4007,7 +4007,7 @@ export function CodexApiServicePage() {
                           disabled={busy}
                           title={t(
                             "codex.localAccess.apiKeyRotate",
-                            "轮换 Key",
+                            "Rotate Key",
                           )}
                         >
                           <RefreshCw size={14} />
@@ -4019,7 +4019,7 @@ export function CodexApiServicePage() {
                           disabled={
                             busy || (collection?.apiKeys.length ?? 0) <= 1
                           }
-                          title={t("common.delete", "删除")}
+                          title={t("common.delete", "Delete")}
                         >
                           <Trash2 size={14} />
                         </button>
@@ -4037,23 +4037,23 @@ export function CodexApiServicePage() {
                         <Route size={16} />
                         <div>
                           <span>
-                            {t("codex.apiService.keys.routingAccounts", "分流账号")}
+                            {t("codex.apiService.keys.routingAccounts", "Routing Accounts")}
                           </span>
                           <strong>
                             {persistedInheritAccountPool
                               ? t(
                                   "codex.apiService.keys.accountScopeInheritedCount",
-                                  "继承服务池 · {{count}} 个账号",
+                                  "Account pool: inheriting {{count}}",
                                   { count: memberIds.length },
                                 )
                               : persistedAccountIds.length === 0
                                 ? t(
                                     "codex.apiService.keys.accountScopeUnavailable",
-                                    "无可用账号",
+                                    "Account pool: no available accounts",
                                   )
                                 : t(
                                     "codex.apiService.keys.accountScopeCount",
-                                    "自定义 · {{selected}}/{{total}} 个账号",
+                                    "Account pool: {{selected}}/{{total}}",
                                     {
                                       selected: persistedAccountIds.length,
                                       total: keySelectableAccountIds.length,
@@ -4066,7 +4066,7 @@ export function CodexApiServicePage() {
                         key={`${statsRange}:${statsTimeRange.startAt}:${statsTimeRange.endAt}`}
                         className="api-key-usage-grid"
                         aria-live="polite"
-                        aria-label={`${selectedStatsRangeTitle} Key 用量`}
+                        aria-label={`${selectedStatsRangeTitle} Key Usage`}
                       >
                         <div className="api-key-usage-grid-head">
                           <Activity size={14} />
@@ -4074,7 +4074,7 @@ export function CodexApiServicePage() {
                         </div>
                         <div>
                           <span>
-                            {t("codex.localAccess.stats.requests", "请求")}
+                            {t("codex.localAccess.stats.requests", "Requests")}
                           </span>
                           <strong>
                             {formatCompactNumber(keyUsage?.requestCount ?? 0)}
@@ -4086,13 +4086,13 @@ export function CodexApiServicePage() {
                         </div>
                         <div>
                           <span>
-                            {t("codex.localAccess.stats.successRateLabel", "成功率")}
+                            {t("codex.localAccess.stats.successRateLabel", "Success Rate")}
                           </span>
                           <strong>{keySuccessRate}%</strong>
                         </div>
                         <div>
                           <span>
-                            {t("codex.localAccess.stats.estimatedCost", "估算费用")}
+                            {t("codex.localAccess.stats.estimatedCost", "Estimated Cost")}
                           </span>
                           <strong>
                             {formatUsdCost(keyUsage?.estimatedCostUsd ?? 0)}
@@ -5121,13 +5121,13 @@ export function CodexApiServicePage() {
                       }
                       placeholder={t(
                         "codex.apiService.logs.modelPlaceholder",
-                        "模型 ID",
+                        "Model ID",
                       )}
                     />
                   </label>
                   <label>
                     <span>
-                      {t("codex.apiService.logs.accountFilter", "账号")}
+                      {t("codex.apiService.logs.accountFilter", "Account")}
                     </span>
                     <input
                       value={requestLogAccountQuery}
@@ -5136,7 +5136,7 @@ export function CodexApiServicePage() {
                       }
                       placeholder={t(
                         "codex.apiService.logs.accountPlaceholder",
-                        "邮箱或账号 ID",
+                        "Email or account ID",
                       )}
                     />
                   </label>
@@ -5151,13 +5151,13 @@ export function CodexApiServicePage() {
                       }
                       placeholder={t(
                         "codex.apiService.logs.apiKeyPlaceholder",
-                        "名称或 ID",
+                        "Name or ID",
                       )}
                     />
                   </label>
                   <label>
                     <span>
-                      {t("codex.apiService.logs.instanceFilter", "实例")}
+                      {t("codex.apiService.logs.instanceFilter", "Instance")}
                     </span>
                     <SingleSelectDropdown
                       value={requestLogInstanceQuery}
@@ -5165,28 +5165,28 @@ export function CodexApiServicePage() {
                       onChange={setRequestLogInstanceQuery}
                       ariaLabel={t(
                         "codex.apiService.logs.instanceFilter",
-                        "实例",
+                        "Instance",
                       )}
                       placeholder={t(
                         "codex.apiService.logs.allInstances",
-                        "全部实例",
+                        "All Instances",
                       )}
                     />
                   </label>
                   <label>
-                    <span>{t("codex.apiService.logs.kindFilter", "类型")}</span>
+                    <span>{t("codex.apiService.logs.kindFilter", "Type")}</span>
                     <SingleSelectDropdown
                       value={requestLogKindFilter}
                       options={requestLogKindOptions}
                       onChange={(value) =>
                         setRequestLogKindFilter(value as RequestLogKindFilter)
                       }
-                      ariaLabel={t("codex.apiService.logs.kindFilter", "类型")}
+                      ariaLabel={t("codex.apiService.logs.kindFilter", "Type")}
                     />
                   </label>
                   <label>
                     <span>
-                      {t("codex.apiService.logs.statusFilter", "状态")}
+                      {t("codex.apiService.logs.statusFilter", "Status")}
                     </span>
                     <SingleSelectDropdown
                       value={requestLogStatusFilter}
@@ -5198,13 +5198,13 @@ export function CodexApiServicePage() {
                       }
                       ariaLabel={t(
                         "codex.apiService.logs.statusFilter",
-                        "状态",
+                        "Status",
                       )}
                     />
                   </label>
                   <label>
                     <span>
-                      {t("codex.apiService.logs.gatewayModeFilter", "模式")}
+                      {t("codex.apiService.logs.gatewayModeFilter", "Mode")}
                     </span>
                     <SingleSelectDropdown
                       value={requestLogGatewayModeFilter}
@@ -5216,13 +5216,13 @@ export function CodexApiServicePage() {
                       }
                       ariaLabel={t(
                         "codex.apiService.logs.gatewayModeFilter",
-                        "模式",
+                        "Mode",
                       )}
                     />
                   </label>
                   <label>
                     <span>
-                      {t("codex.apiService.logs.errorFilter", "错误")}
+                      {t("codex.apiService.logs.errorFilter", "Error")}
                     </span>
                     <input
                       value={requestLogErrorQuery}
@@ -5231,7 +5231,7 @@ export function CodexApiServicePage() {
                       }
                       placeholder={t(
                         "codex.apiService.logs.errorPlaceholder",
-                        "错误分类",
+                        "Error category",
                       )}
                     />
                   </label>
@@ -5241,7 +5241,7 @@ export function CodexApiServicePage() {
                     onClick={clearRequestLogFilters}
                     disabled={!hasRequestLogFilters}
                   >
-                    {t("codex.apiService.logs.clearFilters", "清除筛选")}
+                    {t("codex.apiService.logs.clearFilters", "Clear Filters")}
                   </button>
                 </div>
                 <div className="codex-api-service-log-list">


### PR DESCRIPTION
## Summary

Fixes #1756 by adding missing i18n keys and updating TSX default fallback strings from Chinese to English on the Codex API Service page, client key cards, and request log controls.

### Key Changes
1. **Top Strip Header Title**:
   - Added missing `settings.general.account` key (`"Accounts"` / `"账号"`) across `en.json`, `en-US.json`, and `zh-CN.json`.
   - Updated TSX fallbacks in `CodexApiServicePage.tsx`, `ClaudeAccountsPage.tsx`, `OverviewTabsHeader.tsx`, and `PlatformOverviewTabsHeader.tsx`.
2. **Usage Statistics Toolbar**:
   - Added `codex.apiService.usage.title` ("Usage Stats") and `codex.apiService.usage.lastRecorded` ("Last recorded") keys across locale files and updated TSX fallbacks in `CodexApiServicePage.tsx`.
3. **Client Key Cards**:
   - Added `codex.apiService.keys.lastUsed` ("Last used"), `codex.apiService.keys.routingAccounts` ("Routing Accounts"), and `codex.localAccess.stats.successRateLabel` ("Success Rate") keys.
   - Updated TSX fallbacks for key cards and scope descriptions.
4. **Stats & Logs Filter Bar & Controls**:
   - Added `codex.apiService.logs.allInstances` ("All Instances"), `codex.apiService.logs.instanceFilter` ("Instance"), and `codex.apiService.logs.instanceUnknown` ("Instance -") keys.
   - Updated default fallback strings for all log filter dropdown options, inputs, and placeholders.

## Test Plan
- [x] Ran `npm run typecheck` - Passed with 0 errors.
- [x] Ran `npm run build` - Built successfully.
