### PR TITLE
fix(codex): import full OAuth tokens from Sub2API credentials

### DIFF
--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -6549,7 +6549,7 @@ fn merge_access_token_import_hints(
     primary
 }
 
-fn first_personal_access_token_string(value: &serde_json::Value) -> Option<String> {
+fn first_explicit_personal_access_token_string(value: &serde_json::Value) -> Option<String> {
     first_json_scalar_string(
         value,
         &[
@@ -6580,7 +6580,10 @@ fn first_personal_access_token_string(value: &serde_json::Value) -> Option<Strin
         )
         .and_then(|header| extract_bearer_token_from_header(&header))
     })
-    .or_else(|| {
+}
+
+fn first_personal_access_token_string(value: &serde_json::Value) -> Option<String> {
+    first_explicit_personal_access_token_string(value).or_else(|| {
         first_json_scalar_string(
             value,
             &[
@@ -6908,7 +6911,7 @@ fn extract_codex_import_candidate_from_value(
     value: &serde_json::Value,
 ) -> Option<CodexJsonImportCandidate> {
     if value.is_object() {
-        if let Some(access_token) = first_personal_access_token_string(value) {
+        if let Some(access_token) = first_explicit_personal_access_token_string(value) {
             let hints = extract_access_token_import_hints_from_value(value);
             return Some(CodexJsonImportCandidate::AccessToken {
                 access_token,
@@ -6921,7 +6924,9 @@ fn extract_codex_import_candidate_from_value(
         return Some(candidate);
     }
 
-    if let Some((tokens, account_id_hint)) = extract_codex_tokens_from_value(value) {
+    if let Some((tokens, account_id_hint)) = extract_codex_tokens_from_value(value)
+        .or_else(|| extract_codex_tokens_from_credentials_value(value))
+    {
         return Some(CodexJsonImportCandidate::FullToken {
             tokens,
             account_id_hint,
@@ -9029,6 +9034,62 @@ fn extract_codex_tokens_from_value(
     None
 }
 
+fn extract_codex_tokens_from_credentials_value(
+    value: &serde_json::Value,
+) -> Option<(CodexTokens, Option<String>)> {
+    let obj = value.as_object()?;
+    if obj
+        .get("credentials")
+        .and_then(|value| value.as_object())
+        .is_some()
+    {
+        if let (Some(id_token), Some(access_token)) = (
+            first_json_string(
+                value,
+                &[&["credentials", "id_token"], &["credentials", "idToken"]],
+            ),
+            first_json_string(
+                value,
+                &[
+                    &["credentials", "access_token"],
+                    &["credentials", "accessToken"],
+                ],
+            ),
+        ) {
+            let refresh_token = first_json_string(
+                value,
+                &[
+                    &["credentials", "refresh_token"],
+                    &["credentials", "refreshToken"],
+                ],
+            );
+            let account_id_hint = first_json_string(
+                value,
+                &[
+                    &["credentials", "account_id"],
+                    &["credentials", "accountId"],
+                    &["credentials", "chatgpt_account_id"],
+                    &["credentials", "chatgptAccountId"],
+                    &["credentials", "workspace_id"],
+                    &["credentials", "workspaceId"],
+                    &["account_id"],
+                    &["accountId"],
+                ],
+            );
+            return Some((
+                CodexTokens {
+                    id_token,
+                    access_token,
+                    refresh_token,
+                },
+                account_id_hint,
+            ));
+        }
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -10286,6 +10347,12 @@ mod tests {
 
     #[test]
     fn full_token_sub2api_candidate_preserves_explicit_subscription_expiry() {
+        let id_token = make_jwt(serde_json::json!({
+            "email": "oauth-expiry@example.com",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acc-oauth-expiry"
+            }
+        }));
         let access_token = make_jwt(serde_json::json!({
             "email": "oauth-expiry@example.com",
             "exp": 1_786_466_640,
@@ -10301,9 +10368,10 @@ mod tests {
             "type": "oauth",
             "credentials": {
                 "email": "oauth-expiry@example.com",
-                "id_token": access_token,
-                "access_token": access_token,
+                "id_token": id_token.clone(),
+                "access_token": access_token.clone(),
                 "refresh_token": "rt-oauth-expiry",
+                "chatgpt_account_id": "acc-oauth-expiry",
                 "expires_at": "2026-08-11T16:44:00Z",
                 "subscription_expires_at": "2026-09-20T00:00:00Z"
             }
@@ -10311,6 +10379,46 @@ mod tests {
 
         let candidate = extract_codex_import_candidate_from_value(&value)
             .expect("Sub2API OAuth account should be accepted");
+        match &candidate {
+            CodexJsonImportCandidate::FullToken {
+                tokens,
+                account_id_hint,
+                subscription_active_until_hint,
+                ..
+            } => {
+                assert_eq!(tokens.id_token, id_token);
+                assert_eq!(tokens.access_token, access_token);
+                assert_eq!(tokens.refresh_token.as_deref(), Some("rt-oauth-expiry"));
+                assert_eq!(account_id_hint.as_deref(), Some("acc-oauth-expiry"));
+                assert_eq!(
+                    subscription_active_until_hint.as_deref(),
+                    Some("2026-09-20T00:00:00Z")
+                );
+
+                let mut account = CodexAccount::new(
+                    "codex-sub2api-oauth".to_string(),
+                    "oauth-expiry@example.com".to_string(),
+                    tokens.clone(),
+                );
+                account.account_id = account_id_hint.clone();
+                let auth_file = build_auth_file_value(&account).expect("project auth.json");
+                assert!(auth_file.get("personal_access_token").is_none());
+                assert_eq!(
+                    auth_file
+                        .pointer("/tokens/refresh_token")
+                        .and_then(serde_json::Value::as_str),
+                    Some("rt-oauth-expiry")
+                );
+                assert_eq!(
+                    auth_file
+                        .pointer("/tokens/account_id")
+                        .and_then(serde_json::Value::as_str),
+                    Some("acc-oauth-expiry")
+                );
+            }
+            _ => panic!("expected Sub2API OAuth credentials to become full tokens"),
+        }
+
         let draft = super::codex_batch_import_draft_from_candidate(candidate);
         let preview = super::preview_account_for_draft(&draft)
             .expect("Sub2API OAuth preview should be available");
@@ -10322,7 +10430,47 @@ mod tests {
     }
 
     #[test]
+    fn extract_candidate_prefers_nested_full_oauth_over_opaque_access_token_fallback() {
+        let id_token = make_jwt(serde_json::json!({
+            "email": "opaque-oauth@example.com"
+        }));
+        let value = serde_json::json!({
+            "platform": "openai",
+            "type": "oauth",
+            "credentials": {
+                "idToken": id_token.clone(),
+                "accessToken": "at-opaque-oauth-token",
+                "refreshToken": "rt-opaque-oauth",
+                "chatgptAccountId": "acc-opaque-oauth"
+            }
+        });
+
+        let candidate = extract_codex_import_candidate_from_value(&value)
+            .expect("nested OAuth credentials should be accepted");
+
+        match candidate {
+            CodexJsonImportCandidate::FullToken {
+                tokens,
+                account_id_hint,
+                ..
+            } => {
+                assert_eq!(tokens.id_token, id_token);
+                assert_eq!(tokens.access_token, "at-opaque-oauth-token");
+                assert_eq!(tokens.refresh_token.as_deref(), Some("rt-opaque-oauth"));
+                assert_eq!(account_id_hint.as_deref(), Some("acc-opaque-oauth"));
+            }
+            _ => panic!("expected nested credentials to remain full OAuth tokens"),
+        }
+    }
+
+    #[test]
     fn extract_candidate_prefers_cpa_personal_access_token_over_session_token() {
+        let session_id_token = make_jwt(serde_json::json!({
+            "email": "cpa@example.com",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acc-cpa-session"
+            }
+        }));
         let session_access_token = make_jwt(serde_json::json!({
             "email": "cpa@example.com",
             "https://api.openai.com/auth": {
@@ -10332,7 +10480,7 @@ mod tests {
         let value = serde_json::json!({
             "type": "codex",
             "provider": "openai",
-            "id_token": "",
+            "id_token": session_id_token,
             "access_token": session_access_token,
             "refresh_token": "",
             "email": "cpa@example.com",


### PR DESCRIPTION
## 修复内容

修复 Sub2API 完整 OAuth 凭据位于 `accounts[i].credentials` 时，被错误降级为 access-token-only 的问题。

- 新增独立的 `credentials` 完整 token 提取器，并只在新版候选解析路径中启用，支持 snake_case 与 camelCase。
- 不改动旧文件导入器对顶层与 `tokens.*` 的处理，避免单账号文件绕过备注、订阅信息等新版元数据逻辑。
- 保留顶层、`tokens`、`credentials` 的既有/新增容器优先级。
- 区分显式 PAT 与从普通 `access_token` 推断出的 opaque token：显式 PAT 仍优先，普通 fallback 在完整 OAuth 解析之后执行。
- 保留只有 access token 的 Sub2API/CPA 导入行为。
- 强化原有 Sub2API 测试，直接断言 `FullToken`，并验证最终 `auth.json` 投影不再包含 `personal_access_token`。
- 增加 opaque access token 与显式 PAT 的优先级回归覆盖。

## 根因

完整 token 解析器只读取顶层和 `tokens.*`，但 access-only fallback 会读取 `credentials.access_token`。因此 Sub2API 的完整 OAuth 在导入时丢失 ID Token 和 refresh token，切号后被投影成 `personal_access_token`。

Fixes #1885

## 验证

- `rustfmt --edition 2021 --check src-tauri/src/modules/codex_account.rs`
- 回归测试覆盖：
  - Sub2API `credentials` 完整 OAuth -> `FullToken`
  - 最终 auth 投影包含 `tokens` 且不包含 `personal_access_token`
  - opaque access token 不抢先降级完整 OAuth
  - 显式 PAT 仍保持最高优先级
  - 原有 access-token-only Sub2API 测试保持不变

本机未安装 MSVC C++ linker（`link.exe`），因此改在 fork 的隔离临时分支使用 Ubuntu 22.04 运行上述三个定向 Rust 测试；[GitHub Actions run 31489600946](https://github.com/Jonesxq/cockpit-tools/actions/runs/31489600946) 全部通过。临时 workflow 不在本 PR 的提交或 diff 中。

## 安全说明

测试只使用合成值；没有提交任何真实账号、邮箱、account ID 或 Token。
