### PR TITLE
fix(codex): ensure windows_terminal_available is available on non-windows targets

### DIFF
--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -825,12 +825,12 @@ fn escape_applescript(value: &str) -> String {
 /// Cockpit's `Command::spawn` uses `CreateProcess` directly and bypasses the OS default-terminal
 /// redirection, so for `default_terminal = "system"` we probe for `wt.exe` and route through
 /// Windows Terminal when available.
-#[cfg(any(target_os = "windows", test))]
+#[cfg_attr(not(any(target_os = "windows", test)), allow(dead_code))]
 fn windows_terminal_available() -> bool {
     windows_terminal_available_on_paths(std::env::var_os("PATH"))
 }
 
-#[cfg(any(target_os = "windows", test))]
+#[cfg_attr(not(any(target_os = "windows", test)), allow(dead_code))]
 fn windows_terminal_available_on_paths(path: Option<std::ffi::OsString>) -> bool {
     let candidates = ["wt.exe", "wt"];
     let paths = path.as_deref();

--- a/src-tauri/src/modules/codex_ssh.rs
+++ b/src-tauri/src/modules/codex_ssh.rs
@@ -317,20 +317,15 @@ pub fn sync_current_account(id: &str) -> Result<String, String> {
     }
 
     // Best-effort remote Codex app-server reload (#1404) so Desktop picks up new auth.
-    let mut reload_note = String::new();
     let reload_cmd = format!(
         "command -v pkill >/dev/null 2>&1 && pkill -f 'codex.*app-server' || true; command -v codex >/dev/null 2>&1 && (codex app-server --help >/dev/null 2>&1 || true)"
     );
     let mut reload_args = ssh_base_args(&server);
     reload_args.push(reload_cmd);
-    match run_hidden("ssh", &reload_args) {
-        Ok(_) => {
-            reload_note = "；已尝试重载远端 app-server".to_string();
-        }
-        Err(e) => {
-            reload_note = format!("；远端重载跳过: {e}");
-        }
-    }
+    let reload_note = match run_hidden("ssh", &reload_args) {
+        Ok(_) => "；已尝试重载远端 app-server".to_string(),
+        Err(e) => format!("；远端重载跳过: {e}"),
+    };
 
     Ok(format!(
         "已同步账号 {} 的 {} 到 {}@{}:{}{}",


### PR DESCRIPTION
## Associated Issue

Fixes #1769
Refs #1637, #1636

## Problem

Non-Windows release builds (such as `aarch64-apple-darwin` or Linux targets) failed to compile due to missing `windows_terminal_available` in scope:

```text
error[E0425]: cannot find function `windows_terminal_available` in this scope
   --> src-tauri/src/commands/codex_instance.rs:868:36
    |
868 |         (normalized == "system" && windows_terminal_available()) || normalized == "wt";
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
```

In commit `28bf6ee2c52132cb220336ce4731f44c8993f215` (PR #1637), `windows_terminal_available` and `windows_terminal_available_on_paths` were marked with `#[cfg(any(target_os = "windows", test))]`. However, `build_windows_codex_terminal_launch_plan` (which calls `windows_terminal_available`) is compiled across all platforms under `#[cfg_attr(not(any(target_os = "windows", test)), allow(dead_code))]`.

## Fix

1. Changed `#[cfg(any(target_os = "windows", test))]` to `#[cfg_attr(not(any(target_os = "windows", test)), allow(dead_code))]` for `windows_terminal_available` and `windows_terminal_available_on_paths` so non-Windows builds can resolve the symbol.
2. Cleaned up an `unused_assignments` warning for `reload_note` in `src-tauri/src/modules/codex_ssh.rs`.

## Verification

- Ran local `cargo check` and verification build matrix workflow on `fix/codex-windows-terminal-cfg`.
