### PR TITLE
fix(codex): treat expired subscriptions as free

### DIFF
--- a/src/types/codex.test.ts
+++ b/src/types/codex.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getCodexPlanBadgePresentation,
+  getCodexPlanFilterKey,
+} from "./codex.ts";
+import type { CodexAccount } from "./codex.ts";
+
+function account(partial: Partial<CodexAccount>): CodexAccount {
+  return {
+    id: "account-1",
+    email: "account@example.com",
+    tokens: {
+      id_token: "id-token",
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+    },
+    created_at: Date.now(),
+    last_used: Date.now(),
+    ...partial,
+  };
+}
+
+test("expired paid subscriptions are presented and grouped as free", () => {
+  const expiredPlus = account({
+    plan_type: "plus",
+    subscription_active_until: "2020-01-01T00:00:00Z",
+  });
+
+  assert.equal(getCodexPlanFilterKey(expiredPlus), "FREE");
+  assert.deepEqual(getCodexPlanBadgePresentation(expiredPlus), {
+    label: "FREE",
+    className: "free",
+  });
+});
+
+test("active paid subscriptions keep their paid plan", () => {
+  const activePlus = account({
+    plan_type: "plus",
+    subscription_active_until: "2100-01-01T00:00:00Z",
+  });
+
+  assert.equal(getCodexPlanFilterKey(activePlus), "PLUS");
+  assert.deepEqual(getCodexPlanBadgePresentation(activePlus), {
+    label: "PLUS",
+    className: "plus codex-plus",
+  });
+});
+
+test("paid subscriptions without a usable expiry are not downgraded", () => {
+  const missingExpiry = account({ plan_type: "plus" });
+  const invalidExpiry = account({
+    plan_type: "plus",
+    subscription_active_until: "not-a-date",
+  });
+
+  assert.equal(getCodexPlanFilterKey(missingExpiry), "PLUS");
+  assert.equal(getCodexPlanFilterKey(invalidExpiry), "PLUS");
+});
+
+test("API key and pending accounts keep their special classifications", () => {
+  const apiKeyAccount = account({
+    auth_mode: "apikey",
+    plan_type: "API_KEY",
+    subscription_active_until: "2020-01-01T00:00:00Z",
+  });
+  const pendingAccount = account({
+    authorization_status: "pending",
+    plan_type: "plus",
+    subscription_active_until: "2020-01-01T00:00:00Z",
+  });
+
+  assert.equal(getCodexPlanFilterKey(apiKeyAccount), "API_KEY");
+  assert.equal(getCodexPlanFilterKey(pendingAccount), "PENDING");
+});

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -859,10 +859,35 @@ function normalizeCodexPlanKey(planType?: string): string {
   return normalized;
 }
 
+function getCodexEffectivePlanKey(account: CodexAccount): string {
+  const planKey = normalizeCodexPlanKey(account.plan_type);
+  if (
+    planKey === "free" ||
+    isCodexApiKeyAccount(account) ||
+    isCodexPendingOAuthAccount(account) ||
+    isCodexAgentIdentityAccount(account) ||
+    isCodexWebSessionAccount(account)
+  ) {
+    return planKey;
+  }
+
+  const subscriptionExpiry = parseCodexSubscriptionDate(
+    account.subscription_active_until,
+  );
+  if (subscriptionExpiry && subscriptionExpiry.getTime() <= Date.now()) {
+    return "free";
+  }
+  return planKey;
+}
+
 export function isCodexExplicitFreePlanType(planType?: string): boolean {
   const normalized = (planType || "").trim();
   if (!normalized) return false;
   return normalizeCodexPlanKey(planType) === "free";
+}
+
+export function isCodexEffectiveFreePlan(account: CodexAccount): boolean {
+  return getCodexEffectivePlanKey(account) === "free";
 }
 
 function normalizeCodexAuthFilePlanType(
@@ -898,8 +923,9 @@ function getCodexPlanBadgeLabel(account: CodexAccount): string {
   if (isCodexApiKeyAccount(account)) {
     return "API";
   }
-  const baseLabel = getCodexPlanDisplayName(account.plan_type);
-  if (normalizeCodexPlanKey(account.plan_type) !== "pro") {
+  const effectivePlanKey = getCodexEffectivePlanKey(account);
+  const baseLabel = getCodexPlanDisplayName(effectivePlanKey);
+  if (effectivePlanKey !== "pro") {
     return baseLabel;
   }
 
@@ -918,7 +944,7 @@ function getCodexPlanBadgeClass(account: CodexAccount): string {
   if (isCodexNewApiAccount(account)) {
     return "api-key new-api-exclusive";
   }
-  const baseClass = normalizeCodexPlanKey(account.plan_type);
+  const baseClass = getCodexEffectivePlanKey(account);
   if (baseClass === "plus") {
     return "plus codex-plus";
   }
@@ -967,7 +993,7 @@ export function getCodexPlanBadgePresentationWithStyle(
 
 export function getCodexPlanFilterKey(account: CodexAccount): string {
   if (isCodexPendingOAuthAccount(account)) return "PENDING";
-  return normalizeCodexPlanKey(account.plan_type).toUpperCase();
+  return getCodexEffectivePlanKey(account).toUpperCase();
 }
 
 export function isCodexTeamLikePlan(planType?: string): boolean {

--- a/src/utils/codexLocalAccessAccounts.test.ts
+++ b/src/utils/codexLocalAccessAccounts.test.ts
@@ -72,6 +72,26 @@ test("direct add follows the API service free-account restriction", () => {
   assert.equal(canAddCodexAccountToLocalAccess(free, new Set(), false), true);
 });
 
+test("expired paid subscriptions follow the API service free-account restriction", () => {
+  const expiredPlus = account({
+    plan_type: "plus",
+    subscription_active_until: "2020-01-01T00:00:00Z",
+  });
+
+  assert.equal(
+    getCodexLocalAccessAccountIneligibleReason(expiredPlus, true),
+    "free_restricted",
+  );
+  assert.equal(
+    isCodexLocalAccessEligibleAccount(expiredPlus, true),
+    false,
+  );
+  assert.equal(
+    isCodexLocalAccessEligibleAccount(expiredPlus, false),
+    true,
+  );
+});
+
 test("Agent Identity imports are forced into API service without enabling global sync", () => {
   const regular = account({ id: "regular" });
   const agentIdentity = account({

--- a/src/utils/codexLocalAccessAccounts.ts
+++ b/src/utils/codexLocalAccessAccounts.ts
@@ -1,7 +1,7 @@
 import {
   isCodexApiKeyAccount,
   isCodexAgentIdentityAccount,
-  isCodexExplicitFreePlanType,
+  isCodexEffectiveFreePlan,
   isCodexPendingOAuthAccount,
   isCodexWebSessionAccount,
   type CodexAccount,
@@ -106,7 +106,7 @@ export function getCodexLocalAccessAccountIneligibleReason(
   if (
     restrictFreeAccounts &&
     !isCodexAgentIdentityAccount(account) &&
-    isCodexExplicitFreePlanType(account.plan_type)
+    isCodexEffectiveFreePlan(account)
   ) {
     return "free_restricted";
   }


### PR DESCRIPTION
## Summary

- Treat expired paid Codex subscriptions as effective FREE accounts on initial load
- Use the effective plan consistently for badges, plan filters, quota grouping, and local API-service restrictions
- Preserve API key/pending special classifications and keep expiry status available through the EXPIRED filter
- Add regression coverage for expired, active, missing/invalid-expiry, API key, and pending accounts

## Tests

- `node --test src/types/codex.test.ts src/utils/codexLocalAccessAccounts.test.ts src/utils/codexApiKeyAccountScope.test.ts`
- `npm run typecheck`
- `npm run build`

Fixes #1895