### PR TITLE
test(codex): isolate account test data on Windows

### DIFF
--- a/crates/cockpit-core/src/modules/codex_account.rs
+++ b/crates/cockpit-core/src/modules/codex_account.rs
@@ -875,6 +875,11 @@ fn write_api_key_provider_to_config_toml(
 
 /// 旧版数据目录（~/Library/Application Support/com.antigravity.cockpit-tools/）
 fn get_old_codex_data_dir() -> PathBuf {
+    #[cfg(test)]
+    if let Some(data_dir) = std::env::var_os("COCKPIT_TOOLS_DATA_DIR") {
+        return PathBuf::from(data_dir).join("legacy-codex-data");
+    }
+
     dirs::data_local_dir()
         .unwrap_or_else(|| dirs::home_dir().expect("无法获取用户目录"))
         .join("com.antigravity.cockpit-tools")
@@ -882,6 +887,12 @@ fn get_old_codex_data_dir() -> PathBuf {
 
 /// 将旧目录中的 codex 数据迁移到新目录（一次性，迁移成功后删除旧文件）
 fn migrate_codex_data_if_needed(new_data_dir: &PathBuf) {
+    #[cfg(test)]
+    if std::env::var_os("COCKPIT_TOOLS_DATA_DIR").is_some() {
+        // Test guards use an explicit data root; never migrate the user's legacy files.
+        return;
+    }
+
     let old_dir = get_old_codex_data_dir();
     if !old_dir.exists() {
         return;
@@ -3529,8 +3540,9 @@ mod tests {
 
     struct TestEnvGuard {
         home_dir: std::path::PathBuf,
-        previous_home: Option<String>,
-        previous_codex_home: Option<String>,
+        previous_home: Option<std::ffi::OsString>,
+        previous_codex_home: Option<std::ffi::OsString>,
+        previous_data_dir: Option<std::ffi::OsString>,
     }
 
     impl TestEnvGuard {
@@ -3539,15 +3551,18 @@ mod tests {
             let codex_home = home_dir.join(".codex");
             fs::create_dir_all(&codex_home).expect("create codex home");
 
-            let previous_home = std::env::var("HOME").ok();
-            let previous_codex_home = std::env::var("CODEX_HOME").ok();
+            let previous_home = std::env::var_os("HOME");
+            let previous_codex_home = std::env::var_os("CODEX_HOME");
+            let previous_data_dir = std::env::var_os("COCKPIT_TOOLS_DATA_DIR");
             std::env::set_var("HOME", &home_dir);
             std::env::set_var("CODEX_HOME", &codex_home);
+            std::env::set_var("COCKPIT_TOOLS_DATA_DIR", &home_dir);
 
             Self {
                 home_dir,
                 previous_home,
                 previous_codex_home,
+                previous_data_dir,
             }
         }
 
@@ -3566,8 +3581,44 @@ mod tests {
                 Some(value) => std::env::set_var("CODEX_HOME", value),
                 None => std::env::remove_var("CODEX_HOME"),
             }
+            match self.previous_data_dir.as_ref() {
+                Some(value) => std::env::set_var("COCKPIT_TOOLS_DATA_DIR", value),
+                None => std::env::remove_var("COCKPIT_TOOLS_DATA_DIR"),
+            }
             let _ = fs::remove_dir_all(&self.home_dir);
         }
+    }
+
+    #[test]
+    fn test_env_guard_isolates_and_restores_cockpit_data_dir() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        let previous_data_dir = std::env::var_os("COCKPIT_TOOLS_DATA_DIR");
+        let isolated_data_dir = {
+            let env = TestEnvGuard::new("codex-core-data-dir-guard-test");
+            let legacy_data_dir = env.home_dir.join("legacy-codex-data");
+            fs::create_dir_all(&legacy_data_dir).expect("create isolated legacy data dir");
+            let legacy_index = legacy_data_dir.join("codex_accounts.json");
+            fs::write(&legacy_index, "legacy sentinel").expect("write legacy sentinel");
+
+            assert_eq!(
+                crate::modules::config::get_data_dir().expect("resolve isolated data dir"),
+                env.home_dir
+            );
+            let accounts_storage_path = get_accounts_storage_path();
+            assert_eq!(
+                accounts_storage_path,
+                env.home_dir.join("codex_accounts.json")
+            );
+            assert!(legacy_index.exists());
+            assert!(!accounts_storage_path.exists());
+            env.home_dir.clone()
+        };
+
+        assert_eq!(
+            std::env::var_os("COCKPIT_TOOLS_DATA_DIR"),
+            previous_data_dir
+        );
+        assert!(!isolated_data_dir.exists());
     }
 
     fn make_jwt(payload: serde_json::Value) -> String {


### PR DESCRIPTION
## What changed

- Extend `TestEnvGuard` to isolate and exactly restore `HOME`, `CODEX_HOME`, and `COCKPIT_TOOLS_DATA_DIR` using `OsString` values.
- Keep the legacy Codex migration source inside the temporary test root and prevent test builds with an explicit data root from migrating user files.
- Add a regression test that resolves the real account storage path and verifies a legacy sentinel remains untouched while the temporary root is removed on guard drop.

## Why

The account tests changed `HOME` and `CODEX_HOME`, but Cockpit's data directory on Windows can still resolve through the real `LocalAppData`. Initializing account storage may then run the one-time legacy migration, which deletes migrated source files. A test could therefore read, copy, or remove real user data before cleaning up its temporary target.

## Impact

Cockpit Core tests now keep both current and legacy account data under their temporary root on Windows. The migration behavior in release builds is unchanged because the test-only path handling is guarded by `cfg(test)`.

## Validation

- `cargo fmt --package cockpit-core -- --check`
- `cargo test --package cockpit-core --lib` (97 passed, 1 ignored)
- `git diff --check origin/main...HEAD`

The verification run set `COCKPIT_TOOLS_DATA_DIR` to a dedicated temporary directory.