### PR TITLE
fix(codex): preserve custom API key account labels

### DIFF
--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -1557,6 +1557,7 @@ pub fn update_codex_api_key_credentials(
     api_supports_vision: Option<bool>,
     api_model_vision_support: Option<std::collections::HashMap<String, bool>>,
     api_vision_routing_model: Option<String>,
+    account_name: Option<String>,
 ) -> Result<CodexAccount, String> {
     codex_account::update_api_key_credentials(
         &account_id,
@@ -1572,6 +1573,7 @@ pub fn update_codex_api_key_credentials(
         api_supports_vision.unwrap_or(false),
         api_model_vision_support.unwrap_or_default(),
         api_vision_routing_model,
+        account_name,
     )
 }
 

--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -12035,6 +12035,7 @@ multi_agent = true
             false,
             std::collections::HashMap::new(),
             None,
+            None,
         )
         .expect("update API key account");
 
@@ -13918,6 +13919,7 @@ pub fn update_api_key_credentials(
     api_supports_vision: bool,
     api_model_vision_support: std::collections::HashMap<String, bool>,
     api_vision_routing_model: Option<String>,
+    account_name: Option<String>,
 ) -> Result<CodexAccount, String> {
     let mut account =
         load_account(account_id).ok_or_else(|| format!("账号不存在: {}", account_id))?;
@@ -13963,6 +13965,9 @@ pub fn update_api_key_credentials(
         api_model_vision_support,
         api_vision_routing_model,
     );
+    if let Some(account_name) = normalize_optional_value(account_name) {
+        account.account_name = Some(account_name);
+    }
     account.update_last_used();
     save_account(&account)?;
 

--- a/src/components/codex/CodexModelProviderManager.tsx
+++ b/src/components/codex/CodexModelProviderManager.tsx
@@ -64,6 +64,7 @@ import {
   getCurrentCodexAccount,
   listCodexAccounts,
   syncCodexApiKeyProviderAccounts,
+  updateCodexAccountName,
   updateCodexApiKeyBoundOAuthAccount,
 } from "../../services/codexService";
 import {
@@ -139,6 +140,10 @@ import {
   type CodexProviderWireApi,
 } from "../../utils/codexProviderGateway";
 import { emitAccountsChanged } from "../../utils/accountSyncEvents";
+import {
+  resolveCodexModelProviderAccountName,
+  shouldSyncCodexModelProviderAccountName,
+} from "../../utils/codexModelProviderAccountName";
 import { findCodexAccountsReferencingModelProvider } from "../../utils/codexModelProviderAccountSync";
 import { CodexQuickConfigCard } from "./CodexQuickConfigCard";
 import {
@@ -2376,7 +2381,36 @@ export function CodexModelProviderManager({
       );
       if (next === null) return;
       try {
+        const previousName = apiKey.name;
         await renameApiKeyOnCodexModelProvider(provider.id, apiKey.id, next);
+        const normalizedProviderBaseUrl = normalizeCodexModelProviderBaseUrl(
+          provider.baseUrl,
+        );
+        const nextName = resolveCodexModelProviderAccountName(provider.name, next);
+        const accountsToRename = accounts.filter(
+          (account) =>
+            isCodexApiKeyAccount(account) &&
+            account.openai_api_key?.trim() === apiKey.apiKey.trim() &&
+            (account.api_provider_id === provider.id ||
+              normalizeCodexModelProviderBaseUrl(account.api_base_url ?? "") ===
+                normalizedProviderBaseUrl) &&
+            shouldSyncCodexModelProviderAccountName(
+              account.account_name,
+              provider.name,
+              previousName,
+            ),
+        );
+        if (accountsToRename.length > 0) {
+          await Promise.all(
+            accountsToRename.map((account) =>
+              updateCodexAccountName(account.id, nextName),
+            ),
+          );
+          await emitAccountsChanged({
+            platformId: "codex",
+            reason: "provider-api-key-rename",
+          });
+        }
         await reloadProviders();
         setNotice({
           tone: "success",
@@ -2392,7 +2426,7 @@ export function CodexModelProviderManager({
         });
       }
     },
-    [parseServiceError, reloadProviders, t],
+    [accounts, parseServiceError, reloadProviders, t],
   );
 
   const handleBatchDeleteProviders = useCallback(async () => {

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -208,6 +208,7 @@ import {
   splitCodexImportPayloads,
 } from "../utils/codexJsonImportProgress";
 import { emitAccountsChanged } from "../utils/accountSyncEvents";
+import { resolveCodexModelProviderAccountName } from "../utils/codexModelProviderAccountName";
 import {
   CODEX_OVERVIEW_FILTER_FIELDS,
   CODEX_OVERVIEW_FILTER_SCOPE,
@@ -3920,6 +3921,7 @@ export function CodexAccountsPage() {
       providerPresetId: string,
       providerId: string,
       customProviderName: string,
+      managedProviderApiKeyName?: string | null,
     ): {
       apiProviderMode: CodexApiProviderMode;
       apiProviderId?: string;
@@ -3998,7 +4000,10 @@ export function CodexAccountsPage() {
             ),
           ),
           apiVisionRoutingModel: managedProvider.visionRoutingModel,
-          accountName: managedProvider.name,
+          accountName: resolveCodexModelProviderAccountName(
+            managedProvider.name,
+            managedProviderApiKeyName,
+          ),
         };
       }
 
@@ -6818,6 +6823,10 @@ export function CodexAccountsPage() {
         selectedQuickSwitchProvider.wireApi ?? undefined,
         selectedQuickSwitchProvider.supportsWebsockets,
         quickSwitchAccount.api_sync_model_catalog_to_codex === true,
+        resolveCodexModelProviderAccountName(
+          selectedQuickSwitchProvider.name,
+          selectedQuickSwitchApiKey.name,
+        ),
       );
       setMessage({
         text: t("codex.quickSwitch.success", {
@@ -6892,6 +6901,7 @@ export function CodexAccountsPage() {
         apiProviderPresetId,
         managedProviderId,
         newManagedProviderNameInput,
+        selectedManagedProviderApiKey?.name,
       ),
       apiModelCatalog: apiModelCatalogDraft,
     };
@@ -6936,7 +6946,7 @@ export function CodexAccountsPage() {
             apiSupportsVision: savedProvider.supportsVision,
             apiWireApi: savedProvider.wireApi ?? undefined,
             apiSupportsWebsockets: savedProvider.supportsWebsockets,
-            accountName: savedProvider.name,
+            accountName: providerPayload.accountName || savedProvider.name,
           };
           try {
             const usageSummary = await queryCodexModelProviderUsage({
@@ -8172,6 +8182,7 @@ export function CodexAccountsPage() {
         editingApiProviderPresetId,
         editingManagedProviderId,
         editingNewManagedProviderNameInput,
+        selectedEditingManagedProviderApiKey?.name,
       ),
       apiModelCatalog: editingApiModelCatalogDraft,
     };
@@ -8192,6 +8203,7 @@ export function CodexAccountsPage() {
         providerPayload.apiWireApi,
         providerPayload.apiSupportsWebsockets,
         editingApiSyncModelCatalogToCodex,
+        providerPayload.accountName,
       );
       if (
         validation.apiBaseUrl &&

--- a/src/services/codexService.ts
+++ b/src/services/codexService.ts
@@ -399,6 +399,7 @@ export async function updateCodexApiKeyCredentials(
   apiWireApi?: CodexProviderWireApi,
   apiSupportsWebsockets?: boolean,
   apiSyncModelCatalogToCodex?: boolean,
+  accountName?: string,
 ): Promise<CodexAccount> {
   return await invoke('update_codex_api_key_credentials', {
     accountId,
@@ -414,6 +415,7 @@ export async function updateCodexApiKeyCredentials(
     apiSupportsVision: apiSupportsVision ?? false,
     apiModelVisionSupport: apiModelVisionSupport ?? {},
     apiVisionRoutingModel: apiVisionRoutingModel ?? null,
+    accountName: accountName ?? null,
   });
 }
 

--- a/src/stores/useCodexAccountStore.ts
+++ b/src/stores/useCodexAccountStore.ts
@@ -137,6 +137,7 @@ interface CodexAccountState {
     apiWireApi?: CodexProviderWireApi,
     apiSupportsWebsockets?: boolean,
     apiSyncModelCatalogToCodex?: boolean,
+    accountName?: string,
   ) => Promise<CodexAccount>;
   updateApiKeyBoundOAuthAccount: (
     accountId: string,
@@ -448,6 +449,7 @@ export const useCodexAccountStore = create<CodexAccountState>((set, get) => ({
     apiWireApi?: CodexProviderWireApi,
     apiSupportsWebsockets?: boolean,
     apiSyncModelCatalogToCodex?: boolean,
+    accountName?: string,
   ) => {
     const account = await codexService.updateCodexApiKeyCredentials(
       accountId,
@@ -463,6 +465,7 @@ export const useCodexAccountStore = create<CodexAccountState>((set, get) => ({
       apiWireApi,
       apiSupportsWebsockets,
       apiSyncModelCatalogToCodex,
+      accountName,
     );
     await get().fetchAccounts();
     await get().fetchCurrentAccount();

--- a/src/utils/codexModelProviderAccountName.test.ts
+++ b/src/utils/codexModelProviderAccountName.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveCodexModelProviderAccountName,
+  shouldSyncCodexModelProviderAccountName,
+} from "./codexModelProviderAccountName.ts";
+
+test("API Key name is preferred over the provider name", () => {
+  assert.equal(
+    resolveCodexModelProviderAccountName("Provider", "  Team A  "),
+    "Team A",
+  );
+});
+
+test("provider name is the fallback for an unnamed API Key", () => {
+  assert.equal(resolveCodexModelProviderAccountName("Provider", "  "), "Provider");
+  assert.equal(resolveCodexModelProviderAccountName("  Provider  "), "Provider");
+});
+
+test("renaming a key updates legacy provider/key names but preserves manual names", () => {
+  assert.equal(
+    shouldSyncCodexModelProviderAccountName("Provider", "Provider", "Old key"),
+    true,
+  );
+  assert.equal(
+    shouldSyncCodexModelProviderAccountName("Old key", "Provider", "Old key"),
+    true,
+  );
+  assert.equal(
+    shouldSyncCodexModelProviderAccountName("My account label", "Provider", "Old key"),
+    false,
+  );
+});

--- a/src/utils/codexModelProviderAccountName.ts
+++ b/src/utils/codexModelProviderAccountName.ts
@@ -1,0 +1,20 @@
+export function resolveCodexModelProviderAccountName(
+  providerName: string,
+  apiKeyName?: string | null,
+): string {
+  return apiKeyName?.trim() || providerName.trim();
+}
+
+export function shouldSyncCodexModelProviderAccountName(
+  accountName: string | null | undefined,
+  providerName: string,
+  previousApiKeyName?: string | null,
+): boolean {
+  const current = accountName?.trim() ?? "";
+  if (!current) return true;
+
+  const candidates = [providerName, previousApiKeyName]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+  return candidates.includes(current);
+}


### PR DESCRIPTION
## Summary

- Preserve a saved API key's custom display name when adding it to the Codex account overview.
- Keep that name when editing credentials or quick-switching between provider API keys.
- Synchronize linked legacy account labels when a provider API key is renamed, while preserving manually customized account names.

## Root cause

The custom label is stored in `provider.apiKeys[].name`, but the account creation path passed `managedProvider.name` as `account_name`. The provider name therefore replaced the API key label before the account overview and API service pool could render it.

## Validation

- `node --experimental-strip-types --test src/utils/codexModelProviderAccountName.test.ts`
- `npm run typecheck`
- Targeted Rust tests for API key credential editing and Codex config handling
- `git diff --check`

Fixes #1816
