### PR TITLE
fix(claude): display quota percentages as remaining

### DIFF
--- a/src-tauri/src/modules/macos_native_menu.rs
+++ b/src-tauri/src/modules/macos_native_menu.rs
@@ -3045,16 +3045,18 @@ mod imp {
             .map(|account| {
                 let mut rows = Vec::new();
                 if let Some(quota) = account.quota.as_ref() {
-                    let five_hour = quota.five_hour_percentage.clamp(0, 100);
+                    let five_hour_used = quota.five_hour_percentage.clamp(0, 100);
+                    let five_hour_remaining = (100 - five_hour_used).clamp(0, 100);
                     rows.push(make_progress_row(
                         translate_or(lang, "claude.quota.fiveHour", "Current session", &[]),
-                        format!("{five_hour}%"),
-                        five_hour,
+                        format!("{five_hour_remaining}%"),
+                        five_hour_remaining,
                         format_reset_subtext(lang, quota.five_hour_reset_time),
-                        usage_warning_tone(five_hour),
+                        usage_warning_tone(five_hour_used),
                     ));
 
-                    let seven_day = quota.seven_day_percentage.clamp(0, 100);
+                    let seven_day_used = quota.seven_day_percentage.clamp(0, 100);
+                    let seven_day_remaining = (100 - seven_day_used).clamp(0, 100);
                     rows.push(make_progress_row(
                         translate_or(
                             lang,
@@ -3062,10 +3064,10 @@ mod imp {
                             "Current week (all models)",
                             &[],
                         ),
-                        format!("{seven_day}%"),
-                        seven_day,
+                        format!("{seven_day_remaining}%"),
+                        seven_day_remaining,
                         format_reset_subtext(lang, quota.seven_day_reset_time),
-                        usage_warning_tone(seven_day),
+                        usage_warning_tone(seven_day_used),
                     ));
                 } else if let Some(error) = account.quota_error.as_ref() {
                     rows.push(make_text_row(

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -1092,13 +1092,13 @@ fn build_claude_display_info(lang: &str, desktop: bool) -> AccountDisplayInfo {
         quota_lines.push(format_quota_line(
             lang,
             &get_text("claude_current_session", lang),
-            &format_percent_text(quota.five_hour_percentage),
+            &format_percent_text((100 - quota.five_hour_percentage.clamp(0, 100)).clamp(0, 100)),
             Some(&format_reset_time_from_ts(lang, quota.five_hour_reset_time)),
         ));
         quota_lines.push(format_quota_line(
             lang,
             &get_text("claude_current_week_all_models", lang),
-            &format_percent_text(quota.seven_day_percentage),
+            &format_percent_text((100 - quota.seven_day_percentage.clamp(0, 100)).clamp(0, 100)),
             Some(&format_reset_time_from_ts(lang, quota.seven_day_reset_time)),
         ));
     } else if let Some(error) = &account.quota_error {

--- a/src/pages/ClaudeAccountsPage.tsx
+++ b/src/pages/ClaudeAccountsPage.tsx
@@ -87,7 +87,8 @@ import {
   getClaudeAuthModeLabel,
   getClaudePlanBadge,
   getClaudePlanBadgeClass,
-  getClaudeQuotaClass,
+  getClaudeRemainingPercentage,
+  getClaudeRemainingQuotaClass,
   isClaudeDesktopGatewayAccount,
   isClaudeDesktopOAuthAccount,
   isClaudeDesktopRuntimeAccount,
@@ -705,13 +706,13 @@ function buildClaudeQuotaSummaryItems(account: ClaudeAccount, t: TFunction): Cla
     {
       key: 'five-hour',
       label: t('claude.quota.fiveHour', 'Current session'),
-      percentage: quota.five_hour_percentage,
+      percentage: getClaudeRemainingPercentage(quota.five_hour_percentage),
       resetTime: quota.five_hour_reset_time,
     },
     {
       key: 'seven-day',
       label: t('claude.quota.sevenDay', 'Current week (all models)'),
-      percentage: quota.seven_day_percentage,
+      percentage: getClaudeRemainingPercentage(quota.seven_day_percentage),
       resetTime: quota.seven_day_reset_time,
     },
   ];
@@ -2667,7 +2668,7 @@ export function ClaudeAccountsPage({ subPlatform = 'desktop' }: ClaudeAccountsPa
       <>
         {items.map((item) => {
           const percentage = clampQuotaPercentage(item.percentage);
-          const quotaClass = getClaudeQuotaClass(percentage);
+          const quotaClass = getClaudeRemainingQuotaClass(percentage);
           const resetText = formatClaudeResetTime(item.resetTime);
           const resetDisplay = resetText || '-';
           const Icon = item.key === 'five-hour' ? Clock3 : CalendarDays;

--- a/src/pages/ClaudeInstancesPage.tsx
+++ b/src/pages/ClaudeInstancesPage.tsx
@@ -15,7 +15,8 @@ import {
   getClaudeAccountDisplayEmail,
   getClaudePlanBadge,
   getClaudePlanBadgeClass,
-  getClaudeQuotaClass,
+  getClaudeRemainingPercentage,
+  getClaudeRemainingQuotaClass,
   isClaudeDesktopRuntimeAccount,
 } from '../types/claude';
 import type { InstanceLaunchMode, InstanceProfile } from '../types/instance';
@@ -55,13 +56,13 @@ function renderClaudeQuotaPreview(
     {
       key: 'five-hour',
       label: currentSessionLabel,
-      value: quota.five_hour_percentage,
+      value: getClaudeRemainingPercentage(quota.five_hour_percentage),
       reset: quota.five_hour_reset_time,
     },
     {
       key: 'seven-day',
       label: currentWeekLabel,
-      value: quota.seven_day_percentage,
+      value: getClaudeRemainingPercentage(quota.seven_day_percentage),
       reset: quota.seven_day_reset_time,
     },
   ];
@@ -69,7 +70,7 @@ function renderClaudeQuotaPreview(
   return (
     <div className="account-quota-preview">
       {rows.map((row) => {
-        const quotaClass = getClaudeQuotaClass(row.value);
+        const quotaClass = getClaudeRemainingQuotaClass(row.value);
         const resetText = formatClaudeResetTime(row.reset);
         return (
           <span className="account-quota-item" key={row.key} title={resetText}>

--- a/src/presentation/platformAccountPresentation.ts
+++ b/src/presentation/platformAccountPresentation.ts
@@ -50,7 +50,8 @@ import {
   getClaudeAccountDisplayEmail,
   getClaudePlanBadge,
   getClaudePlanBadgeClass,
-  getClaudeQuotaClass,
+  getClaudeRemainingPercentage,
+  getClaudeRemainingQuotaClass,
 } from "../types/claude";
 import {
   formatGitHubCopilotResetTime,
@@ -787,21 +788,27 @@ export function buildClaudeAccountPresentation(
 ): UnifiedAccountPresentation {
   const quotaItems: UnifiedQuotaMetric[] = [];
   if (account.quota) {
+    const fiveHourRemaining = getClaudeRemainingPercentage(
+      account.quota.five_hour_percentage,
+    );
+    const sevenDayRemaining = getClaudeRemainingPercentage(
+      account.quota.seven_day_percentage,
+    );
     quotaItems.push({
       key: "five_hour",
       label: t("claude.quota.fiveHour", "Current session"),
-      percentage: account.quota.five_hour_percentage,
-      quotaClass: getClaudeQuotaClass(account.quota.five_hour_percentage),
-      valueText: `${account.quota.five_hour_percentage}%`,
+      percentage: fiveHourRemaining,
+      quotaClass: getClaudeRemainingQuotaClass(fiveHourRemaining),
+      valueText: `${fiveHourRemaining}%`,
       resetText: formatClaudeResetTime(account.quota.five_hour_reset_time),
       resetAt: account.quota.five_hour_reset_time,
     });
     quotaItems.push({
       key: "seven_day",
       label: t("claude.quota.sevenDay", "Current week (all models)"),
-      percentage: account.quota.seven_day_percentage,
-      quotaClass: getClaudeQuotaClass(account.quota.seven_day_percentage),
-      valueText: `${account.quota.seven_day_percentage}%`,
+      percentage: sevenDayRemaining,
+      quotaClass: getClaudeRemainingQuotaClass(sevenDayRemaining),
+      valueText: `${sevenDayRemaining}%`,
       resetText: formatClaudeResetTime(account.quota.seven_day_reset_time),
       resetAt: account.quota.seven_day_reset_time,
     });

--- a/src/types/claude.test.ts
+++ b/src/types/claude.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getClaudeRemainingPercentage,
+  getClaudeRemainingQuotaClass,
+} from './claude.ts';
+
+test('converts Claude used percentages to remaining percentages', () => {
+  assert.equal(getClaudeRemainingPercentage(0), 100);
+  assert.equal(getClaudeRemainingPercentage(42), 58);
+  assert.equal(getClaudeRemainingPercentage(100), 0);
+});
+
+test('clamps invalid and out-of-range Claude usage percentages', () => {
+  assert.equal(getClaudeRemainingPercentage(-10), 100);
+  assert.equal(getClaudeRemainingPercentage(120), 0);
+  assert.equal(getClaudeRemainingPercentage(Number.NaN), 0);
+});
+
+test('uses healthy colors for high remaining quota and warning colors when low', () => {
+  assert.equal(getClaudeRemainingQuotaClass(100), 'high');
+  assert.equal(getClaudeRemainingQuotaClass(58), 'medium');
+  assert.equal(getClaudeRemainingQuotaClass(30), 'low');
+  assert.equal(getClaudeRemainingQuotaClass(10), 'critical');
+  assert.equal(getClaudeRemainingQuotaClass(Number.NaN), 'critical');
+});

--- a/src/types/claude.ts
+++ b/src/types/claude.ts
@@ -325,6 +325,20 @@ export function getClaudeQuotaClass(usedPercent: number): 'high' | 'medium' | 'l
   return 'high';
 }
 
+export function getClaudeRemainingPercentage(usedPercent: number): number {
+  if (!Number.isFinite(usedPercent)) return 0;
+  return 100 - Math.max(0, Math.min(100, Math.round(usedPercent)));
+}
+
+export function getClaudeRemainingQuotaClass(
+  remainingPercent: number,
+): 'high' | 'medium' | 'low' | 'critical' {
+  const normalized = Number.isFinite(remainingPercent)
+    ? Math.max(0, Math.min(100, Math.round(remainingPercent)))
+    : 0;
+  return getClaudeQuotaClass(100 - normalized);
+}
+
 export function hasClaudeQuotaData(account: ClaudeAccount): boolean {
   return Boolean(account.quota);
 }


### PR DESCRIPTION
## Summary

- Display Claude five-hour and seven-day quota percentages as remaining capacity instead of consumed capacity.
- Apply the same remaining-capacity presentation across account cards, dashboards, instance previews, tray menus, and the macOS native menu.
- Keep the raw used-percentage values unchanged so automatic account switching, recommendation sorting, and warning thresholds retain their existing behavior.

## Behavior

- 0% used is presented as 100% remaining.
- 42% used is presented as 58% remaining.
- Progress bars now represent remaining capacity while warning colors still derive from the equivalent usage threshold.

## Tests

- node --test src/types/claude.test.ts
- npm run typecheck
- npm run build
- cargo check --locked
- rustfmt --edition 2021 --check src-tauri/src/modules/tray.rs src-tauri/src/modules/macos_native_menu.rs

All checks pass. Cargo reports only pre-existing unused-code warnings.