### PR TITLE
fix(cockpit-cliproxy): decode zstd-compressed HTTP request bodies before model validation

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	internalregistry "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	responsesconverter "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses"
@@ -1454,10 +1455,90 @@ func readAndRestoreBody(r *http.Request) ([]byte, error) {
 	if r == nil || r.Body == nil {
 		return nil, nil
 	}
-	body, err := io.ReadAll(r.Body)
+
+	raw, err := io.ReadAll(r.Body)
 	_ = r.Body.Close()
+	if err != nil {
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		return raw, err
+	}
+
+	contentEncoding := strings.TrimSpace(r.Header.Get("Content-Encoding"))
+	if contentEncoding == "" || strings.EqualFold(contentEncoding, "identity") {
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		return raw, nil
+	}
+
+	body, err := decodeRelayRequestBody(raw, contentEncoding)
+	if err != nil {
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		return nil, err
+	}
+
+	// 请求体现在是普通 JSON，禁止后续处理器再次按 zstd 解压。
+	r.Header.Del("Content-Encoding")
+	r.Header.Del("Transfer-Encoding")
+	r.TransferEncoding = nil
+
 	r.Body = io.NopCloser(bytes.NewReader(body))
-	return body, err
+	r.ContentLength = int64(len(body))
+	r.Header.Set(
+		"Content-Length",
+		strconv.FormatInt(r.ContentLength, 10),
+	)
+
+	return body, nil
+}
+
+func decodeRelayRequestBody(
+	raw []byte,
+	contentEncoding string,
+) ([]byte, error) {
+	encodings := strings.Split(contentEncoding, ",")
+	body := raw
+
+	// Content-Encoding 必须按编码应用顺序的反方向解码。
+	for i := len(encodings) - 1; i >= 0; i-- {
+		encoding := strings.ToLower(
+			strings.TrimSpace(encodings[i]),
+		)
+
+		switch encoding {
+		case "", "identity":
+			continue
+
+		case "zstd":
+			decoder, err := zstd.NewReader(
+				bytes.NewReader(body),
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to create zstd request decoder: %w",
+					err,
+				)
+			}
+
+			decoded, readErr := io.ReadAll(decoder)
+			decoder.Close()
+
+			if readErr != nil {
+				return nil, fmt.Errorf(
+					"failed to decode zstd request body: %w",
+					readErr,
+				)
+			}
+
+			body = decoded
+
+		default:
+			return nil, fmt.Errorf(
+				"unsupported request content encoding: %s",
+				encoding,
+			)
+		}
+	}
+
+	return body, nil
 }
 
 func rewriteBodyModel(m *manifest, spec *apiKeySpec, body []byte) ([]byte, string, error) {


### PR DESCRIPTION
## 问题

Cockpit Codex API Service 运行在一台局域网电脑上，另一台电脑通过 CC Switch 配置 Codex provider，通过ChatGPT App（Windows）直接访问局域网 API。

为了启用 Codex 远程压缩，将provider 的 `name` 设置为 `OpenAI`。关闭 CC Switch 路由并使用 HTTP 后，Codex 发送消息会收到 `model is required`。相同 provider 开启 CC Switch 路由，或者改用 WebSocket，都可以正常使用。

需要强调的是，name = "OpenAI" 和远程压缩是问题暴露时的配置条件，但报错不要求当轮实际发生 `/responses/compact`，出错的请求是普通的 `POST /v1/responses`，请求头包含 `Content-Encoding: zstd`。Cockpit Sidecar 在解析 JSON 前没有解压请求体，因此读不到其中的 `model`。

## 复现环境

- Cockpit Tools `v1.3.16`
- Codex API Service 使用 Sidecar 模式（API服务-新）
- Cockpit API 监听局域网地址，例如 `http://LAN_IP:PORT/v1`
- Codex 与 Cockpit 位于两台不同的局域网电脑
- CC Switch 路由关闭
- provider 的 `name` 设置为 `OpenAI`
- `wire_api = "responses"`
- `supports_websockets = false`，强制使用 HTTP
- Cockpit API Key 和其他认证配置有效

使用的核心配置示例：

```toml
model_provider = "custom"
model = "gpt-5.6-sol"

[model_providers.custom]
name = "OpenAI"
wire_api = "responses"
base_url = "http://LAN_IP:PORT/v1"
requires_openai_auth = false
supports_websockets = false
experimental_bearer_token = "<Cockpit API Key>"
```

此处 `name = "OpenAI"` 是复现条件之一。该名称会让 Codex 把这个自定义 provider 按 OpenAI provider 处理，并使用对应的远程压缩能力（根据CC Switch启用远程压缩后的默认行为，Codex 会根据 provider 身份决定是否使用远程压缩）。

## 复现步骤

1. 在局域网电脑上启动 Cockpit Codex API Service，并选择 Sidecar 模式。
2. 在另一台电脑上通过 CC Switch 添加该 Cockpit API。
3. 将 provider 的 `name` 设置为 `OpenAI`。
4. 关闭 CC Switch 的“启用路由”。
5. 将 `supports_websockets` 设置为 `false`，确保请求使用 HTTP。
6. 重启 Codex，或者新建任务以重新加载 provider 配置。
7. 新建一个空对话并发送 `你好`。

请求会到达 Cockpit，但返回 `model is required`，无法开始正常回复。

以下两种操作可以作为对照：

- 将 `supports_websockets` 改为 `true`，同一 provider 可以正常回复；
- 保持 HTTP，但开启 CC Switch 路由，同一请求也可以正常回复。

因此，模型、账号、Cockpit API Key 和局域网连接本身都是可用的。问题只出现在关闭 CC Switch 路由、直接使用 Cockpit HTTP API，并由 Codex 发送 zstd 压缩请求体的路径上。

## 原因

Cockpit Sidecar 的 `requestPolicy.middleware()` 会在请求进入实际 handler 前调用 `readAndRestoreBody()`，读取 JSON 并检查或重写 `model`。

原来的实现只读取原始请求体：

```go
body, err := io.ReadAll(r.Body)
```

当请求带有 `Content-Encoding: zstd` 时，`body` 中保存的是压缩数据，不是 JSON。

后续处理过程如下：

1. `rewriteBodyModel()` 对压缩数据执行 JSON 解析；
2. JSON 解析失败，无法取得 `model`；
3. 压缩数据被原样恢复到 `r.Body`；
4. `handleExecutorRequest()` 再次读取相同的压缩数据；
5. `requestBodyModel()` 返回空字符串；
6. Sidecar 返回 `model is required`。

内层 CLIProxyAPI 已经能够解压 zstd 请求体，但 Cockpit 外层 relay 会先读取请求，所以请求还没有进入内层解压逻辑就已经解析失败。

### 为什么开启 CC Switch 路由后可以正常使用

开启路由后，Codex 不再直接请求局域网中的 Cockpit，而是先把请求发送到 CC Switch 的本地地址，例如 `http://127.0.0.1:12345/v1`。

CC Switch 3.16.4 及之后的路由层支持处理 zstd 请求体。收到带有 `Content-Encoding: zstd` 的请求后，CC Switch 会先解压，再解析并转发给上游 Cockpit。Cockpit 最终收到的是已经解压的 JSON，因此能够正常读取 `model`。

关闭路由后，请求会直接发送到  `http://LAN_IP:PORT/v1`，中间不再经过 CC Switch 的解压逻辑。zstd 压缩数据会原样到达 Cockpit Sidecar，随后在外层 relay 的 JSON 解析阶段失败并返回 `model is required`。

所以开启路由并没有修复 Cockpit 的请求解析，只是由 CC Switch 在请求到达 Cockpit 前完成了解压。

## 处理方式

`readAndRestoreBody()` 现在会先检查 `Content-Encoding`：

- 没有编码或使用 `identity` 时，保持原有行为；
- 使用 `zstd` 时，先解压请求体再交给 JSON 解析；
- 存在多个编码时，按照编码应用顺序的反方向逐层解码；
- 解压完成后，将普通 JSON 重新写入 `r.Body`；
- 删除旧的 `Content-Encoding` 和传输信息；
- 根据解压后的请求体重新设置 `ContentLength` 和 `Content-Length`；
- 遇到不支持的编码时返回明确错误。

这样 middleware 和后续 handler 读取到的都是同一份已经解压的 JSON，也不会发生重复解压。

## 验证结果

重新编译 `cockpit-cliproxy`，替换 Cockpit 使用的 Sidecar 并重启服务后，使用相同配置重新测试：

- CC Switch 路由保持关闭；
- provider 的 `name` 保持为 `OpenAI`；
- `supports_websockets = false`；
- 通过局域网地址直接访问 Cockpit；
- 新建对话并发送 `你好`。

请求正常完成，Codex 返回了回复，不再出现 `model is required`。

随后恢复 `supports_websockets = true`，WebSocket 路径仍然可以正常使用。


## 修复范围

旧 API（Legacy）模式此前也失败，只是在相同测试条件下返回错误值为 responses 请求体必须是合法 JSON。Sidecar 和 Legacy 使用两套独立的请求处理代码，Legacy 的请求处理位于 `src-tauri/src/modules/codex_local_access.rs`，也将 zstd 压缩字节直接当 JSON 解析

两者的处理思路相同，都是在解析 JSON 前根据 `Content-Encoding` 解压请求体。当前 PR 只修复 Sidecar 的 cockpit-cliproxy，没有修复 Legacy 的 Rust 网关。