### PR TITLE
fix(codex): allow editing provider API keys

### DIFF
--- a/src/components/codex/CodexModelProviderManager.tsx
+++ b/src/components/codex/CodexModelProviderManager.tsx
@@ -14,6 +14,7 @@ import {
   ArrowDownWideNarrow,
   ArrowDown,
   ArrowUp,
+  Check,
   CircleAlert,
   ChevronDown,
   Copy,
@@ -65,6 +66,7 @@ import {
   listCodexAccounts,
   syncCodexApiKeyProviderAccounts,
   updateCodexAccountName,
+  updateCodexApiKeyCredentials,
   updateCodexApiKeyBoundOAuthAccount,
 } from "../../services/codexService";
 import { useDeepSeekDirectModelPrompt } from "./DeepSeekDirectModelModal";
@@ -95,6 +97,7 @@ import {
   normalizeCodexModelProviderBaseUrl,
   removeApiKeyFromCodexModelProvider,
   renameApiKeyOnCodexModelProvider,
+  updateApiKeyOnCodexModelProvider,
   queryCodexModelProviderUsage,
   saveCodexModelProviderDetectedIntegrationType,
   testCodexModelProviderConnection,
@@ -413,6 +416,14 @@ interface ProviderFormState {
   newApiKey: string;
 }
 
+interface EditingApiKeyState {
+  providerId: string;
+  apiKeyId: string;
+  originalApiKey: string;
+  apiKey: string;
+  name: string;
+}
+
 const EMPTY_FORM: ProviderFormState = {
   providerId: null,
   name: "",
@@ -721,6 +732,9 @@ export function CodexModelProviderManager({
   const [batchTestModelCustom, setBatchTestModelCustom] = useState("");
   const [existingApiKeySearchQuery, setExistingApiKeySearchQuery] =
     useState("");
+  const [editingApiKey, setEditingApiKey] = useState<EditingApiKeyState | null>(
+    null,
+  );
   const cancelledBatchTestRunIdsRef = useRef<Set<string>>(new Set());
 
   const sponsorProviderTemplates = useMemo<SponsorProviderTemplate[]>(() => {
@@ -1572,6 +1586,7 @@ export function CodexModelProviderManager({
     setNotice(null);
     setFormError(null);
     setExistingApiKeySearchQuery("");
+    setEditingApiKey(null);
     setForm({
       ...EMPTY_FORM,
       wireApi: resolveDefaultProviderWireApi(CODEX_API_PROVIDER_CUSTOM_ID),
@@ -1616,6 +1631,7 @@ export function CodexModelProviderManager({
     setNotice(null);
     setFormError(null);
     setExistingApiKeySearchQuery("");
+    setEditingApiKey(null);
     const resolvedWireApi = resolveProviderWireApi(provider);
     setForm({
       providerId: provider.id,
@@ -1651,6 +1667,7 @@ export function CodexModelProviderManager({
 
   const closeModal = useCallback(() => {
     if (saving) return;
+    setEditingApiKey(null);
     setShowModal(false);
     setFormError(null);
   }, [saving]);
@@ -2435,6 +2452,104 @@ export function CodexModelProviderManager({
     },
     [parseServiceError, reloadProviders, t],
   );
+
+  const handleSaveApiKeyEdit = useCallback(async () => {
+    if (!editingApiKey || saving) return;
+    const provider = providers.find((item) => item.id === editingApiKey.providerId);
+    if (!provider) return;
+
+    const nextApiKey = editingApiKey.apiKey.trim();
+    if (!nextApiKey) {
+      setNotice({
+        tone: "error",
+        text: t("codex.modelProviders.validation.apiKeyRequired", "API Key 不能为空"),
+      });
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const savedProvider = await updateApiKeyOnCodexModelProvider(
+        provider.id,
+        editingApiKey.apiKeyId,
+        nextApiKey,
+        editingApiKey.name,
+      );
+      const previousApiKey = editingApiKey.originalApiKey.trim();
+      const normalizedProviderBaseUrl = normalizeCodexModelProviderBaseUrl(
+        savedProvider.baseUrl,
+      );
+      const linkedAccounts = accounts.filter(
+        (account) =>
+          isCodexApiKeyAccount(account) &&
+          account.openai_api_key?.trim() === previousApiKey &&
+          normalizeCodexModelProviderBaseUrl(account.api_base_url ?? "") ===
+            normalizedProviderBaseUrl,
+      );
+      const presetId = resolveCodexApiProviderPresetId(savedProvider.baseUrl);
+      const isOpenAIOfficial = presetId === "openai_official";
+      const wireApi = resolveProviderWireApi(savedProvider);
+      const apiProviderMode = isOpenAIOfficial ? "openai_builtin" : "custom";
+      const apiProviderId =
+        presetId === CODEX_API_PROVIDER_CUSTOM_ID ? savedProvider.id : presetId;
+      for (const account of linkedAccounts) {
+        await updateCodexApiKeyCredentials(
+          account.id,
+          nextApiKey,
+          savedProvider.baseUrl,
+          apiProviderMode,
+          apiProviderId,
+          savedProvider.name,
+          savedProvider.modelCatalog,
+          savedProvider.supportsVision === true,
+          Object.fromEntries(
+            Object.entries(savedProvider.modelCapabilities ?? {}).map(
+              ([model, capability]) => [model, capability.supportsVision === true],
+            ),
+          ),
+          savedProvider.visionRoutingModel,
+          wireApi,
+          !isOpenAIOfficial &&
+            wireApi === "responses" &&
+            savedProvider.supportsWebsockets === true,
+          account.api_sync_model_catalog_to_codex,
+          account.account_name,
+          account.api_model_context_windows,
+        );
+      }
+      await reloadProviders();
+      if (linkedAccounts.length > 0) {
+        await emitAccountsChanged({
+          platformId: "codex",
+          reason: "provider-api-key-updated",
+        });
+      }
+      setEditingApiKey(null);
+      setNotice({
+        tone: "success",
+        text: t("codex.modelProviders.updateApiKeySuccess", "API Key 已更新"),
+      });
+    } catch (err) {
+      const raw = String(err ?? "");
+      const message = raw.includes("API_KEY_EXISTS")
+        ? t(
+            "codex.modelProviders.validation.apiKeyExists",
+            "该 API Key 已存在于当前供应商",
+          )
+        : raw.includes("API_KEY_REQUIRED")
+          ? t(
+              "codex.modelProviders.validation.apiKeyRequired",
+              "API Key 不能为空",
+            )
+          : t("codex.modelProviders.updateApiKeyFailed", {
+              defaultValue: "更新 API Key 失败：{{error}}",
+              error: raw.replace(/^Error:\s*/, ""),
+            });
+      setNotice({ tone: "error", text: message });
+    } finally {
+      setSaving(false);
+    }
+  }, [accounts, editingApiKey, providers, reloadProviders, saving, t]);
 
   const handleRenameApiKey = useCallback(
     async (provider: CodexModelProvider, apiKey: CodexModelProviderApiKey) => {
@@ -5108,8 +5223,76 @@ export function CodexModelProviderManager({
                             item.apiKey.toLowerCase().includes(query)
                           );
                         })
-                        .map((item) => (
-                        <div className="codex-provider-key-row" key={item.id}>
+                        .map((item) => {
+                          const isEditing = editingApiKey?.apiKeyId === item.id;
+                          if (isEditing && editingApiKey) {
+                            return (
+                              <div
+                                className="codex-provider-key-row is-editing"
+                                key={item.id}
+                              >
+                                <div className="codex-provider-key-edit-fields">
+                                  <input
+                                    className="form-input"
+                                    type="text"
+                                    value={editingApiKey.name}
+                                    onChange={(event) =>
+                                      setEditingApiKey((current) =>
+                                        current
+                                          ? { ...current, name: event.target.value }
+                                          : current,
+                                      )
+                                    }
+                                    placeholder={t(
+                                      "codex.modelProviders.fields.newApiKeyName",
+                                      "API Key name (optional)",
+                                    )}
+                                    disabled={saving}
+                                  />
+                                  <input
+                                    className="form-input"
+                                    type="password"
+                                    value={editingApiKey.apiKey}
+                                    onChange={(event) =>
+                                      setEditingApiKey((current) =>
+                                        current
+                                          ? { ...current, apiKey: event.target.value }
+                                          : current,
+                                      )
+                                    }
+                                    placeholder={t(
+                                      "codex.modelProviders.fields.apiKey",
+                                      "API Key",
+                                    )}
+                                    autoComplete="off"
+                                    disabled={saving}
+                                  />
+                                </div>
+                                <div className="codex-provider-key-edit-actions">
+                                  <button
+                                    type="button"
+                                    className="action-btn success"
+                                    onClick={() => void handleSaveApiKeyEdit()}
+                                    disabled={saving}
+                                    title={t("common.save", "Save")}
+                                  >
+                                    <Check size={12} />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="action-btn"
+                                    onClick={() => setEditingApiKey(null)}
+                                    disabled={saving}
+                                    title={t("common.cancel", "Cancel")}
+                                  >
+                                    <X size={12} />
+                                  </button>
+                                </div>
+                              </div>
+                            );
+                          }
+                          return (
+                            <div className="codex-provider-key-row" key={item.id}>
                           <div className="codex-provider-key-text">
                             <span className="codex-provider-key-name">
                               {item.name ||
@@ -5121,6 +5304,27 @@ export function CodexModelProviderManager({
                             <code>{maskApiKey(item.apiKey)}</code>
                           </div>
                           <button
+                            type="button"
+                            className="action-btn"
+                            onClick={() =>
+                              setEditingApiKey({
+                                providerId: currentEditingProvider.id,
+                                apiKeyId: item.id,
+                                originalApiKey: item.apiKey,
+                                apiKey: item.apiKey,
+                                name: item.name,
+                              })
+                            }
+                            disabled={saving}
+                            title={t(
+                              "codex.modelProviders.editApiKey",
+                              "Edit API Key",
+                            )}
+                          >
+                            <KeyRound size={12} />
+                          </button>
+                          <button
+                            type="button"
                             className="action-btn"
                             onClick={() =>
                               void handleRenameApiKey(
@@ -5134,6 +5338,7 @@ export function CodexModelProviderManager({
                             <Pencil size={12} />
                           </button>
                           <button
+                            type="button"
                             className="action-btn danger"
                             onClick={() =>
                               void handleDeleteApiKey(
@@ -5146,8 +5351,9 @@ export function CodexModelProviderManager({
                           >
                             <Trash2 size={12} />
                           </button>
-                        </div>
-                      ))}
+                            </div>
+                          );
+                        })}
                     </div>
                   </div>
                 )}

--- a/src/services/codexModelProviderService.ts
+++ b/src/services/codexModelProviderService.ts
@@ -792,6 +792,38 @@ export async function renameApiKeyOnCodexModelProvider(
   return { ...provider, apiKeys: provider.apiKeys.map((item) => ({ ...item })) };
 }
 
+/** Replace the secret for an existing provider API key without changing its id. */
+export async function updateApiKeyOnCodexModelProvider(
+  providerId: string,
+  apiKeyId: string,
+  apiKey: string,
+  name?: string,
+): Promise<CodexModelProvider> {
+  const normalizedApiKey = sanitizeApiKey(apiKey);
+  if (!normalizedApiKey) throw new Error("API_KEY_REQUIRED");
+
+  const providers = await ensureProvidersLoaded();
+  const provider = providers.find((item) => item.id === providerId);
+  if (!provider) throw new Error("PROVIDER_NOT_FOUND");
+  const existing = provider.apiKeys.find((item) => item.id === apiKeyId);
+  if (!existing) throw new Error("API_KEY_NOT_FOUND");
+
+  const duplicate = provider.apiKeys.some(
+    (item) => item.id !== apiKeyId && sanitizeApiKey(item.apiKey) === normalizedApiKey,
+  );
+  if (duplicate) throw new Error("API_KEY_EXISTS");
+
+  const now = Date.now();
+  existing.apiKey = normalizedApiKey;
+  if (name !== undefined) {
+    existing.name = sanitizeName(name);
+  }
+  existing.updatedAt = now;
+  provider.updatedAt = now;
+  await writeProviders(providers);
+  return { ...provider, apiKeys: provider.apiKeys.map((item) => ({ ...item })) };
+}
+
 export async function testCodexModelProviderConnection(input: {
   baseUrl: string;
   apiKey: string;

--- a/src/styles/pages/codex.css
+++ b/src/styles/pages/codex.css
@@ -8636,6 +8636,28 @@
   border-color: var(--border-hover);
 }
 
+.codex-provider-key-row.is-editing {
+  align-items: stretch;
+}
+
+.codex-provider-key-edit-fields {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  gap: 8px;
+}
+
+.codex-provider-key-edit-fields .form-input {
+  min-width: 0;
+  flex: 1;
+}
+
+.codex-provider-key-edit-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .codex-provider-key-text {
   min-width: 0;
   display: flex;


### PR DESCRIPTION
## Summary

- Add an inline edit flow for existing Codex model provider API keys.
- Preserve the provider API key record ID while replacing its secret and optional display name.
- Reject empty or duplicate replacement keys.
- Synchronize Codex API-key accounts that use the old key and matching provider base URL.

## User impact

Users can rotate or correct a provider API key without deleting and recreating the provider entry. Linked Codex accounts receive the replacement credentials automatically.

## Validation

- `npm run typecheck`
- `npm run build`
- `git diff --check`

Fixes #1902
