### PR TITLE
fix(codex): preserve namespaces on replayed call items

### DIFF
--- a/src-tauri/src/modules/codex_protocol.rs
+++ b/src-tauri/src/modules/codex_protocol.rs
@@ -456,9 +456,17 @@ fn normalize_responses_input_item(item: &mut Value) -> bool {
         return false;
     };
 
-    // Provider adapters use this extension to reconstruct namespaced tool calls,
-    // but the official Codex Responses endpoint rejects it on replayed input items.
-    let mut changed = obj.remove("namespace").is_some();
+    // Keep call namespaces for the sidecar's provider-specific compatibility
+    // handling, while dropping unsupported namespaces from other replayed items.
+    let preserves_namespace = matches!(
+        obj.get("type").and_then(Value::as_str),
+        Some("function_call" | "custom_tool_call" | "tool_call" | "mcp_tool_call")
+    );
+    let mut changed = if preserves_namespace {
+        false
+    } else {
+        obj.remove("namespace").is_some()
+    };
     let role = obj
         .get("role")
         .and_then(Value::as_str)
@@ -845,16 +853,29 @@ mod tests {
     }
 
     #[test]
-    fn removes_provider_namespace_from_replayed_input_items() {
+    fn preserves_namespace_on_replayed_function_calls() {
         let mut body = json!({
             "model": "gpt-5.4",
-            "input": [{
-                "type": "function_call",
-                "call_id": "call_1",
-                "name": "lookup",
-                "namespace": "mcp__example",
-                "arguments": "{}"
-            }],
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "namespace": "mcp__example",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "result"
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_2",
+                    "name": "plain_lookup",
+                    "arguments": "{}"
+                }
+            ],
             "tools": [{
                 "type": "namespace",
                 "name": "mcp__example"
@@ -862,7 +883,10 @@ mod tests {
         });
 
         assert!(normalize_responses_body_for_codex(&mut body));
-        assert!(body.pointer("/input/0/namespace").is_none());
+        assert_eq!(
+            body.pointer("/input/0/namespace").and_then(Value::as_str),
+            Some("mcp__example")
+        );
         assert_eq!(
             body.pointer("/input/0/name").and_then(Value::as_str),
             Some("lookup")
@@ -872,9 +896,66 @@ mod tests {
             Some("call_1")
         );
         assert_eq!(
+            body.pointer("/input/1/call_id").and_then(Value::as_str),
+            Some("call_1")
+        );
+        assert_eq!(
+            body.pointer("/input/1/output").and_then(Value::as_str),
+            Some("result")
+        );
+        assert!(body.pointer("/input/2/namespace").is_none());
+        assert_eq!(
+            body.pointer("/input/2/name").and_then(Value::as_str),
+            Some("plain_lookup")
+        );
+        assert_eq!(
+            body.pointer("/input/2/call_id").and_then(Value::as_str),
+            Some("call_2")
+        );
+        assert_eq!(
             body.pointer("/tools/0/type").and_then(Value::as_str),
             Some("namespace")
         );
+    }
+
+    #[test]
+    fn preserving_supported_call_namespaces_does_not_report_change() {
+        for item_type in [
+            "function_call",
+            "custom_tool_call",
+            "tool_call",
+            "mcp_tool_call",
+        ] {
+            let mut item = json!({
+                "type": item_type,
+                "namespace": "mcp__example"
+            });
+            let expected = item.clone();
+
+            assert!(
+                !normalize_responses_input_item(&mut item),
+                "{item_type} should not report a change"
+            );
+            assert_eq!(item, expected);
+        }
+    }
+
+    #[test]
+    fn removes_namespace_from_non_call_replayed_input_items() {
+        let mut body = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "namespace": "mcp__example",
+                    "content": "hello"
+                }
+            ]
+        });
+
+        assert!(normalize_responses_body_for_codex(&mut body));
+        assert!(body.pointer("/input/0/namespace").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Preserve `namespace` on replayed `function_call`, `custom_tool_call`, `tool_call`, and `mcp_tool_call` items. Continue removing `namespace` from other replayed input items.

## Why

The Codex replay normalizer removed `namespace` from every input item. Provider adapters use that field to reconstruct namespaced tool calls, so replaying a namespaced call reached the upstream endpoint without the required namespace and failed with HTTP 400.

## Impact

Namespaced call items retain their provider routing metadata during replay. Ordinary messages and other non-call items keep the existing cleanup behavior.

Fixes #1856

## Validation

- `cargo test -p cockpit-tools codex_protocol::tests --lib -- --test-threads=1` (15 passed)
- `rustfmt --edition 2021 --check src-tauri/src/modules/codex_protocol.rs`
- `git diff --check origin/main...HEAD`

No real credentials or external service data are used by the tests.