### PR TITLE
Allow root URLs for provider usage lookup

### DIFF
--- a/src/services/modelProviderUsageService.test.ts
+++ b/src/services/modelProviderUsageService.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildUsageBaseUrlCandidates,
   resolveNewApiQuotaSnapshot,
   type ModelProviderUsageSummary,
 } from "./modelProviderUsageService.ts";
@@ -14,6 +15,20 @@ function summary(
     ...partial,
   };
 }
+
+test("usage lookup tries a root provider URL before its /v1 fallback", () => {
+  assert.deepEqual(
+    buildUsageBaseUrlCandidates("https://sub2api.example.com/"),
+    ["https://sub2api.example.com/", "https://sub2api.example.com/v1"],
+  );
+});
+
+test("usage lookup does not rewrite providers with an explicit path", () => {
+  assert.deepEqual(
+    buildUsageBaseUrlCandidates("https://sub2api.example.com/api"),
+    ["https://sub2api.example.com/api"],
+  );
+});
 
 test("new_api quota uses token allocation details when available", () => {
   const snapshot = resolveNewApiQuotaSnapshot(

--- a/src/services/modelProviderUsageService.ts
+++ b/src/services/modelProviderUsageService.ts
@@ -87,18 +87,16 @@ export function resolveNewApiQuotaSnapshot(
   return { granted, available, expiresAt };
 }
 
-function buildUsageBaseUrlCandidates(baseUrl: string): string[] {
+export function buildUsageBaseUrlCandidates(baseUrl: string): string[] {
   const trimmed = baseUrl.trim();
   if (!trimmed) return [];
   const candidates = [trimmed];
   try {
     const parsed = new URL(trimmed);
-    const host = parsed.hostname.toLowerCase();
     const path = parsed.pathname.replace(/\/+$/, '');
-    if (
-      (host === 'api.apikey.fun' || host === 'slb.apikey.fun') &&
-      (path === '' || path === '/')
-    ) {
+    if (path === '' || path === '/') {
+      // Sub2API-compatible services may expose /usage at either the host root
+      // or under /v1. Try the user's URL first, then the conventional prefix.
       const usageUrl = `${parsed.origin}/v1`;
       if (!candidates.includes(usageUrl)) candidates.push(usageUrl);
     }


### PR DESCRIPTION
Fixes #1187\n\nTry the configured provider URL first, then fall back to the conventional /v1 path when the configured URL is a host root. This keeps existing root-host /usage endpoints working while allowing Sub2API deployments that expose usage below /v1.\n\nValidation: npm run typecheck; direct Node module assertion for root-to-/v1 candidate ordering. The repository Node test runner could not spawn a worker in this Windows sandbox (EPERM).