### PR TITLE
feat(codex): add OpenCode Go and OpenRouter model presets

### DIFF
--- a/src/utils/codexProviderGateway.ts
+++ b/src/utils/codexProviderGateway.ts
@@ -1,9 +1,10 @@
-import type { CodexApiProviderPreset } from "./codexProviderPresets";
+import type { CodexApiProviderPreset } from "./codexProviderPresets.ts";
 import {
   DEEPSEEK_API_PROVIDER_ID,
+  OPENCODE_GO_API_PROVIDER_ID,
   findCodexApiProviderPresetById,
   resolveCodexApiProviderPresetId,
-} from "./codexProviderPresets";
+} from "./codexProviderPresets.ts";
 
 export type CodexProviderWireApi = "responses" | "chat_completions";
 export type CodexProviderEnableMode = "direct" | "gateway";
@@ -65,6 +66,7 @@ const CHAT_COMPLETIONS_PRESET_IDS = new Set([
   "pipellm",
   "therouter",
   "openrouter",
+  OPENCODE_GO_API_PROVIDER_ID,
 ]);
 
 export function resolveCodexProviderCapabilityProfile(input: {

--- a/src/utils/codexProviderPresets.test.ts
+++ b/src/utils/codexProviderPresets.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEEPSEEK_API_BASE_URL,
+  OPENCODE_GO_API_BASE_URL,
+  OPENCODE_GO_API_PROVIDER_ID,
+  findCodexApiProviderPresetByBaseUrl,
+  findCodexApiProviderPresetById,
+} from "./codexProviderPresets.ts";
+import { resolveCodexProviderCapabilityProfile } from "./codexProviderGateway.ts";
+
+test("OpenRouter preset includes the current Luna Pro model id", () => {
+  const preset = findCodexApiProviderPresetByBaseUrl(
+    "https://openrouter.ai/api/v1/",
+  );
+
+  assert.ok(preset);
+  assert.deepEqual(preset.modelCatalog, ["openai/gpt-5.6-luna-pro"]);
+});
+
+test("OpenCode Go preset exposes DeepSeek models and its chat-completions transport", () => {
+  const preset = findCodexApiProviderPresetById(OPENCODE_GO_API_PROVIDER_ID);
+
+  assert.ok(preset);
+  assert.equal(preset.baseUrls[0], OPENCODE_GO_API_BASE_URL);
+  assert.ok(preset.modelCatalog?.includes("deepseek-v4-pro"));
+  assert.ok(preset.modelCatalog?.includes("deepseek-v4-flash"));
+
+  const profile = resolveCodexProviderCapabilityProfile({
+    presetId: OPENCODE_GO_API_PROVIDER_ID,
+    baseUrl: OPENCODE_GO_API_BASE_URL,
+  });
+  assert.equal(profile.wireApi, "chat_completions");
+  assert.equal(profile.requiresGateway, true);
+});
+
+test("DeepSeek keeps its native Responses default", () => {
+  const profile = resolveCodexProviderCapabilityProfile({
+    presetId: "deepseek",
+    baseUrl: DEEPSEEK_API_BASE_URL,
+  });
+
+  assert.equal(profile.wireApi, "responses");
+});

--- a/src/utils/codexProviderPresets.test.ts
+++ b/src/utils/codexProviderPresets.test.ts
@@ -26,6 +26,7 @@ test("OpenCode Go preset exposes DeepSeek models and its chat-completions transp
   assert.equal(preset.baseUrls[0], OPENCODE_GO_API_BASE_URL);
   assert.ok(preset.modelCatalog?.includes("deepseek-v4-pro"));
   assert.ok(preset.modelCatalog?.includes("deepseek-v4-flash"));
+  assert.ok(preset.modelCatalog?.includes("qwen3.7-plus"));
 
   const profile = resolveCodexProviderCapabilityProfile({
     presetId: OPENCODE_GO_API_PROVIDER_ID,

--- a/src/utils/codexProviderPresets.ts
+++ b/src/utils/codexProviderPresets.ts
@@ -24,17 +24,32 @@ export const OPENCODE_GO_API_PROVIDER_ID = "opencode_go";
 export const OPENCODE_GO_API_BASE_URL = "https://opencode.ai/zen/go/v1";
 /** OpenCode Go models exposed through its OpenAI-compatible chat completions API. */
 export const OPENCODE_GO_CODEX_MODEL_CATALOG = [
-  "grok-4.5",
-  "glm-5.2",
-  "glm-5.1",
+  "minimax-m3",
+  "minimax-m2.7",
+  "minimax-m2.5",
   "kimi-k3",
   "kimi-k2.7-code",
   "kimi-k2.6",
+  "kimi-k2.5",
+  "glm-5.2",
+  "glm-5.3",
+  "glm-5.1",
+  "glm-5",
   "deepseek-v4-pro",
   "deepseek-v4-flash",
-  "mimo-v2.5",
+  "qwen3.7-max",
+  "qwen3.8-max",
+  "qwen3.7-plus",
+  "qwen3.6-plus",
+  "qwen3.5-plus",
+  "mimo-v2-pro",
+  "mimo-v2-omni",
   "mimo-v2.5-pro",
+  "mimo-v2.5",
   "hy3",
+  "hy3-preview",
+  "gpt-5.6-luna",
+  "grok-4.5",
 ] as const;
 
 const COCKPIT_API_HIDDEN_BASE_URLS = [COCKPIT_API_BASE_URL] as const;

--- a/src/utils/codexProviderPresets.ts
+++ b/src/utils/codexProviderPresets.ts
@@ -20,6 +20,22 @@ export const DEEPSEEK_CODEX_MODEL_CATALOG = [
   "deepseek-v4-flash",
   "deepseek-v4-pro",
 ] as const;
+export const OPENCODE_GO_API_PROVIDER_ID = "opencode_go";
+export const OPENCODE_GO_API_BASE_URL = "https://opencode.ai/zen/go/v1";
+/** OpenCode Go models exposed through its OpenAI-compatible chat completions API. */
+export const OPENCODE_GO_CODEX_MODEL_CATALOG = [
+  "grok-4.5",
+  "glm-5.2",
+  "glm-5.1",
+  "kimi-k3",
+  "kimi-k2.7-code",
+  "kimi-k2.6",
+  "deepseek-v4-pro",
+  "deepseek-v4-flash",
+  "mimo-v2.5",
+  "mimo-v2.5-pro",
+  "hy3",
+] as const;
 
 const COCKPIT_API_HIDDEN_BASE_URLS = [COCKPIT_API_BASE_URL] as const;
 
@@ -142,8 +158,17 @@ export const CODEX_API_PROVIDER_PRESETS: readonly CodexApiProviderPreset[] = [
     id: "openrouter",
     name: "OpenRouter",
     baseUrls: ["https://openrouter.ai/api/v1"],
+    modelCatalog: ["openai/gpt-5.6-luna-pro"],
     website: "https://openrouter.ai/",
     apiKeyUrl: "https://openrouter.ai/keys",
+  },
+  {
+    id: OPENCODE_GO_API_PROVIDER_ID,
+    name: "OpenCode Go",
+    baseUrls: [OPENCODE_GO_API_BASE_URL],
+    modelCatalog: [...OPENCODE_GO_CODEX_MODEL_CATALOG],
+    website: "https://opencode.ai/",
+    apiKeyUrl: "https://opencode.ai/auth",
   },
   {
     id: "aicodemirror",


### PR DESCRIPTION
## Summary

- Add an OpenCode Go Codex provider preset at `https://opencode.ai/zen/go/v1`.
- Include the current OpenCode Go model catalog, including `deepseek-v4-pro`, `deepseek-v4-flash`, and `qwen3.7-plus`.
- Route OpenCode Go through the existing OpenAI-compatible Chat Completions gateway.
- Add the OpenRouter `openai/gpt-5.6-luna-pro` model preset.

## User impact

Users can select OpenCode Go and its DeepSeek models directly from Codex model provider setup, and OpenRouter users can select the Luna Pro model without entering the model ID manually.

## Validation

- `node --test src/utils/codexProviderPresets.test.ts` (3 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #1916
Fixes #1861
