### PR TITLE
fix: keep API service account membership in sync

### DIFF
--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/watcher/events.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/internal/watcher/events.go
@@ -27,11 +27,16 @@ func matchProvider(provider string, targets []string) (string, bool) {
 }
 
 func (w *Watcher) start(ctx context.Context) error {
-	if errAddConfig := w.watcher.Add(w.configPath); errAddConfig != nil {
-		log.Errorf("failed to watch config file %s: %v", w.configPath, errAddConfig)
+	// Watch the parent directory instead of the file itself. Cockpit writes
+	// configuration with an atomic temp-file replace; on Windows a file watch
+	// then remains attached to the removed inode and misses every later update.
+	// Directory watching keeps the path observable across replace/rename events.
+	configWatchPath := filepath.Dir(w.configPath)
+	if errAddConfig := w.watcher.Add(configWatchPath); errAddConfig != nil {
+		log.Errorf("failed to watch config directory %s: %v", configWatchPath, errAddConfig)
 		return errAddConfig
 	}
-	log.Debugf("watching config file: %s", w.configPath)
+	log.Debugf("watching config directory for %s: %s", filepath.Base(w.configPath), configWatchPath)
 
 	if errAddAuthDir := w.watcher.Add(w.authDir); errAddAuthDir != nil {
 		log.Errorf("failed to watch auth directory %s: %v", w.authDir, errAddAuthDir)

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/builder.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/builder.go
@@ -62,6 +62,12 @@ type Hooks struct {
 	// OnAfterStart is called after the service has started successfully,
 	// providing access to the service instance for additional operations.
 	OnAfterStart func(*Service)
+
+	// OnConfigReload lets an embedding host rebuild custom routing state when
+	// the file watcher adopts a new config. Without this callback the default
+	// service reload replaces the host's scoped selector with a plain round
+	// robin selector, allowing credentials outside an API-key pool to route.
+	OnConfigReload func(*config.Config)
 }
 
 // NewBuilder creates a Builder with default dependencies left unset.

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/service.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/service.go
@@ -522,7 +522,7 @@ func (s *Service) applyConfigUpdate(newCfg *config.Config) {
 		previousSessionAffinity != nextSessionAffinity ||
 		previousSessionAffinityTTL != nextSessionAffinityTTL
 
-	if s.coreManager != nil && selectorChanged {
+	if s.coreManager != nil && selectorChanged && s.hooks.OnConfigReload == nil {
 		var selector coreauth.Selector
 		switch nextStrategy {
 		case "fill-first":
@@ -545,6 +545,9 @@ func (s *Service) applyConfigUpdate(newCfg *config.Config) {
 		}
 
 		s.coreManager.SetSelector(selector)
+	}
+	if selectorChanged && s.hooks.OnConfigReload != nil {
+		s.hooks.OnConfigReload(newCfg)
 	}
 
 	s.applyRetryConfig(newCfg)

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -137,6 +137,10 @@ type apiKeySpec struct {
 type apiKeyPriorityState struct {
 	PriorityAccountIDs  map[string][]string `json:"priorityAccountIds"`
 	PreferredAccountIDs map[string]string   `json:"preferredAccountIds"`
+	// AccountIDs is the authoritative live scope written by Cockpit's pool
+	// guard. It is separate from priorityAccountIds: an empty scope is valid
+	// and must not fall back to the stale manifest snapshot.
+	AccountIDs map[string][]string `json:"accountIds"`
 }
 
 type apiKeyPriorityStateStore struct {
@@ -144,12 +148,16 @@ type apiKeyPriorityStateStore struct {
 	mu              sync.RWMutex
 	lastModUnixNano int64
 	priorities      map[string][]string
+	scopes          map[string][]string
+	scopeKnown      map[string]bool
 }
 
 func newAPIKeyPriorityStateStore(manifestPath string) *apiKeyPriorityStateStore {
 	store := &apiKeyPriorityStateStore{
 		path:       filepath.Join(filepath.Dir(manifestPath), "api-key-priorities.json"),
 		priorities: make(map[string][]string),
+		scopes:     make(map[string][]string),
+		scopeKnown: make(map[string]bool),
 	}
 	store.reloadIfChanged()
 	return store
@@ -163,6 +171,20 @@ func (s *apiKeyPriorityStateStore) priorityAccountIDs(apiKeyID string) []string 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return append([]string(nil), s.priorities[strings.TrimSpace(apiKeyID)]...)
+}
+
+func (s *apiKeyPriorityStateStore) accountScope(apiKeyID string) ([]string, bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.reloadIfChanged()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	key := strings.TrimSpace(apiKeyID)
+	if !s.scopeKnown[key] {
+		return nil, false
+	}
+	return append([]string(nil), s.scopes[key]...), true
 }
 
 func (s *apiKeyPriorityStateStore) reloadIfChanged() {
@@ -219,9 +241,34 @@ func (s *apiKeyPriorityStateStore) reloadIfChanged() {
 			next[apiKeyID] = []string{accountID}
 		}
 	}
+	nextScopes := make(map[string][]string, len(state.AccountIDs))
+	scopeKnown := make(map[string]bool, len(state.AccountIDs))
+	for apiKeyID, accountIDs := range state.AccountIDs {
+		apiKeyID = strings.TrimSpace(apiKeyID)
+		if apiKeyID == "" {
+			continue
+		}
+		seen := make(map[string]struct{}, len(accountIDs))
+		normalized := make([]string, 0, len(accountIDs))
+		for _, accountID := range accountIDs {
+			accountID = strings.TrimSpace(strings.TrimSuffix(accountID, ".json"))
+			if accountID == "" {
+				continue
+			}
+			if _, exists := seen[accountID]; exists {
+				continue
+			}
+			seen[accountID] = struct{}{}
+			normalized = append(normalized, accountID)
+		}
+		nextScopes[apiKeyID] = normalized
+		scopeKnown[apiKeyID] = true
+	}
 	s.mu.Lock()
 	s.lastModUnixNano = modifiedAt
 	s.priorities = next
+	s.scopes = nextScopes
+	s.scopeKnown = scopeKnown
 	s.mu.Unlock()
 }
 
@@ -885,6 +932,114 @@ type requestPolicy struct {
 	manifest *manifest
 	emitter  *eventEmitter
 	tracker  *requestUsageTracker
+	scopes   *apiKeyAccountScopeStore
+}
+
+// apiKeyAccountScopeStore is deliberately independent from manifest reloads.
+// Cockpit updates config.json and manifest.json as separate atomic files; the
+// config scope is the authoritative API-key membership and can be adopted on
+// the next request without replacing the running HTTP server.
+type apiKeyAccountScopeStore struct {
+	path       string
+	mu         sync.RWMutex
+	modTime    int64
+	scopes     map[string][]string
+	known      map[string]bool
+}
+
+func newAPIKeyAccountScopeStore(path string) *apiKeyAccountScopeStore {
+	return &apiKeyAccountScopeStore{
+		path:  strings.TrimSpace(path),
+		scopes: make(map[string][]string),
+		known:  make(map[string]bool),
+	}
+}
+
+func normalizeScopeAccountID(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimSuffix(value, ".json")
+	return value
+}
+
+func (s *apiKeyAccountScopeStore) reloadIfChanged() {
+	if s == nil || s.path == "" {
+		return
+	}
+	info, err := os.Stat(s.path)
+	if err != nil {
+		return
+	}
+	modTime := info.ModTime().UnixNano()
+	s.mu.RLock()
+	unchanged := modTime == s.modTime
+	s.mu.RUnlock()
+	if unchanged {
+		return
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return
+	}
+	var config struct {
+		AccountScopes map[string][]string `json:"api-key-account-ids"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return
+	}
+	next := make(map[string][]string, len(config.AccountScopes))
+	known := make(map[string]bool, len(config.AccountScopes))
+	for key, values := range config.AccountScopes {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		known[key] = true
+		clean := make([]string, 0, len(values))
+		seen := make(map[string]struct{}, len(values))
+		for _, value := range values {
+			accountID := normalizeScopeAccountID(value)
+			if accountID == "" {
+				continue
+			}
+			if _, exists := seen[accountID]; exists {
+				continue
+			}
+			seen[accountID] = struct{}{}
+			clean = append(clean, accountID)
+		}
+		if len(clean) > 0 {
+			next[key] = clean
+		}
+	}
+	s.mu.Lock()
+	s.modTime = modTime
+	s.scopes = next
+	s.known = known
+	s.mu.Unlock()
+}
+
+func (s *apiKeyAccountScopeStore) accountIDs(apiKeyID string) ([]string, bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.reloadIfChanged()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	key := strings.TrimSpace(apiKeyID)
+	return append([]string(nil), s.scopes[key]...), s.known[key]
+}
+
+func scopedAPIKeySpec(spec *apiKeySpec, scopes *apiKeyAccountScopeStore) *apiKeySpec {
+	if spec == nil || scopes == nil {
+		return spec
+	}
+	accountIDs, known := scopes.accountIDs(spec.ID)
+	if !known {
+		return spec
+	}
+	copySpec := *spec
+	copySpec.AccountIDs = accountIDs
+	return &copySpec
 }
 
 func (p *requestPolicy) middleware() gin.HandlerFunc {
@@ -986,7 +1141,7 @@ func (p *requestPolicy) lookupAPIKey(r *http.Request) *apiKeySpec {
 	if key == "" {
 		return nil
 	}
-	return p.manifest.apiKeyByValue[key]
+	return scopedAPIKeySpec(p.manifest.apiKeyByValue[key], p.scopes)
 }
 
 func ensureRequestID(c *gin.Context) string {
@@ -2348,27 +2503,39 @@ func (s *cockpitSelector) filterAuthsForAPIKeyScope(ctx context.Context, auths [
 		return auths
 	}
 	spec, _ := ctx.Value(clientAPIKeyContextKey).(*apiKeySpec)
-	if spec == nil || len(spec.AccountIDs) == 0 {
+	if spec == nil {
 		return auths
 	}
-
-	allowedAccountIDs := make(map[string]struct{}, len(spec.AccountIDs))
-	for _, accountID := range spec.AccountIDs {
-		if accountID = strings.TrimSpace(accountID); accountID != "" {
-			allowedAccountIDs[accountID] = struct{}{}
+	accountIDs := spec.AccountIDs
+	if s.priorities != nil {
+		if liveAccountIDs, known := s.priorities.accountScope(spec.ID); known {
+			accountIDs = liveAccountIDs
 		}
 	}
-	if len(allowedAccountIDs) == 0 {
+	return filterAuthsForManifestAccountIDs(s.manifest, accountIDs, auths)
+}
+
+func filterAuthsForManifestAccountIDs(m *manifest, accountIDs []string, auths []*coreauth.Auth) []*coreauth.Auth {
+	if m == nil {
+		return auths
+	}
+	allowed := make(map[string]struct{}, len(accountIDs))
+	for _, accountID := range accountIDs {
+		accountID = strings.TrimSpace(strings.TrimSuffix(accountID, ".json"))
+		if accountID != "" {
+			allowed[accountID] = struct{}{}
+		}
+	}
+	if len(allowed) == 0 {
 		return nil
 	}
-
 	scoped := make([]*coreauth.Auth, 0, len(auths))
 	for _, auth := range auths {
-		account := s.accountForAuth(auth)
+		account := accountForAuthInManifest(m, auth)
 		if account == nil {
 			continue
 		}
-		if _, allowed := allowedAccountIDs[account.ID]; allowed {
+		if _, ok := allowed[account.ID]; ok {
 			scoped = append(scoped, auth)
 		}
 	}
@@ -3114,7 +3281,15 @@ func buildCoreAuthSelector(cfg *config.Config, selector coreauth.Selector, m *ma
 			Fallback: selector,
 			TTL:      ttl,
 		})
-		selector = &cockpitSessionAffinitySelector{inner: selector}
+		var priorities *apiKeyPriorityStateStore
+		if cockpit, ok := imageFallback.(*cockpitSelector); ok {
+			priorities = cockpit.priorities
+		}
+		selector = &cockpitSessionAffinitySelector{
+			inner:      selector,
+			manifest:   m,
+			priorities: priorities,
+		}
 		selector = &imageRequestSelector{
 			imageFallback: imageFallback,
 			fallback:      selector,
@@ -3141,7 +3316,9 @@ func buildCoreAuthManager(cfg *config.Config, selector coreauth.Selector, hook c
 }
 
 type cockpitSessionAffinitySelector struct {
-	inner coreauth.Selector
+	inner      coreauth.Selector
+	manifest   *manifest
+	priorities *apiKeyPriorityStateStore
 }
 
 func (s *cockpitSessionAffinitySelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
@@ -3155,6 +3332,15 @@ func (s *cockpitSessionAffinitySelector) Pick(ctx context.Context, provider, mod
 		}
 		metadata[cliproxyexecutor.SessionAffinityNamespaceMetadataKey] = spec.ID
 		opts.Metadata = metadata
+	}
+	// Filter against the live route scope before consulting the affinity cache.
+	// Otherwise a removed account remains eligible from the old sticky binding.
+	if s.manifest != nil && s.priorities != nil {
+		if spec, _ := ctx.Value(clientAPIKeyContextKey).(*apiKeySpec); spec != nil {
+			if accountIDs, known := s.priorities.accountScope(spec.ID); known {
+				auths = filterAuthsForManifestAccountIDs(s.manifest, accountIDs, auths)
+			}
+		}
 	}
 	return s.inner.Pick(ctx, provider, model, opts, auths)
 }
@@ -3329,7 +3515,7 @@ func buildCodexAlphaSearchHeaders(src http.Header, auth *coreauth.Auth) http.Hea
 	return headers
 }
 
-func newSidecarRuntime(ctx context.Context, configPath string, cfg *config.Config, m *manifest, manager *coreauth.Manager) (*sidecarRuntime, error) {
+func newSidecarRuntime(ctx context.Context, configPath string, cfg *config.Config, m *manifest, manager *coreauth.Manager, baseSelector coreauth.Selector, quota *quotaReserveStateStore) (*sidecarRuntime, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
 	}
@@ -3358,6 +3544,12 @@ func newSidecarRuntime(ctx context.Context, configPath string, cfg *config.Confi
 		WithHooks(cliproxy.Hooks{
 			OnAfterStart: func(*cliproxy.Service) {
 				readyOnce.Do(func() { close(readyCh) })
+			},
+			OnConfigReload: func(newCfg *config.Config) {
+				// Keep Cockpit's API-key scope, quota, and affinity wrappers when
+				// CLIProxy hot-reloads its config. The stock service rebuilds a
+				// plain round-robin selector on its own.
+				manager.SetSelector(buildCoreAuthSelector(newCfg, baseSelector, m, quota))
 			},
 		}).
 		Build()
@@ -8094,7 +8286,8 @@ func main() {
 	}
 
 	usageTracker := newRequestUsageTracker()
-	policy := &requestPolicy{manifest: m, emitter: emitter, tracker: usageTracker}
+	scopes := newAPIKeyAccountScopeStore(absConfigPath)
+	policy := &requestPolicy{manifest: m, emitter: emitter, tracker: usageTracker, scopes: scopes}
 	hook := &authHook{manifest: m, emitter: emitter}
 	priorityState := newAPIKeyPriorityStateStore(*manifestPath)
 	selector := &cockpitSelector{
@@ -8115,7 +8308,7 @@ func main() {
 
 	coreusage.RegisterPlugin(&usagePlugin{manifest: m, tracker: usageTracker})
 
-	runtime, err := newSidecarRuntime(ctx, absConfigPath, cfg, m, coreManager)
+	runtime, err := newSidecarRuntime(ctx, absConfigPath, cfg, m, coreManager, selector, quotaState)
 	if err != nil {
 		emitter.emit(map[string]any{"type": "error", "message": err.Error()})
 		os.Exit(1)

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -912,6 +912,79 @@ func TestCockpitSessionAffinitySeparatesClientAPIKeyScopes(t *testing.T) {
 	}
 }
 
+func TestCockpitSessionAffinityDropsAccountRemovedFromLiveScope(t *testing.T) {
+	oldAccount := &accountSpec{ID: "account-old", AuthID: "account-old.json"}
+	k12Account := &accountSpec{ID: "account-k12", AuthID: "account-k12.json"}
+	m := &manifest{
+		accountByAuthID: map[string]*accountSpec{
+			oldAccount.AuthID: oldAccount,
+			k12Account.AuthID: k12Account,
+		},
+		accountByID: map[string]*accountSpec{
+			oldAccount.ID: oldAccount,
+			k12Account.ID: k12Account,
+		},
+	}
+	priorityPath := filepath.Join(t.TempDir(), "api-key-priorities.json")
+	if err := os.WriteFile(priorityPath, []byte(`{"accountIds":{"pool-key":["account-old"]}}`), 0o600); err != nil {
+		t.Fatalf("write initial live scope: %v", err)
+	}
+	store := newAPIKeyPriorityStateStore(priorityPath)
+	fallback := &cockpitSelector{manifest: m, priorities: store}
+	affinity := coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Hour,
+	})
+	selector := &cockpitSessionAffinitySelector{inner: affinity, manifest: m, priorities: store}
+	auths := []*coreauth.Auth{
+		{ID: oldAccount.AuthID, Provider: "codex", Status: coreauth.StatusActive},
+		{ID: k12Account.AuthID, Provider: "codex", Status: coreauth.StatusActive},
+	}
+	ctx := context.WithValue(context.Background(), clientAPIKeyContextKey, &apiKeySpec{ID: "pool-key"})
+	opts := cliproxyexecutor.Options{Headers: http.Header{"X-Session-ID": []string{"sticky"}}}
+	first, err := selector.Pick(ctx, "codex", "gpt-5.4", opts, auths)
+	if err != nil || first.ID != oldAccount.AuthID {
+		t.Fatalf("initial live scope should select old account, got=%v err=%v", first, err)
+	}
+	if err := os.WriteFile(priorityPath, []byte(`{"accountIds":{"pool-key":["account-k12"]}}`), 0o600); err != nil {
+		t.Fatalf("write rotated live scope: %v", err)
+	}
+	updatedAt := time.Now().Add(time.Second)
+	if err := os.Chtimes(priorityPath, updatedAt, updatedAt); err != nil {
+		t.Fatalf("advance live scope timestamp: %v", err)
+	}
+	second, err := selector.Pick(ctx, "codex", "gpt-5.4", opts, auths)
+	if err != nil || second.ID != k12Account.AuthID {
+		t.Fatalf("rotated live scope must evict sticky old account, got=%v err=%v", second, err)
+	}
+}
+
+func TestAPIKeyAccountScopeStoreAdoptsAtomicConfigReplacement(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	write := func(value string) {
+		tmp := path + ".tmp"
+		if err := os.WriteFile(tmp, []byte(value), 0o600); err != nil {
+			t.Fatalf("write temporary config: %v", err)
+		}
+		if err := os.Rename(tmp, path); err != nil {
+			t.Fatalf("replace config: %v", err)
+		}
+	}
+	write(`{"api-key-account-ids":{"pool-key":["codex_old.json"]}}`)
+	store := newAPIKeyAccountScopeStore(path)
+	if got, known := store.accountIDs("pool-key"); !known || len(got) != 1 || got[0] != "codex_old" {
+		t.Fatalf("unexpected initial scope: %#v known=%v", got, known)
+	}
+	write(`{"api-key-account-ids":{"pool-key":["codex_k12.json"]}}`)
+	if got, known := store.accountIDs("pool-key"); !known || len(got) != 1 || got[0] != "codex_k12" {
+		t.Fatalf("atomic replacement was not adopted: %#v known=%v", got, known)
+	}
+	write(`{"api-key-account-ids":{"pool-key":[]}}`)
+	if got, known := store.accountIDs("pool-key"); !known || len(got) != 0 {
+		t.Fatalf("empty live scope must remain authoritative: %#v known=%v", got, known)
+	}
+}
+
 func intPtrForTest(value int) *int {
 	return &value
 }
@@ -1640,7 +1713,7 @@ func TestSidecarRuntimeRegistersConfigCodexAPIKeyAuths(t *testing.T) {
 	}
 	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
 
-	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager)
+	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager, nil, nil)
 	if err != nil {
 		t.Fatalf("newSidecarRuntime: %v", err)
 	}
@@ -1708,7 +1781,7 @@ func TestSidecarRuntimeRegistersManifestCodexAccessTokenAuths(t *testing.T) {
 	}
 	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
 
-	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager)
+	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager, nil, nil)
 	if err != nil {
 		t.Fatalf("newSidecarRuntime: %v", err)
 	}
@@ -4238,7 +4311,7 @@ func TestSidecarRuntimeDoesNotSelectAccountWithExcludedModel(t *testing.T) {
 
 	cfg := &config.Config{AuthDir: authDir}
 	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
-	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager)
+	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager, nil, nil)
 	if err != nil {
 		t.Fatalf("newSidecarRuntime: %v", err)
 	}

--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -3204,8 +3204,13 @@ pub async fn codex_local_access_save_accounts(
 #[tauri::command]
 pub async fn codex_local_access_append_accounts(
     account_ids: Vec<String>,
+    allow_unready: Option<bool>,
 ) -> Result<CodexLocalAccessAppendAccountsResult, String> {
-    codex_local_access::append_local_access_accounts(account_ids).await
+    codex_local_access::append_local_access_accounts(
+        account_ids,
+        allow_unready.unwrap_or(false),
+    )
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/models/codex_local_access.rs
+++ b/src-tauri/src/models/codex_local_access.rs
@@ -819,6 +819,7 @@ pub struct CodexLocalAccessAppendAccountsResult {
     pub state: CodexLocalAccessState,
     pub synced_account_ids: Vec<String>,
     pub added_account_ids: Vec<String>,
+    pub pending_quota_account_ids: Vec<String>,
     pub skipped_accounts: Vec<CodexLocalAccessAppendAccountSkipped>,
 }
 

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -19565,6 +19565,17 @@ fn quota_refresh_route_skip_reason(
     }
 }
 
+fn quota_refresh_allows_manual_preselection(
+    skip_reason: Option<&str>,
+    allow_unready: bool,
+) -> bool {
+    allow_unready
+        && matches!(
+            skip_reason,
+            Some("quota_zero" | "quota_refresh_failed")
+        )
+}
+
 fn apply_account_usage_priority_ids(
     collection: &mut CodexLocalAccessCollection,
     backup_account_ids: Option<&[String]>,
@@ -19710,6 +19721,7 @@ pub async fn save_local_access_accounts(
 
 pub async fn append_local_access_accounts(
     account_ids: Vec<String>,
+    allow_unready: bool,
 ) -> Result<CodexLocalAccessAppendAccountsResult, String> {
     ensure_runtime_loaded_without_start().await?;
 
@@ -19749,9 +19761,16 @@ pub async fn append_local_access_accounts(
     )
     .await?;
     let mut routable_account_ids = Vec::new();
+    let mut pending_quota_account_ids = Vec::new();
     let mut remove_account_ids = HashSet::new();
     for (account_id, refresh_result) in refresh_results {
-        match quota_refresh_route_skip_reason(&refresh_result) {
+        let skip_reason = quota_refresh_route_skip_reason(&refresh_result);
+        if quota_refresh_allows_manual_preselection(skip_reason, allow_unready) {
+            routable_account_ids.push(account_id.clone());
+            pending_quota_account_ids.push(account_id);
+            continue;
+        }
+        match skip_reason {
             None => routable_account_ids.push(account_id),
             Some(reason) => {
                 if matches!(reason, "quota_zero" | "http_401" | "http_402") {
@@ -19810,6 +19829,7 @@ pub async fn append_local_access_accounts(
         state: snapshot_state_without_gateway_reload().await?,
         synced_account_ids,
         added_account_ids,
+        pending_quota_account_ids,
         skipped_accounts,
     })
 }
@@ -26658,6 +26678,26 @@ mod tests {
             )),
             Some("quota_refresh_failed")
         );
+        assert!(super::quota_refresh_allows_manual_preselection(
+            Some("quota_zero"),
+            true
+        ));
+        assert!(super::quota_refresh_allows_manual_preselection(
+            Some("quota_refresh_failed"),
+            true
+        ));
+        assert!(!super::quota_refresh_allows_manual_preselection(
+            Some("http_401"),
+            true
+        ));
+        assert!(!super::quota_refresh_allows_manual_preselection(
+            Some("http_402"),
+            true
+        ));
+        assert!(!super::quota_refresh_allows_manual_preselection(
+            Some("quota_zero"),
+            false
+        ));
     }
 
     #[test]

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -10606,9 +10606,17 @@ fn sidecar_api_key_manifest_values(collection: &CodexLocalAccessCollection) -> V
 
 fn sidecar_api_key_priority_state_values(collection: &CodexLocalAccessCollection) -> Value {
     let mut priority_account_ids = Map::new();
+    let mut account_ids = Map::new();
     for item in &collection.api_keys {
-        if api_key_inherits_account_pool(item) || api_key_has_fixed_account_scope(collection, item)
-        {
+        if !item.enabled || item.key.trim().is_empty() || item.provider_gateway.is_some() {
+            continue;
+        }
+        let scoped_account_ids = normalize_account_id_list(effective_api_key_account_ids(collection, item));
+        account_ids.insert(
+            item.id.clone(),
+            Value::Array(scoped_account_ids.into_iter().map(Value::String).collect()),
+        );
+        if api_key_inherits_account_pool(item) || api_key_has_fixed_account_scope(collection, item) {
             continue;
         }
         let priorities = normalize_account_id_list(item.priority_account_ids.clone())
@@ -10628,6 +10636,7 @@ fn sidecar_api_key_priority_state_values(collection: &CodexLocalAccessCollection
     }
     json!({
         "priorityAccountIds": priority_account_ids,
+        "accountIds": account_ids,
     })
 }
 

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -13829,33 +13829,106 @@ fn collection_content_fingerprint(
         .map_err(|error| format!("序列化 API 服务配置指纹失败: {}", error))
 }
 
-fn collection_disk_snapshot_for_cas(
-    runtime_fingerprint: &[u8],
-) -> Result<Option<(PathBuf, [u8; 32])>, String> {
+type CollectionDiskSnapshot = (PathBuf, CodexLocalAccessCollection, [u8; 32]);
+
+fn collection_disk_snapshot() -> Result<Option<CollectionDiskSnapshot>, String> {
     let path = local_access_file_path()?;
     let content = match std::fs::read(&path) {
         Ok(content) => content,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
             return Err(format!(
-                "读取 API 服务配置 CAS 快照失败: path={}, error={}",
+                "读取 API 服务配置快照失败: path={}, error={}",
                 path.display(),
                 error
             ));
         }
     };
-    let disk_collection =
+    let collection =
         serde_json::from_slice::<CodexLocalAccessCollection>(&content).map_err(|error| {
             format!(
-                "解析 API 服务配置 CAS 快照失败: path={}, error={}",
+                "解析 API 服务配置快照失败: path={}, error={}",
                 path.display(),
                 error
             )
         })?;
+    Ok(Some((path, collection, Sha256::digest(&content).into())))
+}
+
+fn collection_disk_snapshot_for_cas(
+    runtime_fingerprint: &[u8],
+) -> Result<Option<(PathBuf, [u8; 32])>, String> {
+    let Some((path, disk_collection, disk_hash)) = collection_disk_snapshot()? else {
+        return Ok(None);
+    };
     if collection_content_fingerprint(&disk_collection)? != runtime_fingerprint {
         return Ok(None);
     }
-    Ok(Some((path, Sha256::digest(&content).into())))
+    Ok(Some((path, disk_hash)))
+}
+
+fn runtime_collection_matches_disk(
+    runtime: &GatewayRuntime,
+    disk_collection: &CodexLocalAccessCollection,
+) -> Result<bool, String> {
+    let Some(runtime_collection) = runtime.collection.as_ref() else {
+        return Ok(false);
+    };
+    Ok(collection_content_fingerprint(runtime_collection)?
+        == collection_content_fingerprint(disk_collection)?)
+}
+
+/// Adopt atomically-written collection changes made by trusted companion tools.
+/// This updates Cockpit's cached membership and page state only; it deliberately
+/// does not stop or restart the active sidecar.
+async fn sync_runtime_collection_from_disk_if_changed() -> Result<bool, String> {
+    let snapshot = tauri::async_runtime::spawn_blocking(collection_disk_snapshot)
+        .await
+        .map_err(|error| format!("读取 API 服务配置快照任务失败: {}", error))??;
+    let Some((path, disk_collection, expected_disk_hash)) = snapshot else {
+        return Ok(false);
+    };
+
+    let (previous_count, next_count) = {
+        let mut runtime = gateway_runtime().lock().await;
+        if !runtime.loaded || runtime_collection_matches_disk(&runtime, &disk_collection)? {
+            return Ok(false);
+        }
+
+        // Recheck the file while holding the runtime lock. An in-app save writes
+        // disk before publishing runtime; this CAS prevents an older snapshot
+        // from overwriting that newer in-memory state.
+        let current_content = std::fs::read(&path).map_err(|error| {
+            format!(
+                "复核 API 服务配置快照失败: path={}, error={}",
+                path.display(),
+                error
+            )
+        })?;
+        let current_disk_hash: [u8; 32] = Sha256::digest(&current_content).into();
+        if current_disk_hash != expected_disk_hash {
+            return Ok(false);
+        }
+
+        let previous_count = runtime
+            .collection
+            .as_ref()
+            .map(|collection| collection.account_ids.len())
+            .unwrap_or(0);
+        let next_count = disk_collection.account_ids.len();
+        let last_error = runtime.last_error.clone();
+        sync_runtime_collection(&mut runtime, disk_collection);
+        runtime.last_error = last_error;
+        (previous_count, next_count)
+    };
+
+    GATEWAY_COLLECTION_ACCOUNT_SANITIZE_COMPLETED.store(false, Ordering::SeqCst);
+    ensure_collection_account_sanitize_started();
+    logger::log_codex_api_info(&format!(
+        "检测到 API 服务磁盘配置已由外部更新，已同步 Cockpit 运行态显示（不重启 Sidecar）: accounts={} -> {}",
+        previous_count, next_count
+    ));
+    Ok(true)
 }
 
 /// Background membership prune. Never writes a stale clone over a newer collection:
@@ -16538,6 +16611,14 @@ fn build_fresh_state_snapshot(runtime: &mut GatewayRuntime) -> CodexLocalAccessS
 
 async fn snapshot_state() -> Result<CodexLocalAccessState, String> {
     ensure_runtime_loaded_without_start().await?;
+    if let Err(error) = sync_runtime_collection_from_disk_if_changed().await {
+        // A transient external write must not make the API Service page unusable;
+        // keep serving the last valid runtime snapshot and retry on the next read.
+        logger::log_codex_api_warn(&format!(
+            "同步 API 服务外部配置到 Cockpit 运行态失败，暂时保留上次有效状态: {}",
+            error
+        ));
+    }
     let mut runtime = gateway_runtime().lock().await;
     refresh_gateway_process_status(&mut runtime);
     if runtime
@@ -26426,6 +26507,28 @@ mod tests {
             created_at: 0,
             updated_at: 0,
         }
+    }
+
+    #[test]
+    fn runtime_collection_detects_externally_changed_membership() {
+        let mut runtime = super::GatewayRuntime::default();
+        runtime.loaded = true;
+        super::sync_runtime_collection(
+            &mut runtime,
+            test_local_access_collection(vec!["k12-account".to_string()]),
+        );
+        let disk_collection = test_local_access_collection(vec!["pro-account".to_string()]);
+
+        assert!(
+            !super::runtime_collection_matches_disk(&runtime, &disk_collection)
+                .expect("compare changed collection")
+        );
+
+        super::sync_runtime_collection(&mut runtime, disk_collection.clone());
+        assert!(
+            super::runtime_collection_matches_disk(&runtime, &disk_collection)
+                .expect("compare synchronized collection")
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -1,4 +1,6 @@
-use crate::models::codex::{CodexAccount, CodexApiProviderMode, CodexAppSpeed, CodexAuthMode};
+use crate::models::codex::{
+    CodexAccount, CodexApiProviderMode, CodexAppSpeed, CodexAuthMode, CodexQuota,
+};
 use crate::models::codex_local_access::{
     CodexLocalAccessAccountCooldown, CodexLocalAccessAccountHealth,
     CodexLocalAccessAccountModelRule, CodexLocalAccessAccountStats, CodexLocalAccessApiKey,
@@ -19538,6 +19540,31 @@ fn append_eligible_local_access_account_ids(
     )
 }
 
+fn quota_refresh_terminal_http_status(error: &str) -> Option<u16> {
+    error
+        .split(|ch: char| !ch.is_ascii_digit())
+        .filter(|part| !part.is_empty())
+        .filter_map(|part| part.parse::<u16>().ok())
+        .find(|status| matches!(status, 401 | 402))
+}
+
+fn quota_refresh_route_skip_reason(
+    result: &Result<CodexQuota, String>,
+) -> Option<&'static str> {
+    match result {
+        Ok(quota) if quota.hourly_window_present != Some(true) => {
+            Some("quota_refresh_failed")
+        }
+        Ok(quota) if quota.hourly_percentage <= 0 => Some("quota_zero"),
+        Ok(_) => None,
+        Err(error) => match quota_refresh_terminal_http_status(error) {
+            Some(401) => Some("http_401"),
+            Some(402) => Some("http_402"),
+            _ => Some("quota_refresh_failed"),
+        },
+    }
+}
+
 fn apply_account_usage_priority_ids(
     collection: &mut CodexLocalAccessCollection,
     backup_account_ids: Option<&[String]>,
@@ -19686,6 +19713,12 @@ pub async fn append_local_access_accounts(
 ) -> Result<CodexLocalAccessAppendAccountsResult, String> {
     ensure_runtime_loaded_without_start().await?;
 
+    let requested_account_ids = account_ids
+        .into_iter()
+        .map(|account_id| account_id.trim().to_string())
+        .filter(|account_id| !account_id.is_empty())
+        .collect::<Vec<_>>();
+
     let existing_collection = {
         let runtime = gateway_runtime().lock().await;
         runtime.collection.clone()
@@ -19699,34 +19732,77 @@ pub async fn append_local_access_accounts(
         .as_ref()
         .map(|collection| collection.account_ids.as_slice())
         .unwrap_or(&[]);
-    let (next_account_ids, synced_account_ids, added_account_ids, skipped_accounts) =
+    let (_, refresh_candidate_ids, _, mut skipped_accounts) =
         append_eligible_local_access_account_ids(
             current_account_ids,
-            account_ids,
+            requested_account_ids,
             &accounts,
             restrict_free_accounts,
         );
 
-    if !added_account_ids.is_empty() {
+    // Imported/newly selected accounts must have a fresh, successful quota read
+    // before they can receive API traffic. A measured zero or terminal 401/402
+    // also removes an already-routed account, while preserving its vault record.
+    let refresh_results = codex_quota::refresh_quotas_for_account_ids_with_options(
+        &refresh_candidate_ids,
+        false,
+    )
+    .await?;
+    let mut routable_account_ids = Vec::new();
+    let mut remove_account_ids = HashSet::new();
+    for (account_id, refresh_result) in refresh_results {
+        match quota_refresh_route_skip_reason(&refresh_result) {
+            None => routable_account_ids.push(account_id),
+            Some(reason) => {
+                if matches!(reason, "quota_zero" | "http_401" | "http_402") {
+                    remove_account_ids.insert(account_id.clone());
+                }
+                skipped_accounts.push(CodexLocalAccessAppendAccountSkipped {
+                    account_id,
+                    reason: reason.to_string(),
+                });
+            }
+        }
+    }
+
+    // Refresh may update plan/subscription fields used by eligibility checks.
+    let refreshed_accounts = codex_account::list_accounts_checked()?;
+    let (next_account_ids, synced_account_ids, added_account_ids, final_skipped_accounts) =
+        append_eligible_local_access_account_ids(
+            current_account_ids,
+            routable_account_ids,
+            &refreshed_accounts,
+            restrict_free_accounts,
+        );
+    skipped_accounts.extend(final_skipped_accounts);
+
+    if existing_collection.is_some() || !added_account_ids.is_empty() {
         let mut collection = match existing_collection {
             Some(collection) => collection,
             None => new_local_access_collection()?,
         };
+        let previous_account_ids = collection.account_ids.clone();
         collection.account_ids = next_account_ids;
+        let removed_refs =
+            remove_account_refs_from_collection(&mut collection, &remove_account_ids);
         collection.updated_at = now_ms();
-        let (changed, _) = sanitize_collection_with_accounts(&mut collection, &accounts)?;
+        let (changed, _) =
+            sanitize_collection_with_accounts(&mut collection, &refreshed_accounts)?;
         if changed {
             collection.updated_at = now_ms();
         }
-        save_collection_to_disk(&collection)?;
+        let membership_changed = collection.account_ids != previous_account_ids || removed_refs;
+        if membership_changed || changed {
+            save_collection_to_disk(&collection)?;
 
-        let should_reload_gateway = collection.enabled;
-        {
-            let mut runtime = gateway_runtime().lock().await;
-            sync_runtime_collection(&mut runtime, collection);
-        }
-        if should_reload_gateway {
-            trigger_gateway_reload_in_background("导入账号同步加入 API 服务");
+            let should_reload_gateway = collection.enabled;
+            {
+                let mut runtime = gateway_runtime().lock().await;
+                sync_runtime_collection(&mut runtime, collection);
+            }
+            if should_reload_gateway {
+                trigger_gateway_reload_in_background("刷新额度后同步 API 服务账号");
+            }
         }
     }
 
@@ -26528,6 +26604,59 @@ mod tests {
         assert!(
             super::runtime_collection_matches_disk(&runtime, &disk_collection)
                 .expect("compare synchronized collection")
+        );
+    }
+
+    #[test]
+    fn imported_account_routing_requires_fresh_positive_quota() {
+        let positive = Ok(crate::models::codex::CodexQuota {
+            hourly_percentage: 80,
+            hourly_reset_time: None,
+            hourly_window_minutes: Some(300),
+            hourly_window_present: Some(true),
+            weekly_percentage: 50,
+            weekly_reset_time: None,
+            weekly_window_minutes: Some(10_080),
+            weekly_window_present: Some(true),
+            reset_credits_available: None,
+            reset_credits: Vec::new(),
+            reset_credits_next_expires_at: None,
+            raw_data: None,
+        });
+        let mut zero = positive.clone();
+        zero.as_mut().expect("zero quota fixture").hourly_percentage = 0;
+        let mut missing_window = positive.clone();
+        missing_window
+            .as_mut()
+            .expect("missing window fixture")
+            .hourly_window_present = Some(false);
+
+        assert_eq!(super::quota_refresh_route_skip_reason(&positive), None);
+        assert_eq!(
+            super::quota_refresh_route_skip_reason(&zero),
+            Some("quota_zero")
+        );
+        assert_eq!(
+            super::quota_refresh_route_skip_reason(&missing_window),
+            Some("quota_refresh_failed")
+        );
+        assert_eq!(
+            super::quota_refresh_route_skip_reason(&Err(
+                "API 返回错误 401: Unauthorized".to_string()
+            )),
+            Some("http_401")
+        );
+        assert_eq!(
+            super::quota_refresh_route_skip_reason(&Err(
+                "request failed [status=402]".to_string()
+            )),
+            Some("http_402")
+        );
+        assert_eq!(
+            super::quota_refresh_route_skip_reason(&Err(
+                "API 返回错误 429: Too Many Requests".to_string()
+            )),
+            Some("quota_refresh_failed")
         );
     }
 

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -6324,23 +6324,25 @@ export function CodexAccountsPage() {
         const importedIds = result.imported
           .map((account) => account.id)
           .filter(Boolean);
-        const nextLocalAccessAccountIds = Array.from(
-          new Set([
-            ...(localAccessCollection?.accountIds ?? []),
-            ...importedIds,
-          ]),
-        );
         setLocalAccessSaving(true);
         try {
-          const nextState =
-            await codexLocalAccessService.saveCodexLocalAccessAccounts(
-              nextLocalAccessAccountIds,
-              localAccessCollection?.restrictFreeAccounts ?? true,
+          const syncResult =
+            await codexLocalAccessService.appendCodexLocalAccessAccounts(
+              importedIds,
             );
-          setLocalAccessState(nextState);
-          if (importedIds.length > 0) {
+          setLocalAccessState(syncResult.state);
+          if (syncResult.syncedAccountIds.length > 0) {
             await ensureLocalAccessEntryVisible();
-            setImportApiServiceGuideCount(importedIds.length);
+            setImportApiServiceGuideCount(syncResult.syncedAccountIds.length);
+          }
+          if (syncResult.skippedAccounts.length > 0) {
+            apiServiceError = t(
+              "codex.importApiService.quotaRejected",
+              "账号已导入，但 {{count}} 个账号因额度为 0、401/402 或额度刷新失败而未加入 API 服务。",
+            ).replace(
+              "{{count}}",
+              String(syncResult.skippedAccounts.length),
+            );
           }
           window.dispatchEvent(new Event("codex-local-access-state-updated"));
         } catch (apiError) {
@@ -9104,16 +9106,37 @@ export function CodexAccountsPage() {
             ),
           );
         }
-        const filteredAccountIdSet = new Set(filteredAccountIds);
+        const currentAccountIdSet = new Set(
+          localAccessCollection?.accountIds ?? [],
+        );
+        const addedAccountIds = filteredAccountIds.filter(
+          (accountId) => !currentAccountIdSet.has(accountId),
+        );
+        let acceptedAccountIds = filteredAccountIds;
+        if (addedAccountIds.length > 0) {
+          const appendResult =
+            await codexLocalAccessService.appendCodexLocalAccessAccounts(
+              addedAccountIds,
+            );
+          const acceptedNewAccountIdSet = new Set(
+            appendResult.syncedAccountIds,
+          );
+          acceptedAccountIds = filteredAccountIds.filter(
+            (accountId) =>
+              currentAccountIdSet.has(accountId) ||
+              acceptedNewAccountIdSet.has(accountId),
+          );
+        }
+        const acceptedAccountIdSet = new Set(acceptedAccountIds);
         const backupAccountIds = (options?.backupAccountIds ?? []).filter((id) =>
-          filteredAccountIdSet.has(id),
+          acceptedAccountIdSet.has(id),
         );
         const preferredAccountIds = (
           options?.preferredAccountIds ?? []
-        ).filter((id) => filteredAccountIdSet.has(id));
+        ).filter((id) => acceptedAccountIdSet.has(id));
         const nextState =
           await codexLocalAccessService.saveCodexLocalAccessAccounts(
-            filteredAccountIds,
+            acceptedAccountIds,
             restrictFreeAccounts,
             backupAccountIds,
             preferredAccountIds,
@@ -9132,7 +9155,7 @@ export function CodexAccountsPage() {
         setLocalAccessSaving(false);
       }
     },
-    [accounts, setMessage, t],
+    [accounts, localAccessCollection?.accountIds, setMessage, t],
   );
 
   const tierCounts = useMemo(() => {

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -1084,6 +1084,7 @@ export function CodexAccountsPage() {
   const [localAccessState, setLocalAccessState] =
     useState<CodexLocalAccessState | null>(null);
   const localAccessStateRequestSeqRef = useRef(0);
+  const codexAccountsPageRootRef = useRef<HTMLDivElement | null>(null);
   const [showLocalAccessModal, setShowLocalAccessModal] = useState(false);
   const [showLocalAccessHealthModal, setShowLocalAccessHealthModal] =
     useState(false);
@@ -2092,6 +2093,31 @@ export function CodexAccountsPage() {
   useEffect(() => {
     void reloadLocalAccessState();
   }, [reloadLocalAccessState]);
+
+  useEffect(() => {
+    const activelyChanging = Boolean(
+      localAccessState?.collection?.enabled &&
+        (localAccessState?.preparing ||
+          localAccessState?.refreshingAccounts ||
+          (!localAccessState?.running && !localAccessState?.lastError)),
+    );
+    const refreshIntervalMs = activelyChanging ? 750 : 5_000;
+    const timer = window.setInterval(() => {
+      const root = codexAccountsPageRootRef.current;
+      if (!root || root.closest("[hidden]")) {
+        return;
+      }
+      void reloadLocalAccessState();
+    }, refreshIntervalMs);
+    return () => window.clearInterval(timer);
+  }, [
+    localAccessState?.collection?.enabled,
+    localAccessState?.preparing,
+    localAccessState?.refreshingAccounts,
+    localAccessState?.running,
+    localAccessState?.lastError,
+    reloadLocalAccessState,
+  ]);
 
   useEffect(() => {
     if (
@@ -13425,6 +13451,7 @@ export function CodexAccountsPage() {
 
   return (
     <div
+      ref={codexAccountsPageRootRef}
       className={`codex-accounts-page codex-accounts-page--${overviewLayoutMode}`}
     >
       <CodexOverviewTabsHeader

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -9012,9 +9012,10 @@ export function CodexAccountsPage() {
       setAddingLocalAccessAccountId(accountId);
       try {
         const result =
-          await codexLocalAccessService.appendCodexLocalAccessAccounts([
-            accountId,
-          ]);
+          await codexLocalAccessService.appendCodexLocalAccessAccounts(
+            [accountId],
+            { allowUnready: true },
+          );
         setLocalAccessState(result.state);
         const accountAdded = Boolean(
           result.state.collection?.accountIds.includes(accountId),
@@ -9057,7 +9058,12 @@ export function CodexAccountsPage() {
         await ensureLocalAccessEntryVisible();
         window.dispatchEvent(new Event("codex-local-access-state-updated"));
         setMessage({
-          text: t("codex.localAccess.saveSuccess", "API 服务集合已更新"),
+          text: result.pendingQuotaAccountIds.includes(accountId)
+            ? t(
+                "codex.localAccess.addedPendingQuota",
+                "账号已提前加入 API 服务；当前额度为 0 或暂未刷新，额度恢复后将自动参与路由。",
+              )
+            : t("codex.localAccess.saveSuccess", "API 服务集合已更新"),
         });
       } catch (error) {
         console.error("Failed to add account to API service:", error);

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -9020,12 +9020,39 @@ export function CodexAccountsPage() {
           result.state.collection?.accountIds.includes(accountId),
         );
         if (!accountAdded) {
-          throw new Error(
-            t(
-              "codex.localAccess.noEligibleAccountsSelected",
-              "所选账号不在当前环境中，或不符合 API 服务条件。请先在当前环境导入可用 Codex 账号后再添加。",
-            ),
-          );
+          const skippedReason = result.skippedAccounts.find(
+            (item) => item.accountId === accountId,
+          )?.reason;
+          const reasonMessage = (() => {
+            switch (skippedReason) {
+              case "quota_zero":
+                return t(
+                  "codex.localAccess.addRejectedQuotaZero",
+                  "账号真实 5h 额度为 0，已保留账号但未加入 API 服务。",
+                );
+              case "http_401":
+                return t(
+                  "codex.localAccess.addRejectedHttp401",
+                  "账号额度刷新返回 HTTP 401，凭据可能已失效；已保留账号但未加入 API 服务。",
+                );
+              case "http_402":
+                return t(
+                  "codex.localAccess.addRejectedHttp402",
+                  "账号额度刷新返回 HTTP 402，当前订阅不可用；已保留账号但未加入 API 服务。",
+                );
+              case "quota_refresh_failed":
+                return t(
+                  "codex.localAccess.addRejectedQuotaRefreshFailed",
+                  "账号额度刷新失败，未加入 API 服务。请稍后重试。",
+                );
+              default:
+                return t(
+                  "codex.localAccess.noEligibleAccountsSelected",
+                  "所选账号不在当前环境中，或不符合 API 服务条件。请先在当前环境导入可用 Codex 账号后再添加。",
+                );
+            }
+          })();
+          throw new Error(reasonMessage);
         }
         await ensureLocalAccessEntryVisible();
         window.dispatchEvent(new Event("codex-local-access-state-updated"));

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -125,6 +125,8 @@ type RequestLogStatusFilter = "all" | "success" | "failed";
 type RequestLogGatewayModeFilter = "all" | CodexLocalAccessGatewayMode;
 type BuiltinTimeoutPresetId = "long_wait" | "short_wait";
 type TimeoutPresetId = BuiltinTimeoutPresetId | string;
+const ACTIVE_STATE_REFRESH_MS = 750;
+const STABLE_STATE_REFRESH_MS = 5_000;
 
 interface ApiKeyPolicyDraft {
   modelPrefix: string;
@@ -823,6 +825,7 @@ export function CodexApiServicePage() {
   const mountedRef = useRef(true);
   const stateRequestSeqRef = useRef(0);
   const statsRequestSeqRef = useRef(0);
+  const pageRootRef = useRef<HTMLDivElement | null>(null);
   const testChatScrollRef = useRef<HTMLDivElement | null>(null);
 
   const collection = state?.collection ?? null;
@@ -1352,17 +1355,26 @@ export function CodexApiServicePage() {
   }, [addressKind]);
 
   useEffect(() => {
-    if (
-      !collection?.enabled ||
-      (!state?.preparing &&
-        !state?.refreshingAccounts &&
-        (state?.running || Boolean(state?.lastError)))
-    ) {
-      return undefined;
-    }
+    const activelyChanging = Boolean(
+      collection?.enabled &&
+        (state?.preparing ||
+          state?.refreshingAccounts ||
+          (!state?.running && !state?.lastError)),
+    );
+    const refreshIntervalMs = activelyChanging
+      ? ACTIVE_STATE_REFRESH_MS
+      : STABLE_STATE_REFRESH_MS;
     const timer = window.setInterval(() => {
+      const root = pageRootRef.current;
+      if (
+        document.visibilityState !== "visible" ||
+        !root ||
+        root.closest("[hidden]")
+      ) {
+        return;
+      }
       void reloadState();
-    }, 750);
+    }, refreshIntervalMs);
     return () => window.clearInterval(timer);
   }, [
     collection?.enabled,
@@ -3355,7 +3367,7 @@ export function CodexApiServicePage() {
   };
 
   return (
-    <div className="codex-api-service-page">
+    <div ref={pageRootRef} className="codex-api-service-page">
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -1373,10 +1373,16 @@ export function CodexApiServicePage() {
         return;
       }
       void reloadState();
+      // The API-service summary is derived from the account list's quota
+      // snapshots, not only from local-access state. Refresh both together so
+      // a live sidecar quota update cannot leave the page showing an old
+      // 4x100% total after traffic has moved to the K12 pool.
+      void fetchAccounts();
     }, refreshIntervalMs);
     return () => window.clearInterval(timer);
   }, [
     collection?.enabled,
+    fetchAccounts,
     reloadState,
     state?.preparing,
     state?.refreshingAccounts,

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -1367,7 +1367,6 @@ export function CodexApiServicePage() {
     const timer = window.setInterval(() => {
       const root = pageRootRef.current;
       if (
-        document.visibilityState !== "visible" ||
         !root ||
         root.closest("[hidden]")
       ) {

--- a/src/services/codexLocalAccessService.ts
+++ b/src/services/codexLocalAccessService.ts
@@ -46,8 +46,12 @@ export async function saveCodexLocalAccessAccounts(
 
 export async function appendCodexLocalAccessAccounts(
   accountIds: string[],
+  options?: { allowUnready?: boolean },
 ): Promise<CodexLocalAccessAppendAccountsResult> {
-  return await invoke("codex_local_access_append_accounts", { accountIds });
+  return await invoke("codex_local_access_append_accounts", {
+    accountIds,
+    allowUnready: options?.allowUnready ?? false,
+  });
 }
 
 export async function removeCodexLocalAccessAccount(

--- a/src/types/codexLocalAccess.ts
+++ b/src/types/codexLocalAccess.ts
@@ -366,7 +366,11 @@ export interface CodexLocalAccessAppendAccountSkipped {
     | "chat_completions_api_key"
     | "free_restricted"
     | "pending_oauth"
-    | "web_session_quota_only";
+    | "web_session_quota_only"
+    | "quota_zero"
+    | "http_401"
+    | "http_402"
+    | "quota_refresh_failed";
 }
 
 export interface CodexLocalAccessAppendAccountsResult {

--- a/src/types/codexLocalAccess.ts
+++ b/src/types/codexLocalAccess.ts
@@ -377,6 +377,7 @@ export interface CodexLocalAccessAppendAccountsResult {
   state: CodexLocalAccessState;
   syncedAccountIds: string[];
   addedAccountIds: string[];
+  pendingQuotaAccountIds: string[];
   skippedAccounts: CodexLocalAccessAppendAccountSkipped[];
 }
 

--- a/src/utils/codexImportPreferences.test.ts
+++ b/src/utils/codexImportPreferences.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveCodexImportSyncApiServicePreference } from "./codexImportPreferences.ts";
+
+test("new installations automatically add imported accounts to API service", () => {
+  assert.equal(resolveCodexImportSyncApiServicePreference(null), true);
+});
+
+test("an explicit API service import preference is preserved", () => {
+  assert.equal(resolveCodexImportSyncApiServicePreference("true"), true);
+  assert.equal(resolveCodexImportSyncApiServicePreference("false"), false);
+});
+
+test("invalid stored preferences do not silently enable synchronization", () => {
+  assert.equal(resolveCodexImportSyncApiServicePreference("invalid"), false);
+});

--- a/src/utils/codexImportPreferences.ts
+++ b/src/utils/codexImportPreferences.ts
@@ -1,11 +1,20 @@
 const CODEX_IMPORT_SYNC_API_SERVICE_STORAGE_KEY =
   "agtools.codex.import.sync_api_service.v1";
 
+export const resolveCodexImportSyncApiServicePreference = (
+  storedValue: string | null,
+): boolean => {
+  if (storedValue === null) return true;
+  return storedValue === "true";
+};
+
 export const readCodexImportSyncApiService = (): boolean => {
   try {
-    return localStorage.getItem(CODEX_IMPORT_SYNC_API_SERVICE_STORAGE_KEY) === "true";
+    return resolveCodexImportSyncApiServicePreference(
+      localStorage.getItem(CODEX_IMPORT_SYNC_API_SERVICE_STORAGE_KEY),
+    );
   } catch {
-    return false;
+    return true;
   }
 };
 


### PR DESCRIPTION
## Summary

- Detect trusted external changes to `codex_local_access.json` with a content-hash/CAS recheck and synchronize Cockpit's cached API Service membership without stopping or restarting the active sidecar.
- Refresh the visible API Service page every 5 seconds in a stable state and every 750 ms while state is changing; skip polling while the page is hidden.
- Enable the existing "add imported accounts to API Service" flow by default for new installations and unavailable storage, so eligible OAuth, Token/JSON, local-file, batch, API-key, and external imports join the service automatically.
- Preserve an explicit user opt-out and keep invalid stored preference values conservative.
- Keep the existing backend eligibility filters: pending OAuth, Web Session, restricted Free, and incompatible Chat Completions accounts are still skipped.

## Validation

- `node --test src/utils/codexImportPreferences.test.ts src/utils/codexLocalAccessAccounts.test.ts` (10 passed)
- `npm run typecheck`
- `npm run build`

A Rust regression test is included for the external-state synchronization path, but `cargo test` was not run locally because this machine does not have a Rust toolchain. The upstream PR build matrix will compile the Tauri backend on supported platforms.