### PR TITLE
fix(codebuddy): 企业账号用量查询为空，改用 get-enterprise-user-usage 接口

### DIFF
--- a/src-tauri/src/modules/codebuddy_cn_oauth.rs
+++ b/src-tauri/src/modules/codebuddy_cn_oauth.rs
@@ -10,6 +10,8 @@ const CODEBUDDY_API_PREFIX: &str = "/v2/plugin";
 const CODEBUDDY_PLATFORM: &str = "ide";
 const OAUTH_TIMEOUT_SECONDS: u64 = 600;
 const OAUTH_POLL_INTERVAL_MS: u64 = 1500;
+/// 企业版套餐代码（本地标识，用于前端识别企业用量资源）
+pub const ENTERPRISE_PACKAGE_CODE: &str = "TCACA_code_enterprise";
 
 #[derive(Clone)]
 struct PendingOAuthState {
@@ -659,6 +661,141 @@ pub async fn fetch_user_resource_with_access_token(
     Ok(body)
 }
 
+/// 企业版用户用量（网页端 /profile/usage 实际使用的接口）
+///
+/// 网页端企业用量走 `POST /billing/meter/get-enterprise-user-usage`，
+/// 企业 ID 通过请求头 `x-enterprise-id` 传递，body 为空。
+/// 而 `/v2/billing/meter/get-user-resource` 对企业成员账号返回空 Accounts。
+pub async fn fetch_enterprise_user_usage(
+    access_token: &str,
+    enterprise_id: &str,
+) -> Result<Value, String> {
+    let client = build_client()?;
+    let url = format!(
+        "{}/billing/meter/get-enterprise-user-usage",
+        CODEBUDDY_API_ENDPOINT
+    );
+
+    let mut req = client
+        .post(&url)
+        .header("Accept", "application/json, text/plain, */*")
+        .header("Accept-Language", "zh-CN,zh;q=0.9")
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("Content-Type", "application/json")
+        .header("X-Enterprise-Id", enterprise_id)
+        .header("X-Tenant-Id", enterprise_id);
+
+    let resp = req
+        .json(&json!({}))
+        .send()
+        .await
+        .map_err(|e| format!("请求 enterprise user usage 失败: {}", e))?;
+
+    let status_code = resp.status();
+    let body: Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("解析 enterprise user usage 响应失败: {} (http={})", e, status_code.as_u16()))?;
+
+    if !status_code.is_success() {
+        let message = body
+            .get("message")
+            .or_else(|| body.get("msg"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        return Err(format!(
+            "请求 enterprise user usage 失败 (http={}): {}",
+            status_code.as_u16(),
+            message
+        ));
+    }
+
+    if let Some(code) = body.get("code").and_then(|v| v.as_i64()) {
+        if code != 0 && code != 200 {
+            let message = body
+                .get("message")
+                .or_else(|| body.get("msg"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            return Err(format!(
+                "请求 enterprise user usage 失败 (code={}): {}",
+                code, message
+            ));
+        }
+    }
+
+    Ok(body)
+}
+
+/// 将企业用量响应包装成前端可识别的 get-user-resource 结构
+///
+/// 网页端接口返回 `{credit, limitNum, cycleStartTime, cycleEndTime, cycleResetTime}`，
+/// 前端通过 `usage_raw.data.Response.Data.Accounts` 解析配额，
+/// 因此构造一个企业版资源账号，字段与 get-user-resource 对齐。
+pub fn wrap_enterprise_usage_as_resource(
+    usage_body: &Value,
+) -> Value {
+    let data = usage_body.get("data").cloned().unwrap_or_else(|| json!({}));
+    // credit 为周期内已使用积分，剩余 = limitNum - credit
+    let credit = data
+        .get("credit")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let limit_num = data
+        .get("limitNum")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let remain = (limit_num - credit).max(0.0);
+    let cycle_start_time = data
+        .get("cycleStartTime")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let cycle_end_time = data
+        .get("cycleEndTime")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let cycle_reset_time = data
+        .get("cycleResetTime")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let account = json!({
+        "PackageCode": ENTERPRISE_PACKAGE_CODE,
+        "PackageName": "企业版",
+        "CycleCapacitySizePrecise": limit_num.to_string(),
+        "CycleCapacityRemainPrecise": remain.to_string(),
+        "CycleCapacityUsedPrecise": credit.to_string(),
+        "CycleCapacitySize": limit_num,
+        "CycleCapacityRemain": remain,
+        "CycleCapacityUsed": credit,
+        "CapacitySize": limit_num,
+        "CapacityRemain": remain,
+        "CapacityUsed": credit,
+        "CapacityUnit": "credits",
+        "CycleStartTime": cycle_start_time,
+        "CycleEndTime": cycle_end_time,
+        "CycleResetTime": cycle_reset_time,
+        "Status": 0
+    });
+
+    json!({
+        "code": 0,
+        "msg": "OK",
+        "data": {
+            "Response": {
+                "Data": {
+                    "Accounts": [account],
+                    "TotalCount": 1,
+                    "TotalDosage": credit
+                }
+            }
+        }
+    })
+}
+
 async fn fetch_user_resource_with_access_token_default(
     access_token: &str,
     uid: Option<&str>,
@@ -773,8 +910,37 @@ async fn refresh_payload_for_account_inner(
     .await
     {
         Ok(payload) => {
-            logger::log_info("[CodeBuddy][IDE Token] 刷新 user_resource 成功");
-            Some(payload)
+            // 企业账号时 get-user-resource 可能返回空 Accounts，
+            // 改用网页端真实的企业用量接口兜底
+            if let Some(eid) = resolved_enterprise_id.as_deref() {
+                let accounts_empty = payload
+                    .pointer("/data/Response/Data/Accounts")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| arr.is_empty())
+                    .unwrap_or(true);
+                if accounts_empty {
+                    match fetch_enterprise_user_usage(new_access_token.as_str(), eid).await {
+                        Ok(enterprise_body) => {
+                            let wrapped = wrap_enterprise_usage_as_resource(&enterprise_body);
+                            logger::log_info(
+                                "[CodeBuddy][IDE Token] 企业账号 user_resource 为空，已使用企业用量接口兜底",
+                            );
+                            Some(wrapped)
+                        }
+                        Err(enterprise_err) => {
+                            logger::log_warn(&format!(
+                                "[CodeBuddy][IDE Token] 企业用量接口兜底失败: {}",
+                                enterprise_err
+                            ));
+                            Some(payload)
+                        }
+                    }
+                } else {
+                    Some(payload)
+                }
+            } else {
+                Some(payload)
+            }
         }
         Err(err) => {
             logger::log_warn(&format!(

--- a/src-tauri/src/modules/workbuddy_oauth.rs
+++ b/src-tauri/src/modules/workbuddy_oauth.rs
@@ -9,6 +9,8 @@ const WORKBUDDY_API_PREFIX: &str = "/v2/plugin";
 const WORKBUDDY_PLATFORM: &str = "workbuddy";
 const OAUTH_TIMEOUT_SECONDS: u64 = 600;
 const OAUTH_POLL_INTERVAL_MS: u64 = 1500;
+/// 企业版套餐代码（本地标识，用于前端识别企业用量资源）
+const ENTERPRISE_PACKAGE_CODE: &str = "TCACA_code_enterprise";
 
 #[derive(Clone)]
 struct PendingOAuthState {
@@ -655,6 +657,133 @@ pub async fn fetch_user_resource_with_access_token(
     Ok(body)
 }
 
+/// 企业版用户用量（网页端 /profile/usage 实际使用的接口）
+pub async fn fetch_enterprise_user_usage(
+    access_token: &str,
+    enterprise_id: &str,
+) -> Result<Value, String> {
+    let client = build_client()?;
+    let url = format!(
+        "{}/billing/meter/get-enterprise-user-usage",
+        WORKBUDDY_API_ENDPOINT
+    );
+
+    let mut req = client
+        .post(&url)
+        .header("Accept", "application/json, text/plain, */*")
+        .header("Accept-Language", "zh-CN,zh;q=0.9")
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("Content-Type", "application/json")
+        .header("X-Enterprise-Id", enterprise_id)
+        .header("X-Tenant-Id", enterprise_id);
+
+    let resp = req
+        .json(&json!({}))
+        .send()
+        .await
+        .map_err(|e| format!("请求 enterprise user usage 失败:{}", e))?;
+
+    let status_code = resp.status();
+    let body: Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("解析 enterprise user usage 响应失败:{} (http={})", e, status_code.as_u16()))?;
+
+    if !status_code.is_success() {
+        let message = body
+            .get("message")
+            .or_else(|| body.get("msg"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        return Err(format!(
+            "请求 enterprise user usage 失败 (http={}):{}",
+            status_code.as_u16(),
+            message
+        ));
+    }
+
+    if let Some(code) = body.get("code").and_then(|v| v.as_i64()) {
+        if code != 0 && code != 200 {
+            let message = body
+                .get("message")
+                .or_else(|| body.get("msg"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            return Err(format!(
+                "请求 enterprise user usage 失败 (code={}):{}",
+                code, message
+            ));
+        }
+    }
+
+    Ok(body)
+}
+
+/// 将企业用量响应包装成前端可识别的 get-user-resource 结构
+pub fn wrap_enterprise_usage_as_resource(
+    usage_body: &Value,
+) -> Value {
+    let data = usage_body.get("data").cloned().unwrap_or_else(|| json!({}));
+    // credit 为周期内已使用积分，剩余 = limitNum - credit
+    let credit = data
+        .get("credit")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let limit_num = data
+        .get("limitNum")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let remain = (limit_num - credit).max(0.0);
+    let cycle_start_time = data
+        .get("cycleStartTime")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let cycle_end_time = data
+        .get("cycleEndTime")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let cycle_reset_time = data
+        .get("cycleResetTime")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let account = json!({
+        "PackageCode": ENTERPRISE_PACKAGE_CODE,
+        "PackageName": "企业版",
+        "CycleCapacitySizePrecise": limit_num.to_string(),
+        "CycleCapacityRemainPrecise": remain.to_string(),
+        "CycleCapacityUsedPrecise": credit.to_string(),
+        "CycleCapacitySize": limit_num,
+        "CycleCapacityRemain": remain,
+        "CycleCapacityUsed": credit,
+        "CapacitySize": limit_num,
+        "CapacityRemain": remain,
+        "CapacityUsed": credit,
+        "CapacityUnit": "credits",
+        "CycleStartTime": cycle_start_time,
+        "CycleEndTime": cycle_end_time,
+        "CycleResetTime": cycle_reset_time,
+        "Status": 0
+    });
+
+    json!({
+        "code": 0,
+        "msg": "OK",
+        "data": {
+            "Response": {
+                "Data": {
+                    "Accounts": [account],
+                    "TotalCount": 1,
+                    "TotalDosage": credit
+                }
+            }
+        }
+    })
+}
+
 async fn fetch_user_resource_with_access_token_default(
     access_token: &str,
     uid: Option<&str>,
@@ -769,8 +898,37 @@ async fn refresh_payload_for_account_inner(
     .await
     {
         Ok(payload) => {
-            logger::log_info("[WorkBuddy][IDE Token] 刷新 user_resource 成功");
-            Some(payload)
+            // 企业账号时 get-user-resource 可能返回空 Accounts，
+            // 改用网页端真实的企业用量接口兜底
+            if let Some(eid) = resolved_enterprise_id.as_deref() {
+                let accounts_empty = payload
+                    .pointer("/data/Response/Data/Accounts")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| arr.is_empty())
+                    .unwrap_or(true);
+                if accounts_empty {
+                    match fetch_enterprise_user_usage(new_access_token.as_str(), eid).await {
+                        Ok(enterprise_body) => {
+                            let wrapped = wrap_enterprise_usage_as_resource(&enterprise_body);
+                            logger::log_info(
+                                "[WorkBuddy][IDE Token] 企业账号 user_resource 为空，已使用企业用量接口兜底",
+                            );
+                            Some(wrapped)
+                        }
+                        Err(enterprise_err) => {
+                            logger::log_warn(&format!(
+                                "[WorkBuddy][IDE Token] 企业用量接口兜底失败:{}",
+                                enterprise_err
+                            ));
+                            Some(payload)
+                        }
+                    }
+                } else {
+                    Some(payload)
+                }
+            } else {
+                Some(payload)
+            }
         }
         Err(err) => {
             logger::log_warn(&format!(

--- a/src/types/codebuddy-suite.ts
+++ b/src/types/codebuddy-suite.ts
@@ -87,6 +87,7 @@ export const PACKAGE_CODE = {
   activity: 'TCACA_code_007_nzdH5h4Nl0',
   freeMon: 'TCACA_code_008_cfWoLwvjU4',
   extra: 'TCACA_code_009_0XmEQc2xOf',
+  enterprise: 'TCACA_code_enterprise',
 } as const;
 
 /**

--- a/src/utils/codebuddy-suite/quota-model.ts
+++ b/src/utils/codebuddy-suite/quota-model.ts
@@ -250,10 +250,15 @@ export function getOfficialQuotaModel(account: CodebuddySuiteAccountBase): Offic
     const code = typeof a.PackageCode === 'string' ? a.PackageCode : '';
     return code === PACKAGE_CODE.activity;
   });
+  const enterprise = all.filter((a) => {
+    const code = typeof a.PackageCode === 'string' ? a.PackageCode : '';
+    return code === PACKAGE_CODE.enterprise;
+  });
 
   const mergedTrialOrFreeMon = aggregateCycleResources(trialOrFreeMon);
   const mergedFree = aggregateCycleResources(free);
-  const ordered = [mergedTrialOrFreeMon, ...pro, ...activity, mergedFree].filter(
+  const mergedEnterprise = aggregateCycleResources(enterprise);
+  const ordered = [mergedTrialOrFreeMon, ...pro, ...activity, mergedEnterprise, mergedFree].filter(
     (item): item is Record<string, unknown> => item != null && !!item.PackageCode,
   );
   const resources = ordered.map(toOfficialQuotaResource);
@@ -267,6 +272,7 @@ export function getOfficialQuotaModel(account: CodebuddySuiteAccountBase): Offic
  * 解析包名称
  */
 function resolvePackageName(resource: OfficialQuotaResource): string {
+  if (resource.packageCode === PACKAGE_CODE.enterprise) return '企业版';
   if (resource.packageCode === PACKAGE_CODE.extra) return '加量包';
   if (resource.packageCode === PACKAGE_CODE.activity) return '活动赠送包';
   if (resource.packageCode === PACKAGE_CODE.free || resource.packageCode === PACKAGE_CODE.gift || resource.packageCode === PACKAGE_CODE.freeMon) {
@@ -337,7 +343,9 @@ export function getQuotaCategoryGroups(account: CodebuddySuiteAccountBase, t: (k
 
   for (const resource of model.resources) {
     const code = resource.packageCode;
-    if (code === PACKAGE_CODE.free || code === PACKAGE_CODE.gift || code === PACKAGE_CODE.freeMon || code === PACKAGE_CODE.proMon || code === PACKAGE_CODE.proYear) {
+    if (code === PACKAGE_CODE.enterprise) {
+      baseItems.push(resource);
+    } else if (code === PACKAGE_CODE.free || code === PACKAGE_CODE.gift || code === PACKAGE_CODE.freeMon || code === PACKAGE_CODE.proMon || code === PACKAGE_CODE.proYear) {
       baseItems.push(resource);
     } else if (code === PACKAGE_CODE.activity) {
       activityItems.push(resource);


### PR DESCRIPTION
## 问题

CodeBuddy CN / WorkBuddy 企业成员账号刷新配额时，`/v2/billing/meter/get-user-resource` 返回空的 `Accounts`，导致工具中企业版用量显示为 0，而网页端（/profile/usage）实际有用量。

## 根因

网页端企业用量走的是 `POST /billing/meter/get-enterprise-user-usage`（企业 ID 通过请求头 `x-enterprise-id` 传递，body 为空），返回 `{credit, limitNum, cycleStartTime, cycleEndTime, cycleResetTime}`。而工具调用的是 `/v2/billing/meter/get-user-resource`，该接口对企业成员账号返回空资源列表。

## 修复

1. **后端**：新增 `fetch_enterprise_user_usage`，调用网页端实际使用的企业用量接口（Bearer token + `x-enterprise-id` 请求头），并将响应包装为前端可识别的 get-user-resource 结构（`data.Response.Data.Accounts`）；当账号存在 `enterprise_id` 且 get-user-resource 返回空 Accounts 时自动兜底。
2. **前端**：识别企业版套餐代码（`TCACA_code_enterprise`），展示「企业版」用量（总量/已用/剩余），已用 = credit，剩余 = limitNum - credit。

CodeBuddy CN 和 WorkBuddy 共用同一套逻辑，均已修复。

## 验证

- 企业账号刷新后日志显示「企业账号 user_resource 为空，已使用企业用量接口兜底」
- 账号数据写入总量 2000 / 已用 ~378 / 剩余 ~1622，与网页端一致
