### PR TITLE
fix(workbuddy): merge existing sessions on account switch

### DIFF
--- a/src-tauri/src/commands/codebuddy_session.rs
+++ b/src-tauri/src/commands/codebuddy_session.rs
@@ -17,8 +17,9 @@ fn parse_platform(platform: &str) -> Result<CodebuddySessionPlatform, String> {
     match platform {
         "cn" => Ok(CodebuddySessionPlatform::Cn),
         "intl" => Ok(CodebuddySessionPlatform::Intl),
+        "workbuddy" => Ok(CodebuddySessionPlatform::Workbuddy),
         _ => Err(format!(
-            "Unknown platform: {}. Use 'cn' or 'intl'.",
+            "Unknown platform: {}. Use 'cn', 'intl' or 'workbuddy'.",
             platform
         )),
     }

--- a/src-tauri/src/modules/codebuddy_session.rs
+++ b/src-tauri/src/modules/codebuddy_session.rs
@@ -15,6 +15,10 @@ use crate::modules::logger;
 pub enum CodebuddySessionPlatform {
     Cn,
     Intl,
+    /// WorkBuddy stores sessions in `~/.workbuddy/workbuddy.db` (a single sqlite
+    /// database, partitioned by `user_id`), unlike CodeBuddy's per-instance
+    /// `codebuddy-sessions.vscdb` files.
+    Workbuddy,
 }
 
 /// A single session location — which instance it came from.
@@ -79,6 +83,9 @@ fn get_default_user_data_dir(platform: &CodebuddySessionPlatform) -> Result<Path
         CodebuddySessionPlatform::Intl => {
             crate::modules::codebuddy_instance::get_default_codebuddy_user_data_dir()
         }
+        // WorkBuddy sessions live in a single `workbuddy.db` and are handled by
+        // `list_sessions` directly; it never reaches the per-instance directory scan.
+        CodebuddySessionPlatform::Workbuddy => Err("workbuddy sessions are not scanned per-instance".to_string()),
     }
 }
 
@@ -91,6 +98,8 @@ fn load_instance_store(
             crate::modules::codebuddy_cn_instance::load_instance_store()
         }
         CodebuddySessionPlatform::Intl => crate::modules::codebuddy_instance::load_instance_store(),
+        // WorkBuddy uses a single shared database; no per-instance store exists.
+        CodebuddySessionPlatform::Workbuddy => Ok(crate::models::InstanceStore::new()),
     }
 }
 
@@ -120,6 +129,92 @@ fn collect_data_dirs(platform: &CodebuddySessionPlatform) -> Vec<(String, String
 /// Return the path to `codebuddy-sessions.vscdb` inside a user-data dir.
 fn sessions_db_path(user_data_dir: &Path) -> PathBuf {
     user_data_dir.join("codebuddy-sessions.vscdb")
+}
+
+/// Return the path to the WorkBuddy `workbuddy.db` (lives in the config root).
+fn workbuddy_sessions_db_path() -> Result<PathBuf, String> {
+    crate::modules::workbuddy_instance::get_default_workbuddy_config_dir()
+        .map(|p| p.join("workbuddy.db"))
+}
+
+/// Read session records from the WorkBuddy `workbuddy.db` `sessions` table.
+///
+/// Unlike CodeBuddy, WorkBuddy keeps all sessions in a single database and
+/// partitions them by `user_id`. The schema matches
+/// `modules/workbuddy_session_transfer.rs` (`remap_workbuddy_database_user_id`).
+fn read_sessions_from_workbuddy_db(db_path: &Path) -> Vec<RawSession> {
+    if !db_path.exists() {
+        return Vec::new();
+    }
+
+    let conn = match Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+    {
+        Ok(c) => c,
+        Err(e) => {
+            logger::log_warn(&format!(
+                "[CodebuddySession] Failed to open WorkBuddy db {}: {}",
+                db_path.display(),
+                e
+            ));
+            return Vec::new();
+        }
+    };
+
+    let mut stmt = match conn.prepare(
+        "SELECT id, cwd, user_id, title, status, created_at, updated_at, deleted_at, is_playground \
+         FROM sessions",
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            logger::log_warn(&format!(
+                "[CodebuddySession] Failed to prepare WorkBuddy query on {}: {}",
+                db_path.display(),
+                e
+            ));
+            return Vec::new();
+        }
+    };
+
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,                 // id
+            row.get::<_, Option<String>>(1)?,         // cwd
+            row.get::<_, Option<String>>(2)?,         // user_id
+            row.get::<_, Option<String>>(3)?,         // title
+            row.get::<_, Option<String>>(4)?,         // status
+            row.get::<_, Option<i64>>(5)?,            // created_at
+            row.get::<_, Option<i64>>(6)?,            // updated_at
+            row.get::<_, Option<i64>>(7)?,            // deleted_at
+            row.get::<_, i64>(8).unwrap_or(0),        // is_playground
+        ))
+    });
+
+    let mut sessions = Vec::new();
+    if let Ok(rows) = rows {
+        for row in rows {
+            match row {
+                Ok((id, cwd, user_id, title, status, created_at, updated_at, deleted_at, is_play)) => {
+                    sessions.push(RawSession {
+                        conversation_id: id,
+                        title: title.unwrap_or_default(),
+                        cwd: cwd.unwrap_or_default(),
+                        user_id: user_id.unwrap_or_default(),
+                        status: status.unwrap_or_default(),
+                        created_at,
+                        updated_at,
+                        is_deleted: deleted_at.is_some(),
+                        is_playground: is_play != 0,
+                    });
+                }
+                Err(e) => logger::log_warn(&format!(
+                    "[CodebuddySession] Failed to read WorkBuddy row: {}",
+                    e
+                )),
+            }
+        }
+    }
+
+    sessions
 }
 
 // ---------------------------------------------------------------------------
@@ -240,6 +335,16 @@ pub fn list_sessions(
     platform: &CodebuddySessionPlatform,
     filter: &CodebuddySessionFilter,
 ) -> Result<Vec<CodebuddySessionRecord>, String> {
+    // WorkBuddy stores everything in a single `workbuddy.db`; no per-instance
+    // directory scanning needed.
+    if let CodebuddySessionPlatform::Workbuddy = platform {
+        let db_path = workbuddy_sessions_db_path()?;
+        return Ok(aggregate_workbuddy_sessions(
+            read_sessions_from_workbuddy_db(&db_path),
+            filter,
+        ));
+    }
+
     let data_dirs = collect_data_dirs(platform);
     let mut aggregated: HashMap<String, CodebuddySessionRecord> = HashMap::new();
 
@@ -314,4 +419,77 @@ pub fn list_sessions(
     records.sort_by(|a, b| b.updated_at.unwrap_or(0).cmp(&a.updated_at.unwrap_or(0)));
 
     Ok(records)
+}
+
+/// Filter + aggregate WorkBuddy raw sessions (single-database variant of the
+/// per-instance aggregation used above).
+fn aggregate_workbuddy_sessions(
+    raw_sessions: Vec<RawSession>,
+    filter: &CodebuddySessionFilter,
+) -> Vec<CodebuddySessionRecord> {
+    let mut aggregated: HashMap<String, CodebuddySessionRecord> = HashMap::new();
+
+    let keyword = filter
+        .keyword
+        .as_deref()
+        .map(|k| k.to_lowercase())
+        .unwrap_or_default();
+    let status_filter = filter.status.as_deref().unwrap_or("");
+
+    for raw in raw_sessions {
+        if raw.is_deleted {
+            continue;
+        }
+
+        if !status_filter.is_empty() && raw.status != status_filter {
+            continue;
+        }
+
+        if !keyword.is_empty() {
+            let title_lower = raw.title.to_lowercase();
+            let cwd_lower = raw.cwd.to_lowercase();
+            if !title_lower.contains(&keyword) && !cwd_lower.contains(&keyword) {
+                continue;
+            }
+        }
+
+        let conversation_id = raw.conversation_id.clone();
+        let location = CodebuddySessionLocation {
+            instance_id: "workbuddy".to_string(),
+            instance_name: "WorkBuddy".to_string(),
+        };
+
+        aggregated
+            .entry(conversation_id.clone())
+            .and_modify(|existing| {
+                if let Some(new_updated) = raw.updated_at {
+                    if existing.updated_at.map_or(true, |old| new_updated > old) {
+                        existing.updated_at = Some(new_updated);
+                    }
+                }
+                if !existing
+                    .locations
+                    .iter()
+                    .any(|l| l.instance_id == "workbuddy")
+                {
+                    existing.locations.push(location.clone());
+                }
+            })
+            .or_insert_with(|| CodebuddySessionRecord {
+                conversation_id: raw.conversation_id,
+                title: raw.title,
+                cwd: raw.cwd,
+                user_id: raw.user_id,
+                status: raw.status,
+                created_at: raw.created_at,
+                updated_at: raw.updated_at,
+                is_playground: raw.is_playground,
+                locations: vec![location],
+            });
+    }
+
+    let mut records: Vec<CodebuddySessionRecord> = aggregated.into_values().collect();
+    records.sort_by(|a, b| b.updated_at.unwrap_or(0).cmp(&a.updated_at.unwrap_or(0)));
+
+    records
 }

--- a/src-tauri/src/modules/config.rs
+++ b/src-tauri/src/modules/config.rs
@@ -959,7 +959,7 @@ fn default_workbuddy_app_path() -> String {
     String::new()
 }
 fn default_workbuddy_share_sessions_on_switch() -> bool {
-    false
+    true
 }
 fn default_opencode_sync_on_switch() -> bool {
     false

--- a/src-tauri/src/modules/workbuddy_account.rs
+++ b/src-tauri/src/modules/workbuddy_account.rs
@@ -1,3 +1,5 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -1172,6 +1174,26 @@ fn extract_local_workbuddy_token_parts(token: &str) -> Option<(Option<String>, S
     Some((None, trimmed.to_string()))
 }
 
+// 新版 WorkBuddy 本机登录态使用标准 JWT 作为 access token，其 payload 的 `sub`
+// 字段即为客户端账号 uid（与 CodeBuddyExtension/Data/{uid} 目录名一致）。
+// 当 token 前缀/账号字段都无法取出 uid 时，回退到解析 JWT 的 `sub`。
+fn extract_uid_from_jwt(token: &str) -> Option<String> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let decoded = URL_SAFE_NO_PAD
+        .decode(parts[1])
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(parts[1]))
+        .ok()?;
+    let value: Value = serde_json::from_slice(&decoded).ok()?;
+    value
+        .get("sub")
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 fn json_object_string_field(obj: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
     for key in keys {
         let value = obj
@@ -1501,6 +1523,8 @@ pub fn import_payload_from_local() -> Result<Option<WorkbuddyOAuthCompletePayloa
     else {
         return Err("本地 WorkBuddy 登录信息解析失败: access token 无效".to_string());
     };
+    // 回退：新版 JWT token 无法从前缀得到 uid，改从 sub 声明提取。
+    let uid_from_token = uid_from_token.or_else(|| extract_uid_from_jwt(&raw_token));
     let Some(access_token) = normalize_local_workbuddy_token(&normalized_token) else {
         return Err("本地 WorkBuddy 登录信息解析失败: access token 为空".to_string());
     };

--- a/src-tauri/src/modules/workbuddy_session_transfer.rs
+++ b/src-tauri/src/modules/workbuddy_session_transfer.rs
@@ -57,7 +57,9 @@ pub fn prepare_account_switch(
                     );
                 }
             }
-            Ok(None) => {}
+            Ok(None) => logger::log_warn(
+                "[WorkBuddy Session Transfer] 本机未读取到 WorkBuddy 登录信息，已跳过来源会话合并",
+            ),
             Err(error) => logger::log_warn(&format!(
                 "[WorkBuddy Session Transfer] 读取当前登录信息失败，已跳过来源会话合并: {}",
                 error
@@ -97,24 +99,26 @@ pub fn transfer_local_sessions(
     let mut report = WorkbuddySessionTransferReport::default();
     let extension_roots = select_extension_data_roots(source_uid)?;
     if extension_roots.is_empty() {
+        // WorkBuddy 5.x 会话统一存放在 workbuddy.db（按 user_id 区分），不存在
+        // 旧版的 per-uid 本地会话目录，因此这里只跳过目录级合并，仍需执行下方
+        // 的数据库层 user_id 重映射（这才是 WorkBuddy 真正生效的会话合并）。
         logger::log_warn(&format!(
-            "[WorkBuddy Session Transfer] 未找到来源账号会话目录，跳过数据库重映射: source_uid={}",
+            "[WorkBuddy Session Transfer] 未找到来源账号本地会话目录（uid={}），跳过目录级合并，将继续执行数据库层合并",
             source_uid
         ));
-        return Ok(report);
-    }
-
-    for (label, extension_data_dir) in extension_roots {
-        let file_report = codebuddy_session_transfer::sync_history_between_accounts(
-            &extension_data_dir,
-            source_uid,
-            target_uid,
-            &backup_root.join(label),
-        )
-        .map_err(workbuddy_error)?;
-        report.added_conversations += file_report.added_conversations;
-        report.replaced_conversations += file_report.replaced_conversations;
-        report.scanned_workspaces += file_report.scanned_workspaces;
+    } else {
+        for (label, extension_data_dir) in extension_roots {
+            let file_report = codebuddy_session_transfer::sync_history_between_accounts(
+                &extension_data_dir,
+                source_uid,
+                target_uid,
+                &backup_root.join(label),
+            )
+            .map_err(workbuddy_error)?;
+            report.added_conversations += file_report.added_conversations;
+            report.replaced_conversations += file_report.replaced_conversations;
+            report.scanned_workspaces += file_report.scanned_workspaces;
+        }
     }
 
     report.updated_session_rows += remap_workbuddy_database_user_id(

--- a/src/pages/WorkbuddyAccountsPage.tsx
+++ b/src/pages/WorkbuddyAccountsPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../types/workbuddy';
 import { useProviderAccountsPage } from '../hooks/useProviderAccountsPage';
 import { WorkbuddyCheckinModal } from '../components/codebuddy-suite/CodebuddySuiteCheckinModal';
+import { CodebuddySessionManager } from '../components/codebuddy/CodebuddySessionManager';
 import { CodebuddySuiteAccountsSharedView, type CodebuddySuiteAccountsPlatformConfig } from '../components/codebuddy-suite/CodebuddySuiteAccountsSharedView';
 import { compareCurrentAccountFirst } from '../utils/currentAccountSort';
 
@@ -132,8 +133,11 @@ export function WorkbuddyAccountsPage() {
         platform="workbuddy"
         active={activeTab}
         onTabChange={setActiveTab}
+        tabs={['overview', 'sessions', 'instances']}
       />
-      {activeTab === 'instances' ? (
+      {activeTab === 'sessions' ? (
+        <CodebuddySessionManager platform="workbuddy" accounts={store.accounts as any} />
+      ) : activeTab === 'instances' ? (
         <WorkbuddyInstancesContent accountsForSelect={accountsForInstances} />
       ) : (
         <CodebuddySuiteAccountsSharedView

--- a/src/services/codebuddySessionService.ts
+++ b/src/services/codebuddySessionService.ts
@@ -25,7 +25,7 @@ export interface CodebuddySessionRecord {
 // Service calls
 // ---------------------------------------------------------------------------
 
-export type CodebuddySessionPlatform = 'cn' | 'intl';
+export type CodebuddySessionPlatform = 'cn' | 'intl' | 'workbuddy';
 
 export async function codebuddyListSessions(
   platform: CodebuddySessionPlatform,


### PR DESCRIPTION
## Summary
Fixes session merge being silently skipped when switching WorkBuddy accounts.

## Root causes (3)
1. **Config default off**: workbuddy_share_sessions_on_switch defaulted to alse, so prepare_account_switch skipped the whole merge path. Now defaults to 	rue.
2. **JWT uid not parsed**: import_payload_from_local only recognized legacy W{uid}- / T{uid}- prefixed tokens, so the new JWT login state had no uid and fell into the silent Ok(None) branch. Added extract_uid_from_jwt that reads the sub claim as a fallback.
3. **Early return skipped db remap**: 	ransfer_local_sessions returned early when extension_roots was empty, skipping the db-level user_id remap that WorkBuddy 5.x sessions rely on. Changed the directory-merge block to an else so the db remap always runs.

Also wired the workbuddy platform into the CodebuddySessionManager UI/service.

## Verification
- Built and ran via 	auri dev (dev profile).
- Confirmed in logs: switching accounts remapped sessions (e.g. source_uid=3c0c905a... -> target_uid=93df388b..., 13 workspaces merged, db rows remapped).

## Files changed
- src-tauri/src/modules/config.rs (default on)
- src-tauri/src/modules/workbuddy_session_transfer.rs (else branch for db remap)
- src-tauri/src/modules/workbuddy_account.rs (JWT sub fallback)
- src-tauri/src/modules/codebuddy_session.rs + src-tauri/src/commands/codebuddy_session.rs (Workbuddy variants, read workbuddy.db)
- src/pages/WorkbuddyAccountsPage.tsx + src/services/codebuddySessionService.ts (workbuddy platform UI)