### PR TITLE
feat: support claude code model tier alias mapping

### DIFF
--- a/src-tauri/src/models/claude.rs
+++ b/src-tauri/src/models/claude.rs
@@ -226,6 +226,8 @@ pub struct ClaudeDesktopGatewayModelMapping {
     pub upstream_model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label_override: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anthropic_family_tier: Option<String>,
     #[serde(
         default,
         rename = "supports1m",

--- a/src-tauri/src/modules/claude_account.rs
+++ b/src-tauri/src/modules/claude_account.rs
@@ -4066,7 +4066,8 @@ fn build_desktop_gateway_provider_config(account: &ClaudeAccount) -> Result<Valu
                 .filter_map(|model| {
                     let name = normalize_non_empty(Some(model))?;
                     let mut item = json!({ "name": name.clone() });
-                    if let Some(mapping) = mapping_meta.get(&name.to_ascii_lowercase()) {
+                    let mapping = mapping_meta.get(&name.to_ascii_lowercase());
+                    if let Some(mapping) = mapping {
                         if let Some(label_override) = mapping
                             .label_override
                             .as_deref()
@@ -4077,6 +4078,16 @@ fn build_desktop_gateway_provider_config(account: &ClaudeAccount) -> Result<Valu
                         if mapping.supports_1m.unwrap_or(false) {
                             item["supports1m"] = Value::Bool(true);
                         }
+                    }
+                    let family_tier = mapping
+                        .and_then(|mapping| mapping.anthropic_family_tier.as_deref())
+                        .or_else(|| {
+                            crate::modules::claude_desktop_gateway::infer_anthropic_family_tier(
+                                &name,
+                            )
+                        });
+                    if let Some(tier) = family_tier {
+                        item["anthropicFamilyTier"] = Value::String(tier.to_string());
                     }
                     Some(item)
                 })
@@ -5769,6 +5780,11 @@ fn parse_import_item(value: &Value) -> Result<ClaudeAccount, String> {
                                 label_override: item
                                     .get("label_override")
                                     .or_else(|| item.get("labelOverride"))
+                                    .and_then(Value::as_str)
+                                    .and_then(|value| normalize_non_empty(Some(value))),
+                                anthropic_family_tier: item
+                                    .get("anthropic_family_tier")
+                                    .or_else(|| item.get("anthropicFamilyTier"))
                                     .and_then(Value::as_str)
                                     .and_then(|value| normalize_non_empty(Some(value))),
                                 supports_1m: item
@@ -8983,6 +8999,47 @@ mod tests {
             created_at,
             last_used,
         }
+    }
+
+    #[test]
+    fn desktop_gateway_provider_config_pins_model_family_tiers() {
+        let mut account = test_desktop_account(
+            "claude_desktop_gateway_test",
+            "Gateway",
+            None,
+            None,
+            10,
+            20,
+        );
+        account.auth_mode = ClaudeAuthMode::DesktopGateway;
+        account.api_key = Some("test-key".to_string());
+        account.api_base_url = Some("https://gateway.example.test".to_string());
+        account.desktop_gateway_models = Some(vec![
+            "claude-fable-5".to_string(),
+            "claude-haiku-4-5".to_string(),
+            "claude-opus-4-8".to_string(),
+            "claude-sonnet-4-6".to_string(),
+            "claude-custom-route".to_string(),
+        ]);
+        account.desktop_gateway_model_mappings = Some(vec![ClaudeDesktopGatewayModelMapping {
+            desktop_model: "claude-custom-route".to_string(),
+            upstream_model: "custom-upstream-model".to_string(),
+            label_override: None,
+            anthropic_family_tier: Some("haiku".to_string()),
+            supports_1m: None,
+        }]);
+
+        let config = build_desktop_gateway_provider_config(&account)
+            .expect("gateway provider config should build");
+        let models = config["inferenceModels"]
+            .as_array()
+            .expect("inferenceModels should be an array");
+
+        assert_eq!(models[0]["anthropicFamilyTier"], "fable");
+        assert_eq!(models[1]["anthropicFamilyTier"], "haiku");
+        assert_eq!(models[2]["anthropicFamilyTier"], "opus");
+        assert_eq!(models[3]["anthropicFamilyTier"], "sonnet");
+        assert_eq!(models[4]["anthropicFamilyTier"], "haiku");
     }
 
     #[test]

--- a/src-tauri/src/modules/claude_desktop_gateway.rs
+++ b/src-tauri/src/modules/claude_desktop_gateway.rs
@@ -51,6 +51,29 @@ pub fn is_claude_desktop_model(model: &str) -> bool {
     normalized.starts_with("claude-") || normalized.starts_with("anthropic/claude-")
 }
 
+pub fn infer_anthropic_family_tier(model: &str) -> Option<&'static str> {
+    let normalized = model.trim().to_ascii_lowercase();
+    ["haiku", "sonnet", "opus", "fable", "mythos"]
+        .into_iter()
+        .find(|tier| {
+            normalized
+                .split(|ch: char| !ch.is_ascii_alphanumeric())
+                .any(|part| part == *tier)
+        })
+}
+
+fn normalize_anthropic_family_tier(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| {
+            matches!(
+                value.to_ascii_lowercase().as_str(),
+                "haiku" | "sonnet" | "opus" | "fable" | "mythos"
+            )
+        })
+        .map(|value| value.to_ascii_lowercase())
+}
+
 pub fn normalize_connection_mode(value: Option<&str>) -> String {
     match value
         .map(str::trim)
@@ -81,11 +104,16 @@ pub fn normalize_model_mappings(
             .filter(|value| !value.is_empty())
             .map(str::to_string);
         let supports_1m = mapping.supports_1m.filter(|value| *value);
+        let anthropic_family_tier = normalize_anthropic_family_tier(
+            mapping.anthropic_family_tier.as_deref(),
+        )
+        .or_else(|| infer_anthropic_family_tier(&desktop_model).map(str::to_string));
         seen.entry(key)
             .or_insert_with(|| ClaudeDesktopGatewayModelMapping {
                 desktop_model,
                 upstream_model,
                 label_override,
+                anthropic_family_tier,
                 supports_1m,
             });
     }
@@ -112,6 +140,8 @@ pub fn build_default_model_mappings(
                 desktop_model: desktop_model.to_string(),
                 upstream_model: fallback.clone(),
                 label_override: None,
+                anthropic_family_tier: infer_anthropic_family_tier(desktop_model)
+                    .map(str::to_string),
                 supports_1m: None,
             })
         })

--- a/src/pages/ClaudeAccountsPage.tsx
+++ b/src/pages/ClaudeAccountsPage.tsx
@@ -75,6 +75,7 @@ import { useRemoteConfigStore } from '../stores/useRemoteConfigStore';
 import type {
   ClaudeAccount,
   ClaudeDesktopGatewayConnectionMode,
+  ClaudeDesktopGatewayFamilyTier,
   ClaudeDesktopGatewayModelMapping,
   ClaudeDesktopLoginStartResponse,
   ClaudeDesktopLoginProgressPayload,
@@ -110,11 +111,13 @@ import {
 } from '../utils/claudeProviderPresets';
 import {
   CLAUDE_DESKTOP_GATEWAY_DEFAULT_MODELS,
+  CLAUDE_DESKTOP_GATEWAY_FAMILY_TIERS,
   CLAUDE_DESKTOP_GATEWAY_PROVIDER_CUSTOM_ID,
   CLAUDE_DESKTOP_GATEWAY_PROVIDER_PRESETS,
   findClaudeDesktopGatewayProviderPresetById,
   getDefaultClaudeDesktopGatewayProviderPresetId,
   inferClaudeDesktopGatewayApiKeyField,
+  inferClaudeDesktopGatewayFamilyTier,
 } from '../utils/claudeDesktopProviderPresets';
 import {
   APIKEY_FUN_PREFILL_EVENT,
@@ -592,6 +595,7 @@ function buildClaudeDesktopGatewayMappings(
         desktopModel,
         upstreamModel,
         labelOverride: upstreamModel,
+        anthropicFamilyTier: inferClaudeDesktopGatewayFamilyTier(desktopModel),
       };
     });
   }
@@ -600,6 +604,7 @@ function buildClaudeDesktopGatewayMappings(
     .map((desktopModel, index) => ({
       desktopModel,
       upstreamModel: upstreamModels[index]?.trim() || '',
+      anthropicFamilyTier: inferClaudeDesktopGatewayFamilyTier(desktopModel),
     }));
 }
 
@@ -620,6 +625,8 @@ function normalizeClaudeDesktopGatewayMappings(
       upstreamModel,
       labelOverride: upstreamModel,
       ...(mapping.supports1m === true ? { supports1m: true } : {}),
+      anthropicFamilyTier:
+        mapping.anthropicFamilyTier ?? inferClaudeDesktopGatewayFamilyTier(desktopModel),
     });
   });
   return result;
@@ -633,6 +640,8 @@ function cloneClaudeDesktopGatewayMappings(
     upstreamModel: mapping.upstreamModel,
     labelOverride: mapping.labelOverride ?? null,
     supports1m: mapping.supports1m === true,
+    anthropicFamilyTier:
+      mapping.anthropicFamilyTier ?? inferClaudeDesktopGatewayFamilyTier(mapping.desktopModel),
   }));
 }
 
@@ -683,6 +692,13 @@ function buildClaudeDesktopGatewayDesktopModelOptions(
     ...options,
     { value: CLAUDE_DESKTOP_GATEWAY_CUSTOM_DESKTOP_MODEL, label: customLabel },
   ];
+}
+
+function buildClaudeDesktopGatewayFamilyTierOptions() {
+  return CLAUDE_DESKTOP_GATEWAY_FAMILY_TIERS.map((tier) => ({
+    value: tier,
+    label: tier.charAt(0).toUpperCase() + tier.slice(1),
+  }));
 }
 
 function isClaudeProviderApiKeyAccount(account: ClaudeAccount): boolean {
@@ -1822,6 +1838,7 @@ export function ClaudeAccountsPage({ subPlatform = 'desktop' }: ClaudeAccountsPa
         desktopModel: mapping.desktopModel.trim(),
         upstreamModel: mapping.upstreamModel.trim(),
         supports1m: mapping.supports1m === true,
+        anthropicFamilyTier: mapping.anthropicFamilyTier ?? null,
       }))
       .filter((mapping) => mapping.desktopModel || mapping.upstreamModel);
     const desktopGatewayMappings = normalizeClaudeDesktopGatewayMappings(desktopGatewayMappingRows);
@@ -1840,6 +1857,7 @@ export function ClaudeAccountsPage({ subPlatform = 'desktop' }: ClaudeAccountsPa
           desktopModel: mapping.desktopModel,
           upstreamModel: mapping.upstreamModel || mapping.desktopModel,
           supports1m: mapping.supports1m === true,
+          anthropicFamilyTier: mapping.anthropicFamilyTier ?? null,
         })),
     );
     if (addTab === 'desktopGateway') {
@@ -3814,6 +3832,7 @@ export function ClaudeAccountsPage({ subPlatform = 'desktop' }: ClaudeAccountsPa
                                   const desktopModelOptions = buildClaudeDesktopGatewayDesktopModelOptions(
                                     t('claude.apiKey.customProvider', '自定义'),
                                   );
+                                  const familyTierOptions = buildClaudeDesktopGatewayFamilyTierOptions();
                                   const desktopModelInOptions = desktopModelOptions.some((option) => option.value === mapping.desktopModel);
                                   const desktopDropdownValue = desktopModelInOptions && mapping.desktopModel
                                     ? mapping.desktopModel
@@ -3849,6 +3868,10 @@ export function ClaudeAccountsPage({ subPlatform = 'desktop' }: ClaudeAccountsPa
                                                     ? ''
                                                     : mapping.desktopModel
                                                   : value,
+                                              anthropicFamilyTier:
+                                                value === CLAUDE_DESKTOP_GATEWAY_CUSTOM_DESKTOP_MODEL
+                                                  ? mapping.anthropicFamilyTier ?? null
+                                                  : inferClaudeDesktopGatewayFamilyTier(value),
                                             };
                                             setDesktopGatewayModelMappings(next);
                                             setDesktopGatewayModelsError(null);
@@ -3874,6 +3897,24 @@ export function ClaudeAccountsPage({ subPlatform = 'desktop' }: ClaudeAccountsPa
                                           />
                                         )}
                                       </div>
+                                      <SingleSelectDropdown
+                                        value={mapping.anthropicFamilyTier ?? ''}
+                                        options={familyTierOptions}
+                                        onChange={(value) => {
+                                          const next = [...desktopGatewayModelMappings];
+                                          next[index] = {
+                                            ...mapping,
+                                            anthropicFamilyTier:
+                                              (value || null) as ClaudeDesktopGatewayFamilyTier | null,
+                                          };
+                                          setDesktopGatewayModelMappings(next);
+                                          setDesktopGatewayModelsError(null);
+                                          setAddModalError(null);
+                                        }}
+                                        ariaLabel={t('claude.desktopGateway.familyTierLabel', 'Tier alias')}
+                                        placeholder={t('claude.desktopGateway.familyTierLabel', 'Tier alias')}
+                                        menuWidth={150}
+                                      />
                                       <label
                                         className="claude-gateway-supports1m-toggle"
                                         title={t('claude.desktopGateway.supports1mLabel', '声明支持 1M')}
@@ -3912,16 +3953,20 @@ export function ClaudeAccountsPage({ subPlatform = 'desktop' }: ClaudeAccountsPa
                                   type="button"
                                   className="btn btn-secondary"
                                   onClick={() => {
-                                    setDesktopGatewayModelMappings((prev) => [
-                                      ...prev,
-                                      {
-                                        desktopModel: getNextClaudeDesktopGatewaySafeModel(
-                                          prev.map((mapping) => mapping.desktopModel),
-                                        ),
-                                        upstreamModel: '',
-                                        supports1m: false,
-                                      },
-                                    ]);
+                                    setDesktopGatewayModelMappings((prev) => {
+                                      const desktopModel = getNextClaudeDesktopGatewaySafeModel(
+                                        prev.map((mapping) => mapping.desktopModel),
+                                      );
+                                      return [
+                                        ...prev,
+                                        {
+                                          desktopModel,
+                                          upstreamModel: '',
+                                          supports1m: false,
+                                          anthropicFamilyTier: inferClaudeDesktopGatewayFamilyTier(desktopModel),
+                                        },
+                                      ];
+                                    });
                                     setDesktopGatewayMappingsExpanded(true);
                                     setAddModalError(null);
                                   }}

--- a/src/styles/pages/github-copilot.css
+++ b/src/styles/pages/github-copilot.css
@@ -2398,7 +2398,7 @@
 
 .claude-add-modal .claude-gateway-mapping-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(105px, 0.55fr) auto auto;
   gap: 8px;
   align-items: center;
 }
@@ -2415,6 +2415,10 @@
 }
 
 .claude-add-modal .claude-gateway-mapped-model-field .single-select-dropdown {
+  width: 100%;
+}
+
+.claude-add-modal .claude-gateway-mapping-row > .single-select-dropdown {
   width: 100%;
 }
 

--- a/src/types/claude.ts
+++ b/src/types/claude.ts
@@ -117,11 +117,14 @@ export interface ClaudeDesktopGatewayModel {
 
 export type ClaudeDesktopGatewayConnectionMode = 'direct' | 'local_mapping';
 
+export type ClaudeDesktopGatewayFamilyTier = 'haiku' | 'sonnet' | 'opus' | 'fable' | 'mythos';
+
 export interface ClaudeDesktopGatewayModelMapping {
   desktopModel: string;
   upstreamModel: string;
   labelOverride?: string | null;
   supports1m?: boolean | null;
+  anthropicFamilyTier?: ClaudeDesktopGatewayFamilyTier | null;
 }
 
 export interface ClaudeDesktopGatewayModelsResult {

--- a/src/utils/claudeDesktopProviderPresets.ts
+++ b/src/utils/claudeDesktopProviderPresets.ts
@@ -1,5 +1,6 @@
 import type {
   ClaudeDesktopGatewayConnectionMode,
+  ClaudeDesktopGatewayFamilyTier,
   ClaudeDesktopGatewayModelMapping,
 } from '../types/claude';
 import {
@@ -38,6 +39,21 @@ export const CLAUDE_DESKTOP_GATEWAY_DEFAULT_MODELS = [
   'claude-haiku-4-5',
 ] as const;
 
+export const CLAUDE_DESKTOP_GATEWAY_FAMILY_TIERS = [
+  'haiku',
+  'sonnet',
+  'opus',
+  'fable',
+  'mythos',
+] as const satisfies readonly ClaudeDesktopGatewayFamilyTier[];
+
+export function inferClaudeDesktopGatewayFamilyTier(
+  model: string,
+): ClaudeDesktopGatewayFamilyTier | null {
+  const parts = model.trim().toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  return CLAUDE_DESKTOP_GATEWAY_FAMILY_TIERS.find((tier) => parts.includes(tier)) ?? null;
+}
+
 function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
   return Array.from(new Set(values.map((value) => value?.trim() ?? '').filter(Boolean)));
 }
@@ -48,13 +64,17 @@ function createRoute(
   options: {
     labelOverride?: string | null;
     supports1m?: boolean;
+    anthropicFamilyTier?: ClaudeDesktopGatewayFamilyTier | null;
   } = {},
 ): ClaudeDesktopGatewayModelMapping {
+  const anthropicFamilyTier = options.anthropicFamilyTier
+    ?? inferClaudeDesktopGatewayFamilyTier(desktopModel);
   return {
     desktopModel,
     upstreamModel,
     ...(options.labelOverride?.trim() ? { labelOverride: options.labelOverride.trim() } : {}),
     ...(options.supports1m ? { supports1m: true } : {}),
+    ...(anthropicFamilyTier ? { anthropicFamilyTier } : {}),
   };
 }
 
@@ -62,11 +82,7 @@ function directRoutes(
   models: readonly string[] = CLAUDE_DESKTOP_GATEWAY_DEFAULT_MODELS,
   options: { supports1m?: boolean } = {},
 ): ClaudeDesktopGatewayModelMapping[] {
-  return uniqueNonEmpty([...models]).map((model) => ({
-    desktopModel: model,
-    upstreamModel: model,
-    ...(options.supports1m ? { supports1m: true } : {}),
-  }));
+  return uniqueNonEmpty([...models]).map((model) => createRoute(model, model, options));
 }
 
 function roleMappedRoutes(


### PR DESCRIPTION
第三方模型接入 Claude Code 中时支持设置 tier alias.
若不进行这个设置，会导致 Claude Code 在进行复杂任务时开大量 sub agent，全部使用选择的模型，例如选择 5.6-sol，会非常慢，因为十几个并行线程全部是 sol
（正常行为应是：主线程使用 Fable级模型，开数个低级模型的 sub agent 进行调研，读取等工作）
<img width="762" height="764" alt="image" src="https://github.com/user-attachments/assets/dee9d886-9f8a-4f6d-af68-f5e01a7c5e2a" />

对应 Claude Code 设置位置：
<img width="962" height="727" alt="image" src="https://github.com/user-attachments/assets/db40a80b-8c4f-45b5-8066-cbd75ac7cc39" />

