### PR TITLE
Show MiniMax and Zhipu Token Plan quota

### DIFF
--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -2017,6 +2017,79 @@ fn codex_model_provider_deepseek_balance_url(base_url: &str) -> Result<Option<St
     Ok(Some(url.to_string()))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexTokenPlanProvider {
+    MiniMax,
+    Zhipu,
+}
+
+fn codex_model_provider_token_plan_provider(
+    base_url: &str,
+) -> Result<Option<CodexTokenPlanProvider>, String> {
+    let trimmed = base_url.trim();
+    if trimmed.is_empty() {
+        return Err("PROVIDER_BASE_URL_INVALID".to_string());
+    }
+    let url = reqwest::Url::parse(trimmed).map_err(|_| "PROVIDER_BASE_URL_INVALID".to_string())?;
+    match url.scheme() {
+        "http" | "https" => {}
+        _ => return Err("PROVIDER_BASE_URL_INVALID".to_string()),
+    }
+    let Some(host) = url.host_str() else {
+        return Ok(None);
+    };
+    let host = host.to_ascii_lowercase();
+    if matches!(
+        host.as_str(),
+        "api.minimaxi.com"
+            | "www.minimaxi.com"
+            | "api.minimax.io"
+            | "www.minimax.io"
+    ) {
+        return Ok(Some(CodexTokenPlanProvider::MiniMax));
+    }
+    if matches!(
+        host.as_str(),
+        "open.bigmodel.cn" | "bigmodel.cn" | "api.z.ai" | "z.ai"
+    ) {
+        return Ok(Some(CodexTokenPlanProvider::Zhipu));
+    }
+    Ok(None)
+}
+
+fn codex_model_provider_token_plan_urls(
+    base_url: &str,
+    provider: CodexTokenPlanProvider,
+) -> Result<Vec<String>, String> {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Err("PROVIDER_BASE_URL_INVALID".to_string());
+    }
+    let mut url =
+        reqwest::Url::parse(trimmed).map_err(|_| "PROVIDER_BASE_URL_INVALID".to_string())?;
+    match url.scheme() {
+        "http" | "https" => {}
+        _ => return Err("PROVIDER_BASE_URL_INVALID".to_string()),
+    }
+    url.set_query(None);
+    url.set_fragment(None);
+    let endpoints: &[&str] = match provider {
+        CodexTokenPlanProvider::MiniMax => &[
+            "/v1/token_plan/remains",
+            "/v1/api/openplatform/coding_plan/remains",
+        ],
+        CodexTokenPlanProvider::Zhipu => &["/api/monitor/usage/quota/limit"],
+    };
+    Ok(endpoints
+        .iter()
+        .map(|endpoint| {
+            let mut candidate = url.clone();
+            candidate.set_path(endpoint);
+            candidate.to_string()
+        })
+        .collect())
+}
+
 fn codex_model_provider_new_api_billing_url(
     base_url: &str,
     endpoint: &str,
@@ -2764,6 +2837,414 @@ fn summarize_deepseek_balance(
     }
 }
 
+fn json_f64_field(value: &serde_json::Value, keys: &[&str]) -> Option<f64> {
+    keys.iter().find_map(|key| {
+        value.get(*key).and_then(|current| {
+            current
+                .as_f64()
+                .or_else(|| current.as_str()?.trim().parse::<f64>().ok())
+        })
+    })
+}
+
+fn json_string_field(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        value
+            .get(*key)
+            .and_then(|current| current.as_str())
+            .map(str::trim)
+            .filter(|current| !current.is_empty())
+            .map(ToOwned::to_owned)
+    })
+}
+
+fn json_timestamp_seconds(value: &serde_json::Value) -> Option<i64> {
+    if let Some(number) = value
+        .as_f64()
+        .or_else(|| value.as_str()?.trim().parse::<f64>().ok())
+    {
+        if !number.is_finite() || number <= 0.0 {
+            return None;
+        }
+        let seconds = if number > 10_000_000_000.0 {
+            number / 1000.0
+        } else {
+            number
+        };
+        return Some(seconds.floor() as i64);
+    }
+    value
+        .as_str()
+        .and_then(|text| chrono::DateTime::parse_from_rfc3339(text.trim()).ok())
+        .map(|date| date.timestamp())
+}
+
+fn json_timestamp_field(value: &serde_json::Value, keys: &[&str]) -> Option<i64> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(json_timestamp_seconds))
+}
+
+fn clamp_usage_percent(value: f64) -> f64 {
+    value.clamp(0.0, 100.0)
+}
+
+fn token_plan_payload(body: &serde_json::Value) -> &serde_json::Value {
+    body.get("data")
+        .filter(|value| value.is_object())
+        .unwrap_or(body)
+}
+
+fn token_plan_remaining_percent(remaining: Option<f64>, total: Option<f64>) -> Option<f64> {
+    match (remaining, total) {
+        (Some(remaining), Some(total)) if total > 0.0 => {
+            Some(clamp_usage_percent((remaining / total) * 100.0))
+        }
+        _ => None,
+    }
+}
+
+fn summarize_minimax_token_plan_usage(
+    body: &serde_json::Value,
+    latency_ms: u64,
+) -> Result<CodexModelProviderUsageSummary, String> {
+    let payload = token_plan_payload(body);
+    let model_remains = payload
+        .get("model_remains")
+        .and_then(serde_json::Value::as_array);
+    let model = model_remains
+        .and_then(|models| {
+            models
+                .iter()
+                .find(|item| {
+                    json_string_field(item, &["model_name", "modelName"])
+                        .is_some_and(|name| name.to_ascii_lowercase().starts_with("minimax-m"))
+                })
+                .or_else(|| models.first())
+        })
+        .unwrap_or(payload);
+
+    let model_name = json_string_field(model, &["model_name", "modelName"]);
+    let plan_name = json_string_field(payload, &["plan_name", "planName"])
+        .or_else(|| json_string_field(body, &["plan_name", "planName"]))
+        .or_else(|| Some("MiniMax Token Plan".to_string()));
+    let interval_total = json_f64_field(
+        model,
+        &[
+            "current_interval_total_count",
+            "currentIntervalTotalCount",
+        ],
+    );
+    let interval_remaining = json_f64_field(
+        model,
+        &[
+            "current_interval_usage_count",
+            "currentIntervalUsageCount",
+            "current_interval_remaining",
+            "currentIntervalRemaining",
+        ],
+    );
+    let interval_remaining_percent = json_f64_field(
+        model,
+        &[
+            "current_interval_remaining_percent",
+            "currentIntervalRemainingPercent",
+            "remaining_percent",
+            "remainingPercent",
+        ],
+    )
+    .map(clamp_usage_percent)
+    .or_else(|| token_plan_remaining_percent(interval_remaining, interval_total));
+    let weekly_total = json_f64_field(
+        model,
+        &[
+            "current_weekly_total_count",
+            "currentWeeklyTotalCount",
+        ],
+    );
+    let weekly_remaining = json_f64_field(
+        model,
+        &[
+            "current_weekly_usage_count",
+            "currentWeeklyUsageCount",
+            "current_weekly_remaining",
+            "currentWeeklyRemaining",
+        ],
+    );
+    let weekly_remaining_percent = json_f64_field(
+        model,
+        &[
+            "current_weekly_remaining_percent",
+            "currentWeeklyRemainingPercent",
+            "weekly_remaining_percent",
+            "weeklyRemainingPercent",
+        ],
+    )
+    .map(clamp_usage_percent)
+    .or_else(|| token_plan_remaining_percent(weekly_remaining, weekly_total));
+    let remaining_percent = interval_remaining_percent
+        .or(weekly_remaining_percent)
+        .ok_or_else(|| "PROVIDER_USAGE_PARSE_FAILED: MiniMax token plan fields missing".to_string())?;
+    let used_percent = 100.0 - remaining_percent;
+    let interval_expires_at = json_timestamp_field(model, &["end_time", "endTime"]);
+    let weekly_expires_at =
+        json_timestamp_field(model, &["weekly_end_time", "weeklyEndTime"]);
+    let mut details = Vec::new();
+    push_usage_detail(
+        &mut details,
+        "planName",
+        "Plan",
+        plan_name.clone(),
+    );
+    push_usage_detail(
+        &mut details,
+        "modelName",
+        "Model",
+        model_name,
+    );
+    push_usage_detail(
+        &mut details,
+        "remaining",
+        "Remaining",
+        Some(format_usage_number(remaining_percent)),
+    );
+    push_usage_detail(
+        &mut details,
+        "intervalRemaining",
+        "Interval Remaining",
+        interval_remaining.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "intervalLimit",
+        "Interval Limit",
+        interval_total.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "intervalRemainingPercent",
+        "Interval Remaining %",
+        interval_remaining_percent.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "intervalExpiresAt",
+        "Interval Reset",
+        interval_expires_at.map(|value| value.to_string()),
+    );
+    push_usage_detail(
+        &mut details,
+        "weeklyRemaining",
+        "Weekly Remaining",
+        weekly_remaining.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "weeklyLimit",
+        "Weekly Limit",
+        weekly_total.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "weeklyRemainingPercent",
+        "Weekly Remaining %",
+        weekly_remaining_percent.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "weeklyExpiresAt",
+        "Weekly Reset",
+        weekly_expires_at.map(|value| value.to_string()),
+    );
+    push_usage_detail(
+        &mut details,
+        "expiresAt",
+        "Next Reset",
+        interval_expires_at
+            .or(weekly_expires_at)
+            .map(|value| value.to_string()),
+    );
+
+    Ok(CodexModelProviderUsageSummary {
+        mode: Some("token_plan".to_string()),
+        is_valid: Some(remaining_percent > 0.0),
+        status: Some(if remaining_percent > 0.0 {
+            "available".to_string()
+        } else {
+            "exhausted".to_string()
+        }),
+        plan_name,
+        remaining: Some(remaining_percent),
+        balance: Some(remaining_percent),
+        unit: Some("%".to_string()),
+        quota_unlimited: None,
+        quota_limit: Some(100.0),
+        quota_used: Some(used_percent),
+        quota_remaining: Some(remaining_percent),
+        today_requests: None,
+        today_total_tokens: None,
+        today_cost: None,
+        total_requests: None,
+        total_total_tokens: None,
+        total_cost: None,
+        model_stats_count: model_remains.map_or(0, Vec::len),
+        latency_ms,
+        details,
+    })
+}
+
+fn summarize_zhipu_token_plan_usage(
+    body: &serde_json::Value,
+    latency_ms: u64,
+) -> Result<CodexModelProviderUsageSummary, String> {
+    let payload = token_plan_payload(body);
+    let mut limits: Vec<&serde_json::Value> = payload
+        .get("limits")
+        .and_then(serde_json::Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter(|item| {
+                    json_string_field(item, &["type"])
+                        .is_some_and(|kind| kind.eq_ignore_ascii_case("TOKENS_LIMIT"))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    if limits.is_empty() {
+        return Err("PROVIDER_USAGE_PARSE_FAILED: Zhipu token limit fields missing".to_string());
+    }
+    limits.sort_by_key(|item| {
+        json_timestamp_field(item, &["nextResetTime", "next_reset_time"])
+            .unwrap_or(i64::MAX)
+    });
+
+    let mut window_data = Vec::with_capacity(limits.len());
+    for item in &limits {
+        let total = json_f64_field(*item, &["usage", "total", "limit"]);
+        let used = json_f64_field(*item, &["currentValue", "current_value", "used"]);
+        let remaining = json_f64_field(*item, &["remaining", "remain"]);
+        let used_percent = json_f64_field(*item, &["percentage", "usedPercentage"])
+            .or_else(|| match (used, total) {
+                (Some(used), Some(total)) if total > 0.0 => Some((used / total) * 100.0),
+                _ => None,
+            })
+            .map(clamp_usage_percent)
+            .ok_or_else(|| {
+                "PROVIDER_USAGE_PARSE_FAILED: Zhipu token percentage missing".to_string()
+            })?;
+        let remaining_percent = clamp_usage_percent(100.0 - used_percent);
+        let reset_at = json_timestamp_field(item, &["nextResetTime", "next_reset_time"]);
+        window_data.push((
+            total,
+            used,
+            remaining,
+            used_percent,
+            remaining_percent,
+            reset_at,
+        ));
+    }
+
+    let primary = window_data.first().copied().ok_or_else(|| {
+        "PROVIDER_USAGE_PARSE_FAILED: Zhipu token limit fields missing".to_string()
+    })?;
+    let remaining_percent = primary.4;
+    let plan_name = json_string_field(payload, &["level", "planName"])
+        .or_else(|| Some("ZHIPU".to_string()));
+    let mut details = Vec::new();
+    push_usage_detail(
+        &mut details,
+        "planName",
+        "Plan",
+        plan_name.clone(),
+    );
+    push_usage_detail(
+        &mut details,
+        "remaining",
+        "Remaining",
+        Some(format_usage_number(remaining_percent)),
+    );
+    push_usage_detail(
+        &mut details,
+        "expiresAt",
+        "Next Reset",
+        primary.5.map(|value| value.to_string()),
+    );
+    for (index, (total, used, remaining, used_percent, remaining_percent, reset_at)) in
+        window_data.into_iter().enumerate()
+    {
+        let prefix = if index == 0 {
+            "interval"
+        } else if index == 1 {
+            "weekly"
+        } else {
+            "window"
+        };
+        push_usage_detail(
+            &mut details,
+            &format!("{}Limit", prefix),
+            &format!("{} Limit", prefix),
+            total.map(format_usage_number),
+        );
+        push_usage_detail(
+            &mut details,
+            &format!("{}Used", prefix),
+            &format!("{} Used", prefix),
+            used.map(format_usage_number),
+        );
+        push_usage_detail(
+            &mut details,
+            &format!("{}Remaining", prefix),
+            &format!("{} Remaining", prefix),
+            remaining.map(format_usage_number),
+        );
+        push_usage_detail(
+            &mut details,
+            &format!("{}UsedPercent", prefix),
+            &format!("{} Used %", prefix),
+            Some(format_usage_number(used_percent)),
+        );
+        push_usage_detail(
+            &mut details,
+            &format!("{}RemainingPercent", prefix),
+            &format!("{} Remaining %", prefix),
+            Some(format_usage_number(remaining_percent)),
+        );
+        push_usage_detail(
+            &mut details,
+            &format!("{}ExpiresAt", prefix),
+            &format!("{} Reset", prefix),
+            reset_at.map(|value| value.to_string()),
+        );
+    }
+
+    Ok(CodexModelProviderUsageSummary {
+        mode: Some("token_plan".to_string()),
+        is_valid: Some(remaining_percent > 0.0),
+        status: Some(if remaining_percent > 0.0 {
+            "available".to_string()
+        } else {
+            "exhausted".to_string()
+        }),
+        plan_name,
+        remaining: Some(remaining_percent),
+        balance: Some(remaining_percent),
+        unit: Some("%".to_string()),
+        quota_unlimited: None,
+        quota_limit: Some(100.0),
+        quota_used: Some(100.0 - remaining_percent),
+        quota_remaining: Some(remaining_percent),
+        today_requests: None,
+        today_total_tokens: None,
+        today_cost: None,
+        total_requests: None,
+        total_total_tokens: None,
+        total_cost: None,
+        model_stats_count: limits.len(),
+        latency_ms,
+        details,
+    })
+}
+
 fn format_usage_number(value: f64) -> String {
     if value.fract().abs() < f64::EPSILON {
         format!("{:.0}", value)
@@ -3213,6 +3694,10 @@ pub async fn codex_query_model_provider_usage(
         .build()
         .map_err(|e| format!("CREATE_HTTP_CLIENT_FAILED: {}", e))?;
 
+    if let Some(provider) = codex_model_provider_token_plan_provider(&base_url)? {
+        return query_token_plan_model_provider_usage(&client, &base_url, key, provider).await;
+    }
+
     if let Some(url) = codex_model_provider_deepseek_balance_url(&base_url)? {
         return query_deepseek_model_provider_balance(&client, &url, key).await;
     }
@@ -3268,6 +3753,70 @@ async fn query_deepseek_model_provider_balance(
     let parsed = serde_json::from_str::<serde_json::Value>(&text)
         .map_err(|e| format!("PROVIDER_USAGE_PARSE_FAILED: {}", e))?;
     Ok(summarize_deepseek_balance(&parsed, latency_ms))
+}
+
+async fn query_token_plan_model_provider_usage(
+    client: &reqwest::Client,
+    base_url: &str,
+    key: &str,
+    provider: CodexTokenPlanProvider,
+) -> Result<CodexModelProviderUsageSummary, String> {
+    let urls = codex_model_provider_token_plan_urls(base_url, provider)?;
+    let mut last_not_found = None;
+    let mut last_parse_error = None;
+    for url in urls {
+        let started = Instant::now();
+        let request = client
+            .get(&url)
+            .header(reqwest::header::ACCEPT, "application/json");
+        let response = match provider {
+            CodexTokenPlanProvider::MiniMax => request.bearer_auth(key).send().await,
+            CodexTokenPlanProvider::Zhipu => request
+                .header(reqwest::header::AUTHORIZATION, key)
+                .send()
+                .await,
+        }
+        .map_err(|e| format!("PROVIDER_USAGE_NETWORK_FAILED: {}", e))?;
+        let latency_ms = started.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            last_not_found = Some(format!(
+                "PROVIDER_USAGE_HTTP_404: {}",
+                text.chars().take(300).collect::<String>()
+            ));
+            continue;
+        }
+        if !status.is_success() {
+            return Err(format!(
+                "PROVIDER_USAGE_HTTP_{}: {}",
+                status.as_u16(),
+                text.chars().take(300).collect::<String>()
+            ));
+        }
+        let parsed = serde_json::from_str::<serde_json::Value>(&text)
+            .map_err(|e| format!("PROVIDER_USAGE_PARSE_FAILED: {}", e))?;
+        let summary = match provider {
+            CodexTokenPlanProvider::MiniMax => {
+                summarize_minimax_token_plan_usage(&parsed, latency_ms)
+            }
+            CodexTokenPlanProvider::Zhipu => summarize_zhipu_token_plan_usage(&parsed, latency_ms),
+        };
+        match summary {
+            Ok(summary) => return Ok(summary),
+            Err(error)
+                if provider == CodexTokenPlanProvider::MiniMax
+                    && error.starts_with("PROVIDER_USAGE_PARSE_FAILED") =>
+            {
+                last_parse_error = Some(error);
+                continue;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(last_parse_error.or(last_not_found).unwrap_or_else(|| {
+        "PROVIDER_USAGE_HTTP_404: token plan endpoint not found".to_string()
+    }))
 }
 
 async fn query_new_api_model_provider_usage(
@@ -3996,5 +4545,115 @@ mod tests {
             .details
             .iter()
             .any(|detail| detail.key == "grantedBalance" && detail.value == "10"));
+    }
+
+    #[test]
+    fn token_plan_provider_detection_uses_known_hosts() {
+        assert_eq!(
+            codex_model_provider_token_plan_provider("https://api.minimaxi.com/v1")
+                .expect("valid URL"),
+            Some(CodexTokenPlanProvider::MiniMax)
+        );
+        assert_eq!(
+            codex_model_provider_token_plan_provider("https://open.bigmodel.cn/api/coding/paas/v4")
+                .expect("valid URL"),
+            Some(CodexTokenPlanProvider::Zhipu)
+        );
+        assert_eq!(
+            codex_model_provider_token_plan_provider("https://example.com/v1")
+                .expect("valid URL"),
+            None
+        );
+    }
+
+    #[test]
+    fn token_plan_urls_ignore_provider_version_path() {
+        assert_eq!(
+            codex_model_provider_token_plan_urls(
+                "https://api.minimaxi.com/v1",
+                CodexTokenPlanProvider::MiniMax,
+            )
+            .expect("valid URL"),
+            vec![
+                "https://api.minimaxi.com/v1/token_plan/remains",
+                "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains",
+            ]
+        );
+        assert_eq!(
+            codex_model_provider_token_plan_urls(
+                "https://api.z.ai/api/coding/paas/v4",
+                CodexTokenPlanProvider::Zhipu,
+            )
+            .expect("valid URL"),
+            vec!["https://api.z.ai/api/monitor/usage/quota/limit"]
+        );
+    }
+
+    #[test]
+    fn minimax_token_plan_prefers_remaining_percent_for_time_windows() {
+        let summary = summarize_minimax_token_plan_usage(
+            &serde_json::json!({
+                "model_remains": [{
+                    "model_name": "MiniMax-M2.7",
+                    "current_interval_total_count": 0,
+                    "current_interval_usage_count": 0,
+                    "current_interval_remaining_percent": 72,
+                    "current_weekly_remaining_percent": 61,
+                    "end_time": 1773914400000i64,
+                    "weekly_end_time": 1774224000000i64
+                }]
+            }),
+            15,
+        )
+        .expect("token plan response");
+
+        assert_eq!(summary.mode.as_deref(), Some("token_plan"));
+        assert_eq!(summary.remaining, Some(72.0));
+        assert_eq!(summary.quota_used, Some(28.0));
+        assert_eq!(summary.quota_limit, Some(100.0));
+        assert!(summary
+            .details
+            .iter()
+            .any(|detail| detail.key == "intervalRemainingPercent" && detail.value == "72"));
+        assert!(summary
+            .details
+            .iter()
+            .any(|detail| detail.key == "weeklyExpiresAt" && detail.value == "1774224000"));
+    }
+
+    #[test]
+    fn zhipu_token_plan_uses_raw_authorization_shape_and_next_reset() {
+        let summary = summarize_zhipu_token_plan_usage(
+            &serde_json::json!({
+                "code": 200,
+                "success": true,
+                "data": {
+                    "level": "pro",
+                    "limits": [
+                        {
+                            "type": "TOKENS_LIMIT",
+                            "usage": 800000000,
+                            "currentValue": 127694464,
+                            "remaining": 672305536,
+                            "percentage": 15,
+                            "nextResetTime": 1770648402389i64
+                        },
+                        {
+                            "type": "TIME_LIMIT",
+                            "percentage": 30
+                        }
+                    ]
+                }
+            }),
+            21,
+        )
+        .expect("token plan response");
+
+        assert_eq!(summary.mode.as_deref(), Some("token_plan"));
+        assert_eq!(summary.plan_name.as_deref(), Some("pro"));
+        assert_eq!(summary.remaining, Some(85.0));
+        assert_eq!(summary.unit.as_deref(), Some("%"));
+        assert_eq!(summary.details.iter().find(|detail| detail.key == "expiresAt").map(|detail| detail.value.as_str()), Some("1770648402"));
+        assert_eq!(summary.model_stats_count, 1);
     }
 }

--- a/src/components/codex/CodexModelProviderManager.tsx
+++ b/src/components/codex/CodexModelProviderManager.tsx
@@ -3157,6 +3157,39 @@ export function CodexModelProviderManager({
   const formatUsageDetailLabel = useCallback(
     (key: string, fallback: string): string => {
       const labels: Record<string, string> = {
+        modelName: t("codex.modelProviders.usage.fields.modelName", "Model"),
+        intervalRemaining: t(
+          "codex.modelProviders.usage.fields.intervalRemaining",
+          "Interval Remaining",
+        ),
+        intervalLimit: t(
+          "codex.modelProviders.usage.fields.intervalLimit",
+          "Interval Limit",
+        ),
+        intervalRemainingPercent: t(
+          "codex.modelProviders.usage.fields.intervalRemainingPercent",
+          "Interval Remaining %",
+        ),
+        intervalExpiresAt: t(
+          "codex.modelProviders.usage.fields.intervalExpiresAt",
+          "Interval Reset",
+        ),
+        weeklyRemaining: t(
+          "codex.modelProviders.usage.fields.weeklyRemaining",
+          "Weekly Remaining",
+        ),
+        weeklyLimit: t(
+          "codex.modelProviders.usage.fields.weeklyLimit",
+          "Weekly Limit",
+        ),
+        weeklyRemainingPercent: t(
+          "codex.modelProviders.usage.fields.weeklyRemainingPercent",
+          "Weekly Remaining %",
+        ),
+        weeklyExpiresAt: t(
+          "codex.modelProviders.usage.fields.weeklyExpiresAt",
+          "Weekly Reset",
+        ),
         status: t("codex.modelProviders.usage.fields.status", "状态"),
         planName: t("codex.modelProviders.usage.fields.planName", "订阅"),
         remaining: t("codex.modelProviders.usage.fields.remaining", "剩余额度"),
@@ -3237,6 +3270,12 @@ export function CodexModelProviderManager({
         return numeric > 0 ? formatDateTime(numeric * 1000) : "-";
       }
       if (Number.isFinite(numeric) && item.key === "expiresAt") {
+        return numeric > 0 ? formatDateTime(numeric * 1000) : "-";
+      }
+      if (
+        Number.isFinite(numeric) &&
+        (item.key === "intervalExpiresAt" || item.key === "weeklyExpiresAt")
+      ) {
         return numeric > 0 ? formatDateTime(numeric * 1000) : "-";
       }
       if (
@@ -3547,7 +3586,8 @@ export function CodexModelProviderManager({
             const usageMode =
               usageSummary?.mode === "new_api" ||
               usageSummary?.mode === "sub2api" ||
-              usageSummary?.mode === "deepseek"
+              usageSummary?.mode === "deepseek" ||
+              usageSummary?.mode === "token_plan"
                 ? usageSummary.mode
                 : provider.integrationType ?? null;
             const deepSeekDetailValue = (key: string) => {
@@ -3559,6 +3599,17 @@ export function CodexModelProviderManager({
               available: totalAvailable,
               expiresAt,
             } = resolveNewApiQuotaSnapshot(usageSummary);
+            const tokenPlanResetDetail = usageSummary?.details?.find((detail) =>
+              ["intervalExpiresAt", "weeklyExpiresAt", "expiresAt"].includes(
+                detail.key,
+              ),
+            );
+            const tokenPlanResetText = tokenPlanResetDetail
+              ? formatUsageDetailValue(
+                  tokenPlanResetDetail,
+                  usageSummary?.unit,
+                )
+              : "-";
             const progressPercent =
               usageMode === "new_api" &&
               totalGranted != null &&
@@ -3702,6 +3753,38 @@ export function CodexModelProviderManager({
                         <div>
                           <span>{t("codex.modelProviders.usage.fields.toppedUpBalance", "充值余额")}</span>
                           <strong>{deepSeekDetailValue("toppedUpBalance")}</strong>
+                        </div>
+                      </div>
+                    </div>
+                  ) : usageMode === "token_plan" ? (
+                    <div className="codex-api-key-usage-panel token-plan">
+                      <div className="codex-api-key-usage-grid">
+                        <div>
+                          <span>
+                            {t(
+                              "codex.modelProviders.usage.fields.remaining",
+                              "Remaining",
+                            )}
+                          </span>
+                          <strong>{usagePrimaryText}</strong>
+                        </div>
+                        <div>
+                          <span>
+                            {t(
+                              "codex.modelProviders.usage.fields.planName",
+                              "Plan",
+                            )}
+                          </span>
+                          <strong>{usageSummary?.planName || "-"}</strong>
+                        </div>
+                        <div>
+                          <span>
+                            {t(
+                              "codex.modelProviders.usage.fields.expiresAt",
+                              "Next Reset",
+                            )}
+                          </span>
+                          <strong>{tokenPlanResetText}</strong>
                         </div>
                       </div>
                     </div>
@@ -5733,7 +5816,8 @@ export function CodexModelProviderManager({
         const usageMode =
           usageSummary?.mode === "new_api" ||
           usageSummary?.mode === "sub2api" ||
-          usageSummary?.mode === "deepseek"
+          usageSummary?.mode === "deepseek" ||
+          usageSummary?.mode === "token_plan"
             ? usageSummary.mode
             : provider.integrationType ?? null;
         const coreDetailKeys =
@@ -5741,7 +5825,7 @@ export function CodexModelProviderManager({
             ? new Set(["mode", "totalGranted", "totalAvailable", "expiresAt"])
             : usageMode === "sub2api"
               ? new Set(["mode", "remaining", "todayRequests", "todayTokens"])
-              : usageMode === "deepseek"
+            : usageMode === "deepseek"
                 ? new Set([
                     "isAvailable",
                     "currency",
@@ -5749,6 +5833,13 @@ export function CodexModelProviderManager({
                     "grantedBalance",
                     "toppedUpBalance",
                   ])
+                : usageMode === "token_plan"
+                  ? new Set([
+                      "mode",
+                      "remaining",
+                      "planName",
+                      "expiresAt",
+                    ])
                 : new Set<string>();
         const detailMetrics: CodexServicePanelMetricItem[] = [
           {

--- a/src/components/model-provider/ModelProviderUsagePanel.tsx
+++ b/src/components/model-provider/ModelProviderUsagePanel.tsx
@@ -26,7 +26,10 @@ export function ModelProviderUsagePanel({
 }: ModelProviderUsagePanelProps) {
   const { t } = useTranslation();
   const usageMode = resolveModelProviderUsageMode(summary ?? undefined);
-  const isSupportedUsage = usageMode === 'sub2api' || usageMode === 'new_api';
+  const isSupportedUsage =
+    usageMode === 'sub2api' ||
+    usageMode === 'new_api' ||
+    usageMode === 'token_plan';
   const classNames = [
     'codex-api-key-usage-panel',
     usageMode ?? 'sub2api',
@@ -53,6 +56,39 @@ export function ModelProviderUsagePanel({
 
   if (!isSupportedUsage) {
     return null;
+  }
+
+  if (usageMode === 'token_plan') {
+    const resetDetail = summary?.details?.find((item) =>
+      ['intervalExpiresAt', 'weeklyExpiresAt', 'expiresAt'].includes(item.key),
+    );
+    return (
+      <div className={classNames}>
+        <div className="codex-api-key-usage-grid">
+          <div>
+            <span>
+              {t('codex.modelProviders.usage.fields.remaining', 'Remaining')}
+            </span>
+            <strong>
+              {formatModelProviderUsageMoney(
+                summary?.quotaRemaining ?? summary?.remaining,
+                summary?.unit,
+              )}
+            </strong>
+          </div>
+          <div>
+            <span>{t('codex.modelProviders.usage.fields.planName', 'Plan')}</span>
+            <strong>{summary?.planName || '-'}</strong>
+          </div>
+          <div>
+            <span>
+              {t('codex.modelProviders.usage.fields.expiresAt', 'Next Reset')}
+            </span>
+            <strong>{resetDetail?.value || '-'}</strong>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   const balanceText = formatModelProviderUsageMoney(

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -168,6 +168,7 @@ import { CodexCliLaunchDialog } from "../components/codex/CodexCliLaunchDialog";
 import { useDeepSeekDirectModelPrompt } from "../components/codex/DeepSeekDirectModelModal";
 import {
   isDeepSeekAccount,
+  isCodexTokenPlanAccount,
   resolveDeepSeekBindAccountId,
   shouldShowCodexApiKeyUsagePanel,
 } from "../utils/codexDeepSeekAccess";
@@ -720,12 +721,13 @@ function getCockpitApiStatsRecord(
 
 function resolveApiKeyUsageMode(
   summary?: CodexModelProviderUsageSummary,
-): "new_api" | "sub2api" | "deepseek" | null {
+): "new_api" | "sub2api" | "deepseek" | "token_plan" | null {
   if (!summary) return null;
   if (
     summary.mode === "new_api" ||
     summary.mode === "sub2api" ||
-    summary.mode === "deepseek"
+    summary.mode === "deepseek" ||
+    summary.mode === "token_plan"
   ) {
     return summary.mode;
   }
@@ -7645,7 +7647,8 @@ export function CodexAccountsPage() {
     async (account: CodexAccount, provider?: CodexModelProvider | null) => {
       if (
         isCodexChatCompletionsApiKeyAccount(account) &&
-        !isDeepSeekAccount(account)
+        !isDeepSeekAccount(account) &&
+        !isCodexTokenPlanAccount(account)
       ) {
         return;
       }
@@ -7717,7 +7720,8 @@ export function CodexAccountsPage() {
         !isCodexApiKeyAccount(account) ||
         isCodexNewApiAccount(account) ||
         (isCodexChatCompletionsApiKeyAccount(account) &&
-          !isDeepSeekAccount(account))
+          !isDeepSeekAccount(account) &&
+          !isCodexTokenPlanAccount(account))
       ) {
         return false;
       }
@@ -7813,7 +7817,8 @@ export function CodexAccountsPage() {
         .filter(
           (account) =>
             isCodexChatCompletionsApiKeyAccount(account) &&
-            !isDeepSeekAccount(account),
+            !isDeepSeekAccount(account) &&
+            !isCodexTokenPlanAccount(account),
         )
         .map((account) => account.id),
     );
@@ -7959,6 +7964,39 @@ export function CodexAccountsPage() {
   const formatApiKeyUsageDetailLabel = useCallback(
     (key: string, fallback: string): string => {
       const labels: Record<string, string> = {
+        modelName: t("codex.modelProviders.usage.fields.modelName", "Model"),
+        intervalRemaining: t(
+          "codex.modelProviders.usage.fields.intervalRemaining",
+          "Interval Remaining",
+        ),
+        intervalLimit: t(
+          "codex.modelProviders.usage.fields.intervalLimit",
+          "Interval Limit",
+        ),
+        intervalRemainingPercent: t(
+          "codex.modelProviders.usage.fields.intervalRemainingPercent",
+          "Interval Remaining %",
+        ),
+        intervalExpiresAt: t(
+          "codex.modelProviders.usage.fields.intervalExpiresAt",
+          "Interval Reset",
+        ),
+        weeklyRemaining: t(
+          "codex.modelProviders.usage.fields.weeklyRemaining",
+          "Weekly Remaining",
+        ),
+        weeklyLimit: t(
+          "codex.modelProviders.usage.fields.weeklyLimit",
+          "Weekly Limit",
+        ),
+        weeklyRemainingPercent: t(
+          "codex.modelProviders.usage.fields.weeklyRemainingPercent",
+          "Weekly Remaining %",
+        ),
+        weeklyExpiresAt: t(
+          "codex.modelProviders.usage.fields.weeklyExpiresAt",
+          "Weekly Reset",
+        ),
         status: t("codex.modelProviders.usage.fields.status", "状态"),
         planName: t("codex.modelProviders.usage.fields.planName", "订阅"),
         remaining: t("codex.modelProviders.usage.fields.remaining", "剩余额度"),
@@ -8048,6 +8086,12 @@ export function CodexAccountsPage() {
         return numeric > 0 ? formatDate(numeric * 1000) : "-";
       }
       if (
+        Number.isFinite(numeric) &&
+        (item.key === "intervalExpiresAt" || item.key === "weeklyExpiresAt")
+      ) {
+        return numeric > 0 ? formatDate(numeric * 1000) : "-";
+      }
+      if (
         item.key === "quotaUnlimited" ||
         item.key === "modelLimitsEnabled" ||
         item.key === "isAvailable"
@@ -8122,7 +8166,8 @@ export function CodexAccountsPage() {
     ): ReactElement => {
       if (
         isCodexChatCompletionsApiKeyAccount(account) &&
-        !isDeepSeekAccount(account)
+        !isDeepSeekAccount(account) &&
+        !isCodexTokenPlanAccount(account)
       ) {
         return <></>;
       }
@@ -8138,6 +8183,7 @@ export function CodexAccountsPage() {
         isDeepSeekAccount(account) || usageMode === "deepseek";
       const isNewApiUsage = usageMode === "new_api";
       const isSub2ApiUsage = usageMode === "sub2api";
+      const isTokenPlanUsage = usageMode === "token_plan";
       const usedPercent = formatApiKeyUsagePercent(summary);
       if (isDeepSeekUsage) {
         return (
@@ -8225,6 +8271,54 @@ export function CodexAccountsPage() {
               <span className="quota-reset">
                 {t("codex.modelProviders.usage.fields.expiresAt", "过期时间")}：
                 {expiresText}
+              </span>
+            )}
+          </div>
+        );
+      }
+      if (variant === "card" && summary && isTokenPlanUsage) {
+        const resetDetail =
+          findApiKeyUsageDetail(summary, "intervalExpiresAt") ??
+          findApiKeyUsageDetail(summary, "weeklyExpiresAt") ??
+          findApiKeyUsageDetail(summary, "expiresAt");
+        return (
+          <div
+            className="quota-item codex-api-key-quota-item token-plan"
+            title={`${t(
+              "codex.modelProviders.usage.fields.remaining",
+              "Remaining",
+            )}: ${formatApiKeyUsageQuotaValue(
+              summary,
+              summary.quotaRemaining ?? summary.remaining,
+            )}`}
+          >
+            <div className="quota-header">
+              <Database size={14} />
+              <span className="quota-label">
+                {t("codex.modelProviders.usage.fields.planName", "Token Plan")}
+              </span>
+              <span className="quota-pct high">
+                {formatApiKeyUsageQuotaValue(
+                  summary,
+                  summary.quotaRemaining ?? summary.remaining,
+                )}
+              </span>
+            </div>
+            <div className="quota-bar-track">
+              <div
+                className="quota-bar high"
+                style={{ width: `${Math.max(0, Math.min(100, usedPercent))}%` }}
+              />
+            </div>
+            {(summary.planName || resetDetail) && (
+              <span className="quota-reset">
+                {summary.planName || "Token Plan"}
+                {resetDetail
+                  ? ` · ${formatApiKeyUsageDetailValue(
+                      resetDetail,
+                      summary.unit,
+                    )}`
+                  : ""}
               </span>
             )}
           </div>
@@ -8354,6 +8448,50 @@ export function CodexAccountsPage() {
                       </strong>
                     </div>
                   </>
+                ) : isTokenPlanUsage ? (
+                  <>
+                    <div>
+                      <span>
+                        {t(
+                          "codex.modelProviders.usage.fields.remaining",
+                          "Remaining",
+                        )}
+                      </span>
+                      <strong>
+                        {formatApiKeyUsageQuotaValue(
+                          summary,
+                          summary.quotaRemaining ?? summary.remaining,
+                        )}
+                      </strong>
+                    </div>
+                    <div>
+                      <span>
+                        {t(
+                          "codex.modelProviders.usage.fields.planName",
+                          "Plan",
+                        )}
+                      </span>
+                      <strong>{summary.planName || "-"}</strong>
+                    </div>
+                    <div>
+                      <span>
+                        {t(
+                          "codex.modelProviders.usage.fields.expiresAt",
+                          "Next Reset",
+                        )}
+                      </span>
+                      <strong>
+                        {formatApiKeyUsageDetailByKey(
+                          summary,
+                          findApiKeyUsageDetail(summary, "intervalExpiresAt")
+                            ? "intervalExpiresAt"
+                            : findApiKeyUsageDetail(summary, "weeklyExpiresAt")
+                              ? "weeklyExpiresAt"
+                              : "expiresAt",
+                        )}
+                      </strong>
+                    </div>
+                  </>
                 ) : isSub2ApiUsage ? (
                   <>
                     <div>
@@ -8399,7 +8537,7 @@ export function CodexAccountsPage() {
                   </>
                 ) : null}
               </div>
-              {isNewApiUsage ? (
+              {isNewApiUsage || isTokenPlanUsage ? (
                 <div className="codex-api-key-usage-progress">
                   <div className="cockpit-api-progress-track">
                     <div
@@ -11120,6 +11258,9 @@ export function CodexAccountsPage() {
       const compactDeepSeekSummary = isDeepSeekAccount(account)
         ? apiKeyUsageMap[account.id]?.summary
         : undefined;
+      const compactTokenPlanSummary = isCodexTokenPlanAccount(account)
+        ? apiKeyUsageMap[account.id]?.summary
+        : undefined;
       const subscriptionInfo = resolveSubscriptionPresentation(account);
       const showCompactExpiry =
         !isApiKeyAccount && !isAgentIdentityAccount && subscriptionInfo.bucket !== "active";
@@ -11186,6 +11327,44 @@ export function CodexAccountsPage() {
                         compactDeepSeekSummary,
                         "toppedUpBalance",
                       ),
+                    ],
+                  ] as const
+                ).map(([key, label, value]) => (
+                  <span
+                    key={`${account.id}-${key}`}
+                    className={`codex-compact-quota codex-compact-quota-${key}`}
+                    title={`${label} ${value}`}
+                  >
+                    <span className="codex-compact-dot" />
+                    <span className="codex-compact-quota-value high">
+                      {value}
+                    </span>
+                  </span>
+                ))}
+              </>
+            ) : isCodexTokenPlanAccount(account) ? (
+              <>
+                {(
+                  [
+                    [
+                      "remaining",
+                      t(
+                        "codex.modelProviders.usage.fields.remaining",
+                        "Remaining",
+                      ),
+                      formatApiKeyUsageMoney(
+                        compactTokenPlanSummary?.quotaRemaining ??
+                          compactTokenPlanSummary?.remaining,
+                        compactTokenPlanSummary?.unit,
+                      ),
+                    ],
+                    [
+                      "planName",
+                      t(
+                        "codex.modelProviders.usage.fields.planName",
+                        "Plan",
+                      ),
+                      compactTokenPlanSummary?.planName || "-",
                     ],
                   ] as const
                 ).map(([key, label, value]) => (
@@ -11345,6 +11524,8 @@ export function CodexAccountsPage() {
         showApiKeyUsagePanel &&
         (apiKeyUsageMode === "sub2api" ||
           apiKeyUsageProvider?.integrationType === "sub2api");
+      const isTokenPlanUsageAccount =
+        showApiKeyUsagePanel && apiKeyUsageMode === "token_plan";
       const isQuotaAwareApiKeyAccount =
         showApiKeyUsagePanel &&
         !isSponsorApiKeyAccount &&
@@ -11561,7 +11742,7 @@ export function CodexAccountsPage() {
                 >
                   {apiBaseUrlLine}
                 </span>
-                {isSub2ApiUsageAccount && (
+                {(isSub2ApiUsageAccount || isTokenPlanUsageAccount) && (
                   <button
                     type="button"
                     className="codex-provider-inline-switch"
@@ -12754,6 +12935,8 @@ export function CodexAccountsPage() {
         showApiKeyUsagePanel &&
         (apiKeyUsageMode === "sub2api" ||
           apiKeyUsageProvider?.integrationType === "sub2api");
+      const isTokenPlanUsageAccount =
+        showApiKeyUsagePanel && apiKeyUsageMode === "token_plan";
       const isQuotaAwareApiKeyAccount =
         showApiKeyUsagePanel &&
         !isSponsorApiKeyAccount &&
@@ -12929,7 +13112,7 @@ export function CodexAccountsPage() {
                     >
                       {apiBaseUrlLine}
                     </span>
-                    {isSub2ApiUsageAccount && (
+                    {(isSub2ApiUsageAccount || isTokenPlanUsageAccount) && (
                       <button
                         type="button"
                         className="codex-provider-inline-switch"
@@ -13408,8 +13591,10 @@ export function CodexAccountsPage() {
         ? new Set(["mode", "totalGranted", "totalAvailable", "expiresAt"])
         : usageMode === "sub2api"
           ? new Set(["mode", "remaining", "todayRequests", "todayTokens"])
-          : usageMode === "deepseek"
+        : usageMode === "deepseek"
             ? new Set(["mode", "totalBalance", "grantedBalance", "toppedUpBalance"])
+            : usageMode === "token_plan"
+              ? new Set(["mode", "remaining", "planName", "expiresAt"])
           : new Set<string>();
     const details = (summary?.details ?? []).filter(
       (item) => !coreDetailKeys.has(item.key),
@@ -13460,7 +13645,44 @@ export function CodexAccountsPage() {
                   : "-",
             },
           ]
-        : usageMode === "sub2api"
+        : usageMode === "token_plan"
+          ? [
+              {
+                key: "remaining",
+                label: t(
+                  "codex.modelProviders.usage.fields.remaining",
+                  "Remaining",
+                ),
+                value: formatApiKeyUsageQuotaValue(
+                  summary,
+                  summary?.quotaRemaining ?? summary?.remaining,
+                ),
+              },
+              {
+                key: "planName",
+                label: t(
+                  "codex.modelProviders.usage.fields.planName",
+                  "Plan",
+                ),
+                value: summary?.planName || "-",
+              },
+              {
+                key: "expiresAt",
+                label: t(
+                  "codex.modelProviders.usage.fields.expiresAt",
+                  "Next Reset",
+                ),
+                value: formatApiKeyUsageDetailByKey(
+                  summary,
+                  findApiKeyUsageDetail(summary, "intervalExpiresAt")
+                    ? "intervalExpiresAt"
+                    : findApiKeyUsageDetail(summary, "weeklyExpiresAt")
+                      ? "weeklyExpiresAt"
+                      : "expiresAt",
+                ),
+              },
+            ]
+          : usageMode === "sub2api"
           ? [
               {
                 key: "accountBalance",
@@ -13528,7 +13750,9 @@ export function CodexAccountsPage() {
               ]
           : [];
     const summaryGridClassName =
-      usageMode === "sub2api" || usageMode === "new_api"
+      usageMode === "sub2api" ||
+      usageMode === "new_api" ||
+      usageMode === "token_plan"
         ? "cockpit-api-summary-grid compact"
         : "cockpit-api-summary-grid";
 

--- a/src/services/modelProviderUsageService.test.ts
+++ b/src/services/modelProviderUsageService.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  formatModelProviderUsageMoney,
   resolveNewApiQuotaSnapshot,
   type ModelProviderUsageSummary,
 } from "./modelProviderUsageService.ts";
@@ -76,4 +77,8 @@ test("new_api quota ignores malformed numeric details", () => {
     available: 25,
     expiresAt: null,
   });
+});
+
+test("token plan percentages render without currency decimals", () => {
+  assert.equal(formatModelProviderUsageMoney(72, "%"), "72%");
 });

--- a/src/services/modelProviderUsageService.ts
+++ b/src/services/modelProviderUsageService.ts
@@ -1,7 +1,10 @@
 import { invoke } from '@tauri-apps/api/core';
 
 export type ModelProviderUsageIntegrationType = 'sub2api' | 'new_api';
-export type ModelProviderUsageMode = ModelProviderUsageIntegrationType | 'deepseek';
+export type ModelProviderUsageMode =
+  | ModelProviderUsageIntegrationType
+  | 'deepseek'
+  | 'token_plan';
 
 export interface ModelProviderModel {
   id: string;
@@ -158,7 +161,8 @@ export function resolveModelProviderUsageMode(
   if (
     summary.mode === 'new_api' ||
     summary.mode === 'sub2api' ||
-    summary.mode === 'deepseek'
+    summary.mode === 'deepseek' ||
+    summary.mode === 'token_plan'
   ) {
     return summary.mode;
   }
@@ -192,6 +196,9 @@ export function formatModelProviderUsageMoney(
 ): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) return '-';
   const normalizedUnit = unit?.trim() || 'USD';
+  if (normalizedUnit === '%') {
+    return `${Math.round(value)}%`;
+  }
   const formatted = value.toFixed(value >= 100 ? 0 : 2);
   if (normalizedUnit === 'USD') return `$${formatted}`;
   if (normalizedUnit === 'CNY') return `¥${formatted}`;

--- a/src/utils/codexDeepSeekAccess.test.ts
+++ b/src/utils/codexDeepSeekAccess.test.ts
@@ -6,6 +6,7 @@ import {
   isDeepSeekCdpAccess,
   isDeepSeekDirectAccess,
   isCodexApiKeyUsageQueryEligible,
+  isCodexTokenPlanAccount,
   parseCodexBoundAccountId,
   resolveDeepSeekAccessMode,
   resolveDeepSeekBindAccountId,
@@ -152,6 +153,47 @@ test("DeepSeek Responses accounts can query usage", () => {
     })),
     true,
   );
+});
+
+test("detects MiniMax and Zhipu Token Plan accounts", () => {
+  assert.equal(
+    isCodexTokenPlanAccount({
+      api_provider_id: "custom",
+      api_base_url: "https://api.minimaxi.com/v1",
+    }),
+    true,
+  );
+  assert.equal(
+    isCodexTokenPlanAccount({
+      api_provider_id: "custom",
+      api_base_url: "https://open.bigmodel.cn/api/coding/paas/v4",
+    }),
+    true,
+  );
+  assert.equal(
+    isCodexTokenPlanAccount({
+      api_provider_id: "custom",
+      api_base_url: "https://api.example.com/v1",
+    }),
+    false,
+  );
+});
+
+test("MiniMax and Zhipu Chat Completions accounts can query Token Plan usage", () => {
+  for (const baseUrl of [
+    "https://api.minimaxi.com/v1",
+    "https://open.bigmodel.cn/api/coding/paas/v4",
+  ]) {
+    const tokenPlanAccount = account({
+      auth_mode: "apikey",
+      api_provider_id: "custom",
+      api_base_url: baseUrl,
+      api_wire_api: "chat_completions",
+      openai_api_key: "sk-token-plan-test",
+    });
+    assert.equal(isCodexApiKeyUsageQueryEligible(tokenPlanAccount), true);
+    assert.equal(shouldShowCodexApiKeyUsagePanel(tokenPlanAccount, true), true);
+  }
 });
 
 test("ordinary Chat Completions accounts stay excluded from usage query", () => {

--- a/src/utils/codexDeepSeekAccess.ts
+++ b/src/utils/codexDeepSeekAccess.ts
@@ -48,6 +48,38 @@ export type DeepSeekStartChoice = {
   modelId: string;
 };
 
+export function isCodexTokenPlanAccount(
+  account: Pick<CodexAccount, "api_provider_id" | "api_base_url">,
+): boolean {
+  const providerId = (account.api_provider_id || "").trim().toLowerCase();
+  if (
+    providerId === "minimax" ||
+    providerId === "minimax-cn" ||
+    providerId === "minimax-portal" ||
+    providerId === "minimax-portal-cn" ||
+    providerId === "zhipu" ||
+    providerId === "zai" ||
+    providerId === "zai-coding-plan"
+  ) {
+    return true;
+  }
+  try {
+    const host = new URL((account.api_base_url || "").trim()).hostname.toLowerCase();
+    return [
+      "api.minimaxi.com",
+      "www.minimaxi.com",
+      "api.minimax.io",
+      "www.minimax.io",
+      "open.bigmodel.cn",
+      "bigmodel.cn",
+      "api.z.ai",
+      "z.ai",
+    ].includes(host);
+  } catch {
+    return false;
+  }
+}
+
 export function isDeepSeekAccount(
   account: Pick<CodexAccount, "api_provider_id" | "api_base_url">,
 ): boolean {
@@ -65,11 +97,13 @@ export function isDeepSeekAccount(
 export function isCodexApiKeyUsageQueryEligible(
   account: CodexAccount,
 ): boolean {
+  const tokenPlan = isCodexTokenPlanAccount(account);
   return (
     isCodexApiKeyAccount(account) &&
     !isCodexNewApiAccount(account) &&
     (!isCodexChatCompletionsApiKeyAccount(account) ||
-      isDeepSeekAccount(account)) &&
+      isDeepSeekAccount(account) ||
+      tokenPlan) &&
     Boolean(account.openai_api_key?.trim())
   );
 }
@@ -82,10 +116,11 @@ export function shouldShowCodexApiKeyUsagePanel(
     return false;
   }
   const deepseek = isDeepSeekAccount(account);
-  if (isCodexChatCompletionsApiKeyAccount(account) && !deepseek) {
+  const tokenPlan = isCodexTokenPlanAccount(account);
+  if (isCodexChatCompletionsApiKeyAccount(account) && !deepseek && !tokenPlan) {
     return false;
   }
-  return !hideRelayQuota || deepseek;
+  return !hideRelayQuota || deepseek || tokenPlan;
 }
 
 export function isDeepSeekResponsesAccount(


### PR DESCRIPTION
## Summary

- Add built-in quota queries for MiniMax Token Plan and Zhipu/GLM Coding Plan accounts.
- Support MiniMax count-based and time-window responses, including the current and weekly reset windows.
- Use the provider-specific authorization format and fall back to MiniMax's legacy endpoint when needed.
- Allow these Chat Completions accounts to refresh usage and show remaining percentage, plan, and reset information in Codex account views.

## Validation

- `npm run typecheck`
- `$env:COCKPIT_SKIP_CLIPROXY_BUILD='1'; cargo test --manifest-path src-tauri/Cargo.toml --lib token_plan -- --nocapture`

Fixes #1920
