### PR TITLE
fix(accounts): preserve account group data

### DIFF
--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -761,6 +761,30 @@ pub async fn sync_current_from_client(_app: tauri::AppHandle) -> Result<Option<S
 
 const GROUPS_FILE: &str = "account_groups.json";
 
+fn validate_account_groups_payload(data: &str) -> Result<(), String> {
+    let value = serde_json::from_str::<serde_json::Value>(data)
+        .map_err(|e| format!("Invalid groups JSON: {}", e))?;
+    let groups = value
+        .as_array()
+        .ok_or_else(|| "Account groups must be a JSON array".to_string())?;
+
+    for (index, group) in groups.iter().enumerate() {
+        let object = group
+            .as_object()
+            .ok_or_else(|| format!("Account group at index {} must be an object", index))?;
+        if let Some(account_ids) = object.get("accountIds") {
+            if !account_ids.is_array() {
+                return Err(format!(
+                    "Account group at index {} has invalid accountIds",
+                    index
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn load_account_groups() -> Result<String, String> {
     let path = modules::account::get_data_dir()?.join(GROUPS_FILE);
@@ -772,20 +796,41 @@ pub async fn load_account_groups() -> Result<String, String> {
 
 #[tauri::command]
 pub async fn save_account_groups(data: String) -> Result<(), String> {
+    validate_account_groups_payload(&data)?;
     let dir = modules::account::get_data_dir()?;
     if !dir.exists() {
         std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create dir: {}", e))?;
     }
     let path = dir.join(GROUPS_FILE);
-    std::fs::write(&path, data).map_err(|e| format!("Failed to write groups: {}", e))
+    modules::atomic_write::write_string_atomic(&path, &data)
+        .map_err(|e| format!("Failed to write groups: {}", e))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         normalize_antigravity_runtime_target, resolve_antigravity_switch_flow,
-        AntigravityRuntimeTarget, AntigravitySwitchFlow,
+        validate_account_groups_payload, AntigravityRuntimeTarget, AntigravitySwitchFlow,
     };
+
+    #[test]
+    fn account_groups_payload_must_be_a_json_array() {
+        assert!(validate_account_groups_payload("[]").is_ok());
+        assert!(validate_account_groups_payload(
+            r#"[{"id":"group-1","accountIds":[]}]"#
+        )
+        .is_ok());
+        assert!(validate_account_groups_payload("{}").is_err());
+        assert!(validate_account_groups_payload("not-json").is_err());
+    }
+
+    #[test]
+    fn account_groups_payload_rejects_invalid_account_ids() {
+        assert!(validate_account_groups_payload(
+            r#"[{"id":"group-1","accountIds":{}}]"#
+        )
+        .is_err());
+    }
 
     #[test]
     fn antigravity_switch_flow_uses_legacy_for_legacy_target() {

--- a/src/services/accountGroupService.ts
+++ b/src/services/accountGroupService.ts
@@ -23,6 +23,19 @@ export interface AccountGroup {
 // ─── 内存缓存 ───────────────────────────────────────
 let cachedGroups: AccountGroup[] | null = null;
 
+// Serialize read-modify-write operations so concurrent UI actions cannot
+// overwrite a newer group membership snapshot with a stale one.
+let groupsOperation: Promise<unknown> = Promise.resolve();
+
+function enqueue<T>(operation: () => Promise<T>): Promise<T> {
+  const next = groupsOperation.then(operation, operation);
+  groupsOperation = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+}
+
 function cloneGroups(groups: AccountGroup[]): AccountGroup[] {
   return groups.map((group) => ({
     ...group,
@@ -30,13 +43,57 @@ function cloneGroups(groups: AccountGroup[]): AccountGroup[] {
   }));
 }
 
+function parseGroups(raw: string): AccountGroup[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`[AccountGroups] Invalid JSON: ${String(error)}`);
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('[AccountGroups] Stored data must be a JSON array');
+  }
+
+  const groups = parsed.map((value, index) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error(`[AccountGroups] Invalid group at index ${index}`);
+    }
+
+    const group = value as Record<string, unknown>;
+    if (typeof group.id !== 'string' || !group.id.trim()) {
+      throw new Error(`[AccountGroups] Group ${index} has an invalid id`);
+    }
+    if (typeof group.name !== 'string') {
+      throw new Error(`[AccountGroups] Group ${index} has an invalid name`);
+    }
+    if (!Array.isArray(group.accountIds) || group.accountIds.some((id) => typeof id !== 'string')) {
+      throw new Error(`[AccountGroups] Group ${index} has invalid account ids`);
+    }
+
+    return {
+      ...group,
+      id: group.id,
+      name: group.name,
+      accountIds: [...group.accountIds],
+      // Keep older files without createdAt readable without treating them as
+      // an empty data set.
+      createdAt: typeof group.createdAt === 'number' ? group.createdAt : 0,
+    } as AccountGroup;
+  });
+
+  return cloneGroups(groups);
+}
+
 async function loadGroupsFromDisk(): Promise<AccountGroup[]> {
   try {
     const raw: string = await invoke('load_account_groups');
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? cloneGroups(parsed) : [];
-  } catch {
-    return [];
+    return parseGroups(raw);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('[AccountGroups]')) {
+      throw error;
+    }
+    throw new Error(`[AccountGroups] Failed to load groups: ${String(error)}`);
   }
 }
 
@@ -92,42 +149,48 @@ async function saveGroups(groups: AccountGroup[]): Promise<void> {
 
 // ─── 公开 API（全部改为 async） ───────────────────────
 
-export async function getAccountGroups(): Promise<AccountGroup[]> {
-  return loadGroups();
+export function getAccountGroups(): Promise<AccountGroup[]> {
+  return enqueue(() => loadGroups());
 }
 
-export async function createGroup(name: string): Promise<AccountGroup> {
-  const groups = await loadGroups();
-  const group: AccountGroup = {
-    id: generateId(),
-    name: name.trim(),
-    accountIds: [],
-    createdAt: Date.now(),
-  };
-  groups.push(group);
-  await saveGroups(groups);
-  return group;
+export function createGroup(name: string): Promise<AccountGroup> {
+  return enqueue(async () => {
+    const groups = await loadGroups();
+    const group: AccountGroup = {
+      id: generateId(),
+      name: name.trim(),
+      accountIds: [],
+      createdAt: Date.now(),
+    };
+    groups.push(group);
+    await saveGroups(groups);
+    return group;
+  });
 }
 
-export async function deleteGroup(groupId: string): Promise<void> {
-  const groups = (await loadGroups()).filter((g) => g.id !== groupId);
-  await saveGroups(groups);
+export function deleteGroup(groupId: string): Promise<void> {
+  return enqueue(async () => {
+    const groups = (await loadGroups()).filter((g) => g.id !== groupId);
+    await saveGroups(groups);
+  });
 }
 
-export async function renameGroup(groupId: string, name: string): Promise<AccountGroup | null> {
-  const groups = await loadGroups();
-  const group = groups.find((g) => g.id === groupId);
-  if (!group) return null;
-  group.name = name.trim();
-  await saveGroups(groups);
-  return group;
+export function renameGroup(groupId: string, name: string): Promise<AccountGroup | null> {
+  return enqueue(async () => {
+    const groups = await loadGroups();
+    const group = groups.find((g) => g.id === groupId);
+    if (!group) return null;
+    group.name = name.trim();
+    await saveGroups(groups);
+    return group;
+  });
 }
 
-export async function addAccountsToGroup(groupId: string, accountIds: string[]): Promise<AccountGroup | null> {
-  return assignAccountsToGroup(groupId, accountIds)
+export function addAccountsToGroup(groupId: string, accountIds: string[]): Promise<AccountGroup | null> {
+  return enqueue(() => assignAccountsToGroupInternal(groupId, accountIds));
 }
 
-export async function assignAccountsToGroup(groupId: string, accountIds: string[]): Promise<AccountGroup | null> {
+async function assignAccountsToGroupInternal(groupId: string, accountIds: string[]): Promise<AccountGroup | null> {
   const groups = await loadGroups();
   const group = groups.find((g) => g.id === groupId);
   if (!group) return null;
@@ -149,36 +212,46 @@ export async function assignAccountsToGroup(groupId: string, accountIds: string[
   return group;
 }
 
-export async function removeAccountsFromGroup(groupId: string, accountIds: string[]): Promise<AccountGroup | null> {
-  const groups = await loadGroups();
-  const group = groups.find((g) => g.id === groupId);
-  if (!group) return null;
-  const toRemove = new Set(accountIds);
-  group.accountIds = group.accountIds.filter((id) => !toRemove.has(id));
-  await saveGroups(groups);
-  return group;
+export function assignAccountsToGroup(groupId: string, accountIds: string[]): Promise<AccountGroup | null> {
+  return enqueue(() => assignAccountsToGroupInternal(groupId, accountIds));
+}
+
+export function removeAccountsFromGroup(groupId: string, accountIds: string[]): Promise<AccountGroup | null> {
+  return enqueue(async () => {
+    const groups = await loadGroups();
+    const group = groups.find((g) => g.id === groupId);
+    if (!group) return null;
+    const toRemove = new Set(accountIds);
+    group.accountIds = group.accountIds.filter((id) => !toRemove.has(id));
+    await saveGroups(groups);
+    return group;
+  });
 }
 
 /** 清理不存在的账号ID（当账号被删除时调用） */
-export async function cleanupDeletedAccounts(existingAccountIds: Set<string>): Promise<void> {
-  const groups = await loadGroups();
-  let changed = false;
-  for (const group of groups) {
-    const before = group.accountIds.length;
-    group.accountIds = group.accountIds.filter((id) => existingAccountIds.has(id));
-    if (group.accountIds.length !== before) changed = true;
-  }
-  if (changed) await saveGroups(groups);
+export function cleanupDeletedAccounts(existingAccountIds: Set<string>): Promise<void> {
+  return enqueue(async () => {
+    const groups = await loadGroups();
+    let changed = false;
+    for (const group of groups) {
+      const before = group.accountIds.length;
+      group.accountIds = group.accountIds.filter((id) => existingAccountIds.has(id));
+      if (group.accountIds.length !== before) changed = true;
+    }
+    if (changed) await saveGroups(groups);
+  });
 }
 
 /** 将账号从一个分组移动到另一个分组 */
-export async function moveAccountsBetweenGroups(
+export function moveAccountsBetweenGroups(
   fromGroupId: string,
   toGroupId: string,
   accountIds: string[]
 ): Promise<void> {
-  if (fromGroupId === toGroupId) return;
-  await assignAccountsToGroup(toGroupId, accountIds);
+  return enqueue(async () => {
+    if (fromGroupId === toGroupId) return;
+    await assignAccountsToGroupInternal(toGroupId, accountIds);
+  });
 }
 
 /** 使缓存失效，下次 getAccountGroups 时重新从磁盘读取 */


### PR DESCRIPTION
Fixes #1919

## What changed

- Fail closed when account-group storage cannot be read or parsed instead of caching an empty list.
- Serialize account-group read/modify/write operations to prevent concurrent stale writes.
- Validate saved group payloads and use the existing atomic-write helper for durable replacement.

## Validation

- `npm run typecheck`
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -p cockpit-tools commands::account::tests --lib`
- `git diff --check`
