### PR TITLE
fix: minimally sync external API service state

### DIFF
--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/builder.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/builder.go
@@ -62,6 +62,11 @@ type Hooks struct {
 	// OnAfterStart is called after the service has started successfully,
 	// providing access to the service instance for additional operations.
 	OnAfterStart func(*Service)
+
+	// OnConfigReload is called after the service applies a watched config
+	// update. Hosts with a custom selector can restore their selector wrappers
+	// after the stock runtime routing selector has been refreshed.
+	OnConfigReload func(*config.Config)
 }
 
 // NewBuilder creates a Builder with default dependencies left unset.

--- a/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/service.go
+++ b/sidecars/cockpit-cliproxy/cdk/CLIProxyAPI/sdk/cliproxy/service.go
@@ -559,6 +559,9 @@ func (s *Service) applyConfigUpdate(newCfg *config.Config) {
 		s.coreManager.SetConfig(newCfg)
 		s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
 	}
+	if s.hooks.OnConfigReload != nil {
+		s.hooks.OnConfigReload(newCfg)
+	}
 	if newCfg.Home.Enabled {
 		s.registerHomeExecutors()
 	}

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -137,6 +137,9 @@ type apiKeySpec struct {
 type apiKeyPriorityState struct {
 	PriorityAccountIDs  map[string][]string `json:"priorityAccountIds"`
 	PreferredAccountIDs map[string]string   `json:"preferredAccountIds"`
+	// AccountIDs is an authoritative live API-key scope.  Unlike a priority
+	// hint, an explicitly empty slice means this key must route to no account.
+	AccountIDs          map[string][]string `json:"accountIds"`
 }
 
 type apiKeyPriorityStateStore struct {
@@ -144,15 +147,33 @@ type apiKeyPriorityStateStore struct {
 	mu              sync.RWMutex
 	lastModUnixNano int64
 	priorities      map[string][]string
+	scopes          map[string][]string
+	scopeKnown      map[string]bool
 }
 
 func newAPIKeyPriorityStateStore(manifestPath string) *apiKeyPriorityStateStore {
 	store := &apiKeyPriorityStateStore{
 		path:       filepath.Join(filepath.Dir(manifestPath), "api-key-priorities.json"),
 		priorities: make(map[string][]string),
+		scopes:     make(map[string][]string),
+		scopeKnown: make(map[string]bool),
 	}
 	store.reloadIfChanged()
 	return store
+}
+
+func (s *apiKeyPriorityStateStore) scopedAccountIDs(apiKeyID string) ([]string, bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.reloadIfChanged()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	key := strings.TrimSpace(apiKeyID)
+	if !s.scopeKnown[key] {
+		return nil, false
+	}
+	return append([]string(nil), s.scopes[key]...), true
 }
 
 func (s *apiKeyPriorityStateStore) priorityAccountIDs(apiKeyID string) []string {
@@ -190,6 +211,29 @@ func (s *apiKeyPriorityStateStore) reloadIfChanged() {
 		return
 	}
 	next := make(map[string][]string, len(state.PriorityAccountIDs))
+	nextScopes := make(map[string][]string, len(state.AccountIDs))
+	nextScopeKnown := make(map[string]bool, len(state.AccountIDs))
+	for apiKeyID, accountIDs := range state.AccountIDs {
+		apiKeyID = strings.TrimSpace(apiKeyID)
+		if apiKeyID == "" {
+			continue
+		}
+		nextScopeKnown[apiKeyID] = true
+		seen := make(map[string]struct{}, len(accountIDs))
+		scope := make([]string, 0, len(accountIDs))
+		for _, accountID := range accountIDs {
+			accountID = strings.TrimSpace(accountID)
+			if accountID == "" {
+				continue
+			}
+			if _, exists := seen[accountID]; exists {
+				continue
+			}
+			seen[accountID] = struct{}{}
+			scope = append(scope, accountID)
+		}
+		nextScopes[apiKeyID] = scope
+	}
 	for apiKeyID, accountIDs := range state.PriorityAccountIDs {
 		apiKeyID = strings.TrimSpace(apiKeyID)
 		if apiKeyID == "" {
@@ -222,6 +266,8 @@ func (s *apiKeyPriorityStateStore) reloadIfChanged() {
 	s.mu.Lock()
 	s.lastModUnixNano = modifiedAt
 	s.priorities = next
+	s.scopes = nextScopes
+	s.scopeKnown = nextScopeKnown
 	s.mu.Unlock()
 }
 
@@ -2348,12 +2394,27 @@ func (s *cockpitSelector) filterAuthsForAPIKeyScope(ctx context.Context, auths [
 		return auths
 	}
 	spec, _ := ctx.Value(clientAPIKeyContextKey).(*apiKeySpec)
-	if spec == nil || len(spec.AccountIDs) == 0 {
+	if spec == nil {
 		return auths
 	}
+	if s.priorities != nil {
+		if scopedIDs, hasScope := s.priorities.scopedAccountIDs(spec.ID); hasScope {
+			if len(scopedIDs) == 0 {
+				return nil
+			}
+			return s.filterAuthsByAccountIDs(auths, scopedIDs)
+		}
+	}
+	if len(spec.AccountIDs) == 0 {
+		return auths
+	}
+	return s.filterAuthsByAccountIDs(auths, spec.AccountIDs)
+}
 
-	allowedAccountIDs := make(map[string]struct{}, len(spec.AccountIDs))
-	for _, accountID := range spec.AccountIDs {
+func (s *cockpitSelector) filterAuthsByAccountIDs(auths []*coreauth.Auth, accountIDs []string) []*coreauth.Auth {
+
+	allowedAccountIDs := make(map[string]struct{}, len(accountIDs))
+	for _, accountID := range accountIDs {
 		if accountID = strings.TrimSpace(accountID); accountID != "" {
 			allowedAccountIDs[accountID] = struct{}{}
 		}

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -162,9 +162,37 @@ func newAPIKeyPriorityStateStore(manifestPath string) *apiKeyPriorityStateStore 
 	return store
 }
 
-func (s *apiKeyPriorityStateStore) scopedAccountIDs(apiKeyID string) ([]string, bool) {
-	if s == nil {
-		return nil, false
+func (s *apiKeyPriorityStateStore) priorityAccountIDs(apiKeyID string) []string {
+    if s == nil {
+        return nil
+    }
+    s.reloadIfChanged()
+    s.mu.RLock()
+    defer s.mu.RUnlock()
+    return append([]string(nil), s.priorities[strings.TrimSpace(apiKeyID)]...)
+}
+
+// priorityAccountIDsForSpec resolves the route-order map by manifest id first,
+// then by the actual client API-key value used by config.json. Production uses
+// different values for these two fields, so looking up only spec.ID silently
+// disables hot route updates.
+func (s *apiKeyPriorityStateStore) priorityAccountIDsForSpec(spec *apiKeySpec) []string {
+    if s == nil || spec == nil {
+        return nil
+    }
+    if accountIDs := s.priorityAccountIDs(spec.ID); len(accountIDs) > 0 {
+        return accountIDs
+    }
+    key := strings.TrimSpace(spec.Key)
+    if key != "" && key != strings.TrimSpace(spec.ID) {
+        return s.priorityAccountIDs(key)
+    }
+    return nil
+}
+
+func (s *apiKeyPriorityStateStore) accountScope(apiKeyID string) ([]string, bool) {
+    if s == nil {
+        return nil, false
 	}
 	s.reloadIfChanged()
 	s.mu.RLock()
@@ -173,17 +201,23 @@ func (s *apiKeyPriorityStateStore) scopedAccountIDs(apiKeyID string) ([]string, 
 	if !s.scopeKnown[key] {
 		return nil, false
 	}
-	return append([]string(nil), s.scopes[key]...), true
+    return append([]string(nil), s.scopes[key]...), true
 }
 
-func (s *apiKeyPriorityStateStore) priorityAccountIDs(apiKeyID string) []string {
-	if s == nil {
-		return nil
-	}
-	s.reloadIfChanged()
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return append([]string(nil), s.priorities[strings.TrimSpace(apiKeyID)]...)
+// accountScopeForSpec preserves the known/empty distinction: a present empty
+// scope means the key must serve no account and may not fall back to manifest.
+func (s *apiKeyPriorityStateStore) accountScopeForSpec(spec *apiKeySpec) ([]string, bool) {
+    if s == nil || spec == nil {
+        return nil, false
+    }
+    if accountIDs, known := s.accountScope(spec.ID); known {
+        return accountIDs, true
+    }
+    key := strings.TrimSpace(spec.Key)
+    if key != "" && key != strings.TrimSpace(spec.ID) {
+        return s.accountScope(key)
+    }
+    return nil, false
 }
 
 func (s *apiKeyPriorityStateStore) reloadIfChanged() {
@@ -222,7 +256,7 @@ func (s *apiKeyPriorityStateStore) reloadIfChanged() {
 		seen := make(map[string]struct{}, len(accountIDs))
 		scope := make([]string, 0, len(accountIDs))
 		for _, accountID := range accountIDs {
-			accountID = strings.TrimSpace(accountID)
+            accountID = strings.TrimSpace(strings.TrimSuffix(accountID, ".json"))
 			if accountID == "" {
 				continue
 			}
@@ -928,9 +962,180 @@ func withClientInstanceID(ctx context.Context, instanceID string) context.Contex
 }
 
 type requestPolicy struct {
-	manifest *manifest
-	emitter  *eventEmitter
-	tracker  *requestUsageTracker
+    manifest *manifest
+    emitter  *eventEmitter
+    tracker  *requestUsageTracker
+    scopes   *apiKeyAccountScopeStore
+}
+
+// apiKeyAccountScopeStore is independent from manifest reloads. Cockpit can
+// atomically replace config.json while requests are in flight; each new request
+// adopts api-key-account-ids without replacing the HTTP server or active SSEs.
+type apiKeyAccountScopeStore struct {
+    path    string
+    mu      sync.RWMutex
+    modTime int64
+    scopes  map[string][]string
+    known   map[string]bool
+}
+
+func newAPIKeyAccountScopeStore(path string) *apiKeyAccountScopeStore {
+    return &apiKeyAccountScopeStore{
+        path:   strings.TrimSpace(path),
+        scopes: make(map[string][]string),
+        known:  make(map[string]bool),
+    }
+}
+
+func normalizeScopeAccountID(value string) string {
+    value = strings.TrimSpace(value)
+    value = strings.TrimSuffix(value, ".json")
+    return value
+}
+
+func (s *apiKeyAccountScopeStore) reloadIfChanged() {
+    if s == nil || s.path == "" {
+        return
+    }
+    info, err := os.Stat(s.path)
+    if err != nil {
+        return
+    }
+    modTime := info.ModTime().UnixNano()
+    s.mu.RLock()
+    unchanged := modTime == s.modTime
+    s.mu.RUnlock()
+    if unchanged {
+        return
+    }
+    data, err := os.ReadFile(s.path)
+    if err != nil {
+        return
+    }
+    var config struct {
+        AccountScopes map[string][]string `json:"api-key-account-ids"`
+    }
+    if err := json.Unmarshal(data, &config); err != nil {
+        return
+    }
+    next := make(map[string][]string, len(config.AccountScopes))
+    known := make(map[string]bool, len(config.AccountScopes))
+    for key, values := range config.AccountScopes {
+        key = strings.TrimSpace(key)
+        if key == "" {
+            continue
+        }
+        known[key] = true
+        clean := make([]string, 0, len(values))
+        seen := make(map[string]struct{}, len(values))
+        for _, value := range values {
+            accountID := normalizeScopeAccountID(value)
+            if accountID == "" {
+                continue
+            }
+            if _, exists := seen[accountID]; exists {
+                continue
+            }
+            seen[accountID] = struct{}{}
+            clean = append(clean, accountID)
+        }
+        if len(clean) > 0 {
+            next[key] = clean
+        }
+    }
+    s.mu.Lock()
+    s.modTime = modTime
+    s.scopes = next
+    s.known = known
+    s.mu.Unlock()
+}
+
+func (s *apiKeyAccountScopeStore) accountIDs(apiKeyID string) ([]string, bool) {
+    if s == nil {
+        return nil, false
+    }
+    s.reloadIfChanged()
+    s.mu.RLock()
+    defer s.mu.RUnlock()
+    key := strings.TrimSpace(apiKeyID)
+    return append([]string(nil), s.scopes[key]...), s.known[key]
+}
+
+// Production config keys scopes by the client API-key value while manifest
+// uses a separate opaque id. Resolve both and keep a known empty slice final.
+func (s *apiKeyAccountScopeStore) accountIDsForSpec(spec *apiKeySpec) ([]string, bool) {
+    if s == nil || spec == nil {
+        return nil, false
+    }
+    if accountIDs, known := s.accountIDs(spec.ID); known {
+        return accountIDs, true
+    }
+    key := strings.TrimSpace(spec.Key)
+    if key != "" && key != strings.TrimSpace(spec.ID) {
+        return s.accountIDs(key)
+    }
+    return nil, false
+}
+
+func scopedAPIKeySpec(spec *apiKeySpec, scopes *apiKeyAccountScopeStore) *apiKeySpec {
+    if spec == nil || scopes == nil {
+        return spec
+    }
+    accountIDs, known := scopes.accountIDsForSpec(spec)
+    if !known {
+        return spec
+    }
+    copySpec := *spec
+    copySpec.AccountIDs = accountIDs
+	return &copySpec
+}
+
+// intersectAccountScopes is fail-closed while config.json and
+// api-key-priorities.json are being atomically updated. A scope that appears
+// in only one live source must not receive traffic during that tiny window.
+func intersectAccountScopes(primary []string, secondary []string) []string {
+	allowed := make(map[string]struct{}, len(secondary))
+	for _, accountID := range secondary {
+		if accountID = normalizeScopeAccountID(accountID); accountID != "" {
+			allowed[accountID] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(primary))
+	seen := make(map[string]struct{}, len(primary))
+	for _, accountID := range primary {
+		accountID = normalizeScopeAccountID(accountID)
+		if accountID == "" {
+			continue
+		}
+		if _, ok := allowed[accountID]; !ok {
+			continue
+		}
+		if _, duplicate := seen[accountID]; duplicate {
+			continue
+		}
+		seen[accountID] = struct{}{}
+		out = append(out, accountID)
+	}
+	return out
+}
+
+func liveAccountScopeForSpec(spec *apiKeySpec, priorities *apiKeyPriorityStateStore) []string {
+	if spec == nil {
+		return nil
+	}
+	accountIDs := append([]string(nil), spec.AccountIDs...)
+	if priorities == nil {
+		return accountIDs
+	}
+	if priorityScope, known := priorities.accountScopeForSpec(spec); known {
+		// Direct selector callers (including legacy callers) have no config.json
+		// snapshot. In that case the known priority scope is the only live source.
+		if spec.AccountIDs == nil {
+			return priorityScope
+		}
+		return intersectAccountScopes(accountIDs, priorityScope)
+	}
+	return accountIDs
 }
 
 func (p *requestPolicy) middleware() gin.HandlerFunc {
@@ -1032,7 +1237,7 @@ func (p *requestPolicy) lookupAPIKey(r *http.Request) *apiKeySpec {
 	if key == "" {
 		return nil
 	}
-	return p.manifest.apiKeyByValue[key]
+    return scopedAPIKeySpec(p.manifest.apiKeyByValue[key], p.scopes)
 }
 
 func ensureRequestID(c *gin.Context) string {
@@ -2357,7 +2562,7 @@ func (s *cockpitSelector) prioritizeAuthsForAPIKey(ctx context.Context, auths []
 	if spec == nil {
 		return auths
 	}
-	priorityAccountIDs := s.priorities.priorityAccountIDs(spec.ID)
+    priorityAccountIDs := s.priorities.priorityAccountIDsForSpec(spec)
 	if len(priorityAccountIDs) == 0 {
 		return auths
 	}
@@ -2365,9 +2570,9 @@ func (s *cockpitSelector) prioritizeAuthsForAPIKey(ctx context.Context, auths []
 	ordered := make([]*coreauth.Auth, 0, len(auths))
 	selected := make(map[*coreauth.Auth]struct{}, len(priorityAccountIDs))
 	for _, priorityAccountID := range priorityAccountIDs {
+		priorityAccountID = normalizeScopeAccountID(priorityAccountID)
 		for _, auth := range auths {
-			account := s.accountForAuth(auth)
-			if account == nil || account.ID != priorityAccountID {
+			if accountIDForManifestAuth(s.manifest, auth) != priorityAccountID {
 				continue
 			}
 			if _, alreadySelected := selected[auth]; alreadySelected {
@@ -2397,43 +2602,45 @@ func (s *cockpitSelector) filterAuthsForAPIKeyScope(ctx context.Context, auths [
 	if spec == nil {
 		return auths
 	}
-	if s.priorities != nil {
-		if scopedIDs, hasScope := s.priorities.scopedAccountIDs(spec.ID); hasScope {
-			if len(scopedIDs) == 0 {
-				return nil
-			}
-			return s.filterAuthsByAccountIDs(auths, scopedIDs)
-		}
-	}
-	if len(spec.AccountIDs) == 0 {
-		return auths
-	}
-	return s.filterAuthsByAccountIDs(auths, spec.AccountIDs)
+	return filterAuthsForManifestAccountIDs(s.manifest, liveAccountScopeForSpec(spec, s.priorities), auths)
 }
 
-func (s *cockpitSelector) filterAuthsByAccountIDs(auths []*coreauth.Auth, accountIDs []string) []*coreauth.Auth {
-
-	allowedAccountIDs := make(map[string]struct{}, len(accountIDs))
-	for _, accountID := range accountIDs {
-		if accountID = strings.TrimSpace(accountID); accountID != "" {
-			allowedAccountIDs[accountID] = struct{}{}
-		}
+func filterAuthsForManifestAccountIDs(m *manifest, accountIDs []string, auths []*coreauth.Auth) []*coreauth.Auth {
+    if m == nil {
+        return auths
+    }
+    allowedAccountIDs := make(map[string]struct{}, len(accountIDs))
+    for _, accountID := range accountIDs {
+        accountID = normalizeScopeAccountID(accountID)
+        if accountID != "" {
+            allowedAccountIDs[accountID] = struct{}{}
+        }
 	}
 	if len(allowedAccountIDs) == 0 {
 		return nil
 	}
 
-	scoped := make([]*coreauth.Auth, 0, len(auths))
+    scoped := make([]*coreauth.Auth, 0, len(auths))
 	for _, auth := range auths {
-		account := s.accountForAuth(auth)
-		if account == nil {
-			continue
-		}
-		if _, allowed := allowedAccountIDs[account.ID]; allowed {
-			scoped = append(scoped, auth)
-		}
+		accountID := accountIDForManifestAuth(m, auth)
+		if _, allowed := allowedAccountIDs[accountID]; allowed {
+            scoped = append(scoped, auth)
+        }
 	}
 	return scoped
+}
+
+func accountIDForManifestAuth(m *manifest, auth *coreauth.Auth) string {
+	if account := accountForAuthInManifest(m, auth); account != nil {
+		return normalizeScopeAccountID(account.ID)
+	}
+	if auth == nil {
+		return ""
+	}
+	// A newly materialized auth can be observed by CLIProxy's auth-dir watcher
+	// before the static startup manifest knows it. Its stable filename is the
+	// Cockpit account id, so it is still safe to match a live scope.
+	return normalizeScopeAccountID(filepath.Base(auth.ID))
 }
 
 func (s *cockpitSelector) maxConcurrentImageRequests() int {
@@ -3171,11 +3378,19 @@ func buildCoreAuthSelector(cfg *config.Config, selector coreauth.Selector, m *ma
 			ttl = parsed
 		}
 		// Session affinity + per-client-key namespace, with image requests bypassing affinity.
-		selector = coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
-			Fallback: selector,
-			TTL:      ttl,
-		})
-		selector = &cockpitSessionAffinitySelector{inner: selector}
+        selector = coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
+            Fallback: selector,
+            TTL:      ttl,
+        })
+        var priorities *apiKeyPriorityStateStore
+        if cockpit, ok := imageFallback.(*cockpitSelector); ok {
+            priorities = cockpit.priorities
+        }
+        selector = &cockpitSessionAffinitySelector{
+            inner:      selector,
+            manifest:   m,
+            priorities: priorities,
+        }
 		selector = &imageRequestSelector{
 			imageFallback: imageFallback,
 			fallback:      selector,
@@ -3189,35 +3404,53 @@ func buildCoreAuthSelector(cfg *config.Config, selector coreauth.Selector, m *ma
 	return selector
 }
 
+func buildCockpitSelectorStack(cfg *config.Config, selector coreauth.Selector, m *manifest, quota *quotaReserveStateStore, tracker *requestUsageTracker) coreauth.Selector {
+	selector = buildCoreAuthSelector(cfg, selector, m, quota)
+	if tracker != nil {
+		selector = &recordingSelector{inner: selector, manifest: m, tracker: tracker}
+	}
+	return selector
+}
+
 func buildCoreAuthManager(cfg *config.Config, selector coreauth.Selector, hook coreauth.Hook, m *manifest, quota *quotaReserveStateStore, tracker *requestUsageTracker) *coreauth.Manager {
 	tokenStore := sdkauth.GetTokenStore()
 	if dirSetter, ok := tokenStore.(interface{ SetBaseDir(string) }); ok && cfg != nil {
 		dirSetter.SetBaseDir(cfg.AuthDir)
 	}
-	selector = buildCoreAuthSelector(cfg, selector, m, quota)
-	if tracker != nil {
-		selector = &recordingSelector{inner: selector, manifest: m, tracker: tracker}
-	}
+	selector = buildCockpitSelectorStack(cfg, selector, m, quota, tracker)
 	return coreauth.NewManager(tokenStore, selector, hook)
 }
 
 type cockpitSessionAffinitySelector struct {
-	inner coreauth.Selector
+    inner      coreauth.Selector
+    manifest   *manifest
+    priorities *apiKeyPriorityStateStore
 }
 
 func (s *cockpitSessionAffinitySelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
 	if s == nil || s.inner == nil {
 		return nil, errors.New("session affinity selector is unavailable")
 	}
-	if spec, _ := ctx.Value(clientAPIKeyContextKey).(*apiKeySpec); spec != nil && strings.TrimSpace(spec.ID) != "" {
+    if spec, _ := ctx.Value(clientAPIKeyContextKey).(*apiKeySpec); spec != nil && strings.TrimSpace(spec.ID) != "" {
 		metadata := make(map[string]any, len(opts.Metadata)+1)
 		for key, value := range opts.Metadata {
 			metadata[key] = value
 		}
 		metadata[cliproxyexecutor.SessionAffinityNamespaceMetadataKey] = spec.ID
-		opts.Metadata = metadata
+        opts.Metadata = metadata
+    }
+    // Filter before consulting the affinity cache. Otherwise a binding can keep
+    // selecting an exhausted account after the live scope removes it.
+	if s.manifest != nil {
+		if spec, _ := ctx.Value(clientAPIKeyContextKey).(*apiKeySpec); spec != nil {
+			auths = filterAuthsForManifestAccountIDs(
+				s.manifest,
+				liveAccountScopeForSpec(spec, s.priorities),
+				auths,
+			)
+		}
 	}
-	return s.inner.Pick(ctx, provider, model, opts, auths)
+    return s.inner.Pick(ctx, provider, model, opts, auths)
 }
 
 type sidecarRuntime struct {
@@ -3391,6 +3624,10 @@ func buildCodexAlphaSearchHeaders(src http.Header, auth *coreauth.Auth) http.Hea
 }
 
 func newSidecarRuntime(ctx context.Context, configPath string, cfg *config.Config, m *manifest, manager *coreauth.Manager) (*sidecarRuntime, error) {
+	return newSidecarRuntimeWithSelector(ctx, configPath, cfg, m, manager, nil, nil, nil)
+}
+
+func newSidecarRuntimeWithSelector(ctx context.Context, configPath string, cfg *config.Config, m *manifest, manager *coreauth.Manager, baseSelector coreauth.Selector, quota *quotaReserveStateStore, tracker *requestUsageTracker) (*sidecarRuntime, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
 	}
@@ -3416,11 +3653,18 @@ func newSidecarRuntime(ctx context.Context, configPath string, cfg *config.Confi
 		WithConfigPath(configPath).
 		WithAuthManager(authManager).
 		WithCoreAuthManager(manager).
-		WithHooks(cliproxy.Hooks{
-			OnAfterStart: func(*cliproxy.Service) {
-				readyOnce.Do(func() { close(readyCh) })
-			},
-		}).
+        WithHooks(cliproxy.Hooks{
+            OnAfterStart: func(*cliproxy.Service) {
+                readyOnce.Do(func() { close(readyCh) })
+            },
+			OnConfigReload: func(newCfg *config.Config) {
+                // Stock CLIProxy rebuilds a plain selector on config reload.
+                // Reapply Cockpit's live scope, quota and affinity wrappers so
+                // a hot account change cannot widen routing or revive a stale
+                // session binding.
+				manager.SetSelector(buildCockpitSelectorStack(newCfg, baseSelector, m, quota, tracker))
+            },
+        }).
 		Build()
 	if err != nil {
 		return nil, err
@@ -8154,8 +8398,9 @@ func main() {
 		})
 	}
 
-	usageTracker := newRequestUsageTracker()
-	policy := &requestPolicy{manifest: m, emitter: emitter, tracker: usageTracker}
+    usageTracker := newRequestUsageTracker()
+    scopes := newAPIKeyAccountScopeStore(absConfigPath)
+    policy := &requestPolicy{manifest: m, emitter: emitter, tracker: usageTracker, scopes: scopes}
 	hook := &authHook{manifest: m, emitter: emitter}
 	priorityState := newAPIKeyPriorityStateStore(*manifestPath)
 	selector := &cockpitSelector{
@@ -8176,7 +8421,7 @@ func main() {
 
 	coreusage.RegisterPlugin(&usagePlugin{manifest: m, tracker: usageTracker})
 
-	runtime, err := newSidecarRuntime(ctx, absConfigPath, cfg, m, coreManager)
+	runtime, err := newSidecarRuntimeWithSelector(ctx, absConfigPath, cfg, m, coreManager, selector, quotaState, usageTracker)
 	if err != nil {
 		emitter.emit(map[string]any{"type": "error", "message": err.Error()})
 		os.Exit(1)

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -827,7 +827,7 @@ func TestAPIKeyPriorityStateOrdersFallbackAccountsWithoutRestart(t *testing.T) {
 	if err := os.WriteFile(priorityPath, []byte(`{"priorityAccountIds":{"key-team":["account-b","account-a"]}}`), 0o600); err != nil {
 		t.Fatalf("update priority state: %v", err)
 	}
-	updatedAt := time.Now().Add(time.Second)
+	updatedAt := time.Now().Add(5 * time.Second)
 	if err := os.Chtimes(priorityPath, updatedAt, updatedAt); err != nil {
 		t.Fatalf("advance priority state timestamp: %v", err)
 	}
@@ -858,7 +858,7 @@ func TestAPIKeyEmptyLiveScopeEvictsAllAccountsWithoutRestart(t *testing.T) {
 	if err := os.WriteFile(priorityPath, []byte(`{"accountIds":{"key-team":[]}}`), 0o600); err != nil {
 		t.Fatalf("clear live scope: %v", err)
 	}
-	updatedAt := time.Now().Add(time.Second)
+	updatedAt := time.Now().Add(5 * time.Second)
 	if err := os.Chtimes(priorityPath, updatedAt, updatedAt); err != nil {
 		t.Fatalf("advance live scope timestamp: %v", err)
 	}
@@ -940,6 +940,98 @@ func TestCockpitSessionAffinitySeparatesClientAPIKeyScopes(t *testing.T) {
 	if second.ID != "account-scoped.json" {
 		t.Fatalf("expected scoped key not to reuse default key affinity auth, got %q", second.ID)
 	}
+}
+
+func TestAPIKeyAccountScopeStoreUsesClientKeyValueAndKeepsEmptyAuthoritative(t *testing.T) {
+    path := filepath.Join(t.TempDir(), "config.json")
+    updatedAt := time.Now().Add(10 * time.Second)
+    write := func(value string) {
+        if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+            t.Fatalf("write config: %v", err)
+        }
+        updatedAt = updatedAt.Add(time.Second)
+        if err := os.Chtimes(path, updatedAt, updatedAt); err != nil {
+            t.Fatalf("advance config timestamp: %v", err)
+        }
+    }
+    spec := &apiKeySpec{ID: "key-internal-id", Key: "client-secret", AccountIDs: []string{"stale-account"}}
+    write(`{"api-key-account-ids":{"client-secret":["codex_old.json"]}}`)
+    store := newAPIKeyAccountScopeStore(path)
+    scoped := scopedAPIKeySpec(spec, store)
+    if scoped == spec || len(scoped.AccountIDs) != 1 || scoped.AccountIDs[0] != "codex_old" {
+        t.Fatalf("config key/id mismatch was not hot-scoped: %#v", scoped)
+    }
+
+    write(`{"api-key-account-ids":{"client-secret":[]}}`)
+    if got, known := store.accountIDsForSpec(spec); !known || len(got) != 0 {
+        t.Fatalf("known empty scope must not fall back to manifest: %#v known=%v", got, known)
+    }
+}
+
+func TestPriorityStateUsesSpecKeyWhenManifestIDDiffers(t *testing.T) {
+    tempDir := t.TempDir()
+    if err := os.WriteFile(
+        filepath.Join(tempDir, "api-key-priorities.json"),
+        []byte(`{"priorityAccountIds":{"client-secret":["account-b"]},"accountIds":{"client-secret":["account-b"]}}`),
+        0o600,
+    ); err != nil {
+        t.Fatalf("write priority state: %v", err)
+    }
+    store := newAPIKeyPriorityStateStore(filepath.Join(tempDir, "manifest.json"))
+    spec := &apiKeySpec{ID: "key-internal-id", Key: "client-secret"}
+    if got := store.priorityAccountIDsForSpec(spec); len(got) != 1 || got[0] != "account-b" {
+        t.Fatalf("priority key fallback failed: %#v", got)
+    }
+    if got, known := store.accountScopeForSpec(spec); !known || len(got) != 1 || got[0] != "account-b" {
+        t.Fatalf("live-scope key fallback failed: %#v known=%v", got, known)
+    }
+}
+
+func TestLiveScopeIntersectionFailsClosedDuringAtomicRouteUpdate(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(tempDir, "api-key-priorities.json"),
+		[]byte(`{"accountIds":{"client-secret":["account-b"]}}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write priority state: %v", err)
+	}
+	store := newAPIKeyPriorityStateStore(filepath.Join(tempDir, "manifest.json"))
+	spec := &apiKeySpec{
+		ID:         "key-internal-id",
+		Key:        "client-secret",
+		AccountIDs: []string{"account-a", "account-b"},
+	}
+	if got := liveAccountScopeForSpec(spec, store); len(got) != 1 || got[0] != "account-b" {
+		t.Fatalf("live sources must intersect, got %#v", got)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(tempDir, "api-key-priorities.json"),
+		[]byte(`{"accountIds":{"client-secret":[]}}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write empty priority state: %v", err)
+	}
+	updatedAt := time.Now().Add(5 * time.Second)
+	if err := os.Chtimes(filepath.Join(tempDir, "api-key-priorities.json"), updatedAt, updatedAt); err != nil {
+		t.Fatalf("advance priority timestamp: %v", err)
+	}
+	if got := liveAccountScopeForSpec(spec, store); len(got) != 0 {
+		t.Fatalf("an explicit empty live scope must block stale manifest ids, got %#v", got)
+	}
+}
+
+func TestLiveScopeAcceptsNewStableAuthBeforeManifestRestart(t *testing.T) {
+    auth := &coreauth.Auth{ID: "codex_new.json", Provider: "codex", Status: coreauth.StatusActive}
+    got := filterAuthsForManifestAccountIDs(
+        &manifest{accountByAuthID: map[string]*accountSpec{}, accountByID: map[string]*accountSpec{}},
+        []string{"codex_new"},
+        []*coreauth.Auth{auth},
+    )
+    if len(got) != 1 || got[0] != auth {
+        t.Fatalf("new auth should be selectable from its stable filename: %#v", got)
+    }
 }
 
 func intPtrForTest(value int) *int {
@@ -4232,7 +4324,7 @@ func TestSidecarRuntimeDoesNotSelectAccountWithExcludedModel(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(authDir, blockedFile), []byte(`{
   "type":"codex",
   "email":"blocked@example.com",
-  "access_token":"blocked-token",
+  "access_token":"eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.",
   "account_id":"acct-blocked",
   "excluded_models":["GPT-5.6-LUNA", "gpt-5.7-*"]
 }`), 0o600); err != nil {
@@ -4241,7 +4333,7 @@ func TestSidecarRuntimeDoesNotSelectAccountWithExcludedModel(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(authDir, allowedFile), []byte(`{
   "type":"codex",
   "email":"allowed@example.com",
-  "access_token":"allowed-token",
+  "access_token":"eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.",
   "account_id":"acct-allowed"
 }`), 0o600); err != nil {
 		t.Fatalf("write allowed auth: %v", err)

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -837,6 +837,36 @@ func TestAPIKeyPriorityStateOrdersFallbackAccountsWithoutRestart(t *testing.T) {
 	}
 }
 
+func TestAPIKeyEmptyLiveScopeEvictsAllAccountsWithoutRestart(t *testing.T) {
+	tempDir := t.TempDir()
+	priorityPath := filepath.Join(tempDir, "api-key-priorities.json")
+	if err := os.WriteFile(priorityPath, []byte(`{"accountIds":{"key-team":["account-a"]}}`), 0o600); err != nil {
+		t.Fatalf("write live scope: %v", err)
+	}
+	store := newAPIKeyPriorityStateStore(filepath.Join(tempDir, "manifest.json"))
+	accountA := &accountSpec{ID: "account-a"}
+	accountB := &accountSpec{ID: "account-b"}
+	selector := &cockpitSelector{
+		manifest: &manifest{accountByAuthID: map[string]*accountSpec{"auth-a": accountA, "auth-b": accountB}},
+		priorities: store,
+	}
+	ctx := context.WithValue(context.Background(), clientAPIKeyContextKey, &apiKeySpec{ID: "key-team"})
+	auths := []*coreauth.Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	if got := selector.filterAuthsForAPIKeyScope(ctx, auths); len(got) != 1 || got[0].ID != "auth-a" {
+		t.Fatalf("expected initial live scope to select account-a, got %#v", got)
+	}
+	if err := os.WriteFile(priorityPath, []byte(`{"accountIds":{"key-team":[]}}`), 0o600); err != nil {
+		t.Fatalf("clear live scope: %v", err)
+	}
+	updatedAt := time.Now().Add(time.Second)
+	if err := os.Chtimes(priorityPath, updatedAt, updatedAt); err != nil {
+		t.Fatalf("advance live scope timestamp: %v", err)
+	}
+	if got := selector.filterAuthsForAPIKeyScope(ctx, auths); len(got) != 0 {
+		t.Fatalf("expected empty live scope to evict every account, got %#v", got)
+	}
+}
+
 func TestCockpitSessionAffinitySeparatesClientAPIKeyScopes(t *testing.T) {
 	highQuotaAccount := &accountSpec{
 		ID:       "account-high",

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -10117,6 +10117,12 @@ fn stable_sidecar_config_for_fingerprint(config_content: &str) -> String {
         // requests. Excluding this hot-reloadable field keeps active streams alive
         // when the API service speed changes.
         config.remove("payload");
+        // The pool guard atomically changes these route/scope values while the
+        // running sidecar consumes them on the next request.  They are not a
+        // process identity change and must not cause an SSE-breaking restart.
+        config.remove("api-key-account-ids");
+        config.remove("codex-api-key");
+        config.remove("routing");
     }
     serde_json::to_string(&config).unwrap_or_else(|_| config_content.to_string())
 }
@@ -10126,27 +10132,45 @@ fn stable_sidecar_manifest_for_fingerprint(manifest_content: &str) -> String {
         return manifest_content.to_string();
     };
     if let Some(accounts) = manifest.get_mut("accounts").and_then(Value::as_array_mut) {
-        for account in accounts {
-            if let Some(account) = account.as_object_mut() {
-                account.remove("remainingQuota");
-                if let Some(reserve) = account
-                    .get_mut("quotaReserve")
-                    .and_then(Value::as_object_mut)
-                {
-                    for key in [
-                        "snapshotUpdatedAtUnixSeconds",
-                        "hourlyRemainingPercent",
-                        "weeklyRemainingPercent",
-                        "hourlyWindowPresent",
-                        "weeklyWindowPresent",
-                        "hourlyReserveState",
-                        "weeklyReserveState",
-                    ] {
-                        reserve.remove(key);
+        // Ordinary account membership and quota/plan snapshots are supplied by
+        // the watched auth directory and state files. Retain only the optional
+        // per-account reserve thresholds, which are structural configuration.
+        *accounts = accounts
+            .iter()
+            .filter_map(|account| {
+                let account = account.as_object()?;
+                let reserve = account.get("quotaReserve")?.as_object()?;
+                let mut stable_reserve = Map::new();
+                for key in ["hourlyThresholdPercent", "weeklyThresholdPercent"] {
+                    if let Some(value) = reserve.get(key) {
+                        stable_reserve.insert(key.to_string(), value.clone());
                     }
                 }
+                if stable_reserve.is_empty() {
+                    return None;
+                }
+                let mut stable_account = Map::new();
+                if let Some(id) = account.get("id") {
+                    stable_account.insert("id".to_string(), id.clone());
+                }
+                stable_account.insert("quotaReserve".to_string(), Value::Object(stable_reserve));
+                Some(Value::Object(stable_account))
+            })
+            .collect();
+    }
+    // Account membership and per-key scopes are hot-routed by the sidecar.
+    // Keep structural/API-key settings in the fingerprint, but ignore the
+    // externally managed membership payload so a pool tick cannot restart the
+    // gateway and terminate active SSE streams.
+    if let Some(api_keys) = manifest.get_mut("apiKeys").and_then(Value::as_array_mut) {
+        for api_key in api_keys {
+            if let Some(api_key) = api_key.as_object_mut() {
+                api_key.remove("accountIds");
             }
         }
+    }
+    if let Some(manifest) = manifest.as_object_mut() {
+        manifest.remove("customRoutingRules");
     }
     serde_json::to_string(&manifest).unwrap_or_else(|_| manifest_content.to_string())
 }
@@ -10552,7 +10576,6 @@ fn sidecar_codex_key_model_values(collection: &CodexLocalAccessCollection) -> Ve
 fn legacy_api_key_is_active(collection: &CodexLocalAccessCollection) -> bool {
     let key = collection.api_key.trim();
     !key.is_empty()
-        && !collection.account_ids.is_empty()
         && !collection
             .api_keys
             .iter()
@@ -10581,9 +10604,6 @@ fn sidecar_api_key_manifest_values(collection: &CodexLocalAccessCollection) -> V
             continue;
         }
         let account_ids = effective_api_key_account_ids(collection, item);
-        if account_ids.is_empty() {
-            continue;
-        }
         values.push(json!({
             "id": item.id.clone(),
             "label": item.label.clone(),
@@ -10604,7 +10624,17 @@ fn sidecar_api_key_manifest_values(collection: &CodexLocalAccessCollection) -> V
 
 fn sidecar_api_key_priority_state_values(collection: &CodexLocalAccessCollection) -> Value {
     let mut priority_account_ids = Map::new();
+    let mut account_ids = Map::new();
     for item in &collection.api_keys {
+        if !item.enabled || item.key.trim().is_empty() || item.provider_gateway.is_some() {
+            continue;
+        }
+        let scoped_account_ids =
+            normalize_account_id_list(effective_api_key_account_ids(collection, item));
+        account_ids.insert(
+            item.id.clone(),
+            Value::Array(scoped_account_ids.into_iter().map(Value::String).collect()),
+        );
         if api_key_inherits_account_pool(item) || api_key_has_fixed_account_scope(collection, item)
         {
             continue;
@@ -10626,6 +10656,7 @@ fn sidecar_api_key_priority_state_values(collection: &CodexLocalAccessCollection
     }
     json!({
         "priorityAccountIds": priority_account_ids,
+        "accountIds": account_ids,
     })
 }
 
@@ -10954,29 +10985,18 @@ fn remove_account_refs_from_collection(
 
 fn sidecar_client_api_keys(
     collection: &CodexLocalAccessCollection,
-    account_overrides: &HashMap<String, CodexAccount>,
+    _account_overrides: &HashMap<String, CodexAccount>,
 ) -> Vec<String> {
     let mut keys = Vec::new();
     let mut seen = HashSet::new();
     if legacy_api_key_is_active(collection)
-        && !sidecar_auth_ids_for_account_ids_with_overrides(
-            collection.account_ids.clone(),
-            account_overrides,
-        )
-        .is_empty()
         && seen.insert(collection.api_key.trim().to_string())
     {
         keys.push(collection.api_key.trim().to_string());
     }
     for item in &collection.api_keys {
         let key = item.key.trim();
-        let has_resolvable_scope = item.provider_gateway.is_some()
-            || !sidecar_auth_ids_for_account_ids_with_overrides(
-                effective_api_key_account_ids(collection, item),
-                account_overrides,
-            )
-            .is_empty();
-        if item.enabled && !key.is_empty() && has_resolvable_scope && seen.insert(key.to_string()) {
+        if item.enabled && !key.is_empty() && seen.insert(key.to_string()) {
             keys.push(key.to_string());
         }
     }
@@ -10993,9 +11013,7 @@ fn sidecar_api_key_account_scope_values(
             collection.account_ids.clone(),
             account_overrides,
         );
-        if !auth_ids.is_empty() {
-            values.insert(collection.api_key.trim().to_string(), json!(auth_ids));
-        }
+        values.insert(collection.api_key.trim().to_string(), json!(auth_ids));
     }
     for item in &collection.api_keys {
         let key = item.key.trim();
@@ -11009,9 +11027,6 @@ fn sidecar_api_key_account_scope_values(
             effective_api_key_account_ids(collection, item),
             account_overrides,
         );
-        if auth_ids.is_empty() {
-            continue;
-        }
         values.insert(key.to_string(), json!(auth_ids));
     }
     Value::Object(values)
@@ -13929,6 +13944,14 @@ async fn sync_runtime_collection_from_disk_if_changed() -> Result<bool, String> 
     Ok(true)
 }
 
+fn external_pool_change_requires_sidecar_restart() -> bool {
+    // Kept as a named policy seam for callers/tests: account membership and
+    // API-key scopes are consumed from config.json and
+    // api-key-priorities.json by the running sidecar. Restarting here aborts
+    // active SSE streams and makes every Codex task reconnect at once.
+    false
+}
+
 /// Background membership prune. Never writes a stale clone over a newer collection:
 /// sanitize against a snapshot, then commit only if runtime still matches that snapshot.
 fn run_collection_account_sanitize_once() -> Result<bool, String> {
@@ -16611,12 +16634,14 @@ async fn snapshot_state() -> Result<CodexLocalAccessState, String> {
     ensure_runtime_loaded_without_start().await?;
     match sync_runtime_collection_from_disk_if_changed().await {
         Ok(true) => {
-            // External pool managers update accountIds and the sidecar route
-            // files together.  Adopting only Cockpit's cached collection leaves
-            // the running gateway on the old auth/cooldown catalog until a user
-            // manually saves the same selection.  Use the native background
-            // reload path so newly available credentials can take over traffic.
-            trigger_gateway_reload_in_background("应用外部 API 服务账号集合");
+            if external_pool_change_requires_sidecar_restart() {
+                // This branch is deliberately disabled. External pool managers
+                // update accountIds and sidecar route files together; the sidecar
+                // watches those files and applies them without replacing the
+                // process. Keep this guard for an explicit future structural
+                // migration only.
+                trigger_gateway_reload_in_background("应用外部 API 服务账号集合");
+            }
         }
         Ok(false) => {}
         Err(error) => {
@@ -26175,7 +26200,8 @@ mod tests {
         cleanup_provider_gateway_profile_model_overrides, codex_price,
         collect_local_access_profile_takeover_dirs_from_store, compare_routing_candidates,
         count_request_logs_for_model_ids, default_codex_model_ids, effective_api_key_account_ids,
-        empty_stats_snapshot, extract_usage_capture, filter_bound_oauth_quota_reserve_account,
+        empty_stats_snapshot, external_pool_change_requires_sidecar_restart,
+        extract_usage_capture, filter_bound_oauth_quota_reserve_account,
         filter_websocket_client_message, insert_local_access_usage_event,
         inspect_local_access_profile_attachment, inspect_local_access_profile_config,
         is_codex_local_access_auth_text, is_codex_local_access_config_for_api_key,
@@ -27513,9 +27539,12 @@ wire_api = "responses"
         assert!(!api_key_inherits_account_pool(api_key));
         assert!(api_key.account_ids.is_empty());
         assert!(effective_api_key_account_ids(&collection, api_key).is_empty());
-        assert!(sidecar_api_key_manifest_values(&collection)
+        let manifest_keys = sidecar_api_key_manifest_values(&collection);
+        let scoped = manifest_keys
             .iter()
-            .all(|value| value.get("key").and_then(Value::as_str) != Some("scoped-key")));
+            .find(|value| value.get("key").and_then(Value::as_str) == Some("scoped-key"))
+            .expect("empty scoped key must remain available to clients");
+        assert_eq!(scoped.get("accountIds"), Some(&json!([])));
     }
 
     #[test]
@@ -27535,19 +27564,19 @@ wire_api = "responses"
         assert!(collection.api_keys[0].account_ids.is_empty());
         assert!(sidecar_api_key_manifest_values(&collection)
             .iter()
-            .all(|value| value.get("key").and_then(Value::as_str) != Some("local-api-key")));
-        assert!(!sidecar_client_api_keys(&collection, &HashMap::new())
+            .any(|value| value.get("key").and_then(Value::as_str) == Some("local-api-key")));
+        assert!(sidecar_client_api_keys(&collection, &HashMap::new())
             .iter()
             .any(|key| key == "local-api-key"));
-        assert!(
+        assert_eq!(
             sidecar_api_key_account_scope_values(&collection, &HashMap::new())
-                .get("local-api-key")
-                .is_none()
+                .get("local-api-key"),
+            Some(&json!([]))
         );
     }
 
     #[test]
-    fn sidecar_excludes_key_with_unresolved_custom_scope() {
+    fn sidecar_keeps_key_with_unresolved_custom_scope_explicitly_empty() {
         let mut collection = test_local_access_collection(vec!["account-a".to_string()]);
         let mut scoped_key = build_local_access_api_key(Some("Scoped"));
         scoped_key.key = "scoped-key".to_string();
@@ -27555,13 +27584,13 @@ wire_api = "responses"
         scoped_key.account_ids = vec!["missing-account".to_string()];
         collection.api_keys = vec![scoped_key];
 
-        assert!(!sidecar_client_api_keys(&collection, &HashMap::new())
+        assert!(sidecar_client_api_keys(&collection, &HashMap::new())
             .iter()
             .any(|key| key == "scoped-key"));
-        assert!(
+        assert_eq!(
             sidecar_api_key_account_scope_values(&collection, &HashMap::new())
-                .get("scoped-key")
-                .is_none()
+                .get("scoped-key"),
+            Some(&json!([]))
         );
     }
 
@@ -27656,7 +27685,7 @@ wire_api = "responses"
     }
 
     #[test]
-    fn sidecar_fingerprint_ignores_remaining_quota() {
+    fn sidecar_fingerprint_ignores_dynamic_account_quota_and_plan_metadata() {
         let config = r#"{"host":"127.0.0.1","port":58393}"#;
         let manifest_a = r#"{
           "accounts": [
@@ -27681,7 +27710,7 @@ wire_api = "responses"
             sidecar_config_fingerprint(config, manifest_a),
             sidecar_config_fingerprint(config, manifest_b)
         );
-        assert_ne!(
+        assert_eq!(
             sidecar_config_fingerprint(config, manifest_b),
             sidecar_config_fingerprint(config, manifest_c)
         );
@@ -27709,6 +27738,55 @@ wire_api = "responses"
         assert_ne!(
             sidecar_config_fingerprint(priority, manifest),
             sidecar_config_fingerprint(other_port, manifest),
+        );
+    }
+
+    #[test]
+    fn sidecar_fingerprint_ignores_external_hot_route_membership() {
+        let config_a = r#"{
+          "host": "127.0.0.1",
+          "port": 58393,
+          "api-keys": ["client-key"],
+          "api-key-account-ids": {"client-key": ["account-a.json"]},
+          "routing": {"strategy": "round-robin", "session-affinity": true},
+          "codex-api-key": [{"api-key": "upstream-a"}]
+        }"#;
+        let config_b = r#"{
+          "host": "127.0.0.1",
+          "port": 58393,
+          "api-keys": ["client-key"],
+          "api-key-account-ids": {"client-key": []},
+          "routing": {"strategy": "round-robin", "session-affinity": false},
+          "codex-api-key": []
+        }"#;
+        let manifest_a = r#"{
+          "apiKeys": [{"id":"key-1","key":"client-key","accountIds":["account-a"]}],
+          "accounts": [{"id":"account-a","authId":"account-a.json"}],
+          "customRoutingRules": [{"accountId":"account-a","priority":100}],
+          "routingStrategy":"auto"
+        }"#;
+        let manifest_b = r#"{
+          "apiKeys": [{"id":"key-1","key":"client-key","accountIds":[]}],
+          "accounts": [],
+          "customRoutingRules": [],
+          "routingStrategy":"auto"
+        }"#;
+        let other_key = r#"{
+          "apiKeys": [{"id":"key-1","key":"different-client-key","accountIds":[]}],
+          "accounts": [],
+          "customRoutingRules": [],
+          "routingStrategy":"auto"
+        }"#;
+
+        assert!(!external_pool_change_requires_sidecar_restart());
+        assert_eq!(
+            sidecar_config_fingerprint(config_a, manifest_a),
+            sidecar_config_fingerprint(config_b, manifest_b),
+        );
+        assert_ne!(
+            sidecar_config_fingerprint(config_b, manifest_b),
+            sidecar_config_fingerprint(config_b, other_key),
+            "a structural client API-key change must still require a reload",
         );
     }
 

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -13922,10 +13922,8 @@ async fn sync_runtime_collection_from_disk_if_changed() -> Result<bool, String> 
         (previous_count, next_count)
     };
 
-    GATEWAY_COLLECTION_ACCOUNT_SANITIZE_COMPLETED.store(false, Ordering::SeqCst);
-    ensure_collection_account_sanitize_started();
     logger::log_codex_api_info(&format!(
-        "检测到 API 服务磁盘配置已由外部更新，已同步 Cockpit 运行态显示（不重启 Sidecar）: accounts={} -> {}",
+        "检测到 API 服务磁盘配置已由外部更新，已同步 Cockpit 运行态显示: accounts={} -> {}",
         previous_count, next_count
     ));
     Ok(true)

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -16611,13 +16611,24 @@ fn build_fresh_state_snapshot(runtime: &mut GatewayRuntime) -> CodexLocalAccessS
 
 async fn snapshot_state() -> Result<CodexLocalAccessState, String> {
     ensure_runtime_loaded_without_start().await?;
-    if let Err(error) = sync_runtime_collection_from_disk_if_changed().await {
-        // A transient external write must not make the API Service page unusable;
-        // keep serving the last valid runtime snapshot and retry on the next read.
-        logger::log_codex_api_warn(&format!(
-            "同步 API 服务外部配置到 Cockpit 运行态失败，暂时保留上次有效状态: {}",
-            error
-        ));
+    match sync_runtime_collection_from_disk_if_changed().await {
+        Ok(true) => {
+            // External pool managers update accountIds and the sidecar route
+            // files together.  Adopting only Cockpit's cached collection leaves
+            // the running gateway on the old auth/cooldown catalog until a user
+            // manually saves the same selection.  Use the native background
+            // reload path so newly available credentials can take over traffic.
+            trigger_gateway_reload_in_background("应用外部 API 服务账号集合");
+        }
+        Ok(false) => {}
+        Err(error) => {
+            // A transient external write must not make the API Service page unusable;
+            // keep serving the last valid runtime snapshot and retry on the next read.
+            logger::log_codex_api_warn(&format!(
+                "同步 API 服务外部配置到 Cockpit 运行态失败，暂时保留上次有效状态: {}",
+                error
+            ));
+        }
     }
     let mut runtime = gateway_runtime().lock().await;
     refresh_gateway_process_status(&mut runtime);

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -13829,33 +13829,106 @@ fn collection_content_fingerprint(
         .map_err(|error| format!("序列化 API 服务配置指纹失败: {}", error))
 }
 
-fn collection_disk_snapshot_for_cas(
-    runtime_fingerprint: &[u8],
-) -> Result<Option<(PathBuf, [u8; 32])>, String> {
+type CollectionDiskSnapshot = (PathBuf, CodexLocalAccessCollection, [u8; 32]);
+
+fn collection_disk_snapshot() -> Result<Option<CollectionDiskSnapshot>, String> {
     let path = local_access_file_path()?;
     let content = match std::fs::read(&path) {
         Ok(content) => content,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
             return Err(format!(
-                "读取 API 服务配置 CAS 快照失败: path={}, error={}",
+                "读取 API 服务配置快照失败: path={}, error={}",
                 path.display(),
                 error
             ));
         }
     };
-    let disk_collection =
+    let collection =
         serde_json::from_slice::<CodexLocalAccessCollection>(&content).map_err(|error| {
             format!(
-                "解析 API 服务配置 CAS 快照失败: path={}, error={}",
+                "解析 API 服务配置快照失败: path={}, error={}",
                 path.display(),
                 error
             )
         })?;
+    Ok(Some((path, collection, Sha256::digest(&content).into())))
+}
+
+fn collection_disk_snapshot_for_cas(
+    runtime_fingerprint: &[u8],
+) -> Result<Option<(PathBuf, [u8; 32])>, String> {
+    let Some((path, disk_collection, disk_hash)) = collection_disk_snapshot()? else {
+        return Ok(None);
+    };
     if collection_content_fingerprint(&disk_collection)? != runtime_fingerprint {
         return Ok(None);
     }
-    Ok(Some((path, Sha256::digest(&content).into())))
+    Ok(Some((path, disk_hash)))
+}
+
+fn runtime_collection_matches_disk(
+    runtime: &GatewayRuntime,
+    disk_collection: &CodexLocalAccessCollection,
+) -> Result<bool, String> {
+    let Some(runtime_collection) = runtime.collection.as_ref() else {
+        return Ok(false);
+    };
+    Ok(collection_content_fingerprint(runtime_collection)?
+        == collection_content_fingerprint(disk_collection)?)
+}
+
+/// Adopt atomically-written collection changes made by trusted companion tools.
+/// This updates Cockpit's cached membership and page state only; it deliberately
+/// does not stop or restart the active sidecar.
+async fn sync_runtime_collection_from_disk_if_changed() -> Result<bool, String> {
+    let snapshot = tauri::async_runtime::spawn_blocking(collection_disk_snapshot)
+        .await
+        .map_err(|error| format!("读取 API 服务配置快照任务失败: {}", error))??;
+    let Some((path, disk_collection, expected_disk_hash)) = snapshot else {
+        return Ok(false);
+    };
+
+    let (previous_count, next_count) = {
+        let mut runtime = gateway_runtime().lock().await;
+        if !runtime.loaded || runtime_collection_matches_disk(&runtime, &disk_collection)? {
+            return Ok(false);
+        }
+
+        // Recheck the file while holding the runtime lock. An in-app save writes
+        // disk before publishing runtime; this CAS prevents an older snapshot
+        // from overwriting that newer in-memory state.
+        let current_content = std::fs::read(&path).map_err(|error| {
+            format!(
+                "复核 API 服务配置快照失败: path={}, error={}",
+                path.display(),
+                error
+            )
+        })?;
+        let current_disk_hash: [u8; 32] = Sha256::digest(&current_content).into();
+        if current_disk_hash != expected_disk_hash {
+            return Ok(false);
+        }
+
+        let previous_count = runtime
+            .collection
+            .as_ref()
+            .map(|collection| collection.account_ids.len())
+            .unwrap_or(0);
+        let next_count = disk_collection.account_ids.len();
+        let last_error = runtime.last_error.clone();
+        sync_runtime_collection(&mut runtime, disk_collection);
+        runtime.last_error = last_error;
+        (previous_count, next_count)
+    };
+
+    GATEWAY_COLLECTION_ACCOUNT_SANITIZE_COMPLETED.store(false, Ordering::SeqCst);
+    ensure_collection_account_sanitize_started();
+    logger::log_codex_api_info(&format!(
+        "检测到 API 服务磁盘配置已由外部更新，已同步 Cockpit 运行态显示（不重启 Sidecar）: accounts={} -> {}",
+        previous_count, next_count
+    ));
+    Ok(true)
 }
 
 /// Background membership prune. Never writes a stale clone over a newer collection:
@@ -16538,6 +16611,14 @@ fn build_fresh_state_snapshot(runtime: &mut GatewayRuntime) -> CodexLocalAccessS
 
 async fn snapshot_state() -> Result<CodexLocalAccessState, String> {
     ensure_runtime_loaded_without_start().await?;
+    if let Err(error) = sync_runtime_collection_from_disk_if_changed().await {
+        // A transient external write must not make the API Service page unusable;
+        // keep serving the last valid runtime snapshot and retry on the next read.
+        logger::log_codex_api_warn(&format!(
+            "同步 API 服务外部配置到 Cockpit 运行态失败，暂时保留上次有效状态: {}",
+            error
+        ));
+    }
     let mut runtime = gateway_runtime().lock().await;
     refresh_gateway_process_status(&mut runtime);
     if runtime
@@ -26426,6 +26507,28 @@ mod tests {
             created_at: 0,
             updated_at: 0,
         }
+    }
+
+    #[test]
+    fn runtime_collection_detects_externally_changed_membership() {
+        let mut runtime = super::GatewayRuntime::default();
+        runtime.loaded = true;
+        super::sync_runtime_collection(
+            &mut runtime,
+            test_local_access_collection(vec!["k12-account".to_string()]),
+        );
+        let disk_collection = test_local_access_collection(vec!["pro-account".to_string()]);
+
+        assert!(
+            !super::runtime_collection_matches_disk(&runtime, &disk_collection)
+                .expect("compare changed collection")
+        );
+
+        super::sync_runtime_collection(&mut runtime, disk_collection.clone());
+        assert!(
+            super::runtime_collection_matches_disk(&runtime, &disk_collection)
+                .expect("compare synchronized collection")
+        );
     }
 
     #[test]

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -1084,6 +1084,7 @@ export function CodexAccountsPage() {
   const [localAccessState, setLocalAccessState] =
     useState<CodexLocalAccessState | null>(null);
   const localAccessStateRequestSeqRef = useRef(0);
+  const codexAccountsPageRootRef = useRef<HTMLDivElement | null>(null);
   const [showLocalAccessModal, setShowLocalAccessModal] = useState(false);
   const [showLocalAccessHealthModal, setShowLocalAccessHealthModal] =
     useState(false);
@@ -2092,6 +2093,31 @@ export function CodexAccountsPage() {
   useEffect(() => {
     void reloadLocalAccessState();
   }, [reloadLocalAccessState]);
+
+  useEffect(() => {
+    const activelyChanging = Boolean(
+      localAccessState?.collection?.enabled &&
+        (localAccessState?.preparing ||
+          localAccessState?.refreshingAccounts ||
+          (!localAccessState?.running && !localAccessState?.lastError)),
+    );
+    const refreshIntervalMs = activelyChanging ? 750 : 5_000;
+    const timer = window.setInterval(() => {
+      const root = codexAccountsPageRootRef.current;
+      if (!root || root.closest("[hidden]")) {
+        return;
+      }
+      void reloadLocalAccessState();
+    }, refreshIntervalMs);
+    return () => window.clearInterval(timer);
+  }, [
+    localAccessState?.collection?.enabled,
+    localAccessState?.preparing,
+    localAccessState?.refreshingAccounts,
+    localAccessState?.running,
+    localAccessState?.lastError,
+    reloadLocalAccessState,
+  ]);
 
   useEffect(() => {
     if (
@@ -13425,6 +13451,7 @@ export function CodexAccountsPage() {
 
   return (
     <div
+      ref={codexAccountsPageRootRef}
       className={`codex-accounts-page codex-accounts-page--${overviewLayoutMode}`}
     >
       <CodexOverviewTabsHeader

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -125,6 +125,8 @@ type RequestLogStatusFilter = "all" | "success" | "failed";
 type RequestLogGatewayModeFilter = "all" | CodexLocalAccessGatewayMode;
 type BuiltinTimeoutPresetId = "long_wait" | "short_wait";
 type TimeoutPresetId = BuiltinTimeoutPresetId | string;
+const ACTIVE_STATE_REFRESH_MS = 750;
+const STABLE_STATE_REFRESH_MS = 5_000;
 
 interface ApiKeyPolicyDraft {
   modelPrefix: string;
@@ -823,6 +825,7 @@ export function CodexApiServicePage() {
   const mountedRef = useRef(true);
   const stateRequestSeqRef = useRef(0);
   const statsRequestSeqRef = useRef(0);
+  const pageRootRef = useRef<HTMLDivElement | null>(null);
   const testChatScrollRef = useRef<HTMLDivElement | null>(null);
 
   const collection = state?.collection ?? null;
@@ -1352,17 +1355,26 @@ export function CodexApiServicePage() {
   }, [addressKind]);
 
   useEffect(() => {
-    if (
-      !collection?.enabled ||
-      (!state?.preparing &&
-        !state?.refreshingAccounts &&
-        (state?.running || Boolean(state?.lastError)))
-    ) {
-      return undefined;
-    }
+    const activelyChanging = Boolean(
+      collection?.enabled &&
+        (state?.preparing ||
+          state?.refreshingAccounts ||
+          (!state?.running && !state?.lastError)),
+    );
+    const refreshIntervalMs = activelyChanging
+      ? ACTIVE_STATE_REFRESH_MS
+      : STABLE_STATE_REFRESH_MS;
     const timer = window.setInterval(() => {
+      const root = pageRootRef.current;
+      if (
+        document.visibilityState !== "visible" ||
+        !root ||
+        root.closest("[hidden]")
+      ) {
+        return;
+      }
       void reloadState();
-    }, 750);
+    }, refreshIntervalMs);
     return () => window.clearInterval(timer);
   }, [
     collection?.enabled,
@@ -3355,7 +3367,7 @@ export function CodexApiServicePage() {
   };
 
   return (
-    <div className="codex-api-service-page">
+    <div ref={pageRootRef} className="codex-api-service-page">
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -1373,10 +1373,16 @@ export function CodexApiServicePage() {
         return;
       }
       void reloadState();
+      // The API-service summary is derived from the account list's quota
+      // snapshots, not only from local-access state. Refresh both together so
+      // a live sidecar quota update cannot leave the page showing an old
+      // 4x100% total after traffic has moved to the K12 pool.
+      void fetchAccounts();
     }, refreshIntervalMs);
     return () => window.clearInterval(timer);
   }, [
     collection?.enabled,
+    fetchAccounts,
     reloadState,
     state?.preparing,
     state?.refreshingAccounts,

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -1367,7 +1367,6 @@ export function CodexApiServicePage() {
     const timer = window.setInterval(() => {
       const root = pageRootRef.current;
       if (
-        document.visibilityState !== "visible" ||
         !root ||
         root.closest("[hidden]")
       ) {


### PR DESCRIPTION
## Summary

- Adopt trusted external `codex_local_access.json` membership edits through the existing runtime collection path, with a content-hash/CAS recheck and no sidecar restart.
- Refresh the API Service page and the accounts-page API entry only while their mounted ancestor is visible (5 s stable / 750 ms while changing).
- Refresh account quota snapshots alongside API Service state so the overview does not retain stale percentage totals.

## Deliberately out of scope

This replacement keeps Cockpit as an interface. It does **not** add import promotion, K12/Plus/Pro selection policy, fallback policy, sidecar routing extensions, or purchase workflow. Those decisions remain in the external K12-buy controller.

Compared with the superseded patch, this branch is based directly on the current upstream `main` and changes only 3 files (164 insertions, 17 deletions).

## Validation

- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Rust regression coverage is included for disk/runtime membership comparison. This machine has no Rust toolchain; the same backend sync commit previously compiled successfully in the Windows custom build.
