### PR TITLE
Improve Codex quota label layout

### DIFF
--- a/src/styles/pages/codex.css
+++ b/src/styles/pages/codex.css
@@ -3289,11 +3289,15 @@
 }
 
 .codex-quota-mini-label {
-  flex: 0 0 28px;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
   color: var(--text-secondary);
   font-size: 11px;
   font-weight: 700;
   line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .codex-quota-mini-track {


### PR DESCRIPTION
Fixes #1921\n\nKeep Codex quota labels on a single line and use ellipsis when a card is too narrow, so long labels such as GPT 5.3 Codex Spark Weekly no longer wrap into a tall multi-line stack.\n\nValidation: npm run typecheck; git diff --check.