### PR TITLE
feat(codex): add DeepSeek Responses and balance support

### DIFF
--- a/.scratch/deepseek-responses-balance/issues/01-native-deepseek-responses.md
+++ b/.scratch/deepseek-responses-balance/issues/01-native-deepseek-responses.md
@@ -1,0 +1,15 @@
+# 01 — 让新 DeepSeek 账号原生运行 Codex Responses
+
+**What to build:** 用户选择 DeepSeek 官方供应商并导入 API Key 后，可以直接使用 Responses API 启动 Codex，看到 Pro 与 Flash 两个模型，并在切出 DeepSeek 时安全恢复原模型。
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] 官方 DeepSeek Base URL 被规范化为 `https://api.deepseek.com`。
+- [ ] 新账号固定使用 Responses direct，不启动 Chat Completions gateway。
+- [ ] 模型目录包含 Pro 与 Flash 的官方 Codex 元数据。
+- [ ] 无有效 DeepSeek 模型时默认 Pro，已有 Pro/Flash 选择保持不变。
+- [ ] 首次切入时备份原模型，切出时只在用户未手动改模的情况下恢复。
+- [ ] 同名但非官方主机的自定义中转服务保持原行为。
+- [ ] 受管账号投影 seam 的测试通过。

--- a/.scratch/deepseek-responses-balance/issues/02-migrate-existing-deepseek-accounts.md
+++ b/.scratch/deepseek-responses-balance/issues/02-migrate-existing-deepseek-accounts.md
@@ -1,0 +1,15 @@
+# 02 — 自动迁移既有官方 DeepSeek 账号
+
+**What to build:** 用户升级 Cockpit Tools 后，已有官方 DeepSeek 账号、供应商记录、默认 Codex 配置和受管实例自动切换到原生 Responses，无需手动修改。
+
+**Blocked by:** 01 — 让新 DeepSeek 账号原生运行 Codex Responses。
+
+**Status:** ready-for-agent
+
+- [ ] 根路径和 `/v1` 的官方 DeepSeek 账号被幂等迁移到 canonical Base URL 与 Responses。
+- [ ] 供应商记录固定为 DeepSeek usage 类型并保留 Pro、Flash。
+- [ ] 当前启用的默认配置和受管实例立即获得新投影。
+- [ ] 旧 provider gateway 状态和模型覆盖被安全清理。
+- [ ] 迁移失败不会留下部分持久化结果。
+- [ ] 自定义中转服务和非 DeepSeek 账号不被修改。
+- [ ] 重复加载不会产生额外变化。

--- a/.scratch/deepseek-responses-balance/issues/03-deepseek-balance-on-accounts.md
+++ b/.scratch/deepseek-responses-balance/issues/03-deepseek-balance-on-accounts.md
@@ -1,0 +1,17 @@
+# 03 — 在 Codex 账号页查询并展示 DeepSeek 余额
+
+**What to build:** DeepSeek API Key 用户可以在现有 Codex 账号卡片、表格和详情中查看总余额、赠金余额与充值余额，并沿用当前刷新和缓存体验。
+
+**Blocked by:** 01 — 让新 DeepSeek 账号原生运行 Codex Responses。
+
+**Status:** ready-for-agent
+
+- [ ] 使用 Bearer API Key 请求官方 `/user/balance`。
+- [ ] 金额按官方十进制字符串保存，不使用浮点数计算。
+- [ ] 简中与繁中首选 CNY，其他语言首选 USD，缺失时回退第一条真实币种。
+- [ ] `is_available=false` 显示“余额不可用”，不显示金额且不视为错误。
+- [ ] 查询失败不阻止账号导入、编辑、切换或启动。
+- [ ] 导入后立即查询，账号事件遵循 10 分钟缓存门槛，保留手动刷新。
+- [ ] 缓存恢复不丢失多币种余额。
+- [ ] 账号页不显示无意义的今日请求或今日 Token 零值。
+- [ ] Model Provider Usage Summary seam 的测试通过。

--- a/.scratch/deepseek-responses-balance/issues/04-deepseek-balance-on-dashboard.md
+++ b/.scratch/deepseek-responses-balance/issues/04-deepseek-balance-on-dashboard.md
@@ -1,0 +1,13 @@
+# 04 — 在 Dashboard 展示 DeepSeek 余额
+
+**What to build:** DeepSeek API Key 用户可以在 Dashboard 的现有账号概览中看到与 Codex 账号页一致的余额状态和首选币种。
+
+**Blocked by:** 03 — 在 Codex 账号页查询并展示 DeepSeek 余额。
+
+**Status:** ready-for-agent
+
+- [ ] Dashboard 复用同一 DeepSeek usage summary 和缓存。
+- [ ] 总余额、赠金余额、充值余额遵循相同币种选择规则。
+- [ ] 余额不可用和刷新失败沿用现有状态表现。
+- [ ] 不显示今日请求或今日 Token 假零值。
+- [ ] 现有手动刷新行为保持可用。

--- a/.scratch/deepseek-responses-balance/issues/05-deepseek-balance-in-macos-menu.md
+++ b/.scratch/deepseek-responses-balance/issues/05-deepseek-balance-in-macos-menu.md
@@ -1,0 +1,13 @@
+# 05 — 在 macOS 原生菜单展示 DeepSeek 余额
+
+**What to build:** macOS 用户可以在现有 Codex 原生菜单额度区域查看与客户端语言一致的 DeepSeek 余额。
+
+**Blocked by:** 03 — 在 Codex 账号页查询并展示 DeepSeek 余额。
+
+**Status:** ready-for-agent
+
+- [ ] 原生菜单识别 DeepSeek usage summary。
+- [ ] 简中与繁中首选 CNY，其他语言首选 USD，缺失时回退第一条。
+- [ ] 展示总余额、赠金余额和充值余额。
+- [ ] 余额不可用显示明确状态且不显示金额。
+- [ ] 现有刷新操作和其他供应商额度展示不回归。

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# Cockpit Tools Provider Integration
+
+This context describes how external model providers are represented and exposed to Codex users.
+
+## Language
+
+**DeepSeek 原生接入**:
+Codex 通过 DeepSeek 官方 Responses API 使用 DeepSeek 模型；这是产品支持的唯一 DeepSeek 接入方式。
+_Avoid_: DeepSeek Chat 网关、DeepSeek Chat Completions 接入
+
+**首选余额币种**:
+DeepSeek 多币种余额中用于客户端展示的一条记录。简体中文和繁体中文首选 CNY，其他语言首选 USD；目标币种缺失时使用接口返回的第一种实际币种。
+_Avoid_: 默认币种、账户币种
+
+**余额不可用**:
+DeepSeek 成功返回余额信息但声明当前账户没有可供 API 调用的余额。这是账户状态，不是余额查询失败。
+_Avoid_: 查询失败、接口错误

--- a/docs/adr/0001-deepseek-responses-only.md
+++ b/docs/adr/0001-deepseek-responses-only.md
@@ -1,0 +1,7 @@
+---
+status: accepted
+---
+
+# DeepSeek 仅使用 Responses 协议
+
+DeepSeek 曾按 Chat Completions 供应商通过本地网关接入。现在统一改为官方 Responses API：新账号直接使用 Responses，既有 DeepSeek 账号在升级后自动迁移，不提供协议切换入口，并保留 `deepseek-v4-flash` 与 `deepseek-v4-pro` 两个模型。迁移时保留账号已经选择的 Pro 或 Flash；新账号或无有效 DeepSeek 模型的账号默认使用 Pro。首次切入 DeepSeek 时备份原模型；切出时仅在当前模型仍为 DeepSeek 模型的情况下恢复，避免覆盖用户之后的手动选择。虽然官方接入页面在决策时仍提示 Pro 支持稍后开放，产品选择直接支持两者，以保持 DeepSeek 配置单一且无需后续模型迁移。

--- a/docs/superpowers/specs/2026-08-03-deepseek-responses-balance-design.md
+++ b/docs/superpowers/specs/2026-08-03-deepseek-responses-balance-design.md
@@ -1,0 +1,375 @@
+# 设计规格：DeepSeek Responses 接入与余额查询
+
+**日期：** 2026-08-03
+
+**状态：** 已确认
+**作者：** Codex 与用户
+
+## 1. 目标
+
+Cockpit Tools 将 DeepSeek 官方 API 作为 Codex 的原生 Responses 供应商接入，并为 DeepSeek API Key 账号提供余额查询。
+
+完成后：
+
+- DeepSeek 官方账号只使用 Responses API，不再进入 Chat Completions gateway。
+- 新账号和既有官方 DeepSeek 账号都拥有 `deepseek-v4-pro` 与 `deepseek-v4-flash`。
+- 既有官方 DeepSeek 账号在升级后自动迁移，不要求用户手动切换协议。
+- DeepSeek 余额沿用当前额度缓存、刷新入口和展示位置。
+- 简体中文与繁体中文优先显示 CNY，其他语言优先显示 USD。
+
+## 2. 官方依据
+
+- [接入 Codex](https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/codex)
+- [使用 Responses API](https://api-docs.deepseek.com/zh-cn/guides/responses_api)
+- [查询余额](https://api-docs.deepseek.com/zh-cn/api/get-user-balance)
+
+官方文档确认 Codex 通过 Responses API 与 DeepSeek 通信，配置核心为：
+
+```toml
+[model_providers.deepseek]
+base_url = "https://api.deepseek.com/"
+wire_api = "responses"
+experimental_bearer_token = "<DeepSeek API Key>"
+```
+
+Responses API 的主要兼容约束：
+
+- API 无状态，不支持 `previous_response_id` 与 `conversation`。
+- 流式响应以 `response.completed`、`response.incomplete` 或 `response.failed` 结束，没有 `data: [DONE]`。
+- Function 与 Web Search 工具受支持。
+- Custom 工具仅支持名为 `apply_patch` 的工具。
+- 图片和文件输入不受支持。
+- 未支持的顶层参数通常被静默忽略。
+
+官方页面在本文档确认时仍提示 Pro 稍后开放。产品决策明确覆盖该提示：本次同时支持 Pro 与 Flash，不设计后续“模型上新”流程。
+
+## 3. 已确认范围
+
+### 3.1 包含
+
+- DeepSeek 供应商能力从 Chat Completions 调整为原生 Responses。
+- 官方 DeepSeek Base URL 规范化。
+- 既有账号、供应商记录和当前 Codex 配置的幂等迁移。
+- DeepSeek 专用 Codex 模型目录元数据。
+- 默认模型选择及切出 DeepSeek 时的模型恢复。
+- `GET /user/balance` 查询、解析、缓存和展示。
+- Codex 账号页、Dashboard 与 macOS 原生菜单中的余额展示。
+- 所有现有客户端语言的必要翻译键。
+- 单元测试、类型检查和人工验收矩阵。
+
+### 3.2 不包含
+
+- DeepSeek Chat Completions 兼容开关。
+- DeepSeek 协议切换入口。
+- 自定义 DeepSeek 中转服务的自动迁移。
+- 后台定时轮询余额。
+- 新增依赖或新增独立余额存储。
+- 自研 Responses SSE 转换器或 DeepSeek 专用本地 sidecar。
+
+## 4. 当前状态与缺口
+
+当前仓库已经有 DeepSeek 供应商预设和两个模型，但仍存在以下缺口：
+
+1. `src/utils/codexProviderGateway.ts` 将 DeepSeek 归入 Chat Completions 供应商。
+2. `src-tauri/src/modules/codex_local_access.rs` 的主机推断也把 `api.deepseek.com` 归入 Chat Completions。
+3. 既有账号可能持久化了 `api_wire_api = "chat_completions"`，升级后不会自动改变。
+4. 当前模型目录从通用 GPT 模板生成，未完整表达 DeepSeek 官方 Codex 元数据。
+5. 额度查询只识别 `sub2api` 与 `new_api`，没有 DeepSeek 的 `/user/balance`。
+6. 当前单值 `balance + unit` 无法表达官方返回的多币种 `balance_infos`。
+
+## 5. 总体流程
+
+```mermaid
+flowchart TD
+    A["加载 Codex 账号与模型供应商"] --> B{"Base URL 主机是否为 api.deepseek.com"}
+    B -- "否" --> C["保持原有供应商行为"]
+    B -- "是" --> D["幂等迁移为 DeepSeek Responses"]
+    D --> E["写入 Pro 与 Flash 模型目录"]
+    E --> F["应用或恢复账号对应的默认模型"]
+    D --> G["使用同一 API Key 查询 /user/balance"]
+    G --> H["缓存原始多币种余额"]
+    H --> I["按客户端语言选择 CNY 或 USD"]
+    I --> J["账号页、Dashboard、macOS 菜单"]
+```
+
+## 6. DeepSeek Responses 接入设计
+
+### 6.1 官方供应商识别
+
+自动行为只基于解析后的 URL 主机名：
+
+```text
+api.deepseek.com
+```
+
+识别时忽略主机名大小写，并接受现有根路径或 `/v1` 配置。迁移后统一保存为：
+
+```text
+https://api.deepseek.com
+```
+
+仅供应商名称包含 `DeepSeek`、但主机不同的自定义中转服务不迁移，也不强制改写协议。
+
+### 6.2 能力配置
+
+DeepSeek 从 Chat Completions 推断集合中移除，能力固定为：
+
+| 能力 | 值 |
+|---|---|
+| Wire API | `responses` |
+| Adapter | `openai_responses_native` |
+| Gateway strategy | `passthrough` |
+| 默认启用方式 | `direct` |
+| 是否需要 gateway | 否 |
+| 是否支持 direct | 是 |
+
+应用不增加 DeepSeek 请求或 SSE 转换层。Codex 客户端直接访问 DeepSeek Responses API；Cockpit Tools 只负责配置、模型目录与账号生命周期。
+
+### 6.3 模型目录
+
+固定模型顺序：
+
+1. `deepseek-v4-pro`
+2. `deepseek-v4-flash`
+
+继续复用现有 Codex 模型模板，只对两个 DeepSeek 模型覆盖官方所需元数据，避免复制整份大型 `models.json` 或引入新的目录框架。
+
+关键元数据：
+
+| 字段 | 值 |
+|---|---|
+| `context_window` | `1048576` |
+| `max_context_window` | `1048576` |
+| `effective_context_window_percent` | `95` |
+| `prefer_websockets` | `false` |
+| `input_modalities` | `text` |
+| `supports_parallel_tool_calls` | `true` |
+| `apply_patch_tool_type` | `freeform` |
+| `web_search_tool_type` | `text` |
+| `default_reasoning_level` | `high` |
+| 推理档位 | `low`、`high`、`max` |
+| `minimal_client_version` | `0.144.0` |
+| `supported_in_api` | `true` |
+
+### 6.4 默认模型与恢复
+
+切入 DeepSeek 时：
+
+1. 当前模型为 Pro 或 Flash 时保持不变。
+2. 当前模型不是 DeepSeek 模型时，先备份原模型，再将默认模型设为 `deepseek-v4-pro`。
+3. 模型选择器同时展示 Pro 与 Flash。
+
+切出 DeepSeek 时：
+
+1. 当前模型仍为 Pro 或 Flash 时，恢复进入 DeepSeek 前备份的模型。
+2. 用户已经手动选择其他模型时，不覆盖用户选择。
+3. 恢复或确认无需恢复后，清理本次受管备份。
+
+模型备份优先复用现有 provider gateway 的备份约定，不新增第二套通用配置系统。
+
+## 7. 自动迁移设计
+
+迁移必须幂等，应用每次加载旧数据都可以安全执行。
+
+### 7.1 账号记录
+
+对 API Key 账号且官方主机为 `api.deepseek.com` 的记录：
+
+- 将 Base URL 规范化为 `https://api.deepseek.com`。
+- 将 `api_wire_api` 设置为 `responses`。
+- 将模型目录设置为 Pro 与 Flash。
+- 保留 API Key、账号名称、标签和其他凭据元数据。
+- 记录已经选择的 Pro 或 Flash；没有有效选择时按默认模型规则处理。
+
+### 7.2 模型供应商记录
+
+对 `codex_model_providers.json` 中官方 DeepSeek 主机的记录：
+
+- 将 `wireApi` 设置为 `responses`。
+- 将 `integrationType` 设置为 `deepseek`。
+- 将 `modelCatalog` 规范化为 Pro 与 Flash。
+- 不迁移同名但非官方主机的记录。
+
+### 7.3 当前配置与实例
+
+若被迁移账号当前处于启用状态：
+
+- 立即重写对应 Codex 目录的 `config.toml` 与受管模型目录。
+- 停止并清理该账号旧的 provider gateway 状态和模型覆盖。
+- 默认 Codex 目录和受 Cockpit Tools 管理的 Codex 实例都应用相同迁移。
+- 迁移失败时保留原持久化数据并返回可诊断错误，避免部分写入。
+
+## 8. DeepSeek 余额查询设计
+
+### 8.1 请求
+
+```http
+GET https://api.deepseek.com/user/balance
+Accept: application/json
+Authorization: Bearer <DeepSeek API Key>
+```
+
+余额 URL 必须从已验证的官方主机直接构造为 `/user/balance`，不能在旧 `/v1` 路径后简单追加。
+
+DeepSeek 供应商直接选择 `deepseek` 查询模式，不先探测 `new_api` 或 `sub2api`，避免无意义请求。
+
+### 8.2 数据模型
+
+官方金额字段是十进制字符串。应用保留字符串，不使用浮点数参与金额存储或计算。
+
+```ts
+type DeepSeekBalanceInfo = {
+  currency: string;
+  totalBalance: string;
+  grantedBalance: string;
+  toppedUpBalance: string;
+};
+
+type DeepSeekUsageSummary = {
+  mode: "deepseek";
+  isAvailable: boolean;
+  balanceInfos: DeepSeekBalanceInfo[];
+  latencyMs: number;
+};
+```
+
+后端将官方 snake_case 字段映射为现有前端使用的 camelCase JSON。原始响应不写入新的数据库或文件；它继续保存在现有 API Key usage cache 中。
+
+### 8.3 首选余额币种
+
+| 客户端语言 | 首选币种 |
+|---|---|
+| `zh-cn` | CNY |
+| `zh-tw` | CNY |
+| 其他全部语言 | USD |
+
+选择规则：
+
+1. 使用项目现有语言规范化结果，不读取操作系统区域设置。
+2. 在 `balanceInfos` 中按币种大小写不敏感匹配首选币种。
+3. 找不到首选币种时，回退到接口返回的第一条记录。
+4. 回退后始终显示记录的真实币种，不伪装成首选币种。
+5. 数组为空时显示暂无余额数据。
+
+### 8.4 展示字段
+
+DeepSeek 余额展示：
+
+- 总余额 `totalBalance`
+- 赠金余额 `grantedBalance`
+- 充值余额 `toppedUpBalance`
+
+沿用现有金额样式：USD 使用 `$`，CNY 显示数值与 `CNY` 标识。DeepSeek 没有“今日请求”和“今日 Token”数据，因此不显示两个无意义的零值字段。
+
+### 8.5 余额不可用
+
+`isAvailable = false` 是成功响应中的账户状态：
+
+- 显示“余额不可用”。
+- 不显示响应中可能同时存在的金额。
+- 不标记为网络或 API 错误。
+- 保留手动刷新操作。
+
+### 8.6 请求失败
+
+网络错误、非 2xx 响应或 JSON 解析失败：
+
+- 不阻止账号导入、编辑、切换或启动 Codex。
+- 沿用现有额度错误与重试处理。
+- 可以继续显示上一次成功缓存，同时标记本次刷新失败。
+- 错误日志不得包含 API Key，响应摘要保持现有长度限制。
+
+## 9. 刷新与缓存
+
+不增加定时轮询，沿用当前机制：
+
+- 导入 DeepSeek API Key 后立即查询一次。
+- 账号切换或账号更新时，如果缓存已超过 10 分钟则刷新。
+- 用户可以从现有刷新按钮强制刷新。
+- 使用现有 `agtools.codex.apiKeyUsage.cache.v1`，不迁移缓存 key。
+- 新增字段必须完整通过缓存序列化与恢复。
+
+## 10. 展示范围
+
+不增加新入口，在现有额度位置增加 `deepseek` 模式：
+
+1. Codex 账号页的卡片、表格与详情。
+2. Dashboard 的 Codex API Key 账号概览。
+3. macOS 原生菜单的 Codex 额度区域。
+
+三个入口使用相同的可用状态、币种选择和金额字段规则。
+
+## 11. 预计修改位置
+
+| 文件 | 责任 |
+|---|---|
+| `src/utils/codexProviderGateway.ts` | DeepSeek 改为 Responses direct |
+| `src/utils/codexProviderPresets.ts` | 固定 Pro 与 Flash 目录及官方地址 |
+| `src/services/codexModelProviderService.ts` | 供应商记录迁移与 `deepseek` 类型 |
+| `src/services/modelProviderUsageService.ts` | DeepSeek 余额类型、模式和币种选择 helper |
+| `src/components/model-provider/ModelProviderUsagePanel.tsx` | 共享余额展示兼容 |
+| `src/components/codex/CodexModelProviderManager.tsx` | 供应商额度查询识别 DeepSeek |
+| `src/pages/CodexAccountsPage.tsx` | 账号页余额与现有缓存行为 |
+| `src/pages/DashboardPage.tsx` | Dashboard 余额展示 |
+| `src/i18n/index.ts`、`src/locales/*.json` | 语言判断复用与新增文案 |
+| `src-tauri/src/commands/codex.rs` | `/user/balance` 请求、解析和 summary |
+| `src-tauri/src/modules/codex_account.rs` | 账号迁移、模型目录、默认模型与恢复 |
+| `src-tauri/src/modules/codex_local_access.rs` | 移除 DeepSeek Chat gateway 推断并清理旧状态 |
+| `src-tauri/src/modules/codex_protocol.rs` | DeepSeek 模型元数据覆盖 |
+| `src-tauri/src/modules/macos_native_menu.rs` | 原生菜单余额展示 |
+
+实现时以实际调用链为准；若某个展示点已完全复用共享组件，不为形式上的文件清单制造重复代码。
+
+## 12. 测试计划
+
+### 12.1 Rust 单元测试
+
+- 根路径和 `/v1` 都生成 `https://api.deepseek.com/user/balance`。
+- 非 HTTP(S)、空 URL 与非官方主机不会进入 DeepSeek 查询。
+- 正确解析 CNY、USD 和全部十进制字符串字段。
+- `is_available=false` 保持业务状态而非错误。
+- 非 2xx 和无效 JSON 返回现有风格的可诊断错误。
+- 官方 DeepSeek 旧账号从 Chat Completions 幂等迁移为 Responses。
+- 同名自定义中转服务保持不变。
+- Pro/Flash 当前模型得到保留，无效模型默认 Pro。
+- 切出 DeepSeek 时恢复备份；用户手动改模后不覆盖。
+- 两个 DeepSeek 模型生成预期 Codex 元数据。
+
+### 12.2 前端检查
+
+- `zh-cn` 与 `zh-tw` 选择 CNY。
+- 其他每个支持语言选择 USD。
+- 目标币种缺失时回退第一条，并显示真实币种。
+- `isAvailable=false` 只显示“余额不可用”。
+- 缓存写入和恢复不丢失 `balanceInfos`。
+- 三个展示入口不出现“今日请求/今日 Token”的假零值。
+
+### 12.3 验证命令
+
+```bash
+npm run typecheck
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+### 12.4 人工验收
+
+- 新增 DeepSeek API Key 后立即看到余额和两个模型。
+- 旧 DeepSeek Chat Completions 账号升级后无需操作即可启动 Codex Responses。
+- Pro 与 Flash 均可发起包含工具调用的 Codex 会话。
+- 简中、繁中、英文分别显示正确首选币种。
+- API Key 无余额、失效、网络断开时分别呈现正确状态。
+- DeepSeek 与 OpenAI/OAuth 账号来回切换后，默认模型正确恢复。
+- 自定义中转服务的协议和模型目录未被迁移。
+
+## 13. 完成标准
+
+- [ ] DeepSeek 官方账号不再触发 Chat Completions gateway。
+- [ ] 新旧账号都使用 Responses 且提供 Pro、Flash。
+- [ ] 迁移幂等，不修改自定义中转服务。
+- [ ] 模型默认值、备份和恢复符合确认规则。
+- [ ] 余额查询使用官方 `/user/balance` 和 Bearer 认证。
+- [ ] 多币种、不可用状态和请求失败被正确区分。
+- [ ] 三个现有入口遵循相同语言与展示规则。
+- [ ] 现有 10 分钟缓存和手动刷新行为保持不变。
+- [ ] 不新增依赖、sidecar、轮询器或协议切换 UI。
+- [ ] TypeScript 类型检查和 Rust 测试通过。

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "test:codex-api-key-scope": "node --test src/utils/codexApiKeyAccountScope.test.ts",
+    "test:frontend": "node --test scripts/tests/model-provider-usage-helpers.test.mjs",
     "typecheck": "tsc --noEmit",
     "prebuild": "npm run typecheck",
     "build": "npm run sync-version && tsc && vite build",

--- a/scripts/tests/model-provider-usage-helpers.test.mjs
+++ b/scripts/tests/model-provider-usage-helpers.test.mjs
@@ -49,24 +49,23 @@ test('DeepSeek currency selection falls back to the first real currency', () => 
   );
 });
 
-test('DeepSeek cache round-trip preserves balance infos and availability', () => {
-  const cached = helpers.parseCodexApiKeyUsageCache(
-    helpers.serializeCodexApiKeyUsageCache({
-      account: {
-        loading: true,
-        updatedAt: 123,
-        summary: {
-          mode: 'deepseek',
-          isAvailable: false,
-          balanceInfos: balances,
-          modelStatsCount: 0,
-          latencyMs: 19,
-        },
+test('shared in-memory cache preserves balance infos and availability', () => {
+  helpers.writeCodexApiKeyUsageCache({
+    account: {
+      loading: true,
+      updatedAt: 123,
+      summary: {
+        mode: 'deepseek',
+        isAvailable: false,
+        balanceInfos: balances,
+        modelStatsCount: 0,
+        latencyMs: 19,
       },
-    }),
-  );
+    },
+  });
+  const cached = helpers.readCodexApiKeyUsageCache();
 
-  assert.equal(cached.account.loading, false);
+  assert.equal(cached.account.loading, true);
   assert.equal(cached.account.summary.isAvailable, false);
   assert.deepEqual(cached.account.summary.balanceInfos, balances);
 });

--- a/scripts/tests/model-provider-usage-helpers.test.mjs
+++ b/scripts/tests/model-provider-usage-helpers.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import ts from 'typescript';
+
+const source = await readFile(
+  new URL('../../src/services/modelProviderUsageHelpers.ts', import.meta.url),
+  'utf8',
+);
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+});
+const helpers = await import(
+  `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`
+);
+
+const balances = [
+  {
+    currency: 'CNY',
+    totalBalance: '123.4500',
+    grantedBalance: '3.2500',
+    toppedUpBalance: '120.2000',
+  },
+  {
+    currency: 'USD',
+    totalBalance: '17.64',
+    grantedBalance: '0.00',
+    toppedUpBalance: '17.64',
+  },
+];
+
+test('DeepSeek currency follows every supported client language', () => {
+  assert.equal(helpers.preferredDeepSeekCurrency('zh-CN'), 'CNY');
+  assert.equal(helpers.preferredDeepSeekCurrency('zh-tw'), 'CNY');
+  for (const language of [
+    'en', 'ja', 'es', 'de', 'fr', 'pt-br', 'ru', 'ko', 'it', 'tr', 'pl', 'cs',
+    'vi', 'ar', 'id',
+  ]) {
+    assert.equal(helpers.preferredDeepSeekCurrency(language), 'USD', language);
+  }
+});
+
+test('DeepSeek currency selection falls back to the first real currency', () => {
+  assert.equal(helpers.selectDeepSeekBalanceInfo(balances, 'zh-cn').currency, 'CNY');
+  assert.equal(helpers.selectDeepSeekBalanceInfo(balances, 'en').currency, 'USD');
+  assert.equal(
+    helpers.selectDeepSeekBalanceInfo([balances[0]], 'en').currency,
+    'CNY',
+  );
+});
+
+test('DeepSeek cache round-trip preserves balance infos and availability', () => {
+  const cached = helpers.parseCodexApiKeyUsageCache(
+    helpers.serializeCodexApiKeyUsageCache({
+      account: {
+        loading: true,
+        updatedAt: 123,
+        summary: {
+          mode: 'deepseek',
+          isAvailable: false,
+          balanceInfos: balances,
+          modelStatsCount: 0,
+          latencyMs: 19,
+        },
+      },
+    }),
+  );
+
+  assert.equal(cached.account.loading, false);
+  assert.equal(cached.account.summary.isAvailable, false);
+  assert.deepEqual(cached.account.summary.balanceInfos, balances);
+});

--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -1944,6 +1944,20 @@ fn codex_model_provider_usage_url(base_url: &str) -> Result<String, String> {
     Ok(url.to_string())
 }
 
+fn codex_model_provider_deepseek_balance_url(base_url: &str) -> Result<String, String> {
+    let parsed = reqwest::Url::parse(base_url.trim())
+        .map_err(|_| "PROVIDER_BASE_URL_INVALID".to_string())?;
+    if !matches!(parsed.scheme(), "http" | "https")
+        || parsed
+            .host_str()
+            .map(|host| !host.eq_ignore_ascii_case("api.deepseek.com"))
+            .unwrap_or(true)
+    {
+        return Err("PROVIDER_USAGE_DEEPSEEK_HOST_INVALID".to_string());
+    }
+    Ok("https://api.deepseek.com/user/balance".to_string())
+}
+
 fn codex_model_provider_new_api_billing_url(
     base_url: &str,
     endpoint: &str,
@@ -2110,7 +2124,6 @@ fn normalize_model_provider_wire_api(value: Option<&str>, base_url: &str) -> Str
     }
     let lower = base_url.trim().to_ascii_lowercase();
     if lower.contains("/chat/completions")
-        || lower.contains("api.deepseek.com")
         || lower.contains("api.moonshot.cn")
         || lower.contains("api.siliconflow.cn")
         || lower.contains("api.siliconflow.com")
@@ -2457,6 +2470,8 @@ pub struct CodexModelProviderUsageSummary {
     pub remaining: Option<f64>,
     pub balance: Option<f64>,
     pub unit: Option<String>,
+    pub is_available: Option<bool>,
+    pub balance_infos: Vec<CodexDeepSeekBalanceInfo>,
     pub quota_unlimited: Option<bool>,
     pub quota_limit: Option<f64>,
     pub quota_used: Option<f64>,
@@ -2470,6 +2485,18 @@ pub struct CodexModelProviderUsageSummary {
     pub model_stats_count: usize,
     pub latency_ms: u64,
     pub details: Vec<CodexModelProviderUsageDetail>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexDeepSeekBalanceInfo {
+    pub currency: String,
+    #[serde(alias = "total_balance")]
+    pub total_balance: String,
+    #[serde(alias = "granted_balance")]
+    pub granted_balance: String,
+    #[serde(alias = "topped_up_balance")]
+    pub topped_up_balance: String,
 }
 
 fn json_f64_at(value: &serde_json::Value, path: &[&str]) -> Option<f64> {
@@ -2589,6 +2616,8 @@ fn summarize_model_provider_usage(
         remaining: json_f64_at(body, &["remaining"]),
         balance: json_f64_at(body, &["balance"]),
         unit: json_string_at(body, &["unit"]).or_else(|| json_string_at(body, &["quota", "unit"])),
+        is_available: None,
+        balance_infos: Vec::new(),
         quota_unlimited: json_bool_at(body, &["quota", "unlimited"]),
         quota_limit: json_f64_at(body, &["quota", "limit"]),
         quota_used: json_f64_at(body, &["quota", "used"]),
@@ -2741,6 +2770,8 @@ fn summarize_new_api_model_provider_usage(
         remaining: quota_remaining,
         balance: None,
         unit: Some("USD".to_string()),
+        is_available: None,
+        balance_infos: Vec::new(),
         quota_unlimited: Some(quota_unlimited),
         quota_limit,
         quota_used,
@@ -2755,6 +2786,64 @@ fn summarize_new_api_model_provider_usage(
         latency_ms,
         details,
     }
+}
+
+fn summarize_deepseek_model_provider_usage(
+    body: &serde_json::Value,
+    latency_ms: u64,
+) -> Result<CodexModelProviderUsageSummary, String> {
+    let is_available = body
+        .get("is_available")
+        .and_then(serde_json::Value::as_bool)
+        .ok_or_else(|| "PROVIDER_USAGE_PARSE_FAILED: missing is_available".to_string())?;
+    let balance_infos = serde_json::from_value::<Vec<CodexDeepSeekBalanceInfo>>(
+        body.get("balance_infos")
+            .cloned()
+            .ok_or_else(|| "PROVIDER_USAGE_PARSE_FAILED: missing balance_infos".to_string())?,
+    )
+    .map_err(|error| format!("PROVIDER_USAGE_PARSE_FAILED: {}", error))?;
+
+    Ok(CodexModelProviderUsageSummary {
+        mode: Some("deepseek".to_string()),
+        is_valid: None,
+        status: None,
+        plan_name: None,
+        remaining: None,
+        balance: None,
+        unit: None,
+        is_available: Some(is_available),
+        balance_infos,
+        quota_unlimited: None,
+        quota_limit: None,
+        quota_used: None,
+        quota_remaining: None,
+        today_requests: None,
+        today_total_tokens: None,
+        today_cost: None,
+        total_requests: None,
+        total_total_tokens: None,
+        total_cost: None,
+        model_stats_count: 0,
+        latency_ms,
+        details: Vec::new(),
+    })
+}
+
+fn parse_deepseek_balance_response(
+    status: reqwest::StatusCode,
+    text: &str,
+    latency_ms: u64,
+) -> Result<CodexModelProviderUsageSummary, String> {
+    if !status.is_success() {
+        return Err(format!(
+            "PROVIDER_USAGE_HTTP_{}: {}",
+            status.as_u16(),
+            text.chars().take(300).collect::<String>()
+        ));
+    }
+    let parsed = serde_json::from_str::<serde_json::Value>(text)
+        .map_err(|error| format!("PROVIDER_USAGE_PARSE_FAILED: {}", error))?;
+    summarize_deepseek_model_provider_usage(&parsed, latency_ms)
 }
 
 #[tauri::command]
@@ -3058,7 +3147,11 @@ pub async fn codex_query_model_provider_usage(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    if codex_model_provider_deepseek_balance_url(&base_url).is_ok() {
+        return query_deepseek_model_provider_usage(&client, &base_url, key).await;
+    }
     match requested_type {
+        Some("deepseek") => query_deepseek_model_provider_usage(&client, &base_url, key).await,
         Some("new_api") => query_new_api_model_provider_usage(&client, &base_url, key).await,
         Some("sub2api") => query_sub2api_model_provider_usage(&client, &base_url, key).await,
         Some(value) => Err(format!("PROVIDER_USAGE_TYPE_UNSUPPORTED: {}", value)),
@@ -3077,6 +3170,26 @@ pub async fn codex_query_model_provider_usage(
             }
         }
     }
+}
+
+async fn query_deepseek_model_provider_usage(
+    client: &reqwest::Client,
+    base_url: &str,
+    key: &str,
+) -> Result<CodexModelProviderUsageSummary, String> {
+    let url = codex_model_provider_deepseek_balance_url(base_url)?;
+    let started = Instant::now();
+    let response = client
+        .get(url)
+        .bearer_auth(key)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(|error| format!("PROVIDER_USAGE_NETWORK_FAILED: {}", error))?;
+    let latency_ms = started.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    parse_deepseek_balance_response(status, &text, latency_ms)
 }
 
 async fn query_new_api_model_provider_usage(
@@ -3730,5 +3843,62 @@ mod tests {
                 .as_deref(),
             Some("custom-model")
         );
+    }
+
+    #[test]
+    fn deepseek_balance_url_always_uses_the_official_root() {
+        assert_eq!(
+            codex_model_provider_deepseek_balance_url("https://api.deepseek.com/v1/")
+                .expect("deepseek url"),
+            "https://api.deepseek.com/user/balance"
+        );
+        assert!(
+            codex_model_provider_deepseek_balance_url("https://deepseek.example.com/v1").is_err()
+        );
+    }
+
+    #[test]
+    fn deepseek_balance_summary_preserves_decimal_strings_and_availability() {
+        let response = serde_json::json!({
+            "is_available": false,
+            "balance_infos": [
+                {
+                    "currency": "CNY",
+                    "total_balance": "123.4500",
+                    "granted_balance": "3.2500",
+                    "topped_up_balance": "120.2000"
+                },
+                {
+                    "currency": "USD",
+                    "total_balance": "17.64",
+                    "granted_balance": "0.00",
+                    "topped_up_balance": "17.64"
+                }
+            ]
+        });
+
+        let summary =
+            summarize_deepseek_model_provider_usage(&response, 19).expect("deepseek summary");
+        assert_eq!(summary.mode.as_deref(), Some("deepseek"));
+        assert_eq!(summary.is_available, Some(false));
+        assert_eq!(summary.latency_ms, 19);
+        assert_eq!(summary.balance_infos.len(), 2);
+        assert_eq!(summary.balance_infos[0].total_balance, "123.4500");
+        assert_eq!(summary.balance_infos[1].currency, "USD");
+    }
+
+    #[test]
+    fn deepseek_balance_response_reports_http_and_json_failures() {
+        let http_error = parse_deepseek_balance_response(
+            reqwest::StatusCode::UNAUTHORIZED,
+            r#"{"error":"invalid key"}"#,
+            1,
+        )
+        .expect_err("non-success status should fail");
+        assert!(http_error.starts_with("PROVIDER_USAGE_HTTP_401:"));
+
+        let parse_error = parse_deepseek_balance_response(reqwest::StatusCode::OK, "not-json", 1)
+            .expect_err("invalid json should fail");
+        assert!(parse_error.starts_with("PROVIDER_USAGE_PARSE_FAILED:"));
     }
 }

--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -61,6 +61,9 @@ const CODEX_RUNTIME_MODEL_PROVIDER_ID: &str = "codex_local_access";
 const CODEX_LEGACY_API_KEY_OPENAI_PROVIDER_ID: &str = "openai_api_key";
 const CODEX_DEFAULT_RUNTIME_PROVIDER_NAME: &str = "OpenAI Official";
 const CODEX_PROVIDER_WIRE_API: &str = "responses";
+const DEEPSEEK_API_HOST: &str = "api.deepseek.com";
+const DEEPSEEK_DEFAULT_MODEL: &str = "deepseek-v4-pro";
+const DEEPSEEK_MODELS: [&str; 2] = ["deepseek-v4-pro", "deepseek-v4-flash"];
 const APIKEY_FUN_PROVIDER_BASE_URL: &str = "https://api.apikey.fun/v1";
 const CODEX_CONTEXT_WINDOW_1M_VALUE: i64 = 1_000_000;
 const CODEX_AUTO_COMPACT_DEFAULT_LIMIT: i64 = 900_000;
@@ -117,7 +120,40 @@ fn normalize_api_base_url(raw: Option<&str>) -> Option<String> {
     if trimmed.is_empty() {
         return None;
     }
+    if is_official_deepseek_base_url(Some(trimmed)) {
+        return Some(format!("https://{}", DEEPSEEK_API_HOST));
+    }
     Some(trimmed.trim_end_matches('/').to_string())
+}
+
+pub(crate) fn is_official_deepseek_base_url(raw: Option<&str>) -> bool {
+    raw.and_then(|value| reqwest::Url::parse(value.trim()).ok())
+        .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
+        .as_deref()
+        == Some(DEEPSEEK_API_HOST)
+}
+
+fn is_official_deepseek_account(account: &CodexAccount) -> bool {
+    account.is_api_key_auth() && is_official_deepseek_base_url(account.api_base_url.as_deref())
+}
+
+fn read_config_model(base_dir: &Path) -> Option<String> {
+    let content = fs::read_to_string(get_config_toml_path(base_dir)).ok()?;
+    crate::modules::codex_config_format::read_codex_config_doc_from_str(&content)
+        .ok()?
+        .get("model")?
+        .as_str()
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string)
+}
+
+fn current_deepseek_model(base_dir: &Path) -> Option<String> {
+    read_config_model(base_dir).filter(|model| {
+        DEEPSEEK_MODELS
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(model))
+    })
 }
 
 fn normalize_api_base_url_for_match(raw: Option<&str>) -> Option<String> {
@@ -541,6 +577,31 @@ fn normalize_api_key_websocket_capability(account: &mut CodexAccount) -> bool {
         return false;
     }
     account.api_supports_websockets = normalized;
+    true
+}
+
+fn migrate_official_deepseek_account(account: &mut CodexAccount) -> bool {
+    if !is_official_deepseek_account(account) {
+        return false;
+    }
+
+    let canonical_base_url = format!("https://{}", DEEPSEEK_API_HOST);
+    let model_catalog = DEEPSEEK_MODELS
+        .iter()
+        .map(|model| model.to_string())
+        .collect::<Vec<_>>();
+    let changed = account.api_base_url.as_deref() != Some(canonical_base_url.as_str())
+        || account.api_wire_api.as_deref() != Some(CODEX_PROVIDER_WIRE_API)
+        || account.api_provider_mode != CodexApiProviderMode::Custom
+        || account.api_model_catalog != model_catalog;
+    if !changed {
+        return false;
+    }
+
+    account.api_base_url = Some(canonical_base_url);
+    account.api_wire_api = Some(CODEX_PROVIDER_WIRE_API.to_string());
+    account.api_provider_mode = CodexApiProviderMode::Custom;
+    account.api_model_catalog = model_catalog;
     true
 }
 
@@ -1187,7 +1248,7 @@ fn remove_managed_model_catalog_from_doc(doc: &mut Document) -> bool {
 
 fn account_syncs_model_catalog_to_codex(account: &CodexAccount) -> bool {
     account.is_api_key_auth()
-        && account.api_sync_model_catalog_to_codex
+        && (account.api_sync_model_catalog_to_codex || is_official_deepseek_account(account))
         && account.api_provider_mode == CodexApiProviderMode::Custom
         && account
             .api_wire_api
@@ -1202,10 +1263,12 @@ fn sync_api_key_model_catalog_to_dir(
     base_dir: &Path,
     account: &CodexAccount,
 ) -> Result<bool, String> {
+    if is_official_deepseek_account(account) {
+        return sync_official_deepseek_model_catalog_to_dir(base_dir, account);
+    }
     if !account_syncs_model_catalog_to_codex(account) {
         return Ok(false);
     }
-
     let config_path = get_config_toml_path(base_dir);
     let existing = fs::read_to_string(&config_path).unwrap_or_default();
     let mut doc = if existing.trim().is_empty() {
@@ -1267,6 +1330,80 @@ fn sync_api_key_model_catalog_to_dir(
     if let Err(err) = refresh_api_key_provider_projection_in_dir(base_dir, account) {
         logger::log_warn(&format!(
             "[Codex切号] 同步模型目录后刷新 provider 生图配置失败: path={}, error={}",
+            base_dir.display(),
+            err
+        ));
+    }
+    Ok(true)
+}
+
+fn sync_official_deepseek_model_catalog_to_dir(
+    base_dir: &Path,
+    account: &CodexAccount,
+) -> Result<bool, String> {
+    let mut model_ids = normalize_api_model_catalog(account.api_model_catalog.clone());
+    if model_ids.is_empty() {
+        return cleanup_managed_model_catalog_for_dir(base_dir);
+    }
+    if !model_ids
+        .iter()
+        .any(|model| model.eq_ignore_ascii_case(CODEX_AUTO_REVIEW_MODEL_ID))
+    {
+        model_ids.push(CODEX_AUTO_REVIEW_MODEL_ID.to_string());
+    }
+
+    let config_path = get_config_toml_path(base_dir);
+    let existing = fs::read_to_string(&config_path).unwrap_or_default();
+    let mut doc = if existing.trim().is_empty() {
+        Document::new()
+    } else {
+        crate::modules::codex_config_format::read_codex_config_doc_from_str(&existing)
+            .map_err(|e| format!("解析 config.toml 失败: {}", e))?
+    };
+    if let Some(configured_catalog) = doc
+        .get(CODEX_CONFIG_MODEL_CATALOG_JSON_KEY)
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if configured_catalog != CODEX_MANAGED_MODEL_CATALOG_FILE
+            && configured_catalog != CODEX_LOCAL_ACCESS_MODEL_CATALOG_FILE
+        {
+            return Ok(false);
+        }
+    }
+
+    crate::modules::codex_local_access::backup_current_profile_model_before_provider_gateway(
+        base_dir,
+        &DEEPSEEK_MODELS
+            .iter()
+            .map(|model| model.to_string())
+            .collect::<Vec<_>>(),
+    )?;
+    let catalog = crate::modules::codex_protocol::build_codex_client_models_response(&model_ids);
+    let content = serde_json::to_string_pretty(&catalog)
+        .map_err(|e| format!("生成 Codex 模型目录失败: {}", e))?;
+    let catalog_path = base_dir.join(CODEX_MANAGED_MODEL_CATALOG_FILE);
+    write_string_atomic(&catalog_path, &content).map_err(|e| {
+        format!(
+            "写入 Codex 模型目录失败: path={}, error={}",
+            catalog_path.display(),
+            e
+        )
+    })?;
+
+    doc[CODEX_CONFIG_MODEL_CATALOG_JSON_KEY] = value(CODEX_MANAGED_MODEL_CATALOG_FILE);
+    doc["model"] = value(
+        current_deepseek_model(base_dir)
+            .as_deref()
+            .unwrap_or(DEEPSEEK_DEFAULT_MODEL),
+    );
+    let content = crate::modules::codex_config_format::codex_config_doc_to_string(&mut doc);
+    crate::modules::codex_config_format::write_codex_config_toml_atomic(&config_path, &content)
+        .map_err(|e| format!("写入 config.toml 失败: {}", e))?;
+    if let Err(err) = refresh_api_key_provider_projection_in_dir(base_dir, account) {
+        logger::log_warn(&format!(
+            "[Codex切号] 同步 DeepSeek 模型目录后刷新 provider 生图配置失败: path={}, error={}",
             base_dir.display(),
             err
         ));
@@ -3108,7 +3245,16 @@ fn parse_codex_account_compat(
 
 /// 读取单个账号详情
 pub fn load_account(account_id: &str) -> Option<CodexAccount> {
-    load_account_with_summary(account_id, None).ok().flatten()
+    match load_account_with_summary(account_id, None) {
+        Ok(account) => account,
+        Err(error) => {
+            logger::log_warn(&format!(
+                "[Codex Account] 读取账号详情失败: account_id={}, error={}",
+                account_id, error
+            ));
+            None
+        }
+    }
 }
 
 /// 绑定 OAuth 的 API Key：不走本地网关生图兼容（保持绑定显示/客户端能力）。
@@ -3171,10 +3317,15 @@ fn load_account_with_summary(
         let cleared_bound_oauth_gateway = clear_bound_oauth_local_gateway_flag(&mut account);
         let migrated_wire_api = migrate_apikey_fun_wire_api(&mut account);
         let migrated_websocket = normalize_api_key_websocket_capability(&mut account);
+        let migrated_deepseek = migrate_official_deepseek_account(&mut account);
+        if migrated_deepseek {
+            write_migrated_deepseek_projections(&account)?;
+        }
         if needs_rotation
             || migrated_wire_api
             || migrated_websocket
             || cleared_bound_oauth_gateway
+            || migrated_deepseek
             || migrated_index_summary
         {
             let account_for_rewrite = account.clone();
@@ -3198,9 +3349,13 @@ fn load_account_with_summary(
         .map_err(|error| format!("账号详情不是有效 JSON ({}): {}", path.display(), error))?;
     let mut account = parse_codex_account_compat(value.clone(), account_id, summary)?
         .ok_or_else(|| format!("账号详情缺少可识别凭据 ({})", path.display()))?;
+    let migrated_deepseek = migrate_official_deepseek_account(&mut account);
     let _ = migrate_apikey_fun_wire_api(&mut account);
     let _ = clear_bound_oauth_local_gateway_flag(&mut account);
 
+    if migrated_deepseek {
+        write_migrated_deepseek_projections(&account)?;
+    }
     let account_for_rewrite = account.clone();
     crate::modules::deferred_account_rewrite::schedule_account_rewrite_if_unchanged(
         "codex",
@@ -3673,6 +3828,7 @@ pub fn upsert_api_key_account(
     };
 
     account.auth_mode = CodexAuthMode::Apikey;
+    let _ = migrate_official_deepseek_account(&mut account);
     save_account(&account)?;
 
     if let Some(summary) = index.accounts.iter_mut().find(|item| item.id == account.id) {
@@ -4871,8 +5027,6 @@ pub fn write_auth_file_to_dir(base_dir: &Path, account: &CodexAccount) -> Result
         auth_path.display()
     ));
 
-    crate::modules::codex_local_access::cleanup_provider_gateway_profile_model_overrides(base_dir)?;
-
     let auth_file = build_auth_file_value(account)?;
     let content =
         serde_json::to_string_pretty(&auth_file).map_err(|e| format!("序列化失败: {}", e))?;
@@ -4932,6 +5086,7 @@ pub(crate) fn write_prepared_account_bundle_to_dir(
     base_dir: &Path,
     account: &CodexAccount,
 ) -> Result<(), String> {
+    crate::modules::codex_local_access::cleanup_provider_gateway_profile_model_overrides(base_dir)?;
     write_auth_file_to_dir(base_dir, account)?;
     if let Err(err) = write_codex_keychain_to_dir(base_dir, account) {
         logger::log_warn(&format!(
@@ -5489,6 +5644,63 @@ fn write_managed_account_projections(account: &CodexAccount) {
             account.id, err
         ));
     }
+}
+
+fn write_migrated_deepseek_projections(account: &CodexAccount) -> Result<(), String> {
+    let mut dirs = Vec::new();
+    let current_account_id = fs::read_to_string(get_accounts_storage_path())
+        .ok()
+        .and_then(|content| serde_json::from_str::<CodexAccountIndex>(&content).ok())
+        .and_then(|index| index.current_account_id);
+    if current_account_id.as_deref() == Some(account.id.as_str()) {
+        dirs.push(get_codex_home());
+        if let Some(wsl_dir) = configured_codex_wsl_config_dir() {
+            dirs.push(wsl_dir);
+        }
+    }
+    if let Ok(store) = crate::modules::codex_instance::load_instance_store() {
+        if store.default_settings.bind_account_id.as_deref() == Some(account.id.as_str()) {
+            if let Ok(default_home) = crate::modules::codex_instance::get_default_codex_home() {
+                dirs.push(default_home);
+            }
+        }
+        dirs.extend(
+            store
+                .instances
+                .into_iter()
+                .filter(|instance| instance.bind_account_id.as_deref() == Some(account.id.as_str()))
+                .map(|instance| PathBuf::from(instance.user_data_dir)),
+        );
+    }
+
+    let mut seen = HashSet::new();
+    dirs.retain(|dir| seen.insert(dir.to_string_lossy().to_string()));
+    for dir in &dirs {
+        account
+            .bound_oauth_account_id
+            .as_deref()
+            .and_then(load_account)
+            .map_or_else(
+                || write_prepared_account_bundle_to_dir(&dir, account),
+                |oauth| write_api_key_account_bundle_with_oauth_to_dir(&dir, account, &oauth),
+            )
+            .map_err(|error| {
+                format!(
+                    "DeepSeek 受管投影迁移失败: account_id={}, target_dir={}, error={}",
+                    account.id,
+                    dir.display(),
+                    error
+                )
+            })?;
+    }
+    for dir in dirs {
+        crate::modules::codex_local_access::reload_provider_gateway_for_profile_in_background(
+            dir,
+            account.id.clone(),
+            "DeepSeek Responses 迁移后清理旧网关",
+        );
+    }
+    Ok(())
 }
 
 pub fn is_managed_auth_refresh_due(account: &CodexAccount) -> bool {
@@ -9040,7 +9252,7 @@ mod tests {
         format_refresh_error_for_user, get_accounts_dir, get_accounts_storage_path,
         get_current_account_from_loaded, import_from_json, is_loopback_http_base_url,
         is_managed_auth_refresh_due, is_pending_oauth_account, list_accounts_checked, load_account,
-        load_account_index, looks_like_sub2api_export, now_timestamp,
+        load_account_index, load_account_with_summary, looks_like_sub2api_export, now_timestamp,
         parse_agent_identity_from_value, parse_auth_file_last_refresh, parse_codex_account_compat,
         parse_line_delimited_json_values, read_api_provider_from_config_toml,
         read_quick_config_from_config_toml, remove_accounts, resolve_api_provider_config,
@@ -9928,6 +10140,137 @@ mod tests {
 
         let loaded = load_account(&account.id).expect("load account");
         assert_eq!(loaded.bound_oauth_account_id.as_deref(), Some("oauth-1"));
+        assert!(!loaded.bound_oauth_use_local_gateway);
+    }
+
+    #[test]
+    fn load_account_migrates_only_official_deepseek_to_responses() {
+        let _lock = crate::modules::test_support::env_lock()
+            .lock()
+            .expect("lock test env");
+        let _env = TestEnvGuard::new("codex-deepseek-responses-migration");
+        let mut account = CodexAccount::new_api_key(
+            "deepseek-legacy".to_string(),
+            "deepseek@example.com".to_string(),
+            "sk-deepseek".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.deepseek.com/v1/".to_string()),
+            Some("deepseek".to_string()),
+            Some("DeepSeek".to_string()),
+            vec!["deepseek-chat".to_string()],
+        );
+        account.api_wire_api = Some("chat_completions".to_string());
+        save_account(&account).expect("write legacy account");
+
+        let migrated = load_account(&account.id).expect("load migrated account");
+        assert_eq!(
+            migrated.api_base_url.as_deref(),
+            Some("https://api.deepseek.com")
+        );
+        assert_eq!(migrated.api_wire_api.as_deref(), Some("responses"));
+        assert_eq!(
+            migrated.api_model_catalog,
+            vec![
+                "deepseek-v4-pro".to_string(),
+                "deepseek-v4-flash".to_string()
+            ]
+        );
+
+        let first_persisted =
+            fs::read_to_string(get_accounts_dir().join(format!("{}.json", account.id)))
+                .expect("read first migration");
+        let reloaded = load_account(&account.id).expect("reload migrated account");
+        let second_persisted =
+            fs::read_to_string(get_accounts_dir().join(format!("{}.json", account.id)))
+                .expect("read second migration");
+        assert_eq!(reloaded.api_wire_api.as_deref(), Some("responses"));
+        assert_eq!(first_persisted, second_persisted);
+
+        let mut relay = account.clone();
+        relay.id = "deepseek-relay".to_string();
+        relay.api_base_url = Some("https://deepseek.example.com/v1".to_string());
+        relay.api_wire_api = Some("chat_completions".to_string());
+        relay.api_model_catalog = vec!["deepseek-chat".to_string()];
+        save_account(&relay).expect("write relay account");
+        let unchanged = load_account(&relay.id).expect("load relay account");
+        assert_eq!(unchanged.api_wire_api.as_deref(), Some("chat_completions"));
+        assert_eq!(unchanged.api_model_catalog, vec!["deepseek-chat"]);
+    }
+
+    #[test]
+    fn failed_deepseek_projection_keeps_account_pending_for_retry() {
+        let _lock = crate::modules::test_support::env_lock()
+            .lock()
+            .expect("lock test env");
+        let env = TestEnvGuard::new("codex-deepseek-migration-retry");
+        let mut account = CodexAccount::new_api_key(
+            "deepseek-retry".to_string(),
+            "deepseek@example.com".to_string(),
+            "sk-deepseek".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.deepseek.com/v1".to_string()),
+            Some("deepseek".to_string()),
+            Some("DeepSeek".to_string()),
+            vec!["deepseek-chat".to_string()],
+        );
+        account.api_wire_api = Some("chat_completions".to_string());
+        save_account(&account).expect("write legacy account");
+        save_account_index(&build_test_account_index(&account)).expect("write account index");
+
+        let auth_path = env.codex_home().join("auth.json");
+        fs::create_dir(&auth_path).expect("block projection auth file");
+        let error = load_account_with_summary(&account.id, None)
+            .expect_err("projection failure should abort migration");
+        assert!(error.contains("DeepSeek 受管投影迁移失败"));
+        let account_path = get_accounts_dir().join(format!("{}.json", account.id));
+        let account_content = fs::read_to_string(&account_path).expect("read account");
+        let (unchanged, _) = crate::modules::secure_account_storage::deserialize_account_file::<
+            CodexAccount,
+        >(&account_path, &account_content)
+        .expect("decrypt account");
+        assert_eq!(unchanged.api_wire_api.as_deref(), Some("chat_completions"));
+
+        fs::remove_dir(&auth_path).expect("unblock projection auth file");
+        let migrated = load_account_with_summary(&account.id, None)
+            .expect("retry migration")
+            .expect("migrated account");
+        assert_eq!(migrated.api_wire_api.as_deref(), Some("responses"));
+    }
+
+    #[test]
+    fn load_account_respects_explicit_bound_oauth_image_generation_false() {
+        let _lock = crate::modules::test_support::env_lock()
+            .lock()
+            .expect("lock test env");
+        let _env = TestEnvGuard::new("codex-bound-oauth-explicit-false");
+        let mut account = CodexAccount::new_api_key(
+            "api-bound-oauth-explicit-false".to_string(),
+            "api-key@example.com".to_string(),
+            "sk-test".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://relay.example/v1".to_string()),
+            Some("relay".to_string()),
+            Some("Relay".to_string()),
+            vec!["gpt-5.5".to_string()],
+        );
+        account.bound_oauth_account_id = Some("oauth-1".to_string());
+        let accounts_dir = get_accounts_dir();
+        fs::create_dir_all(&accounts_dir).expect("create accounts dir");
+        let mut value = serde_json::to_value(&account).expect("serialize account");
+        value
+            .as_object_mut()
+            .expect("account should be object")
+            .insert(
+                "bound_oauth_use_local_gateway".to_string(),
+                serde_json::json!(false),
+            );
+        fs::write(
+            accounts_dir.join(format!("{}.json", account.id)),
+            serde_json::to_string_pretty(&value).expect("serialize account"),
+        )
+        .expect("write account");
+
+        let loaded = load_account(&account.id).expect("load account");
         assert!(!loaded.bound_oauth_use_local_gateway);
     }
 
@@ -12934,6 +13277,132 @@ supports_websockets = false
     }
 
     #[test]
+    fn deepseek_bundle_defaults_to_pro_and_restores_previous_model() {
+        let base_dir = make_temp_dir("codex-deepseek-model-transition-test");
+        fs::write(base_dir.join("config.toml"), "model = \"gpt-5.5\"\n")
+            .expect("write initial model");
+        let mut deepseek = CodexAccount::new_api_key(
+            "deepseek-api-key".to_string(),
+            "deepseek@example.com".to_string(),
+            "sk-deepseek".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.deepseek.com".to_string()),
+            Some("deepseek".to_string()),
+            Some("DeepSeek".to_string()),
+            vec![
+                "deepseek-v4-pro".to_string(),
+                "deepseek-v4-flash".to_string(),
+            ],
+        );
+        deepseek.api_wire_api = Some("responses".to_string());
+
+        write_account_bundle_to_dir(&base_dir, &deepseek).expect("write deepseek bundle");
+        let deepseek_config =
+            fs::read_to_string(base_dir.join("config.toml")).expect("read deepseek config");
+        assert!(deepseek_config.contains("model = \"deepseek-v4-pro\""));
+
+        let oauth = CodexAccount::new(
+            "openai-oauth".to_string(),
+            "openai@example.com".to_string(),
+            CodexTokens {
+                id_token: "id-token".to_string(),
+                access_token: "access-token".to_string(),
+                refresh_token: Some("refresh-token".to_string()),
+            },
+        );
+        write_account_bundle_to_dir(&base_dir, &oauth).expect("write oauth bundle");
+        let restored = fs::read_to_string(base_dir.join("config.toml")).expect("read config");
+        assert!(restored.contains("model = \"gpt-5.5\""));
+        assert!(!restored.contains("deepseek-v4-pro"));
+
+        fs::remove_dir_all(&base_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn leaving_deepseek_preserves_a_manually_selected_non_deepseek_model() {
+        let base_dir = make_temp_dir("codex-deepseek-manual-model-transition-test");
+        fs::write(base_dir.join("config.toml"), "model = \"gpt-5.5\"\n")
+            .expect("write initial model");
+        let mut deepseek = CodexAccount::new_api_key(
+            "deepseek-api-key".to_string(),
+            "deepseek@example.com".to_string(),
+            "sk-deepseek".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.deepseek.com".to_string()),
+            Some("deepseek".to_string()),
+            Some("DeepSeek".to_string()),
+            vec![
+                "deepseek-v4-pro".to_string(),
+                "deepseek-v4-flash".to_string(),
+            ],
+        );
+        deepseek.api_wire_api = Some("responses".to_string());
+
+        write_account_bundle_to_dir(&base_dir, &deepseek).expect("write deepseek bundle");
+        fs::write(base_dir.join("config.toml"), "model = \"gpt-5.6\"\n")
+            .expect("manually change model");
+
+        let oauth = CodexAccount::new(
+            "openai-oauth".to_string(),
+            "openai@example.com".to_string(),
+            CodexTokens {
+                id_token: "id-token".to_string(),
+                access_token: "access-token".to_string(),
+                refresh_token: Some("refresh-token".to_string()),
+            },
+        );
+        write_account_bundle_to_dir(&base_dir, &oauth).expect("write oauth bundle");
+        let config = fs::read_to_string(base_dir.join("config.toml")).expect("read config");
+        assert!(config.contains("model = \"gpt-5.6\""));
+        assert!(!config.contains("model = \"gpt-5.5\""));
+
+        fs::remove_dir_all(&base_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn api_key_bundle_cleans_empty_managed_model_catalog() {
+        let base_dir = make_temp_dir("codex-api-key-empty-model-catalog-test");
+        fs::write(
+            base_dir.join("config.toml"),
+            format!(
+                "model_catalog_json = \"{}\"\n",
+                super::CODEX_MANAGED_MODEL_CATALOG_FILE
+            ),
+        )
+        .expect("write config");
+        fs::write(
+            base_dir.join(super::CODEX_MANAGED_MODEL_CATALOG_FILE),
+            r#"{"models":[]}"#,
+        )
+        .expect("write managed catalog");
+        let mut account = CodexAccount::new_api_key(
+            "custom-api-key".to_string(),
+            "custom@example.com".to_string(),
+            "sk-custom".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://relay.example.com/v1".to_string()),
+            Some("relay".to_string()),
+            Some("Relay".to_string()),
+            Vec::new(),
+        );
+        account.api_wire_api = Some("responses".to_string());
+        account.api_supports_websockets = true;
+
+        write_account_bundle_to_dir(&base_dir, &account).expect("write account bundle");
+
+        let config = fs::read_to_string(base_dir.join("config.toml")).expect("read config");
+        assert!(config.contains("openai_base_url = \"https://relay.example.com/v1\""));
+        assert!(!config.contains("codex_local_access"));
+        assert!(!config.contains("supports_websockets = "));
+        assert!(!config.contains("model_catalog_json"));
+        assert!(!base_dir
+            .join(super::CODEX_MANAGED_MODEL_CATALOG_FILE)
+            .exists());
+
+        fs::remove_dir_all(&base_dir).expect("cleanup temp dir");
+    }
+
+    #[test]
     fn cleanup_removes_existing_managed_model_catalog() {
         let base_dir = make_temp_dir("codex-managed-model-catalog-cleanup-test");
         fs::write(
@@ -13360,6 +13829,22 @@ multi_agent = true
         let err = validate_api_key_credentials("http://127.0.0.1:3000/v1", None)
             .expect_err("url should be rejected as api key");
         assert!(err.contains("API Key 不能是 URL"));
+    }
+
+    #[test]
+    fn official_deepseek_base_urls_are_canonicalized() {
+        assert_eq!(
+            super::normalize_api_base_url(Some("https://api.deepseek.com/v1/")),
+            Some("https://api.deepseek.com".to_string())
+        );
+        assert_eq!(
+            super::normalize_api_base_url(Some("HTTP://API.DEEPSEEK.COM/v1")),
+            Some("https://api.deepseek.com".to_string())
+        );
+        assert_eq!(
+            super::normalize_api_base_url(Some("https://deepseek.example.com/v1/")),
+            Some("https://deepseek.example.com/v1".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -16977,7 +16977,6 @@ fn provider_gateway_wire_api_for_account(account: &CodexAccount) -> String {
         .and_then(|url| url.host_str().map(|host| host.to_ascii_lowercase()))
         .unwrap_or_default();
     let chat_hosts = [
-        "api.deepseek.com",
         "api.moonshot.cn",
         "api.siliconflow.cn",
         "api.siliconflow.com",
@@ -17943,7 +17942,7 @@ fn delete_provider_model_backup(profile_dir: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn backup_current_profile_model_before_provider_gateway(
+pub(crate) fn backup_current_profile_model_before_provider_gateway(
     profile_dir: &Path,
     provider_models: &[String],
 ) -> Result<(), String> {
@@ -18000,22 +17999,22 @@ pub fn cleanup_provider_gateway_profile_model_overrides(profile_dir: &Path) -> R
             doc.remove("model_catalog_json");
             changed = true;
         }
-        if let Some(previous_model) = previous_model.as_deref() {
-            doc["model"] = value(previous_model);
-            changed = true;
-        } else {
-            let current_model = doc
-                .get("model")
-                .and_then(|item| item.as_str())
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_ascii_lowercase);
-            if let Some(model) = current_model {
-                if managed_models.contains(&model) {
-                    doc.remove("model");
-                    changed = true;
-                }
+        let current_model = doc
+            .get("model")
+            .and_then(|item| item.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_ascii_lowercase);
+        let current_is_managed = current_model
+            .as_ref()
+            .is_some_and(|model| managed_models.contains(model));
+        if current_is_managed || (managed_models.is_empty() && uses_managed_catalog) {
+            if let Some(previous_model) = previous_model.as_deref() {
+                doc["model"] = value(previous_model);
+            } else {
+                doc.remove("model");
             }
+            changed = true;
         }
         if changed {
             let content = crate::modules::codex_config_format::codex_config_doc_to_string(&mut doc);
@@ -18451,7 +18450,10 @@ pub fn reload_provider_gateway_for_profile_in_background(
             Some(account) if account_requires_bound_oauth_local_gateway(&account) => {
                 ensure_bound_oauth_local_gateway_for_dir(&profile_dir, &account_id).await
             }
-            Some(_) => Ok(()),
+            Some(_) => {
+                stop_provider_gateways_for_profile(&profile_dir).await;
+                Ok(())
+            }
             None => Err(format!("账号不存在: {}", account_id)),
         };
         match result {
@@ -26876,6 +26878,22 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings
     }
 
     #[test]
+    fn official_deepseek_defaults_to_responses_without_gateway() {
+        let account = CodexAccount::new_api_key(
+            "local-account-id".to_string(),
+            "deepseek@example.com".to_string(),
+            "sk-test".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://api.deepseek.com/v1".to_string()),
+            Some("deepseek".to_string()),
+            Some("DeepSeek".to_string()),
+            Vec::new(),
+        );
+
+        assert!(!account_requires_provider_gateway(&account));
+    }
+
+    #[test]
     fn responses_bound_oauth_api_key_uses_local_access_pool() {
         let mut account = CodexAccount::new_api_key(
             "local-account-id".to_string(),
@@ -27139,6 +27157,18 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings
                     && model.get("visibility").and_then(Value::as_str) == Some("list")
             }));
         }
+        assert!(models.iter().any(|model| {
+            model.get("slug").and_then(Value::as_str) == Some("deepseek-v4-flash")
+                && model.get("display_name").and_then(Value::as_str) == Some("DeepSeek-V4-Flash")
+                && model.get("visibility").and_then(Value::as_str) == Some("list")
+        }));
+        assert!(models
+            .iter()
+            .any(|model| { model.get("slug").and_then(Value::as_str) == Some("deepseek-v4-pro") }));
+        assert!(models.iter().any(|model| {
+            model.get("slug").and_then(Value::as_str) == Some(CODEX_AUTO_REVIEW_MODEL_ID)
+                && model.get("visibility").and_then(Value::as_str) == Some("hide")
+        }));
         let config =
             fs::read_to_string(profile_dir.join(CODEX_PROFILE_CONFIG_FILE)).expect("read config");
         assert!(config.contains(&format!(

--- a/src-tauri/src/modules/codex_protocol.rs
+++ b/src-tauri/src/modules/codex_protocol.rs
@@ -298,6 +298,42 @@ fn build_codex_client_model(model_id: &str, index: usize) -> Value {
     object.insert("supported_in_api".to_string(), Value::Bool(true));
     object.insert("availability_nux".to_string(), Value::Null);
     object.insert("upgrade".to_string(), Value::Null);
+    if matches!(model_id, "deepseek-v4-pro" | "deepseek-v4-flash") {
+        object.insert("prefer_websockets".to_string(), Value::Bool(false));
+        object.insert(
+            "web_search_tool_type".to_string(),
+            Value::String("text".to_string()),
+        );
+        object.insert("input_modalities".to_string(), json!(["text"]));
+        object.insert(
+            "supports_image_detail_original".to_string(),
+            Value::Bool(false),
+        );
+        object.insert(
+            "truncation_policy".to_string(),
+            json!({ "mode": "tokens", "limit": 10_000 }),
+        );
+        object.insert("multi_agent_version".to_string(), json!("v2"));
+        object.insert("use_responses_lite".to_string(), Value::Bool(false));
+        object.insert(
+            "include_skills_usage_instructions".to_string(),
+            Value::Bool(false),
+        );
+        object.insert("context_window".to_string(), json!(1_048_576));
+        object.insert("max_context_window".to_string(), json!(1_048_576));
+        object.insert("effective_context_window_percent".to_string(), json!(95));
+        object.insert("default_reasoning_level".to_string(), json!("high"));
+        object.insert(
+            "supported_reasoning_levels".to_string(),
+            json!([
+                { "effort": "low", "description": "Fast responses with lighter reasoning" },
+                { "effort": "high", "description": "Extra high reasoning depth for complex problems" },
+                { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" }
+            ]),
+        );
+        object.insert("minimal_client_version".to_string(), json!("0.144.0"));
+        object.insert("priority".to_string(), json!(index + 1));
+    }
     model
 }
 
@@ -372,6 +408,8 @@ fn display_name_for_model(model_id: &str) -> String {
         "gpt-5.1-codex-max" => "GPT-5.1 Codex Max".to_string(),
         "gpt-5.1-codex-mini" => "GPT-5.1 Codex Mini".to_string(),
         "gpt-image-2" => "GPT Image 2".to_string(),
+        "deepseek-v4-pro" => "DeepSeek-V4-Pro".to_string(),
+        "deepseek-v4-flash" => "DeepSeek-V4-Flash".to_string(),
         CODEX_AUTO_REVIEW_MODEL_ID => "Codex Auto Review".to_string(),
         other => other.to_string(),
     }
@@ -1034,5 +1072,61 @@ mod tests {
                 .map(Vec::len),
             Some(0)
         );
+    }
+
+    #[test]
+    fn deepseek_models_use_official_codex_metadata() {
+        let response = build_codex_client_models_response(&[
+            "deepseek-v4-pro".to_string(),
+            "deepseek-v4-flash".to_string(),
+        ]);
+
+        for index in 0..2 {
+            let model = response
+                .pointer(&format!("/models/{index}"))
+                .expect("deepseek model");
+            assert_eq!(
+                model.get("context_window").and_then(Value::as_i64),
+                Some(1_048_576)
+            );
+            assert_eq!(
+                model.get("max_context_window").and_then(Value::as_i64),
+                Some(1_048_576)
+            );
+            assert_eq!(
+                model
+                    .get("effective_context_window_percent")
+                    .and_then(Value::as_i64),
+                Some(95)
+            );
+            assert_eq!(
+                model.get("prefer_websockets").and_then(Value::as_bool),
+                Some(false)
+            );
+            assert_eq!(
+                model.get("input_modalities").and_then(Value::as_array),
+                Some(&vec![Value::String("text".to_string())])
+            );
+            assert_eq!(
+                model.get("web_search_tool_type").and_then(Value::as_str),
+                Some("text")
+            );
+            assert_eq!(
+                model.get("default_reasoning_level").and_then(Value::as_str),
+                Some("high")
+            );
+            assert_eq!(
+                model.get("minimal_client_version").and_then(Value::as_str),
+                Some("0.144.0")
+            );
+            let efforts = model
+                .get("supported_reasoning_levels")
+                .and_then(Value::as_array)
+                .expect("reasoning levels")
+                .iter()
+                .filter_map(|level| level.get("effort").and_then(Value::as_str))
+                .collect::<Vec<_>>();
+            assert_eq!(efforts, vec!["low", "high", "max"]);
+        }
     }
 }

--- a/src-tauri/src/modules/macos_native_menu.rs
+++ b/src-tauri/src/modules/macos_native_menu.rs
@@ -1101,6 +1101,115 @@ mod imp {
             .unwrap_or_else(|| "-".to_string())
     }
 
+    fn format_deepseek_balance_money(value: &str, currency: &str) -> String {
+        let amount = value.trim();
+        let unit = currency.trim().to_ascii_uppercase();
+        if amount.is_empty() {
+            return "-".to_string();
+        }
+        if unit == "USD" {
+            format!("${amount}")
+        } else if unit.is_empty() {
+            amount.to_string()
+        } else {
+            format!("{amount} {unit}")
+        }
+    }
+
+    fn build_deepseek_usage_rows(lang: &str, summary: &Value) -> Option<Vec<QuotaRow>> {
+        if json_path(Some(summary), &["mode"])
+            .and_then(Value::as_str)
+            .map(str::trim)
+            != Some("deepseek")
+        {
+            return None;
+        }
+        if json_path(Some(summary), &["isAvailable"]).and_then(json_bool) == Some(false) {
+            return Some(vec![make_text_row(
+                translate_or(
+                    lang,
+                    "codex.modelProviders.usage.accountBalance",
+                    "Account Balance",
+                    &[],
+                ),
+                translate_or(
+                    lang,
+                    "codex.modelProviders.usage.balanceUnavailable",
+                    "Balance unavailable",
+                    &[],
+                ),
+                None,
+            )]);
+        }
+
+        let infos = json_path(Some(summary), &["balanceInfos"])
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let preferred_currency = if matches!(normalize_lang(lang).as_str(), "zh-cn" | "zh-tw") {
+            "CNY"
+        } else {
+            "USD"
+        };
+        let balance = infos
+            .iter()
+            .find(|info| {
+                json_path(Some(info), &["currency"])
+                    .and_then(Value::as_str)
+                    .is_some_and(|currency| currency.eq_ignore_ascii_case(preferred_currency))
+            })
+            .or_else(|| infos.first());
+        let Some(balance) = balance else {
+            return Some(vec![make_text_row(
+                translate_or(
+                    lang,
+                    "codex.modelProviders.usage.accountBalance",
+                    "Account Balance",
+                    &[],
+                ),
+                translate_or(
+                    lang,
+                    "codex.modelProviders.usage.noBalanceData",
+                    "No balance data",
+                    &[],
+                ),
+                None,
+            )]);
+        };
+        let currency = json_path(Some(balance), &["currency"])
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let row = |key: &str, fallback: &str, field: &str| {
+            make_text_row(
+                translate_or(lang, key, fallback, &[]),
+                format_deepseek_balance_money(
+                    json_path(Some(balance), &[field])
+                        .and_then(Value::as_str)
+                        .unwrap_or_default(),
+                    currency,
+                ),
+                None,
+            )
+        };
+        Some(vec![
+            row(
+                "codex.modelProviders.usage.totalBalance",
+                "Total Balance",
+                "totalBalance",
+            ),
+            row(
+                "codex.modelProviders.usage.grantedBalance",
+                "Granted Balance",
+                "grantedBalance",
+            ),
+            row(
+                "codex.modelProviders.usage.toppedUpBalance",
+                "Topped-up Balance",
+                "toppedUpBalance",
+            ),
+        ])
+    }
+
     fn build_codex_api_key_usage_rows(
         lang: &str,
         account: &crate::models::codex::CodexAccount,
@@ -1112,6 +1221,9 @@ mod imp {
                 Some(modules::i18n::translate(lang, "common.refresh", &[])),
             )];
         };
+        if let Some(rows) = build_deepseek_usage_rows(lang, summary) {
+            return rows;
+        }
         let mode = json_path(Some(summary), &["mode"])
             .and_then(Value::as_str)
             .map(str::trim)
@@ -4756,7 +4868,7 @@ mod imp {
         base_url: &str,
         mode: &str,
     ) -> Result<(), String> {
-        if mode != "new_api" && mode != "sub2api" {
+        if mode != "new_api" && mode != "sub2api" && mode != "deepseek" {
             return Ok(());
         }
         let raw = commands::codex::load_codex_model_providers().await?;
@@ -4796,6 +4908,38 @@ mod imp {
                                 chrono::Utc::now().timestamp_millis(),
                             )),
                         );
+                        changed = true;
+                    }
+                }
+                if mode == "deepseek" {
+                    let expected_models =
+                        serde_json::json!(["deepseek-v4-pro", "deepseek-v4-flash"]);
+                    let needs_normalization = json_path(Some(provider), &["baseUrl"])
+                        .and_then(Value::as_str)
+                        != Some("https://api.deepseek.com")
+                        || json_path(Some(provider), &["wireApi"]).and_then(Value::as_str)
+                            != Some("responses")
+                        || json_path(Some(provider), &["enableModePreference"])
+                            .and_then(Value::as_str)
+                            != Some("direct")
+                        || json_path(Some(provider), &["modelCatalog"]) != Some(&expected_models);
+                    if needs_normalization {
+                        let object = provider
+                            .as_object_mut()
+                            .expect("provider object validated while loading");
+                        object.insert(
+                            "baseUrl".to_string(),
+                            Value::String("https://api.deepseek.com".to_string()),
+                        );
+                        object.insert(
+                            "wireApi".to_string(),
+                            Value::String("responses".to_string()),
+                        );
+                        object.insert(
+                            "enableModePreference".to_string(),
+                            Value::String("direct".to_string()),
+                        );
+                        object.insert("modelCatalog".to_string(), expected_models);
                         changed = true;
                     }
                 }
@@ -5185,6 +5329,70 @@ mod imp {
     fn open_main_window() {
         if let Some(app) = crate::get_app_handle() {
             let _ = modules::floating_card_window::show_main_window(app);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn deepseek_menu_balance_uses_language_currency_and_fallback() {
+            let summary = serde_json::json!({
+                "mode": "deepseek",
+                "isAvailable": true,
+                "balanceInfos": [
+                    {
+                        "currency": "USD",
+                        "totalBalance": "1.25",
+                        "grantedBalance": "0.25",
+                        "toppedUpBalance": "1.00"
+                    },
+                    {
+                        "currency": "CNY",
+                        "totalBalance": "9.0000",
+                        "grantedBalance": "1.0000",
+                        "toppedUpBalance": "8.0000"
+                    }
+                ]
+            });
+
+            let zh_rows = build_deepseek_usage_rows("zh-tw", &summary).expect("deepseek rows");
+            assert_eq!(zh_rows[0].value, "9.0000 CNY");
+            let en_rows = build_deepseek_usage_rows("en", &summary).expect("deepseek rows");
+            assert_eq!(en_rows[0].value, "$1.25");
+
+            let fallback = serde_json::json!({
+                "mode": "deepseek",
+                "isAvailable": true,
+                "balanceInfos": [{
+                    "currency": "EUR",
+                    "totalBalance": "2.50",
+                    "grantedBalance": "0.00",
+                    "toppedUpBalance": "2.50"
+                }]
+            });
+            let fallback_rows =
+                build_deepseek_usage_rows("zh-cn", &fallback).expect("fallback rows");
+            assert_eq!(fallback_rows[0].value, "2.50 EUR");
+        }
+
+        #[test]
+        fn deepseek_menu_balance_unavailable_hides_amounts() {
+            let summary = serde_json::json!({
+                "mode": "deepseek",
+                "isAvailable": false,
+                "balanceInfos": [{
+                    "currency": "CNY",
+                    "totalBalance": "9.00",
+                    "grantedBalance": "1.00",
+                    "toppedUpBalance": "8.00"
+                }]
+            });
+
+            let rows = build_deepseek_usage_rows("zh-cn", &summary).expect("deepseek rows");
+            assert_eq!(rows.len(), 1);
+            assert!(!rows[0].value.contains("9.00"));
         }
     }
 }

--- a/src/components/codex/CodexModelProviderManager.tsx
+++ b/src/components/codex/CodexModelProviderManager.tsx
@@ -46,6 +46,7 @@ import { SingleSelectFilterDropdown } from "../SingleSelectFilterDropdown";
 import { SingleSelectDropdown } from "../SingleSelectDropdown";
 import { AccountTagFilterDropdown } from "../AccountTagFilterDropdown";
 import { PaginationControls } from "../PaginationControls";
+import { ModelProviderUsagePanel } from "../model-provider/ModelProviderUsagePanel";
 import { useEscClose } from "../../hooks/useEscClose";
 import type { CodexAccount } from "../../types/codex";
 import type { InstanceProfile } from "../../types/instance";
@@ -90,6 +91,7 @@ import {
   testCodexModelProviderChatBatch,
   type CodexModelProvider,
   type CodexModelProviderApiKey,
+  type CodexModelProviderIntegrationType,
   type CodexModelProviderChatTestProgressPayload,
   type CodexModelProviderChatTestRecord,
   type CodexModelProviderChatTestTarget,
@@ -103,6 +105,7 @@ import {
 import {
   resolveNewApiQuotaSnapshot,
 } from "../../services/modelProviderUsageService";
+import { resolveModelProviderUsageMode } from "../../services/modelProviderUsageService";
 import { useSponsorStore } from "../../stores/useSponsorStore";
 import type { Sponsor } from "../../types/sponsor";
 import {
@@ -389,7 +392,7 @@ interface ProviderFormState {
   wireApi: CodexProviderWireApi;
   supportsWebsockets: boolean;
   enableModePreference: CodexProviderEnableModePreference;
-  integrationType: "sub2api" | "new_api" | "";
+  integrationType: CodexModelProviderIntegrationType | "";
   newApiKeyName: string;
   newApiKey: string;
 }
@@ -3404,9 +3407,9 @@ export function CodexModelProviderManager({
               provider.baseUrl
             }`;
             const usageMode =
-              usageSummary?.mode === "new_api" || usageSummary?.mode === "sub2api"
-                ? usageSummary.mode
-                : provider.integrationType ?? null;
+              resolveModelProviderUsageMode(usageSummary) ??
+              provider.integrationType ??
+              null;
             const {
               granted: totalGranted,
               available: totalAvailable,
@@ -3541,7 +3544,14 @@ export function CodexModelProviderManager({
                   </span>
                 </div>
                 <div className="codex-quota-section">
-                  {usageMode === "sub2api" ? (
+                  {usageMode === "deepseek" ? (
+                    <ModelProviderUsagePanel
+                      summary={usageSummary}
+                      loading={usageState?.loading}
+                      error={usageState?.error}
+                      unavailable={usageState?.unavailable}
+                    />
+                  ) : usageMode === "sub2api" ? (
                     <div className="codex-api-key-usage-panel sub2api">
                       <div className="codex-api-key-usage-grid">
                         <div>
@@ -4632,7 +4642,7 @@ export function CodexModelProviderManager({
                   disabled={saving}
                 />
               </div>
-              <div className="form-group">
+              {selectedPresetId !== "deepseek" && <div className="form-group">
                 <label className="codex-provider-label-with-help">
                   <span>{t("codex.modelProviders.fields.wireApi", "协议")}</span>
                   <span
@@ -4689,8 +4699,8 @@ export function CodexModelProviderManager({
                     </span>
                   </button>
                 </div>
-              </div>
-              {form.wireApi === "responses" && (
+              </div>}
+              {selectedPresetId !== "deepseek" && form.wireApi === "responses" && (
                 <div className="form-group">
                   <label>
                     {t(
@@ -5533,9 +5543,9 @@ export function CodexModelProviderManager({
         const usageSummary = usageState?.summary;
         const resolvedWireApi = resolveProviderWireApi(provider);
         const usageMode =
-          usageSummary?.mode === "new_api" || usageSummary?.mode === "sub2api"
-            ? usageSummary.mode
-            : provider.integrationType ?? null;
+          resolveModelProviderUsageMode(usageSummary) ??
+          provider.integrationType ??
+          null;
         const coreDetailKeys =
           usageMode === "new_api"
             ? new Set(["mode", "totalGranted", "totalAvailable", "expiresAt"])

--- a/src/components/model-provider/ModelProviderUsagePanel.tsx
+++ b/src/components/model-provider/ModelProviderUsagePanel.tsx
@@ -3,7 +3,9 @@ import {
   formatModelProviderUsageInteger,
   formatModelProviderUsageMoney,
   formatModelProviderUsageTokenCount,
+  formatDeepSeekBalanceMoney,
   resolveModelProviderUsageMode,
+  selectDeepSeekBalanceInfo,
   type ModelProviderUsageSummary,
 } from '../../services/modelProviderUsageService';
 
@@ -24,9 +26,10 @@ export function ModelProviderUsagePanel({
   className,
   variant,
 }: ModelProviderUsagePanelProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const usageMode = resolveModelProviderUsageMode(summary ?? undefined);
-  const isSupportedUsage = usageMode === 'sub2api' || usageMode === 'new_api';
+  const isSupportedUsage =
+    usageMode === 'sub2api' || usageMode === 'new_api' || usageMode === 'deepseek';
   const classNames = [
     'codex-api-key-usage-panel',
     usageMode ?? 'sub2api',
@@ -53,6 +56,49 @@ export function ModelProviderUsagePanel({
 
   if (!isSupportedUsage) {
     return null;
+  }
+
+  if (usageMode === 'deepseek') {
+    if (summary.isAvailable === false) {
+      return (
+        <div className={`${classNames} empty`}>
+          <div className="codex-api-key-usage-empty">
+            {t('codex.modelProviders.usage.balanceUnavailable', '余额不可用')}
+          </div>
+        </div>
+      );
+    }
+    const balance = selectDeepSeekBalanceInfo(
+      summary.balanceInfos,
+      i18n.resolvedLanguage || i18n.language,
+    );
+    if (!balance) {
+      return (
+        <div className={`${classNames} empty`}>
+          <div className="codex-api-key-usage-empty">
+            {t('codex.modelProviders.usage.noBalanceData', '暂无余额数据')}
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className={classNames}>
+        <div className="codex-api-key-usage-grid">
+          <div>
+            <span>{t('codex.modelProviders.usage.totalBalance', '总余额')}</span>
+            <strong>{formatDeepSeekBalanceMoney(balance.totalBalance, balance.currency)}</strong>
+          </div>
+          <div>
+            <span>{t('codex.modelProviders.usage.grantedBalance', '赠金余额')}</span>
+            <strong>{formatDeepSeekBalanceMoney(balance.grantedBalance, balance.currency)}</strong>
+          </div>
+          <div>
+            <span>{t('codex.modelProviders.usage.toppedUpBalance', '充值余额')}</span>
+            <strong>{formatDeepSeekBalanceMoney(balance.toppedUpBalance, balance.currency)}</strong>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   const balanceText = formatModelProviderUsageMoney(

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -3188,6 +3188,11 @@
           "modelLimitsEnabled": "قيود النماذج"
         },
         "accountBalance": "رصيد الحساب",
+        "totalBalance": "الرصيد الإجمالي",
+        "grantedBalance": "الرصيد الممنوح",
+        "toppedUpBalance": "الرصيد المشحون",
+        "balanceUnavailable": "الرصيد غير متاح",
+        "noBalanceData": "لا توجد بيانات رصيد",
         "unlimitedQuota": "غير محدود",
         "booleanTrue": "نعم",
         "booleanFalse": "لا"

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Limity modelů"
         },
         "accountBalance": "Zůstatek účtu",
+        "totalBalance": "Celkový zůstatek",
+        "grantedBalance": "Přidělený zůstatek",
+        "toppedUpBalance": "Dobitý zůstatek",
+        "balanceUnavailable": "Zůstatek není dostupný",
+        "noBalanceData": "Žádné údaje o zůstatku",
         "unlimitedQuota": "Neomezeno",
         "booleanTrue": "Ano",
         "booleanFalse": "Ne"

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Modelllimits"
         },
         "accountBalance": "Kontostand",
+        "totalBalance": "Gesamtguthaben",
+        "grantedBalance": "Gewährtes Guthaben",
+        "toppedUpBalance": "Aufgeladenes Guthaben",
+        "balanceUnavailable": "Guthaben nicht verfügbar",
+        "noBalanceData": "Keine Guthabendaten",
         "unlimitedQuota": "Unbegrenzt",
         "booleanTrue": "Ja",
         "booleanFalse": "Nein"

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -2901,6 +2901,11 @@
           "modelLimitsEnabled": "Model Limits"
         },
         "accountBalance": "Account Balance",
+        "totalBalance": "Total Balance",
+        "grantedBalance": "Granted Balance",
+        "toppedUpBalance": "Topped-up Balance",
+        "balanceUnavailable": "Balance unavailable",
+        "noBalanceData": "No balance data",
         "unlimitedQuota": "Unlimited",
         "booleanTrue": "Yes",
         "booleanFalse": "No"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2901,6 +2901,11 @@
           "modelLimitsEnabled": "Model Limits"
         },
         "accountBalance": "Account Balance",
+        "totalBalance": "Total Balance",
+        "grantedBalance": "Granted Balance",
+        "toppedUpBalance": "Topped-up Balance",
+        "balanceUnavailable": "Balance unavailable",
+        "noBalanceData": "No balance data",
         "unlimitedQuota": "Unlimited",
         "booleanTrue": "Yes",
         "booleanFalse": "No"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Límites de modelo"
         },
         "accountBalance": "Saldo de cuenta",
+        "totalBalance": "Saldo total",
+        "grantedBalance": "Saldo otorgado",
+        "toppedUpBalance": "Saldo recargado",
+        "balanceUnavailable": "Saldo no disponible",
+        "noBalanceData": "Sin datos de saldo",
         "unlimitedQuota": "Ilimitado",
         "booleanTrue": "Sí",
         "booleanFalse": "Desactivado"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Limites modèles"
         },
         "accountBalance": "Solde du compte",
+        "totalBalance": "Solde total",
+        "grantedBalance": "Solde offert",
+        "toppedUpBalance": "Solde rechargé",
+        "balanceUnavailable": "Solde indisponible",
+        "noBalanceData": "Aucune donnée de solde",
         "unlimitedQuota": "Illimité",
         "booleanTrue": "Oui",
         "booleanFalse": "Non"

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -3188,6 +3188,11 @@
           "modelLimitsEnabled": "Batas model"
         },
         "accountBalance": "Saldo akun",
+        "totalBalance": "Total saldo",
+        "grantedBalance": "Saldo diberikan",
+        "toppedUpBalance": "Saldo isi ulang",
+        "balanceUnavailable": "Saldo tidak tersedia",
+        "noBalanceData": "Tidak ada data saldo",
         "unlimitedQuota": "Tak terbatas",
         "booleanTrue": "Ya",
         "booleanFalse": "Tidak"

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Limiti modello"
         },
         "accountBalance": "Saldo account",
+        "totalBalance": "Saldo totale",
+        "grantedBalance": "Saldo concesso",
+        "toppedUpBalance": "Saldo ricaricato",
+        "balanceUnavailable": "Saldo non disponibile",
+        "noBalanceData": "Nessun dato sul saldo",
         "unlimitedQuota": "Illimitato",
         "booleanTrue": "Sì",
         "booleanFalse": "Disattivato"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "モデル制限"
         },
         "accountBalance": "アカウント残高",
+        "totalBalance": "総残高",
+        "grantedBalance": "付与残高",
+        "toppedUpBalance": "チャージ残高",
+        "balanceUnavailable": "残高を利用できません",
+        "noBalanceData": "残高データがありません",
         "unlimitedQuota": "無制限",
         "booleanTrue": "はい",
         "booleanFalse": "いいえ"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "모델 제한"
         },
         "accountBalance": "계정 잔액",
+        "totalBalance": "총 잔액",
+        "grantedBalance": "지급 잔액",
+        "toppedUpBalance": "충전 잔액",
+        "balanceUnavailable": "잔액을 사용할 수 없음",
+        "noBalanceData": "잔액 데이터 없음",
         "unlimitedQuota": "무제한",
         "booleanTrue": "예",
         "booleanFalse": "아니요"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Limity modeli"
         },
         "accountBalance": "Saldo konta",
+        "totalBalance": "Saldo całkowite",
+        "grantedBalance": "Saldo przyznane",
+        "toppedUpBalance": "Saldo doładowane",
+        "balanceUnavailable": "Saldo niedostępne",
+        "noBalanceData": "Brak danych salda",
         "unlimitedQuota": "Bez limitu",
         "booleanTrue": "Tak",
         "booleanFalse": "Nie"

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Limites de modelo"
         },
         "accountBalance": "Saldo da conta",
+        "totalBalance": "Saldo total",
+        "grantedBalance": "Saldo concedido",
+        "toppedUpBalance": "Saldo recarregado",
+        "balanceUnavailable": "Saldo indisponível",
+        "noBalanceData": "Sem dados de saldo",
         "unlimitedQuota": "Ilimitado",
         "booleanTrue": "Sim",
         "booleanFalse": "Não"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Лимиты моделей"
         },
         "accountBalance": "Баланс аккаунта",
+        "totalBalance": "Общий баланс",
+        "grantedBalance": "Подарочный баланс",
+        "toppedUpBalance": "Пополненный баланс",
+        "balanceUnavailable": "Баланс недоступен",
+        "noBalanceData": "Нет данных о балансе",
         "unlimitedQuota": "Безлимитно",
         "booleanTrue": "Да",
         "booleanFalse": "Нет"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Model limitleri"
         },
         "accountBalance": "Hesap bakiyesi",
+        "totalBalance": "Toplam bakiye",
+        "grantedBalance": "Hediye bakiye",
+        "toppedUpBalance": "Yüklenen bakiye",
+        "balanceUnavailable": "Bakiye kullanılamıyor",
+        "noBalanceData": "Bakiye verisi yok",
         "unlimitedQuota": "Sınırsız",
         "booleanTrue": "Evet",
         "booleanFalse": "Hayır"

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "Giới hạn mô hình"
         },
         "accountBalance": "Số dư tài khoản",
+        "totalBalance": "Tổng số dư",
+        "grantedBalance": "Số dư được tặng",
+        "toppedUpBalance": "Số dư đã nạp",
+        "balanceUnavailable": "Số dư không khả dụng",
+        "noBalanceData": "Không có dữ liệu số dư",
         "unlimitedQuota": "Không giới hạn",
         "booleanTrue": "Có",
         "booleanFalse": "Không"

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -2901,6 +2901,11 @@
           "modelLimitsEnabled": "模型限制"
         },
         "accountBalance": "账户余额",
+        "totalBalance": "总余额",
+        "grantedBalance": "赠金余额",
+        "toppedUpBalance": "充值余额",
+        "balanceUnavailable": "余额不可用",
+        "noBalanceData": "暂无余额数据",
         "unlimitedQuota": "无限额度",
         "booleanTrue": "是",
         "booleanFalse": "否"

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -3141,6 +3141,11 @@
           "modelLimitsEnabled": "模型限制"
         },
         "accountBalance": "帳戶餘額",
+        "totalBalance": "總餘額",
+        "grantedBalance": "贈金餘額",
+        "toppedUpBalance": "儲值餘額",
+        "balanceUnavailable": "餘額不可用",
+        "noBalanceData": "暫無餘額資料",
         "unlimitedQuota": "無限額度",
         "booleanTrue": "是",
         "booleanFalse": "否"

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -127,6 +127,7 @@ import {
   summarizeCodexQuotaErrorMessage,
 } from "../utils/codexQuotaError";
 import { buildCodexAccountPresentation } from "../presentation/platformAccountPresentation";
+import { ModelProviderUsagePanel } from "../components/model-provider/ModelProviderUsagePanel";
 import {
   readCodexImportSyncApiService,
   writeCodexImportSyncApiService,
@@ -272,8 +273,12 @@ import {
 import {
   isModelProviderUsageUnavailableError,
   listModelProviderModels,
+  formatDeepSeekBalanceMoney,
+  resolveModelProviderUsageMode,
   resolveNewApiQuotaSnapshot,
+  selectDeepSeekBalanceInfo,
 } from "../services/modelProviderUsageService";
+import { getCurrentLanguage } from "../i18n";
 import { useSponsorStore } from "../stores/useSponsorStore";
 import type { Sponsor } from "../types/sponsor";
 import { buildValidAccountsFilterOption } from "../utils/accountValidityFilter";
@@ -526,7 +531,6 @@ function isPendingOAuthCodexAccount(account?: CodexAccount | null): boolean {
   return isCodexPendingOAuthAccount(account);
 }
 
-
 function isSponsorModelProvider(
   provider: CodexModelProvider | null | undefined,
   sponsorTemplates: SponsorApiProviderTemplate[],
@@ -698,33 +702,8 @@ function getCockpitApiStatsRecord(
 
 function resolveApiKeyUsageMode(
   summary?: CodexModelProviderUsageSummary,
-): "new_api" | "sub2api" | null {
-  if (!summary) return null;
-  if (summary.mode === "new_api" || summary.mode === "sub2api") {
-    return summary.mode;
-  }
-  if (
-    typeof summary.todayRequests === "number" ||
-    typeof summary.todayTotalTokens === "number"
-  ) {
-    return "sub2api";
-  }
-  const detailKeys = new Set((summary.details ?? []).map((item) => item.key));
-  if (
-    detailKeys.has("todayRequests") ||
-    detailKeys.has("todayTokens") ||
-    detailKeys.has("remaining")
-  ) {
-    return "sub2api";
-  }
-  if (
-    detailKeys.has("totalGranted") ||
-    detailKeys.has("totalAvailable") ||
-    detailKeys.has("expiresAt")
-  ) {
-    return "new_api";
-  }
-  return null;
+): "new_api" | "sub2api" | "deepseek" | null {
+  return resolveModelProviderUsageMode(summary);
 }
 
 interface CodexOverviewGeneralConfig {
@@ -6900,6 +6879,7 @@ export function CodexAccountsPage() {
     page.setAddMessage(t("common.shared.token.importing", "正在导入..."));
     try {
       let finalProviderPayload = providerPayload;
+      let initialUsageState: CodexApiKeyUsageState | null = null;
       if (
         validation.apiBaseUrl &&
         providerPayload.apiProviderMode === "custom" &&
@@ -6924,7 +6904,7 @@ export function CodexAccountsPage() {
             supportsVision: providerPayload.sponsorTemplate?.supportsVision,
             website: providerPayload.sponsorTemplate?.website,
             apiKeyUrl: providerPayload.sponsorTemplate?.apiKeyUrl,
-            wireApi: providerPayload.sponsorTemplate?.wireApi,
+            wireApi: providerPayload.apiWireApi,
             integrationType: providerPayload.sponsorTemplate?.integrationType,
           });
           finalProviderPayload = {
@@ -6944,6 +6924,11 @@ export function CodexAccountsPage() {
               apiKey: validation.apiKey,
               integrationType: savedProvider.integrationType ?? null,
             });
+            initialUsageState = {
+              loading: false,
+              summary: usageSummary,
+              updatedAt: Date.now(),
+            };
             if (
               (usageSummary.mode === "sub2api" ||
                 usageSummary.mode === "new_api") &&
@@ -6956,6 +6941,14 @@ export function CodexAccountsPage() {
             }
           } catch (usageErr) {
             console.warn("[CodexModelProviders] 额度类型探测失败", usageErr);
+            initialUsageState = {
+              loading: false,
+              error: isModelProviderUsageUnavailableError(usageErr)
+                ? undefined
+                : String(usageErr).replace(/^Error:\s*/, ""),
+              unavailable: isModelProviderUsageUnavailableError(usageErr),
+              updatedAt: Date.now(),
+            };
           }
           await reloadManagedProviders();
         } catch (providerErr) {
@@ -6981,6 +6974,12 @@ export function CodexAccountsPage() {
         finalProviderPayload.apiSupportsWebsockets,
         apiSyncModelCatalogToCodex,
       );
+      if (initialUsageState) {
+        setApiKeyUsageMap((previous) => ({
+          ...previous,
+          [account.id]: initialUsageState,
+        }));
+      }
       await fetchAccounts();
       await fetchCurrentAccount();
       await assignCodexAccountsToTargetGroup([account]);
@@ -7832,10 +7831,23 @@ export function CodexAccountsPage() {
       const baseUrl =
         provider?.baseUrl.trim() || (account.api_base_url || "").trim();
       const canRefresh = Boolean(apiKey && baseUrl);
-      const usageMode = resolveApiKeyUsageMode(summary);
+      const usageMode = resolveModelProviderUsageMode(summary);
+      const isDeepSeekUsage =
+        usageMode === "deepseek" || provider?.integrationType === "deepseek";
       const isNewApiUsage = usageMode === "new_api";
       const isSub2ApiUsage = usageMode === "sub2api";
       const usedPercent = formatApiKeyUsagePercent(summary);
+      if (isDeepSeekUsage) {
+        return (
+          <ModelProviderUsagePanel
+            summary={summary}
+            loading={loading}
+            error={usageState?.error}
+            unavailable={usageState?.unavailable}
+            variant={variant}
+          />
+        );
+      }
       if (variant === "card" && summary && isNewApiUsage) {
         const quota = resolveNewApiQuotaSnapshot(summary);
         const grantedText = formatApiKeyUsageMoney(quota.granted, summary.unit);
@@ -10793,7 +10805,7 @@ export function CodexAccountsPage() {
           apiKeyUsageProvider,
           sponsorApiProviderTemplates,
         );
-      const apiKeyUsageMode = resolveApiKeyUsageMode(
+      const apiKeyUsageMode = resolveModelProviderUsageMode(
         apiKeyUsageMap[account.id]?.summary,
       );
       const showApiKeyUsagePanel =
@@ -10810,7 +10822,8 @@ export function CodexAccountsPage() {
         !isSponsorApiKeyAccount &&
         (apiKeyUsageMode !== null ||
           apiKeyUsageProvider?.integrationType === "new_api" ||
-          apiKeyUsageProvider?.integrationType === "sub2api");
+          apiKeyUsageProvider?.integrationType === "sub2api" ||
+          apiKeyUsageProvider?.integrationType === "deepseek");
       const shouldRenderQuotaSection =
         (!hideRelayQuota && showApiKeyUsagePanel) ||
         !isApiKeyAccount ||
@@ -12200,7 +12213,7 @@ export function CodexAccountsPage() {
           apiKeyUsageProvider,
           sponsorApiProviderTemplates,
         );
-      const apiKeyUsageMode = resolveApiKeyUsageMode(
+      const apiKeyUsageMode = resolveModelProviderUsageMode(
         apiKeyUsageMap[account.id]?.summary,
       );
       const showApiKeyUsagePanel =
@@ -12217,7 +12230,8 @@ export function CodexAccountsPage() {
         !isSponsorApiKeyAccount &&
         (apiKeyUsageMode !== null ||
           apiKeyUsageProvider?.integrationType === "new_api" ||
-          apiKeyUsageProvider?.integrationType === "sub2api");
+          apiKeyUsageProvider?.integrationType === "sub2api" ||
+          apiKeyUsageProvider?.integrationType === "deepseek");
       const displayPlanClass = isSponsorApiKeyAccount
         ? "sponsor-api"
         : isQuotaAwareApiKeyAccount
@@ -12867,6 +12881,10 @@ export function CodexAccountsPage() {
       provider?.baseUrl.trim() || (account.api_base_url || "").trim() || "-";
     const usedPercent = formatApiKeyUsagePercent(summary);
     const newApiQuota = resolveNewApiQuotaSnapshot(summary);
+    const deepSeekBalance = selectDeepSeekBalanceInfo(
+      summary?.balanceInfos,
+      getCurrentLanguage(),
+    );
     const summaryDetails =
       usageMode === "new_api"
         ? [
@@ -12943,9 +12961,73 @@ export function CodexAccountsPage() {
                   : "-",
               },
             ]
-          : [];
+          : usageMode === "deepseek"
+            ? summary?.isAvailable === false
+              ? [
+                  {
+                    key: "balanceUnavailable",
+                    label: t(
+                      "codex.modelProviders.usage.accountBalance",
+                      "账户余额",
+                    ),
+                    value: t(
+                      "codex.modelProviders.usage.balanceUnavailable",
+                      "余额不可用",
+                    ),
+                  },
+                ]
+              : deepSeekBalance
+                ? [
+                    {
+                      key: "totalBalance",
+                      label: t(
+                        "codex.modelProviders.usage.totalBalance",
+                        "总余额",
+                      ),
+                      value: formatDeepSeekBalanceMoney(
+                        deepSeekBalance.totalBalance,
+                        deepSeekBalance.currency,
+                      ),
+                    },
+                    {
+                      key: "grantedBalance",
+                      label: t(
+                        "codex.modelProviders.usage.grantedBalance",
+                        "赠金余额",
+                      ),
+                      value: formatDeepSeekBalanceMoney(
+                        deepSeekBalance.grantedBalance,
+                        deepSeekBalance.currency,
+                      ),
+                    },
+                    {
+                      key: "toppedUpBalance",
+                      label: t(
+                        "codex.modelProviders.usage.toppedUpBalance",
+                        "充值余额",
+                      ),
+                      value: formatDeepSeekBalanceMoney(
+                        deepSeekBalance.toppedUpBalance,
+                        deepSeekBalance.currency,
+                      ),
+                    },
+                  ]
+                : [
+                    {
+                      key: "noBalanceData",
+                      label: t(
+                        "codex.modelProviders.usage.accountBalance",
+                        "账户余额",
+                      ),
+                      value: t(
+                        "codex.modelProviders.usage.noBalanceData",
+                        "暂无余额数据",
+                      ),
+                    },
+                  ]
+            : [];
     const summaryGridClassName =
-      usageMode === "sub2api" || usageMode === "new_api"
+      usageMode === "sub2api" || usageMode === "new_api" || usageMode === "deepseek"
         ? "cockpit-api-summary-grid compact"
         : "cockpit-api-summary-grid";
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -116,12 +116,15 @@ import {
   refreshCodexApiKeyUsageForAccounts,
 } from '../services/codexApiKeyUsageRefreshService';
 import {
+  CODEX_API_KEY_USAGE_AUTO_REFRESH_INTERVAL_MS,
   isModelProviderUsageUnavailableError,
+  resolveModelProviderUsageMode,
   resolveNewApiQuotaSnapshot,
   type ModelProviderUsageSummary,
 } from '../services/modelProviderUsageService';
 import * as traeService from '../services/traeService';
 import type { TraePlatformId } from '../services/traeService';
+import { ModelProviderUsagePanel } from '../components/model-provider/ModelProviderUsagePanel';
 
 interface DashboardPageProps {
   onNavigate: (page: Page) => void;
@@ -189,37 +192,6 @@ function pickRecommendedTraeAccount(accounts: TraeAccount[], currentId?: string 
 
 function toFiniteNumber(value: number | null | undefined): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-function resolveDashboardCodexApiUsageMode(
-  summary?: ModelProviderUsageSummary | null,
-): 'new_api' | 'sub2api' | null {
-  if (!summary) return null;
-  if (summary.mode === 'new_api' || summary.mode === 'sub2api') {
-    return summary.mode;
-  }
-  if (
-    typeof summary.todayRequests === 'number' ||
-    typeof summary.todayTotalTokens === 'number'
-  ) {
-    return 'sub2api';
-  }
-  const detailKeys = new Set((summary.details ?? []).map((item) => item.key));
-  if (
-    detailKeys.has('todayRequests') ||
-    detailKeys.has('todayTokens') ||
-    detailKeys.has('remaining')
-  ) {
-    return 'sub2api';
-  }
-  if (
-    detailKeys.has('totalGranted') ||
-    detailKeys.has('totalAvailable') ||
-    detailKeys.has('expiresAt')
-  ) {
-    return 'new_api';
-  }
-  return null;
 }
 
 function resolveDashboardCurrentAccount<T extends { id: string }>(
@@ -884,9 +856,9 @@ export function DashboardPage({
       setCodexApiUsageMap((prev) => ({
         ...prev,
         [account.id]: {
-          ...usageState,
-          loading: false,
-        },
+        ...usageState,
+        loading: false,
+      },
       }));
     } catch (error) {
       setCodexApiUsageMap((prev) => ({
@@ -2283,7 +2255,7 @@ export function DashboardPage({
         isCodexChatCompletionsApiKeyAccount(account);
       const usageState = codexApiUsageMap[account.id];
       const usageSummary = usageState?.summary;
-      const usageMode = resolveDashboardCodexApiUsageMode(usageSummary);
+      const usageMode = resolveModelProviderUsageMode(usageSummary);
       const newApiQuota = resolveNewApiQuotaSnapshot(usageSummary);
       const newApiGranted = newApiQuota.granted;
       const newApiAvailable = newApiQuota.available;
@@ -2311,7 +2283,14 @@ export function DashboardPage({
 
           {!isChatCompletionsApiKey && (
             <div className="account-mini-quotas codex-api-mini-quotas">
-              {usageMode === 'new_api' ? (
+              {usageMode === 'deepseek' ? (
+                <ModelProviderUsagePanel
+                  summary={usageSummary}
+                  loading={usageState?.loading}
+                  error={usageState?.error}
+                  unavailable={usageState?.unavailable}
+                />
+              ) : usageMode === 'new_api' ? (
                 <div className="mini-quota-row-stacked">
                   <div className="mini-quota-header">
                     <span className="model-name">{t('codex.cockpitApi.balance', '额度')}</span>
@@ -2400,13 +2379,13 @@ export function DashboardPage({
         !isCodexChatCompletionsApiKeyAccount(account!),
     );
     targetAccounts.forEach((account) => {
-      const usageState = codexApiUsageMap[account.id];
+      const usage = codexApiUsageMap[account.id];
+      if (usage?.loading) {
+        return;
+      }
       if (
-        usageState?.loading ||
-        usageState?.summary ||
-        usageState?.unavailable ||
-        usageState?.error ||
-        usageState?.updatedAt !== undefined
+        (usage?.updatedAt ?? 0) > 0 &&
+        Date.now() - (usage?.updatedAt ?? 0) < CODEX_API_KEY_USAGE_AUTO_REFRESH_INTERVAL_MS
       ) {
         return;
       }

--- a/src/services/codexApiKeyUsageRefreshService.ts
+++ b/src/services/codexApiKeyUsageRefreshService.ts
@@ -9,73 +9,19 @@ import {
   findCodexModelProviderById,
   listCodexModelProviders,
   queryCodexModelProviderUsage,
-  type CodexModelProviderUsageSummary,
 } from './codexModelProviderService';
 import { isModelProviderUsageUnavailableError } from './modelProviderUsageService';
+import {
+  readCodexApiKeyUsageCache,
+  writeCodexApiKeyUsageCache,
+  type CodexApiKeyUsageCacheEntry,
+} from './modelProviderUsageHelpers';
 
-export const CODEX_API_KEY_USAGE_CACHE_KEY = 'agtools.codex.apiKeyUsage.cache.v1';
+export { readCodexApiKeyUsageCache, writeCodexApiKeyUsageCache } from './modelProviderUsageHelpers';
+
 export const CODEX_API_KEY_USAGE_REFRESHED_EVENT = 'codex-api-key-usage-refreshed';
 
-export type CodexApiKeyUsageState = {
-  loading: boolean;
-  summary?: CodexModelProviderUsageSummary;
-  error?: string;
-  unavailable?: boolean;
-  updatedAt?: number;
-};
-
-export function readCodexApiKeyUsageCache(): Record<string, CodexApiKeyUsageState> {
-  try {
-    const raw = localStorage.getItem(CODEX_API_KEY_USAGE_CACHE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    if (!parsed || typeof parsed !== 'object') return {};
-
-    const next: Record<string, CodexApiKeyUsageState> = {};
-    for (const [accountId, value] of Object.entries(parsed)) {
-      if (!value || typeof value !== 'object') continue;
-      const item = value as Omit<CodexApiKeyUsageState, 'loading'>;
-      next[accountId] = {
-        loading: false,
-        summary: item.summary,
-        error: typeof item.error === 'string' ? item.error : undefined,
-        unavailable: item.unavailable === true,
-        updatedAt:
-          typeof item.updatedAt === 'number' && Number.isFinite(item.updatedAt)
-            ? item.updatedAt
-            : undefined,
-      };
-    }
-    return next;
-  } catch {
-    return {};
-  }
-}
-
-export function writeCodexApiKeyUsageCache(
-  value: Record<string, CodexApiKeyUsageState>,
-): void {
-  try {
-    localStorage.setItem(
-      CODEX_API_KEY_USAGE_CACHE_KEY,
-      JSON.stringify(
-        Object.fromEntries(
-          Object.entries(value).map(([accountId, item]) => [
-            accountId,
-            {
-              summary: item.summary,
-              error: item.error,
-              unavailable: item.unavailable === true,
-              updatedAt: item.updatedAt,
-            },
-          ]),
-        ),
-      ),
-    );
-  } catch {
-    // Ignore cache persistence failures; quota refresh remains available.
-  }
-}
+export type CodexApiKeyUsageState = CodexApiKeyUsageCacheEntry;
 
 function notifyCodexApiKeyUsageRefreshed(): void {
   window.dispatchEvent(new CustomEvent(CODEX_API_KEY_USAGE_REFRESHED_EVENT));

--- a/src/services/codexModelProviderService.ts
+++ b/src/services/codexModelProviderService.ts
@@ -14,10 +14,16 @@ import {
   isApiKeyFunProviderBaseUrl,
 } from '../utils/apikeyFunLinks';
 import {
+  isOfficialDeepSeekBaseUrl,
   queryModelProviderUsage,
+  type ModelProviderUsageIntegrationType,
   type ModelProviderUsageSummary,
 } from './modelProviderUsageService';
 import { moveCodexProviderApiKey } from '../utils/codexModelProviderApiKeyMove';
+
+export type CodexModelProviderIntegrationType = ModelProviderUsageIntegrationType;
+
+const DEEPSEEK_MODEL_CATALOG = ['deepseek-v4-pro', 'deepseek-v4-flash'];
 
 export interface CodexModelProviderApiKey {
   id: string;
@@ -32,7 +38,7 @@ export interface CodexModelProvider {
   name: string;
   baseUrl: string;
   sourceTag?: string;
-  integrationType?: 'sub2api' | 'new_api';
+  integrationType?: CodexModelProviderIntegrationType;
   modelCatalog?: string[];
   supportsVision?: boolean;
   modelCapabilities?: Record<string, { supportsVision?: boolean }>;
@@ -67,7 +73,7 @@ interface UpsertFromCredentialInput {
   apiKeyUrl?: string | null;
   wireApi?: CodexProviderWireApi | null;
   supportsWebsockets?: boolean;
-  integrationType?: 'sub2api' | 'new_api' | null;
+  integrationType?: CodexModelProviderIntegrationType | null;
 }
 
 let providerIdCounter = 0;
@@ -156,8 +162,10 @@ function hasOwnProperty(value: object, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
 }
 
-function normalizeIntegrationType(value: unknown): 'sub2api' | 'new_api' | undefined {
-  return value === 'sub2api' || value === 'new_api' ? value : undefined;
+function normalizeIntegrationType(value: unknown): CodexModelProviderIntegrationType | undefined {
+  return value === 'sub2api' || value === 'new_api' || value === 'deepseek'
+    ? value
+    : undefined;
 }
 
 function migrateApiKeyFunProviderWireApi(
@@ -211,10 +219,37 @@ function normalizeBaseUrlForStore(value: string): string {
   try {
     const parsed = new URL(trimmed);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return trimmed;
+    if (parsed.hostname.toLowerCase() === 'api.deepseek.com') {
+      return 'https://api.deepseek.com';
+    }
     return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, '');
   } catch {
     return trimmed;
   }
+}
+
+function rawProviderNeedsDeepSeekMigration(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const provider = value as Record<string, unknown>;
+  if (!isOfficialDeepSeekBaseUrl(provider.baseUrl)) return false;
+  const models = normalizeModelCatalog(provider.modelCatalog);
+  const rawBaseUrl = String(provider.baseUrl ?? '').trim().replace(/\/+$/, '');
+  return (
+    rawBaseUrl !== 'https://api.deepseek.com' ||
+    provider.wireApi !== 'responses' ||
+    provider.integrationType !== 'deepseek' ||
+    provider.enableModePreference === 'gateway' ||
+    models?.join('\n') !== 'deepseek-v4-pro\ndeepseek-v4-flash'
+  );
+}
+
+function enforceOfficialDeepSeekProvider(provider: CodexModelProvider): void {
+  if (!isOfficialDeepSeekBaseUrl(provider.baseUrl)) return;
+  provider.baseUrl = 'https://api.deepseek.com';
+  provider.wireApi = 'responses';
+  provider.enableModePreference = 'direct';
+  provider.integrationType = 'deepseek';
+  provider.modelCatalog = [...DEEPSEEK_MODEL_CATALOG];
 }
 
 function deriveProviderNameFromBaseUrl(baseUrl: string): string {
@@ -264,29 +299,44 @@ function toValidProviderList(raw: unknown): CodexModelProvider[] {
   if (!Array.isArray(raw)) return [];
   const now = Date.now();
   const providers: CodexModelProvider[] = [];
-  const seenBaseUrls = new Set<string>();
+  const seenBaseUrls = new Map<string, CodexModelProvider>();
   for (const item of raw) {
     if (!item || typeof item !== 'object') continue;
     const name = sanitizeName(String((item as { name?: unknown }).name ?? ''));
     const baseUrl = normalizeBaseUrlForStore(String((item as { baseUrl?: unknown }).baseUrl ?? ''));
     const normalizedBaseUrl = normalizeCodexModelProviderBaseUrl(baseUrl);
     if (!name || !baseUrl || !normalizedBaseUrl) continue;
-    if (seenBaseUrls.has(normalizedBaseUrl)) continue;
-    seenBaseUrls.add(normalizedBaseUrl);
+    const apiKeys = toValidApiKeys((item as { apiKeys?: unknown }).apiKeys, now);
+    const existing = seenBaseUrls.get(normalizedBaseUrl);
+    if (existing) {
+      if (isOfficialDeepSeekBaseUrl(baseUrl)) {
+        for (const apiKey of apiKeys) {
+          if (!existing.apiKeys.some((current) => current.apiKey === apiKey.apiKey)) {
+            existing.apiKeys.push(apiKey);
+          }
+        }
+      }
+      continue;
+    }
     const boundOauthAccountId = normalizeBoundOauthAccountId(
       (item as { boundOauthAccountId?: unknown }).boundOauthAccountId,
     );
-    const wireApi = normalizeWireApi((item as { wireApi?: unknown }).wireApi);
-    providers.push({
+    const isDeepSeek = isOfficialDeepSeekBaseUrl(baseUrl);
+    const wireApi = isDeepSeek
+      ? 'responses'
+      : normalizeWireApi((item as { wireApi?: unknown }).wireApi);
+    const provider: CodexModelProvider = {
       id: String((item as { id?: unknown }).id ?? createProviderId()),
       name,
       baseUrl,
       sourceTag: sanitizeName(String((item as { sourceTag?: unknown }).sourceTag ?? '')) || undefined,
-      integrationType: normalizeIntegrationType(
-        (item as { integrationType?: unknown }).integrationType,
-      ),
+      integrationType: isDeepSeek
+        ? 'deepseek'
+        : normalizeIntegrationType((item as { integrationType?: unknown }).integrationType),
       modelCatalog:
-        normalizeModelCatalog((item as { modelCatalog?: unknown }).modelCatalog) ??
+        (isDeepSeek
+          ? [...DEEPSEEK_MODEL_CATALOG]
+          : normalizeModelCatalog((item as { modelCatalog?: unknown }).modelCatalog)) ??
         presetModelCatalogForBaseUrl(baseUrl),
       supportsVision: (item as { supportsVision?: unknown }).supportsVision === true,
       modelCapabilities: normalizeModelCapabilities(
@@ -310,10 +360,13 @@ function toValidProviderList(raw: unknown): CodexModelProvider[] {
         (item as { enableModePreference?: unknown }).enableModePreference,
       ),
       boundOauthAccountId,
-      apiKeys: toValidApiKeys((item as { apiKeys?: unknown }).apiKeys, now),
+      apiKeys,
       createdAt: Number((item as { createdAt?: unknown }).createdAt ?? now),
       updatedAt: Number((item as { updatedAt?: unknown }).updatedAt ?? now),
-    });
+    };
+    enforceOfficialDeepSeekProvider(provider);
+    providers.push(provider);
+    seenBaseUrls.set(normalizedBaseUrl, provider);
   }
   return providers.sort((a, b) => a.createdAt - b.createdAt);
 }
@@ -340,6 +393,7 @@ async function loadProvidersFromDisk(): Promise<{
   providers: CodexModelProvider[];
   removedImageGenerationSetting: boolean;
   migratedSupportsWebsockets: boolean;
+  migratedDeepSeekProviders: boolean;
 }> {
   const raw = await invoke<string>('load_codex_model_providers');
   const parsed = JSON.parse(raw);
@@ -347,6 +401,14 @@ async function loadProvidersFromDisk(): Promise<{
     providers: toValidProviderList(parsed),
     removedImageGenerationSetting: hasRemovedImageGenerationSetting(parsed),
     migratedSupportsWebsockets: hasLegacySupportsWebsocketsProvider(parsed),
+    migratedDeepSeekProviders:
+      Array.isArray(parsed) &&
+      (parsed.some(rawProviderNeedsDeepSeekMigration) ||
+        parsed.filter((provider) =>
+          isOfficialDeepSeekBaseUrl(
+            (provider as { baseUrl?: unknown } | null)?.baseUrl,
+          ),
+        ).length > 1),
   };
 }
 
@@ -362,6 +424,7 @@ async function ensureProvidersLoaded(): Promise<CodexModelProvider[]> {
     providers: [],
     removedImageGenerationSetting: false,
     migratedSupportsWebsockets: false,
+    migratedDeepSeekProviders: false,
   }));
   const loadedProviders = loadResult.providers;
   let loaded = loadedProviders.filter((provider) => {
@@ -377,9 +440,10 @@ async function ensureProvidersLoaded(): Promise<CodexModelProvider[]> {
     loaded.length !== loadedProviders.length ||
     migration.changed ||
     loadResult.removedImageGenerationSetting ||
-    loadResult.migratedSupportsWebsockets
+    loadResult.migratedSupportsWebsockets ||
+    loadResult.migratedDeepSeekProviders
   ) {
-    await saveProvidersToDisk(loaded).catch(() => { });
+    await saveProvidersToDisk(loaded);
   }
   cachedProviders = loaded;
   return cloneProviders(cachedProviders);
@@ -387,8 +451,8 @@ async function ensureProvidersLoaded(): Promise<CodexModelProvider[]> {
 
 async function writeProviders(providers: CodexModelProvider[]): Promise<void> {
   const next = cloneProviders(providers);
-  cachedProviders = next;
   await saveProvidersToDisk(next);
+  cachedProviders = next;
 }
 
 export async function listCodexModelProviders(): Promise<CodexModelProvider[]> {
@@ -457,7 +521,7 @@ export async function createCodexModelProvider(input: {
   wireApi?: CodexProviderWireApi;
   supportsWebsockets?: boolean;
   enableModePreference?: CodexProviderEnableModePreference;
-  integrationType?: 'sub2api' | 'new_api';
+  integrationType?: CodexModelProviderIntegrationType;
   boundOauthAccountId?: string | null;
   initialApiKey?: string;
   initialApiKeyName?: string;
@@ -499,6 +563,7 @@ export async function createCodexModelProvider(input: {
   if (input.initialApiKey) {
     ensureApiKeyOnProvider(provider, input.initialApiKey, input.initialApiKeyName);
   }
+  enforceOfficialDeepSeekProvider(provider);
   providers.push(provider);
   await writeProviders(providers);
   return { ...provider, apiKeys: provider.apiKeys.map((apiKey) => ({ ...apiKey })) };
@@ -520,7 +585,7 @@ export async function updateCodexModelProvider(
     wireApi?: CodexProviderWireApi | null;
     supportsWebsockets?: boolean;
     enableModePreference?: CodexProviderEnableModePreference | null;
-    integrationType?: 'sub2api' | 'new_api' | null;
+    integrationType?: CodexModelProviderIntegrationType | null;
     boundOauthAccountId?: string | null;
   },
 ): Promise<CodexModelProvider> {
@@ -612,6 +677,7 @@ export async function updateCodexModelProvider(
         : normalizeBoundOauthAccountId(patch.boundOauthAccountId);
   }
   provider.updatedAt = Date.now();
+  enforceOfficialDeepSeekProvider(provider);
   await writeProviders(providers);
   return { ...provider, apiKeys: provider.apiKeys.map((apiKey) => ({ ...apiKey })) };
 }
@@ -626,6 +692,7 @@ export async function addApiKeyToCodexModelProvider(
   if (!provider) throw new Error('PROVIDER_NOT_FOUND');
   ensureApiKeyOnProvider(provider, apiKey, apiKeyName);
   provider.updatedAt = Date.now();
+  enforceOfficialDeepSeekProvider(provider);
   await writeProviders(providers);
   return { ...provider, apiKeys: provider.apiKeys.map((item) => ({ ...item })) };
 }
@@ -751,14 +818,14 @@ export async function cancelCodexModelProviderChatTest(runId: string): Promise<b
 export async function queryCodexModelProviderUsage(input: {
   baseUrl: string;
   apiKey: string;
-  integrationType?: 'sub2api' | 'new_api' | null;
+  integrationType?: CodexModelProviderIntegrationType | null;
 }): Promise<CodexModelProviderUsageSummary> {
   return await queryModelProviderUsage(input);
 }
 
 export async function saveCodexModelProviderDetectedIntegrationType(
   providerId: string,
-  integrationType: 'sub2api' | 'new_api',
+  integrationType: CodexModelProviderIntegrationType,
 ): Promise<CodexModelProvider> {
   return updateCodexModelProvider(providerId, { integrationType });
 }
@@ -865,6 +932,7 @@ export async function upsertCodexModelProviderFromCredential(
     provider.integrationType = normalizeIntegrationType(input.integrationType);
   }
   provider.updatedAt = Date.now();
+  enforceOfficialDeepSeekProvider(provider);
   await writeProviders(providers);
   return { ...provider, apiKeys: provider.apiKeys.map((item) => ({ ...item })) };
 }

--- a/src/services/modelProviderUsageHelpers.ts
+++ b/src/services/modelProviderUsageHelpers.ts
@@ -1,0 +1,125 @@
+export interface DeepSeekBalanceInfo {
+  currency: string;
+  totalBalance: string;
+  grantedBalance: string;
+  toppedUpBalance: string;
+}
+
+export interface ModelProviderUsageSummary {
+  mode?: string | null;
+  isValid?: boolean | null;
+  status?: string | null;
+  planName?: string | null;
+  remaining?: number | null;
+  balance?: number | null;
+  unit?: string | null;
+  isAvailable?: boolean | null;
+  balanceInfos?: DeepSeekBalanceInfo[];
+  quotaUnlimited?: boolean | null;
+  quotaLimit?: number | null;
+  quotaUsed?: number | null;
+  quotaRemaining?: number | null;
+  todayRequests?: number | null;
+  todayTotalTokens?: number | null;
+  todayCost?: number | null;
+  totalRequests?: number | null;
+  totalTotalTokens?: number | null;
+  totalCost?: number | null;
+  modelStatsCount: number;
+  latencyMs: number;
+  details?: Array<{
+    key: string;
+    label: string;
+    value: string;
+  }>;
+}
+
+export interface CodexApiKeyUsageCacheEntry {
+  loading: boolean;
+  summary?: ModelProviderUsageSummary;
+  error?: string;
+  unavailable?: boolean;
+  updatedAt?: number;
+}
+
+export function parseCodexApiKeyUsageCache(
+  raw: string | null,
+): Record<string, CodexApiKeyUsageCacheEntry> {
+  if (!raw) return {};
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  if (!parsed || typeof parsed !== 'object') return {};
+  return Object.fromEntries(
+    Object.entries(parsed)
+      .filter(([, value]) => Boolean(value) && typeof value === 'object')
+      .map(([accountId, value]) => {
+        const entry = value as Omit<CodexApiKeyUsageCacheEntry, 'loading'>;
+        return [
+          accountId,
+          {
+            loading: false,
+            summary: entry.summary,
+            error: typeof entry.error === 'string' ? entry.error : undefined,
+            unavailable: entry.unavailable === true,
+            updatedAt:
+              typeof entry.updatedAt === 'number' && Number.isFinite(entry.updatedAt)
+                ? entry.updatedAt
+                : undefined,
+          },
+        ];
+      }),
+  );
+}
+
+export function serializeCodexApiKeyUsageCache(
+  value: Record<string, CodexApiKeyUsageCacheEntry>,
+): string {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(value).map(([accountId, entry]) => [
+        accountId,
+        {
+          summary: entry.summary,
+          error: entry.error,
+          unavailable: entry.unavailable === true,
+          updatedAt: entry.updatedAt,
+        },
+      ]),
+    ),
+  );
+}
+
+export function isOfficialDeepSeekBaseUrl(baseUrl: unknown): boolean {
+  try {
+    return new URL(String(baseUrl ?? '').trim()).hostname.toLowerCase() === 'api.deepseek.com';
+  } catch {
+    return false;
+  }
+}
+
+export function preferredDeepSeekCurrency(language: string): 'CNY' | 'USD' {
+  const normalized = language.trim().toLowerCase();
+  return normalized === 'zh-cn' || normalized === 'zh-tw' ? 'CNY' : 'USD';
+}
+
+export function selectDeepSeekBalanceInfo(
+  balanceInfos: DeepSeekBalanceInfo[] | null | undefined,
+  language: string,
+): DeepSeekBalanceInfo | null {
+  if (!balanceInfos?.length) return null;
+  const preferred = preferredDeepSeekCurrency(language);
+  return (
+    balanceInfos.find(
+      (balance) => String(balance?.currency ?? '').trim().toUpperCase() === preferred,
+    ) ?? balanceInfos[0]
+  );
+}
+
+export function formatDeepSeekBalanceMoney(
+  value: string | null | undefined,
+  currency: string | null | undefined,
+): string {
+  const amount = String(value ?? '').trim();
+  if (!amount) return '-';
+  const unit = String(currency ?? '').trim().toUpperCase();
+  return unit === 'USD' ? `$${amount}` : `${amount}${unit ? ` ${unit}` : ''}`;
+}

--- a/src/services/modelProviderUsageHelpers.ts
+++ b/src/services/modelProviderUsageHelpers.ts
@@ -42,49 +42,22 @@ export interface CodexApiKeyUsageCacheEntry {
   updatedAt?: number;
 }
 
-export function parseCodexApiKeyUsageCache(
-  raw: string | null,
-): Record<string, CodexApiKeyUsageCacheEntry> {
-  if (!raw) return {};
-  const parsed = JSON.parse(raw) as Record<string, unknown>;
-  if (!parsed || typeof parsed !== 'object') return {};
+let codexApiKeyUsageCache: Record<string, CodexApiKeyUsageCacheEntry> = {};
+
+export function readCodexApiKeyUsageCache(): Record<string, CodexApiKeyUsageCacheEntry> {
   return Object.fromEntries(
-    Object.entries(parsed)
-      .filter(([, value]) => Boolean(value) && typeof value === 'object')
-      .map(([accountId, value]) => {
-        const entry = value as Omit<CodexApiKeyUsageCacheEntry, 'loading'>;
-        return [
-          accountId,
-          {
-            loading: false,
-            summary: entry.summary,
-            error: typeof entry.error === 'string' ? entry.error : undefined,
-            unavailable: entry.unavailable === true,
-            updatedAt:
-              typeof entry.updatedAt === 'number' && Number.isFinite(entry.updatedAt)
-                ? entry.updatedAt
-                : undefined,
-          },
-        ];
-      }),
+    Object.entries(codexApiKeyUsageCache).map(([accountId, entry]) => [
+      accountId,
+      { ...entry },
+    ]),
   );
 }
 
-export function serializeCodexApiKeyUsageCache(
+export function writeCodexApiKeyUsageCache(
   value: Record<string, CodexApiKeyUsageCacheEntry>,
-): string {
-  return JSON.stringify(
-    Object.fromEntries(
-      Object.entries(value).map(([accountId, entry]) => [
-        accountId,
-        {
-          summary: entry.summary,
-          error: entry.error,
-          unavailable: entry.unavailable === true,
-          updatedAt: entry.updatedAt,
-        },
-      ]),
-    ),
+): void {
+  codexApiKeyUsageCache = Object.fromEntries(
+    Object.entries(value).map(([accountId, entry]) => [accountId, { ...entry }]),
   );
 }
 

--- a/src/services/modelProviderUsageService.ts
+++ b/src/services/modelProviderUsageService.ts
@@ -1,6 +1,27 @@
 import { invoke } from '@tauri-apps/api/core';
 
-export type ModelProviderUsageIntegrationType = 'sub2api' | 'new_api';
+import {
+  parseCodexApiKeyUsageCache,
+  serializeCodexApiKeyUsageCache,
+} from './modelProviderUsageHelpers';
+export {
+  formatDeepSeekBalanceMoney,
+  isOfficialDeepSeekBaseUrl,
+  preferredDeepSeekCurrency,
+  selectDeepSeekBalanceInfo,
+} from './modelProviderUsageHelpers';
+export type {
+  CodexApiKeyUsageCacheEntry,
+  DeepSeekBalanceInfo,
+  ModelProviderUsageSummary,
+} from './modelProviderUsageHelpers';
+import {
+  isOfficialDeepSeekBaseUrl,
+  type CodexApiKeyUsageCacheEntry,
+  type ModelProviderUsageSummary,
+} from './modelProviderUsageHelpers';
+
+export type ModelProviderUsageIntegrationType = 'sub2api' | 'new_api' | 'deepseek';
 export type ModelProviderUsageMode = ModelProviderUsageIntegrationType;
 
 export interface ModelProviderModel {
@@ -13,31 +34,29 @@ export interface ModelProviderModelsResult {
   latencyMs: number;
 }
 
-export interface ModelProviderUsageSummary {
-  mode?: string | null;
-  isValid?: boolean | null;
-  status?: string | null;
-  planName?: string | null;
-  remaining?: number | null;
-  balance?: number | null;
-  unit?: string | null;
-  quotaUnlimited?: boolean | null;
-  quotaLimit?: number | null;
-  quotaUsed?: number | null;
-  quotaRemaining?: number | null;
-  todayRequests?: number | null;
-  todayTotalTokens?: number | null;
-  todayCost?: number | null;
-  totalRequests?: number | null;
-  totalTotalTokens?: number | null;
-  totalCost?: number | null;
-  modelStatsCount: number;
-  latencyMs: number;
-  details?: Array<{
-    key: string;
-    label: string;
-    value: string;
-  }>;
+const CODEX_API_KEY_USAGE_CACHE_KEY = 'agtools.codex.apiKeyUsage.cache.v1';
+export const CODEX_API_KEY_USAGE_AUTO_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+
+export function readCodexApiKeyUsageCache(): Record<string, CodexApiKeyUsageCacheEntry> {
+  try {
+    const raw = localStorage.getItem(CODEX_API_KEY_USAGE_CACHE_KEY);
+    return parseCodexApiKeyUsageCache(raw);
+  } catch {
+    return {};
+  }
+}
+
+export function writeCodexApiKeyUsageCache(
+  value: Record<string, CodexApiKeyUsageCacheEntry>,
+): void {
+  try {
+    localStorage.setItem(
+      CODEX_API_KEY_USAGE_CACHE_KEY,
+      serializeCodexApiKeyUsageCache(value),
+    );
+  } catch {
+    // ignore persistence failures
+  }
 }
 
 export interface NewApiQuotaSnapshot {
@@ -120,7 +139,8 @@ export async function queryModelProviderUsage(input: {
       return await invoke('codex_query_model_provider_usage', {
         baseUrl,
         apiKey: input.apiKey,
-        integrationType: input.integrationType ?? null,
+        integrationType:
+          isOfficialDeepSeekBaseUrl(baseUrl) ? 'deepseek' : input.integrationType ?? null,
       });
     } catch (error) {
       lastError = error;
@@ -155,7 +175,11 @@ export function resolveModelProviderUsageMode(
   summary?: ModelProviderUsageSummary,
 ): ModelProviderUsageMode | null {
   if (!summary) return null;
-  if (summary.mode === 'new_api' || summary.mode === 'sub2api') {
+  if (
+    summary.mode === 'new_api' ||
+    summary.mode === 'sub2api' ||
+    summary.mode === 'deepseek'
+  ) {
     return summary.mode;
   }
   if (

--- a/src/services/modelProviderUsageService.ts
+++ b/src/services/modelProviderUsageService.ts
@@ -1,14 +1,12 @@
 import { invoke } from '@tauri-apps/api/core';
 
-import {
-  parseCodexApiKeyUsageCache,
-  serializeCodexApiKeyUsageCache,
-} from './modelProviderUsageHelpers';
 export {
   formatDeepSeekBalanceMoney,
   isOfficialDeepSeekBaseUrl,
   preferredDeepSeekCurrency,
+  readCodexApiKeyUsageCache,
   selectDeepSeekBalanceInfo,
+  writeCodexApiKeyUsageCache,
 } from './modelProviderUsageHelpers';
 export type {
   CodexApiKeyUsageCacheEntry,
@@ -17,7 +15,6 @@ export type {
 } from './modelProviderUsageHelpers';
 import {
   isOfficialDeepSeekBaseUrl,
-  type CodexApiKeyUsageCacheEntry,
   type ModelProviderUsageSummary,
 } from './modelProviderUsageHelpers';
 
@@ -34,30 +31,7 @@ export interface ModelProviderModelsResult {
   latencyMs: number;
 }
 
-const CODEX_API_KEY_USAGE_CACHE_KEY = 'agtools.codex.apiKeyUsage.cache.v1';
 export const CODEX_API_KEY_USAGE_AUTO_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
-
-export function readCodexApiKeyUsageCache(): Record<string, CodexApiKeyUsageCacheEntry> {
-  try {
-    const raw = localStorage.getItem(CODEX_API_KEY_USAGE_CACHE_KEY);
-    return parseCodexApiKeyUsageCache(raw);
-  } catch {
-    return {};
-  }
-}
-
-export function writeCodexApiKeyUsageCache(
-  value: Record<string, CodexApiKeyUsageCacheEntry>,
-): void {
-  try {
-    localStorage.setItem(
-      CODEX_API_KEY_USAGE_CACHE_KEY,
-      serializeCodexApiKeyUsageCache(value),
-    );
-  } catch {
-    // ignore persistence failures
-  }
-}
 
 export interface NewApiQuotaSnapshot {
   granted: number | null;

--- a/src/utils/codexProviderGateway.ts
+++ b/src/utils/codexProviderGateway.ts
@@ -36,7 +36,6 @@ export interface CodexProviderCapabilityProfile {
 }
 
 const CHAT_COMPLETIONS_PRESET_IDS = new Set([
-  "deepseek",
   "moonshot",
   "siliconflow",
   "siliconflow_en",


### PR DESCRIPTION
## Summary

- Add official DeepSeek Responses API support for Codex.
- Add `deepseek-v4-pro` and `deepseek-v4-flash` model metadata with direct Responses routing.
- Migrate existing official DeepSeek accounts and provider records idempotently; custom relays are left unchanged.
- Add DeepSeek `GET /user/balance` querying with decimal-preserving multi-currency parsing.
- Show DeepSeek balances on Codex Accounts, Dashboard, and the macOS native menu.
- Use CNY for `zh-cn`/`zh-tw` and USD for other client languages, with fallback to the first returned currency.
- Keep usage/balance cache in process memory instead of browser localStorage to avoid clear-text sensitive-data storage flagged by CodeQL.
- Add design/ADR/ticket documentation and regression tests.

## Validation

- `npm run typecheck`
- `npm run test:frontend` (3 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml` (351 passed, 1 existing manual test ignored)
- DeepSeek-focused Rust tests (12 passed)
- CodeQL: no new alerts on the security follow-up commit

## Notes

- The Windows x64 NSIS/MSI artifacts were built separately for manual testing and are not committed to this PR.
- No API keys or other credentials are included.

