### PR TITLE
fix(codex): route Spark to eligible accounts

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -92,12 +92,18 @@ var (
 	imageStreamIdleTimeout = 60 * time.Second
 )
 
+type accountModelRule struct {
+	AccountID      string   `json:"accountId"`
+	ExcludedModels []string `json:"excludedModels"`
+}
+
 type manifest struct {
 	APIKeys                    []apiKeySpec        `json:"apiKeys"`
 	Accounts                   []accountSpec       `json:"accounts"`
 	ModelIDs                   []string            `json:"modelIds"`
 	ModelAliases               []modelAliasSpec    `json:"modelAliases"`
 	ExcludedModels             []string            `json:"excludedModels"`
+	AccountModelRules          []accountModelRule  `json:"accountModelRules"`
 	RoutingStrategy            string              `json:"routingStrategy"`
 	CustomRoutingRules         []customRoutingRule `json:"customRoutingRules"`
 	ImmediateSSEResponse       bool                `json:"immediateSseResponse"`
@@ -744,6 +750,10 @@ func loadManifest(path string) (*manifest, error) {
 	}
 	m.ModelIDs = normalizeStringList(m.ModelIDs)
 	m.ExcludedModels = normalizeStringList(m.ExcludedModels)
+	for index := range m.AccountModelRules {
+		m.AccountModelRules[index].AccountID = strings.TrimSpace(m.AccountModelRules[index].AccountID)
+		m.AccountModelRules[index].ExcludedModels = normalizeStringList(m.AccountModelRules[index].ExcludedModels)
+	}
 	return &m, nil
 }
 
@@ -1921,6 +1931,13 @@ type imageRequestSelector struct {
 	fallback      coreauth.Selector
 }
 
+// modelExclusionSelector filters account-level model exclusions before wrappers
+// such as session affinity can reuse a cached account binding.
+type modelExclusionSelector struct {
+	manifest *manifest
+	fallback coreauth.Selector
+}
+
 func (s *imageRequestSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
 	requestKind, _ := ctx.Value(requestKindContextKey).(string)
 	if isImageRequestKind(requestKind) && s.imageFallback != nil {
@@ -1933,6 +1950,35 @@ func (s *imageRequestSelector) Pick(ctx context.Context, provider, model string,
 }
 
 func (s *imageRequestSelector) Stop() {
+	if stoppable, ok := s.fallback.(coreauth.StoppableSelector); ok {
+		stoppable.Stop()
+	}
+}
+
+func (s *modelExclusionSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
+	if s == nil || s.fallback == nil {
+		return nil, fmt.Errorf("model exclusion selector is not initialized")
+	}
+	if strings.TrimSpace(model) == "" {
+		return s.fallback.Pick(ctx, provider, model, opts, auths)
+	}
+	filtered := make([]*coreauth.Auth, 0, len(auths))
+	for _, auth := range auths {
+		if authModelExcluded(s.manifest, auth, model) {
+			continue
+		}
+		filtered = append(filtered, auth)
+	}
+	if len(filtered) == 0 {
+		return nil, noAuthAvailableError(nil)
+	}
+	return s.fallback.Pick(ctx, provider, model, opts, filtered)
+}
+
+func (s *modelExclusionSelector) Stop() {
+	if s == nil || s.fallback == nil {
+		return
+	}
 	if stoppable, ok := s.fallback.(coreauth.StoppableSelector); ok {
 		stoppable.Stop()
 	}
@@ -3054,6 +3100,7 @@ func buildCoreAuthSelector(cfg *config.Config, selector coreauth.Selector, m *ma
 	if m != nil {
 		selector = &backupAccountSelector{manifest: m, fallback: selector}
 		selector = &quotaReserveSelector{manifest: m, fallback: selector, quota: quota}
+		selector = &modelExclusionSelector{manifest: m, fallback: selector}
 	}
 	return selector
 }
@@ -3706,7 +3753,7 @@ func registerManifestModelsForAuth(manager *coreauth.Manager, m *manifest, auth 
 	if manager == nil || m == nil || auth == nil || strings.TrimSpace(auth.ID) == "" {
 		return
 	}
-	models := manifestRegistryModels(m)
+	models := filterRegistryModelsByExcluded(manifestRegistryModels(m), excludedModelsForAuth(m, auth))
 	if len(models) == 0 {
 		cliproxy.GlobalModelRegistry().UnregisterClient(auth.ID)
 		manager.RefreshSchedulerEntry(auth.ID)
@@ -3715,6 +3762,115 @@ func registerManifestModelsForAuth(manager *coreauth.Manager, m *manifest, auth 
 	cliproxy.GlobalModelRegistry().RegisterClient(auth.ID, "codex", models)
 	manager.ReconcileRegistryModelStates(context.Background(), auth.ID)
 	manager.RefreshSchedulerEntry(auth.ID)
+}
+
+func excludedModelsForAuth(m *manifest, auth *coreauth.Auth) []string {
+	seen := make(map[string]struct{})
+	add := func(items []string) {
+		for _, item := range items {
+			trimmed := strings.TrimSpace(item)
+			if trimmed == "" {
+				continue
+			}
+			key := strings.ToLower(trimmed)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+	}
+	if m != nil {
+		add(m.ExcludedModels)
+		if account := accountForAuthInManifest(m, auth); account != nil {
+			add(accountExcludedModelsFromManifest(m, account.ID))
+		}
+	}
+	if auth != nil {
+		add(extractExcludedModelsFromMetadataMap(auth.Metadata))
+		if auth.Attributes != nil {
+			add(strings.Split(auth.Attributes["excluded_models"], ","))
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for item := range seen {
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func accountExcludedModelsFromManifest(m *manifest, accountID string) []string {
+	if m == nil || strings.TrimSpace(accountID) == "" {
+		return nil
+	}
+	for _, rule := range m.AccountModelRules {
+		if strings.TrimSpace(rule.AccountID) == accountID {
+			return append([]string(nil), rule.ExcludedModels...)
+		}
+	}
+	return nil
+}
+
+func extractExcludedModelsFromMetadataMap(metadata map[string]any) []string {
+	if metadata == nil {
+		return nil
+	}
+	raw, ok := metadata["excluded_models"]
+	if !ok {
+		raw, ok = metadata["excluded-models"]
+	}
+	if !ok || raw == nil {
+		return nil
+	}
+	switch values := raw.(type) {
+	case string:
+		return strings.Split(values, ",")
+	case []string:
+		return append([]string(nil), values...)
+	case []any:
+		out := make([]string, 0, len(values))
+		for _, item := range values {
+			if value, ok := item.(string); ok {
+				out = append(out, value)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func filterRegistryModelsByExcluded(models []*cliproxy.ModelInfo, excluded []string) []*cliproxy.ModelInfo {
+	if len(models) == 0 || len(excluded) == 0 {
+		return models
+	}
+	filtered := make([]*cliproxy.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" || modelMatchesAnyRule(model.ID, excluded) {
+			continue
+		}
+		filtered = append(filtered, model)
+	}
+	return filtered
+}
+
+func authModelExcluded(m *manifest, auth *coreauth.Auth, model string) bool {
+	model = strings.TrimSpace(model)
+	if model == "" || auth == nil {
+		return false
+	}
+	excluded := excludedModelsForAuth(m, auth)
+	if len(excluded) == 0 {
+		return false
+	}
+	if modelMatchesAnyRule(model, excluded) {
+		return true
+	}
+	canonical := resolveSupportedModelAlias(m, model)
+	return canonical != "" && modelMatchesAnyRule(canonical, excluded)
 }
 
 func manifestRegistryModels(m *manifest) []*cliproxy.ModelInfo {

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -3995,3 +3995,46 @@ func TestResponsesWebsocketRejectsProviderGatewayBeforeCodexAuth(t *testing.T) {
 		t.Fatalf("body = %s", w.Body.String())
 	}
 }
+
+func TestCoreAuthSelectorFiltersNewModelExclusionsBeforeSessionAffinity(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Routing.SessionAffinity = true
+	cfg.Routing.SessionAffinityTTL = "1h"
+	selector := buildCoreAuthSelector(cfg, &coreauth.RoundRobinSelector{}, &manifest{}, nil)
+	if stoppable, ok := selector.(coreauth.StoppableSelector); ok {
+		t.Cleanup(stoppable.Stop)
+	}
+
+	plus := &coreauth.Auth{
+		ID:       "plus.json",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{},
+	}
+	pro := &coreauth.Auth{
+		ID:       "pro.json",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+	}
+	auths := []*coreauth.Auth{plus, pro}
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{"Session_id": []string{"spark-session"}},
+	}
+
+	first, err := selector.Pick(context.Background(), "codex", codexSparkModel, opts, auths)
+	if err != nil {
+		t.Fatalf("initial Pick: %v", err)
+	}
+	if first == nil || first.ID != plus.ID {
+		t.Fatalf("initial Pick = %#v, want %q", first, plus.ID)
+	}
+
+	plus.Metadata["excluded_models"] = []any{codexSparkModel}
+	second, err := selector.Pick(context.Background(), "codex", codexSparkModel, opts, auths)
+	if err != nil {
+		t.Fatalf("Pick after exclusion: %v", err)
+	}
+	if second == nil || second.ID != pro.ID {
+		t.Fatalf("Pick after exclusion = %#v, want %q", second, pro.ID)
+	}
+}

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -5393,6 +5393,143 @@ fn merge_collection_and_account_excluded_models(
     normalize_model_rule_list(rules)
 }
 
+fn normalize_quota_limit_name_to_model_pattern(limit_name: &str) -> Option<String> {
+    let trimmed = limit_name.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_ascii_lowercase().replace(' ', "-"))
+}
+
+fn metered_features_in_quota_raw(raw: &Value) -> HashSet<String> {
+    let mut features = HashSet::new();
+    let Some(limits) = raw.get("additional_rate_limits").and_then(Value::as_array) else {
+        return features;
+    };
+    for entry in limits {
+        let Some(feature) = entry
+            .get("metered_feature")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        features.insert(feature.to_ascii_lowercase());
+    }
+    features
+}
+
+fn quota_disallowed_model_patterns(account: &CodexAccount) -> Vec<String> {
+    let Some(raw) = account
+        .quota
+        .as_ref()
+        .and_then(|quota| quota.raw_data.as_ref())
+    else {
+        return Vec::new();
+    };
+    let Some(limits) = raw.get("additional_rate_limits").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut patterns = Vec::new();
+    for entry in limits {
+        let allowed = entry
+            .get("rate_limit")
+            .and_then(|value| value.get("allowed"))
+            .and_then(Value::as_bool);
+        if allowed != Some(false) {
+            continue;
+        }
+        let Some(limit_name) = entry.get("limit_name").and_then(Value::as_str) else {
+            continue;
+        };
+        if let Some(pattern) = normalize_quota_limit_name_to_model_pattern(limit_name) {
+            patterns.push(pattern);
+        }
+    }
+    patterns
+}
+
+fn metered_feature_model_patterns_for_pool(
+    collection: &CodexLocalAccessCollection,
+    account_overrides: &HashMap<String, CodexAccount>,
+) -> HashMap<String, String> {
+    let persisted_accounts = codex_account::list_accounts_checked().ok();
+    let mut patterns = HashMap::new();
+    for account_id in effective_sidecar_account_ids(collection) {
+        let account = account_overrides.get(&account_id).or_else(|| {
+            persisted_accounts
+                .as_ref()
+                .and_then(|accounts| accounts.iter().find(|account| account.id == account_id))
+        });
+        let Some(raw) = account
+            .and_then(|account| account.quota.as_ref())
+            .and_then(|quota| quota.raw_data.as_ref())
+        else {
+            continue;
+        };
+        let Some(limits) = raw.get("additional_rate_limits").and_then(Value::as_array) else {
+            continue;
+        };
+        for entry in limits {
+            let feature = entry
+                .get("metered_feature")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_ascii_lowercase);
+            let limit_name = entry.get("limit_name").and_then(Value::as_str);
+            if let (Some(feature), Some(limit_name)) = (feature, limit_name) {
+                if let Some(pattern) = normalize_quota_limit_name_to_model_pattern(limit_name) {
+                    patterns.entry(feature).or_insert(pattern);
+                }
+            }
+        }
+    }
+    patterns
+}
+
+fn implicit_metered_feature_exclusions(
+    account: &CodexAccount,
+    feature_patterns: &HashMap<String, String>,
+) -> Vec<String> {
+    if feature_patterns.is_empty() {
+        return Vec::new();
+    }
+    let Some(raw) = account
+        .quota
+        .as_ref()
+        .and_then(|quota| quota.raw_data.as_ref())
+    else {
+        return Vec::new();
+    };
+    let present = metered_features_in_quota_raw(raw);
+    feature_patterns
+        .iter()
+        .filter_map(|(feature, pattern)| {
+            if present.contains(feature) {
+                None
+            } else {
+                Some(pattern.clone())
+            }
+        })
+        .collect()
+}
+
+fn sidecar_excluded_models_for_account(
+    account: &CodexAccount,
+    collection: &CodexLocalAccessCollection,
+    metered_feature_patterns: &HashMap<String, String>,
+) -> Vec<String> {
+    let mut excluded = merge_collection_and_account_excluded_models(collection, &account.id);
+    excluded.extend(quota_disallowed_model_patterns(account));
+    excluded.extend(implicit_metered_feature_exclusions(
+        account,
+        metered_feature_patterns,
+    ));
+    normalize_model_rule_list(excluded)
+}
+
 fn custom_rule_map(rules: &[CodexLocalAccessCustomRoutingRule]) -> HashMap<&str, (i32, u32, bool)> {
     rules
         .iter()
@@ -10465,13 +10602,30 @@ fn sidecar_auth_json_for_account(
     collection: &CodexLocalAccessCollection,
     proxy_url: Option<&str>,
 ) -> Value {
+    let metered_feature_patterns =
+        metered_feature_model_patterns_for_pool(collection, &HashMap::new());
+    sidecar_auth_json_for_account_with_metered_feature_patterns(
+        account,
+        collection,
+        proxy_url,
+        &metered_feature_patterns,
+    )
+}
+
+fn sidecar_auth_json_for_account_with_metered_feature_patterns(
+    account: &CodexAccount,
+    collection: &CodexLocalAccessCollection,
+    proxy_url: Option<&str>,
+    metered_feature_patterns: &HashMap<String, String>,
+) -> Value {
     let account_id = account
         .account_id
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(account.id.as_str());
-    let excluded_models = merge_collection_and_account_excluded_models(collection, &account.id);
+    let excluded_models =
+        sidecar_excluded_models_for_account(account, collection, metered_feature_patterns);
     if let Some(identity) = account.agent_identity.as_ref() {
         let mut value = json!({
             "type": "codex",
@@ -11017,6 +11171,22 @@ fn sidecar_codex_key_config_value(
     collection: &CodexLocalAccessCollection,
     proxy_url: Option<&str>,
 ) -> Option<Value> {
+    let metered_feature_patterns =
+        metered_feature_model_patterns_for_pool(collection, &HashMap::new());
+    sidecar_codex_key_config_value_with_metered_feature_patterns(
+        account,
+        collection,
+        proxy_url,
+        &metered_feature_patterns,
+    )
+}
+
+fn sidecar_codex_key_config_value_with_metered_feature_patterns(
+    account: &CodexAccount,
+    collection: &CodexLocalAccessCollection,
+    proxy_url: Option<&str>,
+    metered_feature_patterns: &HashMap<String, String>,
+) -> Option<Value> {
     let api_key = account.openai_api_key.as_deref()?.trim();
     if api_key.is_empty() {
         return None;
@@ -11029,7 +11199,8 @@ fn sidecar_codex_key_config_value(
         ));
         return None;
     };
-    let excluded_models = merge_collection_and_account_excluded_models(collection, &account.id);
+    let excluded_models =
+        sidecar_excluded_models_for_account(account, collection, metered_feature_patterns);
     let mut value = json!({
         "api-key": api_key,
         "base-url": base_url,
@@ -11383,6 +11554,8 @@ fn prepare_sidecar_launch_config_in_dir_sync(
     let mut manifest_accounts = Vec::new();
     let mut codex_keys = Vec::new();
     let mut expected_auth_files = HashSet::new();
+    let metered_feature_patterns =
+        metered_feature_model_patterns_for_pool(collection, &account_overrides);
     for (index, account_id) in effective_sidecar_account_ids(collection)
         .into_iter()
         .enumerate()
@@ -11425,9 +11598,12 @@ fn prepare_sidecar_launch_config_in_dir_sync(
         }
 
         if account.is_api_key_auth() {
-            if let Some(config_value) =
-                sidecar_codex_key_config_value(&account, collection, effective_proxy_url_ref)
-            {
+            if let Some(config_value) = sidecar_codex_key_config_value_with_metered_feature_patterns(
+                &account,
+                collection,
+                effective_proxy_url_ref,
+                &metered_feature_patterns,
+            ) {
                 codex_keys.push(config_value);
                 manifest_accounts.push(sidecar_account_manifest_value(&account, None, collection));
             } else {
@@ -11443,8 +11619,12 @@ fn prepare_sidecar_launch_config_in_dir_sync(
         let auth_path = auths_dir.join(&file_name);
         expected_auth_files.insert(file_name.clone());
         adopt_sidecar_agent_identity_task(&mut account, &auth_path)?;
-        let auth_json =
-            sidecar_auth_json_for_account(&account, collection, effective_proxy_url_ref);
+        let auth_json = sidecar_auth_json_for_account_with_metered_feature_patterns(
+            &account,
+            collection,
+            effective_proxy_url_ref,
+            &metered_feature_patterns,
+        );
         let auth_content = serde_json::to_string_pretty(&auth_json)
             .map_err(|e| format!("序列化 sidecar Codex OAuth 认证失败: {}", e))?;
         write_string_atomic_if_changed(&auth_path, &auth_content)?;
@@ -26879,6 +27059,87 @@ wire_api = "responses"
             merge_collection_and_account_excluded_models(&collection, "account-a"),
             vec!["gpt-5.2".to_string(), "gpt-5.4-mini".to_string()]
         );
+    }
+
+    #[test]
+    fn scoped_api_key_pool_discovers_spark_entitlement_from_effective_accounts() {
+        let mut plus = test_account_with_plan("plus");
+        plus.id = "scoped-plus".to_string();
+        plus.quota = Some(CodexQuota {
+            hourly_percentage: 100,
+            hourly_reset_time: None,
+            hourly_window_minutes: Some(300),
+            hourly_window_present: Some(true),
+            weekly_percentage: 100,
+            weekly_reset_time: None,
+            weekly_window_minutes: Some(10_080),
+            weekly_window_present: Some(true),
+            reset_credits_available: None,
+            reset_credits: Vec::new(),
+            reset_credits_next_expires_at: None,
+            raw_data: Some(json!({ "additional_rate_limits": [] })),
+        });
+
+        let mut pro = test_account_with_plan("pro");
+        pro.id = "scoped-pro".to_string();
+        pro.quota = Some(CodexQuota {
+            hourly_percentage: 100,
+            hourly_reset_time: None,
+            hourly_window_minutes: Some(300),
+            hourly_window_present: Some(true),
+            weekly_percentage: 100,
+            weekly_reset_time: None,
+            weekly_window_minutes: Some(10_080),
+            weekly_window_present: Some(true),
+            reset_credits_available: None,
+            reset_credits: Vec::new(),
+            reset_credits_next_expires_at: None,
+            raw_data: Some(json!({
+                "additional_rate_limits": [{
+                    "limit_name": "GPT-5.3-Codex-Spark",
+                    "metered_feature": "codex_spark",
+                    "rate_limit": { "allowed": true }
+                }]
+            })),
+        });
+
+        let mut collection = test_local_access_collection(Vec::new());
+        collection.api_key.clear();
+        let mut api_key = build_local_access_api_key(Some("Scoped Spark"));
+        api_key.key = "scoped-spark-key".to_string();
+        api_key.inherit_account_pool = Some(false);
+        api_key.account_ids = vec![plus.id.clone(), pro.id.clone()];
+        collection.api_keys = vec![api_key];
+
+        let dir = make_temp_dir("codex-scoped-spark-entitlement");
+        let overrides = HashMap::from([(plus.id.clone(), plus.clone()), (pro.id.clone(), pro)]);
+        super::prepare_sidecar_launch_config_in_dir_sync(
+            &collection,
+            dir.clone(),
+            HashMap::new(),
+            None,
+            overrides,
+            None,
+        )
+        .expect("prepare scoped sidecar config");
+
+        let auth_path = sidecar_auths_dir(&dir).join(sidecar_auth_file_name(&plus.id));
+        let auth: Value =
+            serde_json::from_str(&fs::read_to_string(auth_path).expect("read scoped Plus auth"))
+                .expect("parse scoped Plus auth");
+        let excluded = auth
+            .get("excluded_models")
+            .and_then(Value::as_array)
+            .expect("excluded_models should be an array");
+        assert!(
+            excluded
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|model| model.eq_ignore_ascii_case("gpt-5.3-codex-spark")),
+            "Plus account should exclude Spark discovered from its scoped Pro peer"
+        );
+
+        fs::remove_dir_all(dir).expect("cleanup scoped sidecar config");
     }
 
     fn make_temp_dir(prefix: &str) -> PathBuf {


### PR DESCRIPTION
## Summary
- derive account model exclusions from quota metered features instead of hardcoding Spark
- apply exclusions before session affinity, backup, and quota routing wrappers
- include accounts referenced only by scoped API key pools when deriving entitlement

## Tests
- go test .
- cargo test --manifest-path src-tauri/Cargo.toml codex_local_access::tests --lib

Fixes #1736
Related #1385