### PR TITLE
fix: resolve Codex, Trae, Grok, and Linux issue batch

### DIFF
--- a/crates/cockpit-core/src/modules/trae_account.rs
+++ b/crates/cockpit-core/src/modules/trae_account.rs
@@ -1136,6 +1136,121 @@ fn apply_payload(account: &mut TraeAccount, payload: TraeImportPayload) {
     account.last_used = now_ts();
 }
 
+fn is_runtime_preserved_auth_key(key: &str) -> bool {
+    matches!(
+        key,
+        "platformId"
+            | "platform_id"
+            | "platform"
+            | "callbackQuery"
+            | "callback_query"
+            | "deviceInfo"
+            | "device_info"
+            | "deviceKeyPair"
+            | "device_key_pair"
+            | "exchangeResponse"
+            | "exchange_response"
+            | "host"
+            | "loginHost"
+            | "login_host"
+            | "authDomain"
+            | "auth_domain"
+            | "clientId"
+            | "client_id"
+            | "ClientID"
+            | "scope"
+    )
+}
+
+fn merge_runtime_json(existing: Option<&Value>, incoming: Option<&Value>) -> Option<Value> {
+    let Some(incoming) = incoming else {
+        return existing.cloned();
+    };
+    let Some(incoming_object) = incoming.as_object() else {
+        return Some(incoming.clone());
+    };
+
+    let mut merged = existing
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for (key, incoming_value) in incoming_object {
+        if is_runtime_preserved_auth_key(key) && merged.contains_key(key) {
+            continue;
+        }
+        let value = match merged.get(key) {
+            Some(existing_value)
+                if existing_value.is_object() && incoming_value.is_object() => {
+                merge_runtime_json(Some(existing_value), Some(incoming_value))
+                    .unwrap_or_else(|| incoming_value.clone())
+            }
+            _ => incoming_value.clone(),
+        };
+        merged.insert(key.clone(), value);
+    }
+    Some(Value::Object(merged))
+}
+
+fn apply_runtime_session_payload(account: &mut TraeAccount, payload: TraeImportPayload) {
+    if !payload.access_token.trim().is_empty() {
+        account.access_token = payload.access_token.clone();
+    }
+    if let Some(refresh_token) = normalize_non_empty(payload.refresh_token.as_deref()) {
+        account.refresh_token = Some(refresh_token);
+    }
+    if let Some(token_type) = normalize_non_empty(payload.token_type.as_deref()) {
+        account.token_type = Some(token_type);
+    }
+    if payload.expires_at.is_some() {
+        account.expires_at = normalize_timestamp(payload.expires_at);
+    }
+
+    let mut auth_raw = merge_runtime_json(
+        account.trae_auth_raw.as_ref(),
+        payload.trae_auth_raw.as_ref(),
+    )
+    .unwrap_or_else(|| Value::Object(Map::new()));
+    if let Some(auth_object) = auth_raw.as_object_mut() {
+        auth_object.insert(
+            "accessToken".to_string(),
+            Value::String(account.access_token.clone()),
+        );
+        auth_object.insert("token".to_string(), Value::String(account.access_token.clone()));
+        if let Some(refresh_token) = account.refresh_token.as_ref() {
+            auth_object.insert(
+                "refreshToken".to_string(),
+                Value::String(refresh_token.clone()),
+            );
+        }
+        if let Some(token_type) = account.token_type.as_ref() {
+            auth_object.insert("tokenType".to_string(), Value::String(token_type.clone()));
+        }
+        if let Some(expires_at) = account.expires_at {
+            auth_object.insert(
+                "expiresAt".to_string(),
+                Value::Number(serde_json::Number::from(expires_at)),
+            );
+        }
+    }
+    account.trae_auth_raw = Some(auth_raw);
+    account.trae_profile_raw = merge_runtime_json(
+        account.trae_profile_raw.as_ref(),
+        payload.trae_profile_raw.as_ref(),
+    );
+    account.trae_entitlement_raw = merge_runtime_json(
+        account.trae_entitlement_raw.as_ref(),
+        payload.trae_entitlement_raw.as_ref(),
+    );
+    account.trae_usage_raw = merge_runtime_json(
+        account.trae_usage_raw.as_ref(),
+        payload.trae_usage_raw.as_ref(),
+    );
+    account.trae_server_raw = merge_runtime_json(
+        account.trae_server_raw.as_ref(),
+        payload.trae_server_raw.as_ref(),
+    );
+}
+
 pub fn list_accounts() -> Vec<TraeAccount> {
     let index = load_account_index();
     index
@@ -4523,7 +4638,7 @@ fn apply_runtime_storage_payload_for_usage_refresh(
     }
 
     let previous_access_token = account.access_token.clone();
-    apply_payload(account, payload);
+    apply_runtime_session_payload(account, payload);
     logger::log_info(&format!(
         "[Trae Refresh] 已同步运行中实例会话快照: account_id={}, path={}, token_changed={}",
         account.id,
@@ -4793,6 +4908,84 @@ mod tests {
                 .and_then(Value::as_str),
             Some("李杰")
         );
+    }
+
+    #[test]
+    fn runtime_session_merge_preserves_oauth_context() {
+        let mut account = sample_account();
+        account.trae_auth_raw = Some(serde_json::json!({
+            "platformId": "trae_solo_cn",
+            "callbackQuery": {
+                "scope": "solo",
+                "host": "https://api.trae.com.cn"
+            },
+            "deviceInfo": {
+                "PlatformCode": "SOLO_PC",
+                "DeviceID": "device-old"
+            },
+            "deviceKeyPair": {
+                "privateKeyPEM": "private-old",
+                "publicKeyPEM": "public-old"
+            },
+            "exchangeResponse": {
+                "Result": { "ClientID": "solo-client" }
+            },
+            "nested": { "keep": "old" }
+        }));
+
+        let email = account.email.clone();
+        let user_id = account.user_id.clone();
+        apply_runtime_session_payload(
+            &mut account,
+            TraeImportPayload {
+                email,
+                user_id,
+                nickname: None,
+                access_token: "new-access".to_string(),
+                refresh_token: Some("new-refresh".to_string()),
+                token_type: Some("Bearer".to_string()),
+                expires_at: Some(1_800_000_000),
+                plan_type: None,
+                plan_reset_at: None,
+                trae_auth_raw: Some(serde_json::json!({
+                    "platformId": "trae_cn",
+                    "callbackQuery": {
+                        "scope": "cn",
+                        "host": "https://api.trae.cn"
+                    },
+                    "deviceInfo": {
+                        "PlatformCode": "CN_PC",
+                        "DeviceID": "device-new"
+                    },
+                    "deviceKeyPair": {
+                        "privateKeyPEM": "private-new",
+                        "publicKeyPEM": "public-new"
+                    },
+                    "exchangeResponse": {
+                        "Result": { "ClientID": "cn-client" }
+                    },
+                    "nested": { "added": "runtime" }
+                })),
+                trae_profile_raw: None,
+                trae_entitlement_raw: None,
+                trae_usage_raw: None,
+                trae_server_raw: None,
+                trae_usertag_raw: None,
+                status: None,
+                status_reason: None,
+            },
+        );
+
+        let auth = account.trae_auth_raw.as_ref().unwrap();
+        assert_eq!(account.access_token, "new-access");
+        assert_eq!(account.refresh_token.as_deref(), Some("new-refresh"));
+        assert_eq!(auth["platformId"], "trae_solo_cn");
+        assert_eq!(auth["callbackQuery"]["scope"], "solo");
+        assert_eq!(auth["deviceInfo"]["DeviceID"], "device-old");
+        assert_eq!(auth["deviceKeyPair"]["publicKeyPEM"], "public-old");
+        assert_eq!(auth["exchangeResponse"]["Result"]["ClientID"], "solo-client");
+        assert_eq!(auth["nested"]["keep"], "old");
+        assert_eq!(auth["nested"]["added"], "runtime");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -202,6 +202,20 @@ fn summarize_deep_link_args(args: &[String]) -> Vec<String> {
         .collect()
 }
 
+#[cfg(target_os = "linux")]
+fn configure_linux_main_window(app: &tauri::AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        logger::log_warn("[Linux] main window not found while applying window controls");
+        return;
+    };
+    if let Err(err) = window.set_decorations(false) {
+        logger::log_warn(&format!(
+            "[Linux] failed to disable native decorations: {}",
+            err
+        ));
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     logger::init_logger();
@@ -267,6 +281,9 @@ pub fn run() {
 
             // 存储全局 AppHandle
             let _ = APP_HANDLE.set(app.handle().clone());
+
+            #[cfg(target_os = "linux")]
+            configure_linux_main_window(app.handle());
 
             if let Err(err) = modules::app_lifecycle::install_system_shutdown_listener() {
                 logger::log_warn(&format!("[Lifecycle] 安装系统关机监听失败: {}", err));

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -17354,8 +17354,34 @@ pub(crate) fn provider_model_slots_need_upstream_rewrite(
         .any(|slot| !slot.client_model.eq_ignore_ascii_case(&slot.upstream_model))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderModelCatalogCapabilities {
+    /// Responses Lite is an internal Codex transport contract. Providers must
+    /// opt in explicitly; an unknown or third-party Responses provider stays
+    /// on the public Responses shape.
+    pub(crate) supports_responses_lite: bool,
+}
+
+impl Default for ProviderModelCatalogCapabilities {
+    fn default() -> Self {
+        Self {
+            supports_responses_lite: false,
+        }
+    }
+}
+
 pub(crate) fn build_provider_model_catalog_json(
     slots: &[ProviderGatewayModelSlot],
+) -> Result<String, String> {
+    build_provider_model_catalog_json_with_capabilities(
+        slots,
+        ProviderModelCatalogCapabilities::default(),
+    )
+}
+
+pub(crate) fn build_provider_model_catalog_json_with_capabilities(
+    slots: &[ProviderGatewayModelSlot],
+    capabilities: ProviderModelCatalogCapabilities,
 ) -> Result<String, String> {
     let mut model_ids = slots
         .iter()
@@ -17401,6 +17427,9 @@ pub(crate) fn build_provider_model_catalog_json(
             // Ensure mapped provider models show up in the official picker.
             if !slug.eq_ignore_ascii_case(CODEX_AUTO_REVIEW_MODEL_ID) {
                 object.insert("visibility".to_string(), Value::String("list".to_string()));
+            }
+            if !capabilities.supports_responses_lite {
+                object.insert("use_responses_lite".to_string(), Value::Bool(false));
             }
         }
     }
@@ -27012,6 +27041,58 @@ mod tests {
         assert_eq!(window("gpt-5.4"), Some(272000));
         assert_eq!(window("gpt-5.6-sol"), Some(900_000));
         assert_eq!(window("gpt-5.5"), Some(1048576));
+    }
+
+    #[test]
+    fn provider_catalog_normalizes_responses_lite_per_capability() {
+        let slots = vec![
+            super::ProviderGatewayModelSlot {
+                client_model: "gpt-5.6-sol".to_string(),
+                upstream_model: "relay-sol".to_string(),
+            },
+            super::ProviderGatewayModelSlot {
+                client_model: "gpt-5.6-terra".to_string(),
+                upstream_model: "relay-terra".to_string(),
+            },
+        ];
+        let standard: serde_json::Value = serde_json::from_str(
+            &super::build_provider_model_catalog_json(&slots).expect("standard catalog"),
+        )
+        .expect("parse standard catalog");
+        let lite: serde_json::Value = serde_json::from_str(
+            &super::build_provider_model_catalog_json_with_capabilities(
+                &slots,
+                super::ProviderModelCatalogCapabilities {
+                    supports_responses_lite: true,
+                },
+            )
+            .expect("lite catalog"),
+        )
+        .expect("parse lite catalog");
+
+        for slug in ["gpt-5.6-sol", "gpt-5.6-terra"] {
+            let standard_model = standard["models"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|model| model["slug"] == slug)
+                .expect("standard model");
+            let lite_model = lite["models"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|model| model["slug"] == slug)
+                .expect("lite model");
+            assert_eq!(
+                standard_model["use_responses_lite"],
+                serde_json::json!(false)
+            );
+            assert_eq!(lite_model["use_responses_lite"], serde_json::json!(true));
+            assert_eq!(
+                standard_model["multi_agent_version"],
+                lite_model["multi_agent_version"],
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/modules/grok_account.rs
+++ b/src-tauri/src/modules/grok_account.rs
@@ -3,9 +3,10 @@ use crate::models::grok::{
     GrokProductUsage, GrokQuota,
 };
 use crate::modules::{account, atomic_write, config, grok_oauth, logger, provider_current_state};
+use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use chrono::{DateTime, Utc};
 use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
@@ -1712,6 +1713,97 @@ fn raw_string(value: Option<&Value>) -> Option<String> {
         .and_then(|value| normalize_text(Some(value)))
 }
 
+fn normalized_tier(value: &str) -> String {
+    value
+        .trim()
+        .to_ascii_uppercase()
+        .replace(' ', "_")
+        .replace('-', "_")
+}
+
+fn tier_is_heavy(value: &str) -> bool {
+    let normalized = normalized_tier(value).replace('_', "");
+    normalized.contains("SUPERGROKHEAVY") || normalized.contains("GROKHEAVY")
+}
+
+fn subscription_tier_from_value(value: &Value) -> Option<String> {
+    [
+        "tier",
+        "subscriptionTier",
+        "subscription_tier",
+        "plan",
+        "planType",
+    ]
+    .iter()
+    .find_map(|key| raw_string(value.get(*key)))
+}
+
+fn decode_access_token_payload(access_token: &str) -> Option<Value> {
+    let encoded = access_token.split('.').nth(1)?.trim();
+    if encoded.is_empty() {
+        return None;
+    }
+    let mut padded = encoded.to_string();
+    while padded.len() % 4 != 0 {
+        padded.push('=');
+    }
+    let bytes = URL_SAFE.decode(padded).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn access_token_subscription_tier(access_token: &str) -> Option<String> {
+    let payload = decode_access_token_payload(access_token)?;
+    let raw = payload
+        .get("subscriptionTier")
+        .or_else(|| payload.get("subscription_tier"))
+        .or_else(|| payload.get("tier"));
+    match raw {
+        Some(Value::String(value)) => normalize_text(Some(value)),
+        Some(Value::Number(value)) => match value.as_u64() {
+            Some(0) => Some("SUBSCRIPTION_TIER_FREE".to_string()),
+            Some(1) => Some("SUBSCRIPTION_TIER_SUPERGROK".to_string()),
+            Some(2) => Some("SUBSCRIPTION_TIER_X_BASIC".to_string()),
+            Some(3) => Some("SUBSCRIPTION_TIER_X_PREMIUM".to_string()),
+            Some(4) => Some("SUBSCRIPTION_TIER_X_PREMIUM_PLUS".to_string()),
+            Some(5) => Some("SUBSCRIPTION_TIER_SUPERGROK_HEAVY".to_string()),
+            Some(6) => Some("SUBSCRIPTION_TIER_SUPERGROK_LITE".to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn resolve_subscription_tier(
+    config: &Value,
+    subscription: Option<&Value>,
+    cli_user: Option<&Value>,
+    access_token_tier: Option<&str>,
+) -> Option<String> {
+    let mut candidates = Vec::new();
+    if let Some(value) = raw_string(config.get("subscription_tier"))
+        .or_else(|| raw_string(config.get("subscriptionTier")))
+    {
+        candidates.push(value);
+    }
+    if let Some(value) = subscription.and_then(subscription_tier_from_value) {
+        candidates.push(value);
+    }
+    if let Some(value) = cli_user
+        .map(user_payload)
+        .and_then(subscription_tier_from_value)
+    {
+        candidates.push(value);
+    }
+    if let Some(value) = access_token_tier.and_then(|value| normalize_text(Some(value))) {
+        candidates.push(value);
+    }
+
+    if candidates.iter().any(|value| tier_is_heavy(value)) {
+        return Some("SUBSCRIPTION_TIER_SUPERGROK_HEAVY".to_string());
+    }
+    candidates.into_iter().next()
+}
+
 fn active_subscription(value: &Value) -> Option<&Value> {
     value
         .get("subscriptions")
@@ -1841,13 +1933,23 @@ fn credit_usage_amounts(billing: &Value, config: &Value) -> (Option<f64>, Option
         .unwrap_or((None, None))
 }
 
-fn product_usage_from_value(item: &Value) -> Option<GrokProductUsage> {
+fn product_usage_from_value(
+    item: &Value,
+    fallback_product: Option<&str>,
+) -> Option<GrokProductUsage> {
     let product = raw_string(item.get("product"))
         .or_else(|| raw_string(item.get("name")))
-        .or_else(|| raw_string(item.get("productName")))?;
-    let (used, total, remaining) = credit_bag_amounts(item).unwrap_or((None, None, None));
+        .or_else(|| raw_string(item.get("productName")))
+        .or_else(|| raw_string(item.get("productId")))
+        .or_else(|| fallback_product.and_then(|value| normalize_text(Some(value))))?;
+    let usage = item.get("usage").filter(|value| value.is_object());
+    let (used, total, remaining) = credit_bag_amounts(item)
+        .or_else(|| usage.and_then(credit_bag_amounts))
+        .unwrap_or((None, None, None));
     let usage_percent = number(item.get("usagePercent"))
         .or_else(|| number(item.get("usedPercent")))
+        .or_else(|| usage.and_then(|value| number(value.get("usagePercent"))))
+        .or_else(|| usage.and_then(|value| number(value.get("usedPercent"))))
         .or_else(|| match (used, total) {
             (Some(used), Some(total)) if total > 0.0 => {
                 Some(((used.max(0.0) / total) * 100.0).clamp(0.0, 100.0))
@@ -1863,41 +1965,57 @@ fn product_usage_from_value(item: &Value) -> Option<GrokProductUsage> {
     })
 }
 
+fn product_usages_from_value(value: &Value) -> Vec<GrokProductUsage> {
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .filter(|item| item.is_object())
+            .filter_map(|item| product_usage_from_value(item, None))
+            .collect(),
+        Value::Object(items) => items
+            .iter()
+            .filter(|(_, item)| item.is_object())
+            .filter_map(|(name, item)| product_usage_from_value(item, Some(name)))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 fn quota_from_payload(
     billing: &Value,
     subscriptions: Option<&Value>,
     cli_user: Option<&Value>,
     task_usage: Option<&Value>,
+    access_token_tier: Option<&str>,
 ) -> GrokQuota {
     let config = billing.get("config").unwrap_or(billing);
-    let period = config.get("currentPeriod").unwrap_or(&Value::Null);
+    let period = config
+        .get("currentPeriod")
+        .or_else(|| config.get("current_period"))
+        .unwrap_or(&Value::Null);
     let subscription = cli_user
         .and_then(user_subscription)
         .or_else(|| subscriptions.and_then(active_subscription))
         .or_else(|| active_subscription(config));
-    let subscription_tier = raw_string(config.get("subscription_tier"))
-        .or_else(|| raw_string(config.get("subscriptionTier")))
-        .or_else(|| subscription.and_then(|item| raw_string(item.get("tier"))))
-        .or_else(|| {
-            cli_user.and_then(|value| {
-                let user = user_payload(value);
-                raw_string(user.get("subscriptionTier"))
-                    .or_else(|| raw_string(user.get("subscription_tier")))
-            })
-        });
+    let subscription_tier =
+        resolve_subscription_tier(config, subscription, cli_user, access_token_tier);
     let products = config
         .get("productUsage")
-        .and_then(Value::as_array)
-        .map(|items| items.iter().filter_map(product_usage_from_value).collect())
+        .or_else(|| config.get("product_usage"))
+        .or_else(|| config.get("products"))
+        .map(product_usages_from_value)
         .unwrap_or_default();
     let (weekly_used, weekly_total) = credit_usage_amounts(billing, config);
     GrokQuota {
         period_type: raw_string(period.get("type")),
         period_start: raw_string(period.get("start"))
-            .or_else(|| raw_string(config.get("billingPeriodStart"))),
+            .or_else(|| raw_string(config.get("billingPeriodStart")))
+            .or_else(|| raw_string(config.get("billing_period_start"))),
         period_end: raw_string(period.get("end"))
-            .or_else(|| raw_string(config.get("billingPeriodEnd"))),
+            .or_else(|| raw_string(config.get("billingPeriodEnd")))
+            .or_else(|| raw_string(config.get("billing_period_end"))),
         weekly_limit_percent: number(config.get("creditUsagePercent"))
+            .or_else(|| number(config.get("credit_usage_percent")))
             .or_else(|| credit_usage_percent(billing, config)),
         weekly_used,
         weekly_total,
@@ -1909,7 +2027,13 @@ fn quota_from_payload(
         occasional_usage: task_usage.and_then(|value| nested_number(value, "occasionalUsage")),
         occasional_limit: task_usage.and_then(|value| nested_number(value, "occasionalLimit")),
         subscription_tier,
-        subscription_status: subscription.and_then(|item| raw_string(item.get("status"))),
+        subscription_status: subscription
+            .and_then(|item| raw_string(item.get("status")))
+            .or_else(|| {
+                cli_user
+                    .and_then(|value| user_subscription(value))
+                    .and_then(|item| raw_string(item.get("status")))
+            }),
         products,
     }
 }
@@ -2466,11 +2590,13 @@ async fn query_quota(account: &mut GrokAccount) -> Result<(), String> {
         subscriptions_for(account, &client_version).await
     };
     let task_usage_result = task_usage_for(account).await;
+    let access_token_tier = access_token_subscription_tier(&account.access_token);
     let quota = quota_from_payload(
         &billing,
         subscriptions.as_ref(),
         cli_user.as_ref(),
         task_usage_result.as_ref().ok(),
+        access_token_tier.as_deref(),
     );
     let has_usage_quota = quota.weekly_limit_percent.is_some()
         || quota
@@ -2481,7 +2607,9 @@ async fn query_quota(account: &mut GrokAccount) -> Result<(), String> {
         || quota.prepaid_balance.is_some_and(|value| value > 0.0)
         || quota.frequent_limit.is_some_and(|value| value > 0.0)
         || quota.occasional_limit.is_some_and(|value| value > 0.0);
-    account.plan_type = quota.subscription_tier.clone();
+    if quota.subscription_tier.is_some() {
+        account.plan_type = quota.subscription_tier.clone();
+    }
     account.quota = Some(quota);
     account.billing_raw = Some(billing);
     account.subscription_raw = subscriptions;
@@ -2898,11 +3026,11 @@ pub fn run_quota_alert_if_needed() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        access_still_usable, account_from_auth_object, accounts_match_for_upsert,
-        acquire_secret_lock, apply_refreshed_token, auth_entry_matches_account,
-        auth_registry_entry, auth_registry_for, default_grok_home, ensure_secret_dir,
-        find_matching_auth_entry_in_registry, list_accounts_checked, load_account,
-        load_account_from_path, load_index_from_paths, parse_auth_registry,
+        access_still_usable, access_token_subscription_tier, account_from_auth_object,
+        accounts_match_for_upsert, acquire_secret_lock, apply_refreshed_token,
+        auth_entry_matches_account, auth_registry_entry, auth_registry_for, default_grok_home,
+        ensure_secret_dir, find_matching_auth_entry_in_registry, list_accounts_checked,
+        load_account, load_account_from_path, load_index_from_paths, parse_auth_registry,
         pick_best_live_credential, quota_from_payload, quota_remaining_metrics, remove_account,
         remove_matching_auth_scope, resolve_account_id_from_registry, save_account_locked,
         should_retry_quota_after_unauthorized, string_field, validate_api_provider_config,
@@ -2912,6 +3040,7 @@ mod tests {
     use crate::models::grok::{
         GrokAccount, GrokAccountView, GrokAuthMode, GrokProductUsage, GrokQuota,
     };
+    use base64::{engine::general_purpose::URL_SAFE, Engine as _};
     use serde_json::{json, Value};
     use std::path::PathBuf;
 
@@ -3680,7 +3809,7 @@ mod tests {
                 "productUsage": [{"product":"coding", "usagePercent":12.0}]
             }
         });
-        let quota = quota_from_payload(&billing, None, None, None);
+        let quota = quota_from_payload(&billing, None, None, None, None);
         assert_eq!(
             quota.subscription_tier.as_deref(),
             Some("SUBSCRIPTION_TIER_SUPERGROK")
@@ -3700,7 +3829,7 @@ mod tests {
                 }
             }
         });
-        let quota = quota_from_payload(&billing, None, None, None);
+        let quota = quota_from_payload(&billing, None, None, None, None);
         assert_eq!(quota.weekly_limit_percent, Some(25.0));
         assert_eq!(quota.weekly_used, Some(25.0));
         assert_eq!(quota.weekly_total, Some(100.0));
@@ -3720,7 +3849,7 @@ mod tests {
                 }]
             }
         });
-        let quota = quota_from_payload(&billing, None, None, None);
+        let quota = quota_from_payload(&billing, None, None, None, None);
         assert_eq!(quota.products[0].product, "GrokBuild");
         assert_eq!(quota.products[0].usage_percent, Some(40.0));
         assert_eq!(quota.products[0].used, Some(40.0));
@@ -3738,7 +3867,7 @@ mod tests {
                 "status": "SUBSCRIPTION_STATUS_ACTIVE"
             }
         });
-        let quota = quota_from_payload(&billing, None, Some(&cli_user), None);
+        let quota = quota_from_payload(&billing, None, Some(&cli_user), None, None);
         assert_eq!(
             quota.subscription_tier.as_deref(),
             Some("SUBSCRIPTION_TIER_SUPERGROK_HEAVY")
@@ -3750,6 +3879,41 @@ mod tests {
     }
 
     #[test]
+    fn resolves_heavy_tier_from_token_and_object_product_usage() {
+        let header = URL_SAFE.encode(br#"{"alg":"none","typ":"JWT"}"#);
+        let payload = URL_SAFE.encode(br#"{"tier":5}"#);
+        let access_token = format!("{header}.{payload}.signature");
+        assert_eq!(
+            access_token_subscription_tier(&access_token).as_deref(),
+            Some("SUBSCRIPTION_TIER_SUPERGROK_HEAVY")
+        );
+
+        let billing = json!({
+            "config": {
+                "current_period": {"end": "2099-01-01T00:00:00Z"},
+                "credit_usage_percent": 18.0,
+                "productUsage": {
+                    "GrokBuild": {"usagePercent": 32.0}
+                }
+            }
+        });
+        let quota = quota_from_payload(
+            &billing,
+            None,
+            None,
+            None,
+            Some("SUBSCRIPTION_TIER_SUPERGROK_HEAVY"),
+        );
+        assert_eq!(
+            quota.subscription_tier.as_deref(),
+            Some("SUBSCRIPTION_TIER_SUPERGROK_HEAVY")
+        );
+        assert_eq!(quota.weekly_limit_percent, Some(18.0));
+        assert_eq!(quota.products[0].product, "GrokBuild");
+        assert_eq!(quota.products[0].usage_percent, Some(32.0));
+    }
+
+    #[test]
     fn parses_task_usage_limits() {
         let billing = json!({"config": {}});
         let task_usage = json!({
@@ -3758,7 +3922,7 @@ mod tests {
             "occasionalUsage": 3,
             "occasionalLimit": 30
         });
-        let quota = quota_from_payload(&billing, None, None, Some(&task_usage));
+        let quota = quota_from_payload(&billing, None, None, Some(&task_usage), None);
         assert_eq!(quota.frequent_usage, Some(2.0));
         assert_eq!(quota.frequent_limit, Some(10.0));
         assert_eq!(quota.occasional_usage, Some(3.0));

--- a/src-tauri/src/modules/trae_account.rs
+++ b/src-tauri/src/modules/trae_account.rs
@@ -1237,6 +1237,121 @@ fn apply_payload(account: &mut TraeAccount, payload: TraeImportPayload) {
     account.last_used = now_ts();
 }
 
+fn is_runtime_preserved_auth_key(key: &str) -> bool {
+    matches!(
+        key,
+        "platformId"
+            | "platform_id"
+            | "platform"
+            | "callbackQuery"
+            | "callback_query"
+            | "deviceInfo"
+            | "device_info"
+            | "deviceKeyPair"
+            | "device_key_pair"
+            | "exchangeResponse"
+            | "exchange_response"
+            | "host"
+            | "loginHost"
+            | "login_host"
+            | "authDomain"
+            | "auth_domain"
+            | "clientId"
+            | "client_id"
+            | "ClientID"
+            | "scope"
+    )
+}
+
+fn merge_runtime_json(existing: Option<&Value>, incoming: Option<&Value>) -> Option<Value> {
+    let Some(incoming) = incoming else {
+        return existing.cloned();
+    };
+    let Some(incoming_object) = incoming.as_object() else {
+        return Some(incoming.clone());
+    };
+
+    let mut merged = existing
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for (key, incoming_value) in incoming_object {
+        if is_runtime_preserved_auth_key(key) && merged.contains_key(key) {
+            continue;
+        }
+        let value = match merged.get(key) {
+            Some(existing_value)
+                if existing_value.is_object() && incoming_value.is_object() => {
+                merge_runtime_json(Some(existing_value), Some(incoming_value))
+                    .unwrap_or_else(|| incoming_value.clone())
+            }
+            _ => incoming_value.clone(),
+        };
+        merged.insert(key.clone(), value);
+    }
+    Some(Value::Object(merged))
+}
+
+fn apply_runtime_session_payload(account: &mut TraeAccount, payload: TraeImportPayload) {
+    if !payload.access_token.trim().is_empty() {
+        account.access_token = payload.access_token.clone();
+    }
+    if let Some(refresh_token) = normalize_non_empty(payload.refresh_token.as_deref()) {
+        account.refresh_token = Some(refresh_token);
+    }
+    if let Some(token_type) = normalize_non_empty(payload.token_type.as_deref()) {
+        account.token_type = Some(token_type);
+    }
+    if payload.expires_at.is_some() {
+        account.expires_at = normalize_timestamp(payload.expires_at);
+    }
+
+    let mut auth_raw = merge_runtime_json(
+        account.trae_auth_raw.as_ref(),
+        payload.trae_auth_raw.as_ref(),
+    )
+    .unwrap_or_else(|| Value::Object(Map::new()));
+    if let Some(auth_object) = auth_raw.as_object_mut() {
+        auth_object.insert(
+            "accessToken".to_string(),
+            Value::String(account.access_token.clone()),
+        );
+        auth_object.insert("token".to_string(), Value::String(account.access_token.clone()));
+        if let Some(refresh_token) = account.refresh_token.as_ref() {
+            auth_object.insert(
+                "refreshToken".to_string(),
+                Value::String(refresh_token.clone()),
+            );
+        }
+        if let Some(token_type) = account.token_type.as_ref() {
+            auth_object.insert("tokenType".to_string(), Value::String(token_type.clone()));
+        }
+        if let Some(expires_at) = account.expires_at {
+            auth_object.insert(
+                "expiresAt".to_string(),
+                Value::Number(serde_json::Number::from(expires_at)),
+            );
+        }
+    }
+    account.trae_auth_raw = Some(auth_raw);
+    account.trae_profile_raw = merge_runtime_json(
+        account.trae_profile_raw.as_ref(),
+        payload.trae_profile_raw.as_ref(),
+    );
+    account.trae_entitlement_raw = merge_runtime_json(
+        account.trae_entitlement_raw.as_ref(),
+        payload.trae_entitlement_raw.as_ref(),
+    );
+    account.trae_usage_raw = merge_runtime_json(
+        account.trae_usage_raw.as_ref(),
+        payload.trae_usage_raw.as_ref(),
+    );
+    account.trae_server_raw = merge_runtime_json(
+        account.trae_server_raw.as_ref(),
+        payload.trae_server_raw.as_ref(),
+    );
+}
+
 pub fn list_accounts() -> Vec<TraeAccount> {
     let index = load_account_index();
     index
@@ -4851,7 +4966,7 @@ fn sync_account_tokens_from_storage_path(
 
     let previous_access_token = account.access_token.clone();
     let previous_refresh_token = account.refresh_token.clone();
-    apply_payload(account, payload);
+    apply_runtime_session_payload(account, payload);
     let token_changed = previous_access_token != account.access_token
         || previous_refresh_token != account.refresh_token;
     logger::log_info(&format!(
@@ -5716,6 +5831,84 @@ mod tests {
                 .and_then(Value::as_str),
             Some("李杰")
         );
+    }
+
+    #[test]
+    fn runtime_session_merge_preserves_oauth_context() {
+        let mut account = sample_account();
+        account.trae_auth_raw = Some(serde_json::json!({
+            "platformId": "trae_solo_cn",
+            "callbackQuery": {
+                "scope": "solo",
+                "host": "https://api.trae.com.cn"
+            },
+            "deviceInfo": {
+                "PlatformCode": "SOLO_PC",
+                "DeviceID": "device-old"
+            },
+            "deviceKeyPair": {
+                "privateKeyPEM": "private-old",
+                "publicKeyPEM": "public-old"
+            },
+            "exchangeResponse": {
+                "Result": { "ClientID": "solo-client" }
+            },
+            "nested": { "keep": "old" }
+        }));
+
+        let email = account.email.clone();
+        let user_id = account.user_id.clone();
+        apply_runtime_session_payload(
+            &mut account,
+            TraeImportPayload {
+                email,
+                user_id,
+                nickname: None,
+                access_token: "new-access".to_string(),
+                refresh_token: Some("new-refresh".to_string()),
+                token_type: Some("Bearer".to_string()),
+                expires_at: Some(1_800_000_000),
+                plan_type: None,
+                plan_reset_at: None,
+                trae_auth_raw: Some(serde_json::json!({
+                    "platformId": "trae_cn",
+                    "callbackQuery": {
+                        "scope": "cn",
+                        "host": "https://api.trae.cn"
+                    },
+                    "deviceInfo": {
+                        "PlatformCode": "CN_PC",
+                        "DeviceID": "device-new"
+                    },
+                    "deviceKeyPair": {
+                        "privateKeyPEM": "private-new",
+                        "publicKeyPEM": "public-new"
+                    },
+                    "exchangeResponse": {
+                        "Result": { "ClientID": "cn-client" }
+                    },
+                    "nested": { "added": "runtime" }
+                })),
+                trae_profile_raw: None,
+                trae_entitlement_raw: None,
+                trae_usage_raw: None,
+                trae_server_raw: None,
+                trae_usertag_raw: None,
+                status: None,
+                status_reason: None,
+            },
+        );
+
+        let auth = account.trae_auth_raw.as_ref().unwrap();
+        assert_eq!(account.access_token, "new-access");
+        assert_eq!(account.refresh_token.as_deref(), Some("new-refresh"));
+        assert_eq!(auth["platformId"], "trae_solo_cn");
+        assert_eq!(auth["callbackQuery"]["scope"], "solo");
+        assert_eq!(auth["deviceInfo"]["DeviceID"], "device-old");
+        assert_eq!(auth["deviceKeyPair"]["publicKeyPEM"], "public-old");
+        assert_eq!(auth["exchangeResponse"]["Result"]["ClientID"], "solo-client");
+        assert_eq!(auth["nested"]["keep"], "old");
+        assert_eq!(auth["nested"]["added"], "runtime");
     }
 
     #[test]

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -2,9 +2,13 @@
 //! 管理系统托盘图标和菜单
 
 #[cfg(not(target_os = "macos"))]
-use std::collections::{HashMap, HashSet};
+use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
+#[cfg(not(target_os = "macos"))]
+use std::hash::{Hash, Hasher};
 #[cfg(target_os = "macos")]
 use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(not(target_os = "macos"))]
+use std::sync::{Mutex, OnceLock};
 
 #[cfg(target_os = "macos")]
 use tauri::image::Image;
@@ -310,12 +314,13 @@ pub mod menu_ids {
 
 /// 账号显示信息
 #[cfg(not(target_os = "macos"))]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct AccountDisplayInfo {
     account: String,
     quota_lines: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg(not(target_os = "macos"))]
 enum TrayMenuEntry {
     Platform(PlatformId),
@@ -325,6 +330,17 @@ enum TrayMenuEntry {
         platforms: Vec<PlatformId>,
     },
 }
+
+#[cfg(not(target_os = "macos"))]
+#[derive(Debug, Clone)]
+struct TrayMenuSnapshot {
+    lang: String,
+    entries: Vec<TrayMenuEntry>,
+    platform_infos: HashMap<PlatformId, AccountDisplayInfo>,
+}
+
+#[cfg(not(target_os = "macos"))]
+static LAST_TRAY_MENU_SNAPSHOT_HASH: OnceLock<Mutex<Option<u64>>> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy)]
 #[cfg(not(target_os = "macos"))]
@@ -470,11 +486,56 @@ pub fn create_tray_skeleton<R: Runtime>(
     Ok(tray)
 }
 
-/// 构建托盘菜单
+/// 收集托盘菜单内容快照
 #[cfg(not(target_os = "macos"))]
-fn build_tray_menu<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<Menu<R>, tauri::Error> {
-    let config = crate::modules::config::get_user_config();
-    let lang = &config.language;
+fn collect_tray_menu_snapshot() -> TrayMenuSnapshot {
+    let lang = crate::modules::config::get_user_config().language;
+    let entries = resolve_tray_entries();
+    let mut platform_infos = HashMap::new();
+
+    for platform in entries.iter().flat_map(|entry| match entry {
+        TrayMenuEntry::Platform(platform) => vec![*platform],
+        TrayMenuEntry::Group { platforms, .. } => platforms.clone(),
+    }) {
+        platform_infos
+            .entry(platform)
+            .or_insert_with(|| get_account_display_info(platform, &lang));
+    }
+
+    TrayMenuSnapshot {
+        lang,
+        entries,
+        platform_infos,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn tray_menu_snapshot_hash(snapshot: &TrayMenuSnapshot) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    snapshot.lang.hash(&mut hasher);
+    snapshot.entries.hash(&mut hasher);
+
+    // Hash display data in menu order instead of iterating the HashMap, so the
+    // digest remains stable across process runs and map randomization.
+    for entry in &snapshot.entries {
+        let platforms = match entry {
+            TrayMenuEntry::Platform(platform) => std::slice::from_ref(platform),
+            TrayMenuEntry::Group { platforms, .. } => platforms.as_slice(),
+        };
+        for platform in platforms {
+            platform.hash(&mut hasher);
+            snapshot.platform_infos.get(platform).hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn build_tray_menu_from_snapshot<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    snapshot: &TrayMenuSnapshot,
+) -> Result<Menu<R>, tauri::Error> {
+    let lang = &snapshot.lang;
 
     let show_window = MenuItem::with_id(
         app,
@@ -512,18 +573,27 @@ fn build_tray_menu<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<Menu<R>, tau
         None::<&str>,
     )?;
 
-    let ordered_entries = resolve_tray_entries();
-    let split_index = ordered_entries.len().min(TRAY_PLATFORM_MAX_VISIBLE);
-    let (visible_entries, overflow_entries) = ordered_entries.split_at(split_index);
+    let split_index = snapshot.entries.len().min(TRAY_PLATFORM_MAX_VISIBLE);
+    let (visible_entries, overflow_entries) = snapshot.entries.split_at(split_index);
 
     let mut visible_submenus: Vec<Submenu<R>> = Vec::new();
     for entry in visible_entries {
-        visible_submenus.push(build_tray_entry_submenu(app, entry, lang)?);
+        visible_submenus.push(build_tray_entry_submenu(
+            app,
+            entry,
+            lang,
+            &snapshot.platform_infos,
+        )?);
     }
 
     let mut overflow_submenus: Vec<Submenu<R>> = Vec::new();
     for entry in overflow_entries {
-        overflow_submenus.push(build_tray_entry_submenu(app, entry, lang)?);
+        overflow_submenus.push(build_tray_entry_submenu(
+            app,
+            entry,
+            lang,
+            &snapshot.platform_infos,
+        )?);
     }
 
     let overflow_refs: Vec<&dyn IsMenuItem<R>> = overflow_submenus
@@ -583,14 +653,17 @@ fn build_tray_entry_submenu<R: Runtime>(
     app: &tauri::AppHandle<R>,
     entry: &TrayMenuEntry,
     lang: &str,
+    platform_infos: &HashMap<PlatformId, AccountDisplayInfo>,
 ) -> Result<Submenu<R>, tauri::Error> {
     match entry {
-        TrayMenuEntry::Platform(platform) => build_platform_submenu(app, *platform, lang),
+        TrayMenuEntry::Platform(platform) => {
+            build_platform_submenu(app, *platform, lang, platform_infos)
+        }
         TrayMenuEntry::Group {
             id,
             name,
             platforms,
-        } => build_platform_group_submenu(app, id, name, platforms, lang),
+        } => build_platform_group_submenu(app, id, name, platforms, lang, platform_infos),
     }
 }
 
@@ -601,6 +674,7 @@ fn build_platform_group_submenu<R: Runtime>(
     group_name: &str,
     platforms: &[PlatformId],
     lang: &str,
+    platform_infos: &HashMap<PlatformId, AccountDisplayInfo>,
 ) -> Result<Submenu<R>, tauri::Error> {
     if let [platform] = platforms {
         return build_platform_details_submenu(
@@ -609,12 +683,20 @@ fn build_platform_group_submenu<R: Runtime>(
             group_name,
             *platform,
             lang,
+            platform_infos
+                .get(platform)
+                .expect("tray snapshot must contain every visible platform"),
         );
     }
 
     let mut submenus: Vec<Submenu<R>> = Vec::new();
     for platform in platforms {
-        submenus.push(build_platform_submenu(app, *platform, lang)?);
+        submenus.push(build_platform_submenu(
+            app,
+            *platform,
+            lang,
+            platform_infos,
+        )?);
     }
 
     let refs: Vec<&dyn IsMenuItem<R>> = submenus
@@ -755,6 +837,7 @@ fn build_platform_submenu<R: Runtime>(
     app: &tauri::AppHandle<R>,
     platform: PlatformId,
     lang: &str,
+    platform_infos: &HashMap<PlatformId, AccountDisplayInfo>,
 ) -> Result<Submenu<R>, tauri::Error> {
     build_platform_details_submenu(
         app,
@@ -762,6 +845,9 @@ fn build_platform_submenu<R: Runtime>(
         platform.title(),
         platform,
         lang,
+        platform_infos
+            .get(&platform)
+            .expect("tray snapshot must contain every visible platform"),
     )
 }
 
@@ -771,15 +857,15 @@ fn build_platform_details_submenu<R: Runtime>(
     submenu_id: &str,
     title: &str,
     platform: PlatformId,
-    lang: &str,
+    _lang: &str,
+    info: &AccountDisplayInfo,
 ) -> Result<Submenu<R>, tauri::Error> {
-    let info = get_account_display_info(platform, lang);
     let mut items: Vec<MenuItem<R>> = Vec::new();
 
     items.push(MenuItem::with_id(
         app,
         format!("platform:{}:account", platform.as_str()),
-        info.account,
+        info.account.clone(),
         true,
         None::<&str>,
     )?);
@@ -3612,8 +3698,19 @@ pub fn update_tray_menu<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Str
 
     #[cfg(not(target_os = "macos"))]
     if let Some(tray) = app.tray_by_id(TRAY_ID) {
-        let menu = build_tray_menu(app).map_err(|e| e.to_string())?;
+        let snapshot = collect_tray_menu_snapshot();
+        let snapshot_hash = tray_menu_snapshot_hash(&snapshot);
+        let snapshot_lock = LAST_TRAY_MENU_SNAPSHOT_HASH.get_or_init(|| Mutex::new(None));
+        let mut last_hash = snapshot_lock
+            .lock()
+            .map_err(|_| "tray menu snapshot lock poisoned".to_string())?;
+        if last_hash.as_ref() == Some(&snapshot_hash) {
+            return Ok(());
+        }
+
+        let menu = build_tray_menu_from_snapshot(app, &snapshot).map_err(|e| e.to_string())?;
         tray.set_menu(Some(menu)).map_err(|e| e.to_string())?;
+        *last_hash = Some(snapshot_hash);
         logger::log_info("[Tray] 托盘菜单已更新");
     }
     Ok(())
@@ -3842,5 +3939,43 @@ fn get_text(key: &str, lang: &str) -> String {
         ("no_platform_selected", _) => "No tray platforms selected".to_string(),
 
         _ => key.to_string(),
+    }
+}
+
+#[cfg(all(test, not(target_os = "macos")))]
+mod tests {
+    use super::{
+        tray_menu_snapshot_hash, AccountDisplayInfo, PlatformId, TrayMenuEntry, TrayMenuSnapshot,
+    };
+    use std::collections::HashMap;
+
+    fn snapshot(quota_line: &str) -> TrayMenuSnapshot {
+        let platform = PlatformId::Codex;
+        TrayMenuSnapshot {
+            lang: "en".to_string(),
+            entries: vec![TrayMenuEntry::Platform(platform)],
+            platform_infos: HashMap::from([(
+                platform,
+                AccountDisplayInfo {
+                    account: "user@example.com".to_string(),
+                    quota_lines: vec![quota_line.to_string()],
+                },
+            )]),
+        }
+    }
+
+    #[test]
+    fn tray_menu_snapshot_hash_is_stable_and_tracks_display_changes() {
+        let first = snapshot("Weekly: 80% left");
+        assert_eq!(
+            tray_menu_snapshot_hash(&first),
+            tray_menu_snapshot_hash(&first.clone())
+        );
+
+        let changed = snapshot("Weekly: 79% left");
+        assert_ne!(
+            tray_menu_snapshot_hash(&first),
+            tray_menu_snapshot_hash(&changed)
+        );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,6 +22,7 @@
         "center": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "decorations": true,
         "transparent": false,
         "resizable": true
       },

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -14,6 +14,7 @@
         "center": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "decorations": true,
         "transparent": false,
         "resizable": true
       },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,11 @@ import {
   getWorkbuddyAutoCheckinConfig,
   migrateWorkbuddyAutoCheckinConfigAsync,
 } from './services/workbuddyAutoCheckinService';
+import {
+  getTraeAutoCheckinNextDelayMs,
+  runTraeAutoCheckinCycleIfNeeded,
+  TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT,
+} from './services/traeAutoCheckinService';
 import { prepareCodexLocalAccessForRestart } from './services/codexLocalAccessService';
 import { applyReducedMotion } from './utils/reducedMotion';
 import {
@@ -783,6 +788,46 @@ function MainApp() {
         store.setHideClassicSwitchPrompt(true);
       }
     });
+
+    let disposed = false;
+    let timerId: number | undefined;
+
+    const schedule = (delayMs?: number) => {
+      if (timerId !== undefined) {
+        window.clearTimeout(timerId);
+      }
+      timerId = window.setTimeout(() => {
+        void runCycle();
+      }, Math.max(1_000, delayMs ?? getTraeAutoCheckinNextDelayMs()));
+    };
+
+    const runCycle = async () => {
+      if (disposed) {
+        return;
+      }
+      let result: Awaited<ReturnType<typeof runTraeAutoCheckinCycleIfNeeded>>;
+      try {
+        result = await runTraeAutoCheckinCycleIfNeeded();
+      } catch (error) {
+        console.warn('[TraeAutoCheckin] 自动签到调度失败:', error);
+        result = 'retry';
+      }
+      if (!disposed) {
+        schedule(getTraeAutoCheckinNextDelayMs(result));
+      }
+    };
+
+    const handleConfigChange = () => schedule(1_000);
+    window.addEventListener(TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT, handleConfigChange);
+    schedule(1_000);
+
+    return () => {
+      disposed = true;
+      window.removeEventListener(TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT, handleConfigChange);
+      if (timerId !== undefined) {
+        window.clearTimeout(timerId);
+      }
+    };
   }, []);
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,15 @@ import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 import { useTranslation } from 'react-i18next';
-import { FileText, FolderOpen, RefreshCw, X } from 'lucide-react';
+import {
+  FileText,
+  FolderOpen,
+  Maximize2,
+  Minimize2,
+  Minus,
+  RefreshCw,
+  X,
+} from 'lucide-react';
 import { SideNav } from './components/layout/SideNav';
 import { BootReadyMarker, VisibleBootPage } from './components/BootReadyMarker';
 import { GlobalModal } from './components/GlobalModal';
@@ -741,6 +749,97 @@ function isWindowsPlatform(): boolean {
   const navWithUAData = navigator as Navigator & { userAgentData?: { platform?: string } };
   const platform = navWithUAData.userAgentData?.platform || navigator.platform || '';
   return platform.toLowerCase().includes('win');
+}
+
+function isLinuxPlatform(): boolean {
+  const navWithUAData = navigator as Navigator & { userAgentData?: { platform?: string } };
+  const platform = navWithUAData.userAgentData?.platform || navigator.platform || '';
+  return platform.toLowerCase().includes('linux');
+}
+
+function LinuxWindowControls() {
+  const { t } = useTranslation();
+  const [maximized, setMaximized] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const currentWindow = useMemo(() => getCurrentWindow(), []);
+
+  const syncMaximized = useCallback(async () => {
+    try {
+      setMaximized(await currentWindow.isMaximized());
+    } catch (error) {
+      console.warn('[Window] failed to read maximized state:', error);
+    }
+  }, [currentWindow]);
+
+  useEffect(() => {
+    let active = true;
+    let unlisten: UnlistenFn | undefined;
+    void syncMaximized();
+    void currentWindow.onResized(() => {
+      if (active) void syncMaximized();
+    }).then((cleanup) => {
+      if (active) {
+        unlisten = cleanup;
+      } else {
+        cleanup();
+      }
+    });
+    return () => {
+      active = false;
+      if (unlisten) unlisten();
+    };
+  }, [currentWindow, syncMaximized]);
+
+  const runWindowAction = useCallback(
+    async (action: () => Promise<void>) => {
+      if (busy) return;
+      setBusy(true);
+      try {
+        await action();
+        await syncMaximized();
+      } catch (error) {
+        console.warn('[Window] Linux window action failed:', error);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy, syncMaximized],
+  );
+
+  return (
+    <div className="linux-window-controls" role="toolbar" aria-label={t('window.controls', 'Window controls')}>
+      <button
+        type="button"
+        className="linux-window-control"
+        onClick={() => void runWindowAction(() => currentWindow.minimize())}
+        disabled={busy}
+        aria-label={t('window.minimize', 'Minimize')}
+        title={t('window.minimize', 'Minimize')}
+      >
+        <Minus size={15} />
+      </button>
+      <button
+        type="button"
+        className="linux-window-control"
+        onClick={() => void runWindowAction(() => currentWindow.toggleMaximize())}
+        disabled={busy}
+        aria-label={t('window.maximize', maximized ? 'Restore' : 'Maximize')}
+        title={t('window.maximize', maximized ? 'Restore' : 'Maximize')}
+      >
+        {maximized ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+      </button>
+      <button
+        type="button"
+        className="linux-window-control close"
+        onClick={() => void runWindowAction(() => currentWindow.close())}
+        disabled={busy}
+        aria-label={t('window.close', 'Close')}
+        title={t('window.close', 'Close')}
+      >
+        <X size={15} />
+      </button>
+    </div>
+  );
 }
 
 function MainApp() {
@@ -3731,7 +3830,7 @@ function MainApp() {
 
   return (
     <div
-      className={`app-container${isWindowsPlatform() ? ' app-container-windows' : ''}${sideNavLayoutMode === 'classic' ? ' app-container-side-nav-classic' : ''}${sideNavLayoutMode === 'classic' && sideNavClassicCollapsed ? ' app-container-side-nav-classic-collapsed' : ''}`}
+      className={`app-container${isWindowsPlatform() ? ' app-container-windows' : ''}${isLinuxPlatform() ? ' app-container-linux' : ''}${sideNavLayoutMode === 'classic' ? ' app-container-side-nav-classic' : ''}${sideNavLayoutMode === 'classic' && sideNavClassicCollapsed ? ' app-container-side-nav-classic-collapsed' : ''}`}
     >
       {/* 更新通知：活跃状态时保持挂载，关闭后继续保留当前更新状态 */}
       {shouldRenderUpdateNotification && (
@@ -3995,6 +4094,8 @@ function MainApp() {
         data-tauri-drag-region
         onMouseDown={handleDragStart}
       />
+
+      {isLinuxPlatform() ? <LinuxWindowControls /> : null}
 
       {/* 左侧悬浮导航 */}
       <SideNav

--- a/src/components/codebuddy-suite/TraeCheckinModal.tsx
+++ b/src/components/codebuddy-suite/TraeCheckinModal.tsx
@@ -18,11 +18,18 @@ import {
   Flame,
   Trophy,
   Ban,
+  Settings,
 } from 'lucide-react';
 import { TraeAccount } from '../../types/trae';
 import { TraeCheckinStatusResult, getTraeCheckinStatus, claimTraeCheckin } from '../../services/traeService';
 import { useEscClose } from '../../hooks/useEscClose';
 import { getTraeAccountDisplayEmail } from '../../types/trae';
+import {
+  getTraeAutoCheckinConfig,
+  saveTraeAutoCheckinConfig,
+  type TraeAutoCheckinConfig,
+} from '../../services/traeAutoCheckinService';
+import { TraeAutoCheckinConfigModal } from './TraeAutoCheckinConfigModal';
 
 type CheckinUiState = 'loading' | 'available' | 'claimed' | 'inactive' | 'error';
 
@@ -68,6 +75,10 @@ export function TraeCheckinModal({
   const [accountStates, setAccountStates] = useState<Record<string, AccountCheckinState>>({});
   const [checkAllLoading, setCheckAllLoading] = useState(false);
   const [refreshLoading, setRefreshLoading] = useState(false);
+  const [showConfigModal, setShowConfigModal] = useState(false);
+  const [autoCheckinConfig, setAutoCheckinConfig] = useState<TraeAutoCheckinConfig>(() =>
+    getTraeAutoCheckinConfig(),
+  );
 
   const updateAccountState = useCallback(
     (accountId: string, update: Partial<AccountCheckinState>) => {
@@ -309,6 +320,31 @@ export function TraeCheckinModal({
           <div className="checkin-empty">
             <p>{t('workbuddy.checkin.noAccounts', '暂无账号')}</p>
           </div>
+        )}
+
+        <div className="modal-footer checkin-modal-footer">
+          <button
+            className="btn btn-secondary icon-only"
+            onClick={() => setShowConfigModal(true)}
+            title={t('trae.checkin.autoCheckinSettings', '自动签到设置')}
+            aria-label={t('trae.checkin.autoCheckinSettings', '自动签到设置')}
+          >
+            <Settings size={14} />
+          </button>
+          <button className="btn btn-secondary" onClick={onClose}>
+            {t('common.close', '关闭')}
+          </button>
+        </div>
+
+        {showConfigModal && (
+          <TraeAutoCheckinConfigModal
+            config={autoCheckinConfig}
+            onSave={(newConfig) => {
+              saveTraeAutoCheckinConfig(newConfig);
+              setAutoCheckinConfig(newConfig);
+            }}
+            onClose={() => setShowConfigModal(false)}
+          />
         )}
       </div>
     </div>

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -4722,6 +4722,11 @@ export function CodexAccountsPage() {
           return;
         }
       }
+      // OAuth completion can finish the account write and the API-service/group
+      // sync on separate Tauri tasks. Fetch once more after those mutations so
+      // the overview cannot keep the pre-OAuth account snapshot.
+      await fetchAccounts({ allowEmpty: true });
+      await fetchCurrentAccount({ allowEmpty: true });
       setAddStatus("success");
       setAddMessage(t("common.shared.oauth.success", "授权成功"));
       oauthActiveRef.current = false;

--- a/src/pages/CodexApiServicePage.css
+++ b/src/pages/CodexApiServicePage.css
@@ -168,6 +168,57 @@
   min-width: 0;
 }
 
+.codex-api-service-key-search {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 220px;
+  color: var(--text-muted);
+}
+
+.codex-api-service-key-search > svg {
+  position: absolute;
+  left: 10px;
+  pointer-events: none;
+}
+
+.codex-api-service-key-search input {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px 0 30px;
+  border: 1px solid var(--codex-api-border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-surface) 88%, transparent);
+  color: var(--text-primary);
+  outline: none;
+  font: inherit;
+  font-size: 12px;
+}
+
+.codex-api-service-key-search input:focus {
+  border-color: color-mix(in srgb, var(--primary) 48%, var(--border));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 12%, transparent);
+}
+
+.codex-api-service-empty-state {
+  padding: 18px 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .codex-api-service-hero-actions {
   gap: 5px;
   flex-wrap: wrap;
@@ -2720,6 +2771,11 @@ html[data-reduced-motion="true"] .codex-api-service-key-advanced-toggle[aria-exp
   .codex-api-service-input-row .btn,
   .codex-api-service-hero-actions .btn {
     width: 100%;
+  }
+
+  .codex-api-service-key-search {
+    width: 100%;
+    min-width: 0;
   }
 
   .codex-api-service-proxy-input-row {

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -26,6 +26,7 @@ import {
   Power,
   RefreshCw,
   Route,
+  Search,
   Send,
   ShieldCheck,
   SlidersHorizontal,
@@ -821,6 +822,7 @@ export function CodexApiServicePage() {
   const [memberModalOpen, setMemberModalOpen] = useState(false);
   const [healthModalOpen, setHealthModalOpen] = useState(false);
   const [apiServiceIsCurrent, setApiServiceIsCurrent] = useState(false);
+  const [apiKeySearchQuery, setApiKeySearchQuery] = useState("");
   const [apiKeyDrafts, setApiKeyDrafts] = useState<Record<string, string>>({});
   const [apiKeyPolicyDrafts, setApiKeyPolicyDrafts] = useState<
     Record<string, ApiKeyPolicyDraft>
@@ -894,6 +896,37 @@ export function CodexApiServicePage() {
   const testChatScrollRef = useRef<HTMLDivElement | null>(null);
 
   const collection = state?.collection ?? null;
+  const visibleApiKeys = useMemo(() => {
+    const apiKeys = collection?.apiKeys ?? [];
+    const query = apiKeySearchQuery.trim().toLowerCase();
+    if (!query) return apiKeys;
+
+    return apiKeys.filter((apiKey) => {
+      let providerGatewayText = "";
+      if (typeof apiKey.providerGateway === "string") {
+        providerGatewayText = apiKey.providerGateway;
+      } else if (apiKey.providerGateway != null) {
+        try {
+          providerGatewayText = JSON.stringify(apiKey.providerGateway) ?? "";
+        } catch {
+          providerGatewayText = String(apiKey.providerGateway);
+        }
+      }
+      const searchableText = [
+        apiKey.id,
+        apiKey.label,
+        apiKey.key,
+        apiKey.modelPrefix,
+        providerGatewayText,
+        ...(apiKey.allowedModels ?? []),
+        ...(apiKey.excludedModels ?? []),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return searchableText.includes(query);
+    });
+  }, [apiKeySearchQuery, collection?.apiKeys]);
   const stats = state?.stats ?? null;
   const memberView = useCodexAccountOverviewMemberView({
     accounts,
@@ -4161,6 +4194,26 @@ export function CodexApiServicePage() {
             <div className="codex-api-service-panel-head">
               <h2>{t("codex.localAccess.apiKeysTitle", "客户端 Key")}</h2>
               <div className="codex-api-service-head-actions">
+                <label className="codex-api-service-key-search">
+                  <Search size={14} aria-hidden="true" />
+                  <span className="sr-only">
+                    {t("codex.localAccess.apiKeySearchLabel", "Search API keys")}
+                  </span>
+                  <input
+                    type="search"
+                    value={apiKeySearchQuery}
+                    onChange={(event) => setApiKeySearchQuery(event.target.value)}
+                    placeholder={t(
+                      "codex.localAccess.apiKeySearchPlaceholder",
+                      "Search keys, labels, models, or gateways",
+                    )}
+                    aria-label={t(
+                      "codex.localAccess.apiKeySearchLabel",
+                      "Search API keys",
+                    )}
+                    disabled={!collection}
+                  />
+                </label>
                 <button
                   type="button"
                   className="btn btn-primary btn-sm"
@@ -4173,7 +4226,7 @@ export function CodexApiServicePage() {
               </div>
             </div>
             <div className="codex-api-service-table">
-              {(collection?.apiKeys ?? []).map((apiKey) => {
+              {visibleApiKeys.map((apiKey) => {
                 const labelDraft = apiKeyDrafts[apiKey.id] ?? apiKey.label;
                 const policyDraft =
                   apiKeyPolicyDrafts[apiKey.id] ??
@@ -4852,6 +4905,14 @@ export function CodexApiServicePage() {
                   </div>
                 );
               })}
+              {visibleApiKeys.length === 0 && (collection?.apiKeys.length ?? 0) > 0 ? (
+                <div className="codex-api-service-empty-state">
+                  {t(
+                    "codex.localAccess.apiKeySearchEmpty",
+                    "No API keys match your search",
+                  )}
+                </div>
+              ) : null}
             </div>
           </section>
         )}

--- a/src/pages/TraeAccountsPage.tsx
+++ b/src/pages/TraeAccountsPage.tsx
@@ -24,6 +24,7 @@ import {
   Eye,
   EyeOff,
   BookOpen,
+  CalendarCheck,
 } from 'lucide-react';
 import { TagEditModal } from '../components/TagEditModal';
 import { ExportJsonModal } from '../components/ExportJsonModal';
@@ -76,6 +77,7 @@ import {
   removeAccountsOverviewFilterField,
   writeAccountsOverviewFilterField,
 } from '../utils/accountsOverviewFilterPersistence';
+import { TraeCheckinModal } from '../components/codebuddy-suite/TraeCheckinModal';
 
 const FILTER_TYPES_FIELD = 'filter_types';
 const TRAE_KNOWN_SORT_KEYS = ['created_at', 'plan', 'quota'] as const;
@@ -169,6 +171,8 @@ function getTraeAccountSwitchLabel(account: TraeAccount): string {
 
 export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps) {
   const platformConfig = TRAE_PLATFORM_PAGE_CONFIG[platformId];
+  const supportsCheckin = platformId === 'trae_solo_cn';
+  const [showCheckinModal, setShowCheckinModal] = useState(false);
   const filterPersistenceScopeSeed = platformConfig.platformKey;
   const targetFilterPersistenceScope = normalizeAccountsOverviewScope(filterPersistenceScopeSeed);
   const [activeTab, setActiveTab] = useState<PlatformOverviewTab>('overview');
@@ -1409,6 +1413,17 @@ export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps)
               >
                 <RefreshCw size={14} className={refreshingAll ? 'loading-spinner' : ''} />
               </button>
+              {supportsCheckin && (
+                <button
+                  className="btn btn-secondary icon-only"
+                  onClick={() => setShowCheckinModal(true)}
+                  title={t('trae.checkin.open', '每日签到')}
+                  aria-label={t('trae.checkin.open', '每日签到')}
+                  disabled={accounts.length === 0}
+                >
+                  <CalendarCheck size={14} />
+                </button>
+              )}
               <button
                 className="btn btn-secondary icon-only"
                 onClick={togglePrivacyMode}
@@ -1957,6 +1972,16 @@ export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps)
             onClose={() => setShowTagModal(null)}
             onSave={handleSaveTags}
           />
+
+          {supportsCheckin && showCheckinModal && (
+            <TraeCheckinModal
+              accounts={accounts}
+              onClose={() => setShowCheckinModal(false)}
+              onCheckinComplete={() => {
+                void store.fetchAccounts();
+              }}
+            />
+          )}
         </>
       )}
 

--- a/src/stores/usePlatformLayoutStore.ts
+++ b/src/stores/usePlatformLayoutStore.ts
@@ -589,10 +589,12 @@ function normalizePlatformGroups(
   raw: unknown,
   fallbackToDefault: boolean,
   options: {
+    migrateAntigravitySuite?: boolean;
     restoreDefaultTraeSuiteGroup?: boolean;
     attachCodexApiServiceToCodexGroup?: boolean;
   } = {},
 ): PlatformLayoutGroup[] {
+  const shouldMigrateAntigravitySuite = options.migrateAntigravitySuite === true;
   const shouldRestoreDefaultTraeSuiteGroup = options.restoreDefaultTraeSuiteGroup === true;
   const shouldAttachCodexApiService = options.attachCodexApiServiceToCodexGroup === true;
   const source = Array.isArray(raw) ? raw : (fallbackToDefault ? defaultPlatformGroups() : []);
@@ -649,7 +651,7 @@ function normalizePlatformGroups(
     usedGroupIds.add(groupId);
   });
 
-  if (!usedPlatformIds.has('antigravity_ide')) {
+  if (shouldMigrateAntigravitySuite && !usedPlatformIds.has('antigravity_ide')) {
     const antigravityGroup = result.find((group) => group.platformIds.includes('antigravity'));
     if (antigravityGroup) {
       antigravityGroup.platformIds = [...antigravityGroup.platformIds, 'antigravity_ide'];
@@ -1256,6 +1258,7 @@ function loadPersistedState(): NormalizedLayoutStateData {
       parsed.platformGroups,
       parsed.platformGroups === undefined,
       {
+        migrateAntigravitySuite: !antigravityGroupFirstMigrated,
         restoreDefaultTraeSuiteGroup: !traeSuiteDefaultGroupRestored,
         attachCodexApiServiceToCodexGroup: !codexApiServiceSuiteMigrated,
       },

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -28,6 +28,57 @@
   z-index: 900;
 }
 
+.app-container-linux {
+  border-radius: 0;
+}
+
+.app-container-linux .drag-region {
+  /* Keep the custom controls clickable while retaining a draggable title area. */
+  z-index: 900;
+}
+
+.linux-window-controls {
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 13060;
+  display: inline-flex;
+  align-items: center;
+  height: 38px;
+  padding: 0 4px;
+  -webkit-app-region: no-drag;
+}
+
+.linux-window-control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 30px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+  transition: background 140ms ease, color 140ms ease;
+}
+
+.linux-window-control:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.linux-window-control.close:hover:not(:disabled) {
+  background: #dc2626;
+  color: #fff;
+}
+
+.linux-window-control:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
 .app-container-windows .side-nav,
 .app-container-windows .side-nav-classic-handle {
   -webkit-app-region: no-drag;

--- a/src/types/grok.test.ts
+++ b/src/types/grok.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getGrokPlanBadge,
+  getGrokQuotaSummaryItems,
+  type GrokAccount,
+} from "./grok.ts";
+
+function account(overrides: Partial<GrokAccount>): GrokAccount {
+  return {
+    id: "grok-test",
+    email: "grok@example.com",
+    access_token: "",
+    created_at: 0,
+    last_used: 0,
+    ...overrides,
+  };
+}
+
+test("recognizes the spaced SuperGrok Heavy tier enum", () => {
+  assert.equal(
+    getGrokPlanBadge(
+      account({ plan_type: "SUBSCRIPTION_TIER_SUPER_GROK_HEAVY" }),
+    ),
+    "SuperGrok Heavy",
+  );
+});
+
+test("keeps weekly and Grok Build product usage visible", () => {
+  const items = getGrokQuotaSummaryItems(
+    account({
+      quota: {
+        weeklyLimitPercent: 18,
+        periodEnd: "2099-01-01T00:00:00Z",
+        products: [
+          {
+            product: "GrokBuild",
+            usagePercent: 32,
+          },
+        ],
+      },
+    }),
+    (_key, defaultValue) => defaultValue ?? "",
+  );
+
+  assert.deepEqual(
+    items.map((item) => ({ key: item.key, label: item.label, percentage: item.percentage })),
+    [
+      { key: "weekly", label: "", percentage: 18 },
+      { key: "product-0", label: "GrokBuild", percentage: 32 },
+    ],
+  );
+});

--- a/src/types/grok.ts
+++ b/src/types/grok.ts
@@ -302,11 +302,14 @@ export function getGrokPlanBadge(account: GrokAccount): string {
   }
   if (
     [
+      "SUBSCRIPTION_TIER_SUPER_GROK_HEAVY",
       "SUBSCRIPTION_TIER_SUPERGROK_HEAVY",
       "SUBSCRIPTION_TIER_GROK_HEAVY",
     ].includes(normalized) ||
     compact === "SUPERGROKHEAVY" ||
-    compact === "GROKHEAVY"
+    compact === "GROKHEAVY" ||
+    compact === "SUBSCRIPTIONTIERSUPERGROKHEAVY" ||
+    compact === "SUBSCRIPTIONTIERGROKHEAVY"
   ) {
     return "SuperGrok Heavy";
   }


### PR DESCRIPTION
## Summary

This batch resolves ten open issues across Codex, Trae, Grok, and Linux desktop behavior:

- Normalize the Responses Lite capability per provider so third-party Responses relays keep the standard tool contract, while preserving model metadata.
- Refresh the Codex account overview after OAuth completion.
- Preserve the requested Trae OAuth platform context during usage refresh.
- Persist the selected Antigravity default item and expose the Trae automatic check-in controls.
- Add searchable Codex API-key service entries.
- Improve Grok Heavy tier detection and retain weekly, GrokBuild, and object-shaped product usage data.
- Add Linux custom minimize, maximize, and close controls with a square window style.
- Deduplicate unchanged Linux tray menu content before rebuilding and replacing the native menu.

## Validation

- `npm run typecheck`
- `cargo check -p cockpit-tools --lib` with `COCKPIT_SKIP_CLIPROXY_BUILD=1`
- `cargo test -p cockpit-tools modules::grok_account::tests --lib`
- `cargo test -p cockpit-tools modules::codex_local_access::tests --lib`
- `cargo test -p cockpit-tools modules::codex_account::tests --lib`
- `cargo test -p cockpit-tools modules::tray::tests --lib`
- `rustfmt --edition 2021 --config skip_children=true --check src-tauri/src/lib.rs src-tauri/src/modules/grok_account.rs src-tauri/src/modules/tray.rs`
- `git diff --check`

`node --test src/types/grok.test.ts` remains blocked by the Windows sandbox's `spawn EPERM`; the TypeScript typecheck and equivalent Rust regression tests pass.

## Related issues

Fixes #1868
Fixes #1934
Fixes #1869
Fixes #1894
Fixes #1908
Fixes #1910
Fixes #1797
Fixes #1805
Fixes #1914
Fixes #1893
