### PR TITLE
feat(codex): add custom provider usage and model catalogs

### DIFF
--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -2002,6 +2002,64 @@ fn codex_model_provider_usage_url(base_url: &str) -> Result<String, String> {
     Ok(url.to_string())
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexModelProviderUsageQuery {
+    pub endpoint: String,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    #[serde(default)]
+    pub mappings: HashMap<String, String>,
+}
+
+fn codex_model_provider_custom_usage_url(base_url: &str, endpoint: &str) -> Result<String, String> {
+    let base = reqwest::Url::parse(base_url.trim())
+        .map_err(|_| "PROVIDER_BASE_URL_INVALID".to_string())?;
+    if !matches!(base.scheme(), "http" | "https") || base.host_str().is_none() {
+        return Err("PROVIDER_BASE_URL_INVALID".to_string());
+    }
+    let endpoint = endpoint.trim();
+    if endpoint.is_empty()
+        || endpoint.len() > 512
+        || endpoint.contains('?')
+        || endpoint.contains('#')
+    {
+        return Err("PROVIDER_USAGE_ENDPOINT_INVALID".to_string());
+    }
+
+    let expanded = endpoint.replace("{{baseUrl}}", base.as_str().trim_end_matches('/'));
+    let mut url = if expanded.starts_with("http://") || expanded.starts_with("https://") {
+        reqwest::Url::parse(&expanded).map_err(|_| "PROVIDER_USAGE_ENDPOINT_INVALID".to_string())?
+    } else {
+        let mut next = base.clone();
+        if expanded.starts_with('/') {
+            next.set_path(expanded.trim_end_matches('/'));
+        } else {
+            let base_path = next.path().trim_end_matches('/');
+            let path = if base_path.is_empty() {
+                format!("/{}", expanded.trim_matches('/'))
+            } else {
+                format!("{}/{}", base_path, expanded.trim_matches('/'))
+            };
+            next.set_path(path.as_str());
+        }
+        next
+    };
+
+    let same_origin = url.scheme().eq_ignore_ascii_case(base.scheme())
+        && url
+            .host_str()
+            .zip(base.host_str())
+            .is_some_and(|(left, right)| left.eq_ignore_ascii_case(right))
+        && url.port_or_known_default() == base.port_or_known_default();
+    if !same_origin {
+        return Err("PROVIDER_USAGE_ENDPOINT_MUST_BE_SAME_ORIGIN".to_string());
+    }
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url.to_string())
+}
+
 fn codex_model_provider_deepseek_balance_url(base_url: &str) -> Result<Option<String>, String> {
     let mut url = reqwest::Url::parse(base_url.trim())
         .map_err(|_| "PROVIDER_BASE_URL_INVALID".to_string())?;
@@ -2657,6 +2715,263 @@ fn json_bool_at(value: &serde_json::Value, path: &[&str]) -> Option<bool> {
         current = current.get(*key)?;
     }
     current.as_bool()
+}
+
+fn json_value_at_path<'a>(
+    value: &'a serde_json::Value,
+    raw_path: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut path = raw_path.trim();
+    if let Some(stripped) = path.strip_prefix('$') {
+        path = stripped.trim_start_matches('.');
+    }
+    if path.is_empty() {
+        return Some(value);
+    }
+
+    let mut current = value;
+    for raw_segment in path.split('.') {
+        let mut segment = raw_segment;
+        if segment.is_empty() {
+            continue;
+        }
+        loop {
+            if let Some(open) = segment.find('[') {
+                let key = &segment[..open];
+                if !key.is_empty() {
+                    current = current.get(key)?;
+                }
+                let close = segment[open + 1..].find(']')? + open + 1;
+                let index = segment[open + 1..close].parse::<usize>().ok()?;
+                current = current.get(index)?;
+                segment = &segment[close + 1..];
+                if segment.is_empty() {
+                    break;
+                }
+                continue;
+            }
+            current = current.get(segment)?;
+            break;
+        }
+    }
+    Some(current)
+}
+
+fn json_f64_value(value: &serde_json::Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_i64().map(|number| number as f64))
+        .or_else(|| value.as_u64().map(|number| number as f64))
+        .or_else(|| value.as_str()?.trim().parse::<f64>().ok())
+}
+
+fn json_i64_value(value: &serde_json::Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|number| i64::try_from(number).ok()))
+        .or_else(|| value.as_str()?.trim().parse::<i64>().ok())
+}
+
+fn json_bool_value(value: &serde_json::Value) -> Option<bool> {
+    value
+        .as_bool()
+        .or_else(|| value.as_str()?.trim().parse::<bool>().ok())
+}
+
+fn custom_usage_value<'a>(
+    body: &'a serde_json::Value,
+    query: &CodexModelProviderUsageQuery,
+    field: &str,
+    fallback: &[&str],
+) -> Option<&'a serde_json::Value> {
+    query
+        .mappings
+        .get(field)
+        .map(String::as_str)
+        .filter(|path| !path.trim().is_empty())
+        .and_then(|path| json_value_at_path(body, path))
+        .or_else(|| {
+            let mut current = body;
+            for key in fallback {
+                current = current.get(*key)?;
+            }
+            Some(current)
+        })
+}
+
+fn custom_usage_unit(
+    body: &serde_json::Value,
+    query: &CodexModelProviderUsageQuery,
+) -> Option<String> {
+    let raw = query.mappings.get("unit")?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Some(path) = raw.strip_prefix('$') {
+        return json_value_at_path(body, path)
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+    }
+    Some(raw.to_string())
+}
+
+fn summarize_custom_model_provider_usage(
+    body: &serde_json::Value,
+    query: &CodexModelProviderUsageQuery,
+    latency_ms: u64,
+) -> Result<CodexModelProviderUsageSummary, String> {
+    let number = |field: &str, fallback: &[&str]| {
+        custom_usage_value(body, query, field, fallback).and_then(json_f64_value)
+    };
+    let integer = |field: &str, fallback: &[&str]| {
+        custom_usage_value(body, query, field, fallback).and_then(json_i64_value)
+    };
+    let string = |field: &str, fallback: &[&str]| {
+        custom_usage_value(body, query, field, fallback)
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    let remaining = number("remaining", &["remaining"]);
+    let balance = number("balance", &["balance"]);
+    let quota_limit = number("quotaLimit", &["quota", "limit"]);
+    let quota_used = number("quotaUsed", &["quota", "used"]);
+    let quota_remaining = number("quotaRemaining", &["quota", "remaining"]);
+    let today_requests = integer("todayRequests", &["usage", "today", "requests"]);
+    let today_total_tokens = integer("todayTotalTokens", &["usage", "today", "total_tokens"]);
+    let today_cost = number("todayCost", &["usage", "today", "cost"]);
+    let total_requests = integer("totalRequests", &["usage", "total", "requests"]);
+    let total_total_tokens = integer("totalTotalTokens", &["usage", "total", "total_tokens"]);
+    let total_cost = number("totalCost", &["usage", "total", "cost"]);
+    let status = string("status", &["status"]);
+    let plan_name = string("planName", &["planName"]);
+    let is_valid = custom_usage_value(body, query, "isValid", &["is_active", "isValid"])
+        .and_then(json_bool_value)
+        .or_else(|| Some(true));
+    let unit = custom_usage_unit(body, query).or_else(|| {
+        custom_usage_value(body, query, "unit", &["unit", "quota", "unit"])
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    });
+    let quota_unlimited =
+        custom_usage_value(body, query, "quotaUnlimited", &["quota", "unlimited"])
+            .and_then(json_bool_value);
+
+    if remaining.is_none()
+        && balance.is_none()
+        && quota_remaining.is_none()
+        && quota_limit.is_none()
+        && today_requests.is_none()
+        && today_total_tokens.is_none()
+        && total_requests.is_none()
+        && total_total_tokens.is_none()
+    {
+        return Err(
+            "PROVIDER_USAGE_PARSE_FAILED: custom mappings matched no supported fields".to_string(),
+        );
+    }
+
+    let mut details = Vec::new();
+    push_usage_detail(&mut details, "status", "Status", status.clone());
+    push_usage_detail(&mut details, "planName", "Plan", plan_name.clone());
+    push_usage_detail(
+        &mut details,
+        "remaining",
+        "Remaining",
+        remaining.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "balance",
+        "Balance",
+        balance.map(format_usage_number),
+    );
+    push_usage_detail(&mut details, "unit", "Unit", unit.clone());
+    push_usage_detail(
+        &mut details,
+        "quotaLimit",
+        "Quota Limit",
+        quota_limit.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "quotaUsed",
+        "Quota Used",
+        quota_used.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "quotaRemaining",
+        "Quota Remaining",
+        quota_remaining.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "todayRequests",
+        "Today Requests",
+        today_requests.map(|value| value.to_string()),
+    );
+    push_usage_detail(
+        &mut details,
+        "todayTotalTokens",
+        "Today Tokens",
+        today_total_tokens.map(|value| value.to_string()),
+    );
+    push_usage_detail(
+        &mut details,
+        "todayCost",
+        "Today Cost",
+        today_cost.map(format_usage_number),
+    );
+    push_usage_detail(
+        &mut details,
+        "totalRequests",
+        "Total Requests",
+        total_requests.map(|value| value.to_string()),
+    );
+    push_usage_detail(
+        &mut details,
+        "totalTotalTokens",
+        "Total Tokens",
+        total_total_tokens.map(|value| value.to_string()),
+    );
+    push_usage_detail(
+        &mut details,
+        "totalCost",
+        "Total Cost",
+        total_cost.map(format_usage_number),
+    );
+
+    Ok(CodexModelProviderUsageSummary {
+        mode: Some("custom".to_string()),
+        is_valid,
+        status,
+        plan_name,
+        remaining,
+        balance,
+        unit,
+        quota_unlimited,
+        quota_limit,
+        quota_used,
+        quota_remaining: quota_remaining.or(remaining),
+        today_requests,
+        today_total_tokens,
+        today_cost,
+        total_requests,
+        total_total_tokens,
+        total_cost,
+        model_stats_count: body
+            .get("model_stats")
+            .and_then(serde_json::Value::as_array)
+            .map_or(0, Vec::len),
+        latency_ms,
+        details,
+    })
 }
 
 fn summarize_model_provider_usage(
@@ -3684,6 +3999,7 @@ pub async fn codex_query_model_provider_usage(
     base_url: String,
     api_key: String,
     integration_type: Option<String>,
+    usage_query: Option<CodexModelProviderUsageQuery>,
 ) -> Result<CodexModelProviderUsageSummary, String> {
     let key = api_key.trim();
     if key.is_empty() {
@@ -3693,6 +4009,10 @@ pub async fn codex_query_model_provider_usage(
         .timeout(Duration::from_secs(CODEX_MODEL_PROVIDER_TEST_TIMEOUT_SECS))
         .build()
         .map_err(|e| format!("CREATE_HTTP_CLIENT_FAILED: {}", e))?;
+
+    if let Some(query) = usage_query.as_ref() {
+        return query_custom_model_provider_usage(&client, &base_url, key, query).await;
+    }
 
     if let Some(provider) = codex_model_provider_token_plan_provider(&base_url)? {
         return query_token_plan_model_provider_usage(&client, &base_url, key, provider).await;
@@ -3725,6 +4045,58 @@ pub async fn codex_query_model_provider_usage(
             }
         }
     }
+}
+
+async fn query_custom_model_provider_usage(
+    client: &reqwest::Client,
+    base_url: &str,
+    key: &str,
+    query: &CodexModelProviderUsageQuery,
+) -> Result<CodexModelProviderUsageSummary, String> {
+    let url = codex_model_provider_custom_usage_url(base_url, &query.endpoint)?;
+    let mut request = client
+        .get(&url)
+        .header(reqwest::header::ACCEPT, "application/json");
+    let mut has_authorization = false;
+    for (raw_name, raw_value) in &query.headers {
+        let name = reqwest::header::HeaderName::from_bytes(raw_name.trim().as_bytes())
+            .map_err(|_| "PROVIDER_USAGE_HEADER_INVALID".to_string())?;
+        if name == reqwest::header::HOST
+            || name == reqwest::header::CONTENT_LENGTH
+            || name == reqwest::header::COOKIE
+        {
+            return Err("PROVIDER_USAGE_HEADER_FORBIDDEN".to_string());
+        }
+        let value = raw_value
+            .replace("{{apiKey}}", key)
+            .replace("{{baseUrl}}", base_url.trim_end_matches('/'));
+        let header_value = reqwest::header::HeaderValue::from_str(value.trim())
+            .map_err(|_| "PROVIDER_USAGE_HEADER_INVALID".to_string())?;
+        has_authorization |= name == reqwest::header::AUTHORIZATION;
+        request = request.header(name, header_value);
+    }
+    if !has_authorization {
+        request = request.bearer_auth(key);
+    }
+
+    let started = Instant::now();
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("PROVIDER_USAGE_NETWORK_FAILED: {}", e))?;
+    let latency_ms = started.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(format!(
+            "PROVIDER_USAGE_HTTP_{}: {}",
+            status.as_u16(),
+            text.chars().take(300).collect::<String>()
+        ));
+    }
+    let parsed = serde_json::from_str::<serde_json::Value>(&text)
+        .map_err(|e| format!("PROVIDER_USAGE_PARSE_FAILED: {}", e))?;
+    summarize_custom_model_provider_usage(&parsed, query, latency_ms)
 }
 
 async fn query_deepseek_model_provider_balance(
@@ -4545,6 +4917,76 @@ mod tests {
             .details
             .iter()
             .any(|detail| detail.key == "grantedBalance" && detail.value == "10"));
+    }
+
+    #[test]
+    fn custom_usage_url_stays_on_provider_origin() {
+        assert_eq!(
+            codex_model_provider_custom_usage_url(
+                "https://provider.example.com/v1",
+                "/user/balance",
+            )
+            .expect("same-origin endpoint"),
+            "https://provider.example.com/user/balance"
+        );
+        assert_eq!(
+            codex_model_provider_custom_usage_url(
+                "https://provider.example.com/v1",
+                "{{baseUrl}}/usage",
+            )
+            .expect("base URL template"),
+            "https://provider.example.com/v1/usage"
+        );
+        assert!(codex_model_provider_custom_usage_url(
+            "https://provider.example.com/v1",
+            "https://other.example.com/usage",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn custom_usage_mappings_extract_remaining_balance_and_unit() {
+        let query = CodexModelProviderUsageQuery {
+            endpoint: "/v1/usage".to_string(),
+            headers: HashMap::new(),
+            mappings: HashMap::from([
+                ("remaining".to_string(), "quota.remaining".to_string()),
+                ("isValid".to_string(), "is_active".to_string()),
+                ("unit".to_string(), "CNY".to_string()),
+            ]),
+        };
+        let summary = summarize_custom_model_provider_usage(
+            &serde_json::json!({
+                "is_active": true,
+                "quota": { "remaining": "88.5" }
+            }),
+            &query,
+            9,
+        )
+        .expect("custom usage response");
+
+        assert_eq!(summary.mode.as_deref(), Some("custom"));
+        assert_eq!(summary.remaining, Some(88.5));
+        assert_eq!(summary.quota_remaining, Some(88.5));
+        assert_eq!(summary.unit.as_deref(), Some("CNY"));
+        assert_eq!(summary.is_valid, Some(true));
+    }
+
+    #[test]
+    fn custom_usage_mappings_support_array_json_paths() {
+        let query = CodexModelProviderUsageQuery {
+            endpoint: "/balance".to_string(),
+            headers: HashMap::new(),
+            mappings: HashMap::from([("balance".to_string(), "data[0].value".to_string())]),
+        };
+        let summary = summarize_custom_model_provider_usage(
+            &serde_json::json!({ "data": [{ "value": 42 }] }),
+            &query,
+            1,
+        )
+        .expect("array path should resolve");
+
+        assert_eq!(summary.balance, Some(42.0));
     }
 
     #[test]

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -2562,6 +2562,32 @@ fn visible_codex_model_ids_for_api_key_with_optional_accounts(
         &[],
         &collection.excluded_models,
     );
+    if let Some(accounts) = accounts {
+        let scoped_account_ids: HashSet<&str> =
+            scoped_account_ids.iter().map(String::as_str).collect();
+        let mut seen: HashSet<String> = visible
+            .iter()
+            .map(|model| model.trim().to_ascii_lowercase())
+            .filter(|model| !model.is_empty())
+            .collect();
+        let catalog_models = accounts
+            .iter()
+            .filter(|account| {
+                account.is_api_key_auth() && scoped_account_ids.contains(account.id.as_str())
+            })
+            .flat_map(|account| account.api_model_catalog.iter())
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        for model in apply_model_aliases_to_ids(catalog_models, &collection.model_aliases)
+        {
+            if seen.insert(model.to_ascii_lowercase()) {
+                visible.push(model);
+            }
+        }
+    }
     if let Some(provider_gateway) = api_key.provider_gateway.as_ref() {
         let mut seen: HashSet<String> = visible
             .iter()
@@ -32224,6 +32250,44 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
         let restricted = visible_codex_model_ids_for_api_key(&collection, &api_key, None);
         assert!(restricted.iter().any(|model| model == "gpt-5.4"));
         assert!(!restricted.iter().any(|model| model.starts_with("gpt-5.6-")));
+    }
+
+    #[test]
+    fn api_key_model_visibility_includes_scoped_account_catalog_models() {
+        let collection = test_local_access_collection(vec!["account-1".to_string()]);
+        let mut account = CodexAccount::new_api_key(
+            "account-1".to_string(),
+            "api@example.com".to_string(),
+            "sk-test".to_string(),
+            CodexApiProviderMode::Custom,
+            Some("https://provider.example.com/v1".to_string()),
+            Some("provider".to_string()),
+            Some("Provider".to_string()),
+            vec!["gpt-5.6-luna".to_string(), "provider-only-model".to_string()],
+        );
+        account.api_wire_api = Some("responses".to_string());
+        let api_key = ResolvedLocalApiKey {
+            id: "key-1".to_string(),
+            label: "Key".to_string(),
+            provider_gateway: None,
+            inherit_account_pool: false,
+            account_ids: vec!["account-1".to_string()],
+            model_prefix: None,
+            allowed_models: Vec::new(),
+            excluded_models: Vec::new(),
+            token_limit: None,
+            token_used: 0,
+        };
+
+        let models = visible_codex_model_ids_for_api_key_with_accounts(
+            &collection,
+            &api_key,
+            &[account],
+            None,
+        );
+
+        assert!(models.iter().any(|model| model == "provider-only-model"));
+        assert!(models.iter().any(|model| model == "gpt-5.6-luna"));
     }
 
     #[test]

--- a/src-tauri/src/modules/macos_native_menu.rs
+++ b/src-tauri/src/modules/macos_native_menu.rs
@@ -4853,10 +4853,18 @@ mod imp {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(str::to_string);
+        let usage_query = provider
+            .as_ref()
+            .and_then(|provider| json_path(Some(provider), &["usageQuery"]).cloned())
+            .and_then(|value| {
+                serde_json::from_value::<commands::codex::CodexModelProviderUsageQuery>(value)
+                    .ok()
+            });
         let summary = commands::codex::codex_query_model_provider_usage(
             base_url.clone(),
             api_key.to_string(),
             integration_type,
+            usage_query,
         )
         .await?;
         let summary_value = serde_json::to_value(&summary)

--- a/src/components/codex/CodexModelProviderManager.tsx
+++ b/src/components/codex/CodexModelProviderManager.tsx
@@ -107,6 +107,7 @@ import {
   type CodexModelProviderChatTestProgressPayload,
   type CodexModelProviderChatTestRecord,
   type CodexModelProviderChatTestTarget,
+  type CodexModelProviderUsageQuery,
   type CodexModelProviderUsageSummary,
   updateCodexModelProvider,
 } from "../../services/codexModelProviderService";
@@ -202,6 +203,108 @@ function parseModelCatalogText(value: string): string[] {
       models.push(model);
     });
   return models;
+}
+
+const USAGE_QUERY_FIELDS = [
+  "isValid",
+  "status",
+  "planName",
+  "remaining",
+  "balance",
+  "unit",
+  "quotaUnlimited",
+  "quotaLimit",
+  "quotaUsed",
+  "quotaRemaining",
+  "todayRequests",
+  "todayTotalTokens",
+  "todayCost",
+  "totalRequests",
+  "totalTotalTokens",
+  "totalCost",
+] as const;
+
+function usageQueryTextFromProvider(
+  query?: CodexModelProviderUsageQuery,
+): {
+  usageEndpoint: string;
+  usageHeadersText: string;
+  usageMappingsText: string;
+} {
+  return {
+    usageEndpoint: query?.endpoint ?? "",
+    usageHeadersText: query?.headers
+      ? JSON.stringify(query.headers, null, 2)
+      : "",
+    usageMappingsText: query?.mappings
+      ? JSON.stringify(query.mappings, null, 2)
+      : "",
+  };
+}
+
+function parseUsageQueryDraft(
+  endpointDraft: string,
+  headersDraft: string,
+  mappingsDraft: string,
+): { ok: true; value?: CodexModelProviderUsageQuery } | { ok: false; error: string } {
+  const endpoint = endpointDraft.trim();
+  if (!endpoint) return { ok: true };
+  if (
+    endpoint.length > 512 ||
+    endpoint.includes("?") ||
+    endpoint.includes("#") ||
+    endpoint.includes("\\")
+  ) {
+    return { ok: false, error: "自定义额度接口路径无效" };
+  }
+
+  const parseObject = (draft: string, label: string): Record<string, unknown> | undefined => {
+    if (!draft.trim()) return undefined;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(draft);
+    } catch {
+      throw new Error(`${label}必须是有效 JSON`);
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`${label}必须是 JSON 对象`);
+    }
+    return parsed as Record<string, unknown>;
+  };
+
+  try {
+    const rawHeaders = parseObject(headersDraft, "自定义请求头");
+    const headers: Record<string, string> = {};
+    for (const [name, rawValue] of Object.entries(rawHeaders ?? {})) {
+      const trimmedName = name.trim();
+      const value = String(rawValue ?? "").trim();
+      if (!trimmedName || !value) continue;
+      if (trimmedName.length > 128 || value.length > 2048) {
+        return { ok: false, error: "自定义请求头过长" };
+      }
+      headers[trimmedName] = value;
+    }
+
+    const rawMappings = parseObject(mappingsDraft, "额度字段映射");
+    const mappings: Record<string, string> = {};
+    for (const field of USAGE_QUERY_FIELDS) {
+      const value = String(rawMappings?.[field] ?? "").trim();
+      if (!value) continue;
+      if (value.length > 256) return { ok: false, error: "额度字段路径过长" };
+      mappings[field] = value;
+    }
+
+    return {
+      ok: true,
+      value: {
+        endpoint,
+        ...(Object.keys(headers).length > 0 ? { headers } : {}),
+        ...(Object.keys(mappings).length > 0 ? { mappings } : {}),
+      },
+    };
+  } catch (error) {
+    return { ok: false, error: String(error).replace(/^Error:\s*/, "") };
+  }
 }
 
 function parseVisionModelText(value: string): Record<string, { supportsVision: boolean }> {
@@ -401,6 +504,9 @@ interface ProviderFormState {
   providerId: string | null;
   name: string;
   baseUrl: string;
+  usageEndpoint: string;
+  usageHeadersText: string;
+  usageMappingsText: string;
   modelCatalogText: string;
   modelContextWindowsDraft: Record<string, string>;
   supportsVision: boolean;
@@ -428,6 +534,9 @@ const EMPTY_FORM: ProviderFormState = {
   providerId: null,
   name: "",
   baseUrl: "",
+  usageEndpoint: "",
+  usageHeadersText: "",
+  usageMappingsText: "",
   modelCatalogText: "",
   modelContextWindowsDraft: {},
   supportsVision: false,
@@ -1637,6 +1746,7 @@ export function CodexModelProviderManager({
       providerId: provider.id,
       name: provider.name,
       baseUrl: provider.baseUrl,
+      ...usageQueryTextFromProvider(provider.usageQuery),
       modelCatalogText: (provider.modelCatalog ?? []).join("\n"),
       modelContextWindowsDraft: contextWindowDraftsFromRecord(
         provider.modelContextWindows,
@@ -1697,6 +1807,9 @@ export function CodexModelProviderManager({
       mutateForm({
         name: preset.name,
         baseUrl: preset.baseUrls[0] ?? "",
+        usageEndpoint: "",
+        usageHeadersText: "",
+        usageMappingsText: "",
         modelCatalogText: (preset.modelCatalog ?? []).join("\n"),
         modelContextWindowsDraft: contextWindowDraftsFromRecord(
           undefined,
@@ -1730,6 +1843,9 @@ export function CodexModelProviderManager({
       mutateForm({
         name: template.name,
         baseUrl: template.baseUrl,
+        usageEndpoint: "",
+        usageHeadersText: "",
+        usageMappingsText: "",
         modelCatalogText: template.modelCatalog.join("\n"),
         modelContextWindowsDraft: contextWindowDraftsFromRecord(
           undefined,
@@ -1782,6 +1898,12 @@ export function CodexModelProviderManager({
         return t(
           "codex.modelProviders.validation.providerNotFound",
           "供应商不存在",
+        );
+      }
+      if (raw.includes("PROVIDER_USAGE_ENDPOINT")) {
+        return t(
+          "codex.modelProviders.usage.customEndpointInvalid",
+          "自定义额度接口必须指向当前供应商的同源路径",
         );
       }
       return raw.replace(/^Error:\s*/, "");
@@ -2207,6 +2329,15 @@ export function CodexModelProviderManager({
       );
       return;
     }
+    const parsedUsageQuery = parseUsageQueryDraft(
+      form.usageEndpoint,
+      form.usageHeadersText,
+      form.usageMappingsText,
+    );
+    if (!parsedUsageQuery.ok) {
+      setFormError(parsedUsageQuery.error);
+      return;
+    }
     const modelCapabilities = parseVisionModelText(form.visionModelText);
     const visionRoutingModel = form.visionRoutingModel.trim();
     const isCreate = !form.providerId;
@@ -2253,6 +2384,7 @@ export function CodexModelProviderManager({
         savedProvider = await createCodexModelProvider({
           name,
           baseUrl,
+          usageQuery: parsedUsageQuery.value,
           sourceTag: selectedSponsorTemplate?.id,
           modelCatalog,
           modelContextWindows: parsedWindows.windows,
@@ -2272,6 +2404,7 @@ export function CodexModelProviderManager({
         savedProvider = await updateCodexModelProvider(form.providerId, {
           name,
           baseUrl,
+          usageQuery: parsedUsageQuery.value ?? null,
           sourceTag: selectedSponsorTemplate?.id ?? null,
           modelCatalog,
           modelContextWindows: parsedWindows.windows,
@@ -2299,6 +2432,7 @@ export function CodexModelProviderManager({
             baseUrl: savedProvider.baseUrl,
             apiKey: newApiKey,
             integrationType: savedProvider.integrationType ?? null,
+            usageQuery: savedProvider.usageQuery ?? null,
           });
           setProviderUsageMap((previous) => ({
             ...previous,
@@ -3186,6 +3320,7 @@ export function CodexModelProviderManager({
           baseUrl: provider.baseUrl,
           apiKey: apiKey.apiKey,
           integrationType: provider.integrationType ?? null,
+          usageQuery: provider.usageQuery ?? null,
         });
         if (
           (summary.mode === "sub2api" || summary.mode === "new_api") &&
@@ -3702,7 +3837,8 @@ export function CodexModelProviderManager({
               usageSummary?.mode === "new_api" ||
               usageSummary?.mode === "sub2api" ||
               usageSummary?.mode === "deepseek" ||
-              usageSummary?.mode === "token_plan"
+              usageSummary?.mode === "token_plan" ||
+              usageSummary?.mode === "custom"
                 ? usageSummary.mode
                 : provider.integrationType ?? null;
             const deepSeekDetailValue = (key: string) => {
@@ -3964,6 +4100,35 @@ export function CodexModelProviderManager({
                             ? `${t("codex.modelProviders.usage.fields.expiresAt", "过期时间")} ${new Date(expiresAt * 1000).toLocaleDateString()}`
                             : t("dashboard.noData", "暂无数据")}
                         </span>
+                      </div>
+                    </div>
+                  ) : usageMode === "custom" ? (
+                    <div className="codex-api-key-usage-panel custom">
+                      <div className="codex-api-key-usage-grid">
+                        <div>
+                          <span>
+                            {t(
+                              "codex.modelProviders.usage.fields.remaining",
+                              "Remaining",
+                            )}
+                          </span>
+                          <strong>{usagePrimaryText}</strong>
+                        </div>
+                        <div>
+                          <span>
+                            {t("codex.modelProviders.usage.fields.status", "Status")}
+                          </span>
+                          <strong>
+                            {usageSummary?.status ||
+                              (usageSummary?.isValid === false ? "invalid" : "available")}
+                          </strong>
+                        </div>
+                        <div>
+                          <span>
+                            {t("codex.modelProviders.usage.fields.unit", "Unit")}
+                          </span>
+                          <strong>{usageSummary?.unit || "-"}</strong>
+                        </div>
                       </div>
                     </div>
                   ) : (
@@ -4995,6 +5160,84 @@ export function CodexModelProviderManager({
                 />
               </div>
               <div className="form-group">
+                <label>
+                  {t(
+                    "codex.modelProviders.usage.customEndpoint",
+                    "自定义额度接口（可选）",
+                  )}
+                </label>
+                <input
+                  className="form-input"
+                  type="text"
+                  value={form.usageEndpoint}
+                  onChange={(event) =>
+                    mutateForm({ usageEndpoint: event.target.value })
+                  }
+                  placeholder="/v1/usage 或 /user/balance"
+                  disabled={saving}
+                />
+                <p className="api-provider-hint">
+                  {t(
+                    "codex.modelProviders.usage.customEndpointHint",
+                    "仅发起 GET 请求；可填写相对路径，或使用 {{baseUrl}}/user/balance。留空则使用内置额度检测。",
+                  )}
+                </p>
+              </div>
+              {form.usageEndpoint.trim() && (
+                <>
+                  <div className="form-group">
+                    <label>
+                      {t(
+                        "codex.modelProviders.usage.customHeaders",
+                        "自定义请求头（JSON，可选）",
+                      )}
+                    </label>
+                    <textarea
+                      className="form-input"
+                      rows={3}
+                      value={form.usageHeadersText}
+                      onChange={(event) =>
+                        mutateForm({ usageHeadersText: event.target.value })
+                      }
+                      placeholder={'{"Authorization":"Bearer {{apiKey}}"}'}
+                      disabled={saving}
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label>
+                      {t(
+                        "codex.modelProviders.usage.customMappings",
+                        "额度字段映射（JSON，可选）",
+                      )}
+                    </label>
+                    <textarea
+                      className="form-input"
+                      rows={5}
+                      value={form.usageMappingsText}
+                      onChange={(event) =>
+                        mutateForm({ usageMappingsText: event.target.value })
+                      }
+                      placeholder={JSON.stringify(
+                        {
+                          remaining: "quota.remaining",
+                          isValid: "is_active",
+                          unit: "CNY",
+                        },
+                        null,
+                        2,
+                      )}
+                      disabled={saving}
+                    />
+                    <p className="api-provider-hint">
+                      {t(
+                        "codex.modelProviders.usage.customMappingsHint",
+                        "字段值使用点号 JSON 路径；unit 可填写固定值（如 CNY），或使用 $.unit 从响应读取。",
+                      )}
+                    </p>
+                  </div>
+                </>
+              )}
+              <div className="form-group">
                 <label className="codex-provider-label-with-help">
                   <span>{t("codex.modelProviders.fields.wireApi", "协议")}</span>
                   <span
@@ -6023,7 +6266,8 @@ export function CodexModelProviderManager({
           usageSummary?.mode === "new_api" ||
           usageSummary?.mode === "sub2api" ||
           usageSummary?.mode === "deepseek" ||
-          usageSummary?.mode === "token_plan"
+          usageSummary?.mode === "token_plan" ||
+          usageSummary?.mode === "custom"
             ? usageSummary.mode
             : provider.integrationType ?? null;
         const coreDetailKeys =
@@ -6046,6 +6290,19 @@ export function CodexModelProviderManager({
                       "planName",
                       "expiresAt",
                     ])
+                  : usageMode === "custom"
+                    ? new Set([
+                        "mode",
+                        "isValid",
+                        "status",
+                        "remaining",
+                        "balance",
+                        "unit",
+                        "quotaUnlimited",
+                        "quotaLimit",
+                        "quotaUsed",
+                        "quotaRemaining",
+                      ])
                 : new Set<string>();
         const detailMetrics: CodexServicePanelMetricItem[] = [
           {
@@ -6201,8 +6458,8 @@ export function CodexModelProviderManager({
                   ),
                 },
               ]
-            : usageMode === "sub2api"
-              ? [
+              : usageMode === "sub2api"
+                ? [
                   {
                     key: "accountBalance",
                     label: t("codex.modelProviders.usage.accountBalance", "账户余额"),
@@ -6224,6 +6481,34 @@ export function CodexModelProviderManager({
                     value: (usageSummary?.todayTotalTokens ?? 0).toLocaleString("en-US"),
                   },
                 ]
+              : usageMode === "custom"
+                ? [
+                    {
+                      key: "remaining",
+                      label: t(
+                        "codex.modelProviders.usage.fields.remaining",
+                        "Remaining",
+                      ),
+                      value: formatUsageQuotaValue(
+                        usageSummary,
+                        usageSummary?.remaining ??
+                          usageSummary?.balance ??
+                          usageSummary?.quotaRemaining,
+                      ),
+                    },
+                    {
+                      key: "status",
+                      label: t("codex.modelProviders.usage.fields.status", "Status"),
+                      value:
+                        usageSummary?.status ||
+                        (usageSummary?.isValid === false ? "invalid" : "available"),
+                    },
+                    {
+                      key: "unit",
+                      label: t("codex.modelProviders.usage.fields.unit", "Unit"),
+                      value: usageSummary?.unit || "-",
+                    },
+                  ]
               : [];
 
         const actions: CodexServicePanelActionItem[] = [

--- a/src/components/model-provider/ModelProviderUsagePanel.tsx
+++ b/src/components/model-provider/ModelProviderUsagePanel.tsx
@@ -29,7 +29,8 @@ export function ModelProviderUsagePanel({
   const isSupportedUsage =
     usageMode === 'sub2api' ||
     usageMode === 'new_api' ||
-    usageMode === 'token_plan';
+    usageMode === 'token_plan' ||
+    usageMode === 'custom';
   const classNames = [
     'codex-api-key-usage-panel',
     usageMode ?? 'sub2api',
@@ -85,6 +86,29 @@ export function ModelProviderUsagePanel({
               {t('codex.modelProviders.usage.fields.expiresAt', 'Next Reset')}
             </span>
             <strong>{resetDetail?.value || '-'}</strong>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (usageMode === 'custom') {
+    const remaining = summary.remaining ?? summary.balance ?? summary.quotaRemaining;
+    const status = summary.status || (summary.isValid === false ? 'invalid' : 'available');
+    return (
+      <div className={classNames}>
+        <div className="codex-api-key-usage-grid">
+          <div>
+            <span>{t('codex.modelProviders.usage.fields.remaining', 'Remaining')}</span>
+            <strong>{formatModelProviderUsageMoney(remaining, summary.unit)}</strong>
+          </div>
+          <div>
+            <span>{t('codex.modelProviders.usage.fields.status', 'Status')}</span>
+            <strong>{status}</strong>
+          </div>
+          <div>
+            <span>{t('codex.modelProviders.usage.fields.unit', 'Unit')}</span>
+            <strong>{summary.unit || '-'}</strong>
           </div>
         </div>
       </div>

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -715,13 +715,14 @@ function getCockpitApiStatsRecord(
 
 function resolveApiKeyUsageMode(
   summary?: CodexModelProviderUsageSummary,
-): "new_api" | "sub2api" | "deepseek" | "token_plan" | null {
+): "new_api" | "sub2api" | "deepseek" | "token_plan" | "custom" | null {
   if (!summary) return null;
   if (
     summary.mode === "new_api" ||
     summary.mode === "sub2api" ||
     summary.mode === "deepseek" ||
-    summary.mode === "token_plan"
+    summary.mode === "token_plan" ||
+    summary.mode === "custom"
   ) {
     return summary.mode;
   }
@@ -7220,6 +7221,7 @@ export function CodexAccountsPage() {
               baseUrl: savedProvider.baseUrl,
               apiKey: validation.apiKey,
               integrationType: savedProvider.integrationType ?? null,
+              usageQuery: savedProvider.usageQuery ?? null,
             });
             if (
               (usageSummary.mode === "sub2api" ||
@@ -7685,6 +7687,7 @@ export function CodexAccountsPage() {
           baseUrl,
           apiKey,
           integrationType: targetProvider?.integrationType ?? null,
+          usageQuery: targetProvider?.usageQuery ?? null,
         });
         const updatedAt = Date.now();
         if (
@@ -8193,6 +8196,7 @@ export function CodexAccountsPage() {
       const isNewApiUsage = usageMode === "new_api";
       const isSub2ApiUsage = usageMode === "sub2api";
       const isTokenPlanUsage = usageMode === "token_plan";
+      const isCustomUsage = usageMode === "custom";
       const usedPercent = formatApiKeyUsagePercent(summary);
       if (isDeepSeekUsage) {
         return (
@@ -8376,6 +8380,35 @@ export function CodexAccountsPage() {
           </div>
         );
       }
+      if (variant === "card" && summary && isCustomUsage) {
+        const remaining =
+          summary.remaining ?? summary.balance ?? summary.quotaRemaining;
+        return (
+          <div
+            className="quota-item codex-api-key-quota-item custom"
+            title={`${t(
+              "codex.modelProviders.usage.fields.remaining",
+              "Remaining",
+            )}: ${formatApiKeyUsageMoney(remaining, summary.unit)}`}
+          >
+            <div className="quota-header">
+              <Database size={14} />
+              <span className="quota-label">
+                {t("codex.modelProviders.usage.custom", "Custom usage")}
+              </span>
+              <span className="quota-pct high">
+                {formatApiKeyUsageMoney(remaining, summary.unit)}
+              </span>
+            </div>
+            <span className="quota-reset">
+              {summary.status ||
+                (summary.isValid === false
+                  ? t("codex.modelProviders.usage.invalid", "Invalid")
+                  : t("codex.modelProviders.usage.available", "Available"))}
+            </span>
+          </div>
+        );
+      }
       if (summary && !usageMode) {
         return <></>;
       }
@@ -8542,6 +8575,38 @@ export function CodexAccountsPage() {
                           summary.todayTotalTokens ?? 0,
                         )}
                       </strong>
+                    </div>
+                  </>
+                ) : isCustomUsage ? (
+                  <>
+                    <div>
+                      <span>
+                        {t(
+                          "codex.modelProviders.usage.fields.remaining",
+                          "Remaining",
+                        )}
+                      </span>
+                      <strong>
+                        {formatApiKeyUsageMoney(
+                          summary.remaining ??
+                            summary.balance ??
+                            summary.quotaRemaining,
+                          summary.unit,
+                        )}
+                      </strong>
+                    </div>
+                    <div>
+                      <span>
+                        {t("codex.modelProviders.usage.fields.status", "Status")}
+                      </span>
+                      <strong>
+                        {summary.status ||
+                          (summary.isValid === false ? "invalid" : "available")}
+                      </strong>
+                    </div>
+                    <div>
+                      <span>{t("codex.modelProviders.usage.fields.unit", "Unit")}</span>
+                      <strong>{summary.unit || "-"}</strong>
                     </div>
                   </>
                 ) : null}
@@ -8755,6 +8820,7 @@ export function CodexAccountsPage() {
               baseUrl: savedProvider.baseUrl,
               apiKey: validation.apiKey,
               integrationType: savedProvider.integrationType ?? null,
+              usageQuery: savedProvider.usageQuery ?? null,
             });
             if (
               (usageSummary.mode === "sub2api" ||

--- a/src/services/codexApiKeyUsageRefreshService.ts
+++ b/src/services/codexApiKeyUsageRefreshService.ts
@@ -112,6 +112,7 @@ export async function refreshCodexApiKeyUsageForAccounts(
         baseUrl,
         apiKey,
         integrationType: provider?.integrationType ?? null,
+        usageQuery: provider?.usageQuery ?? null,
       });
       updates[account.id] = { loading: false, summary, updatedAt: Date.now() };
     } catch (error) {

--- a/src/services/codexModelProviderService.ts
+++ b/src/services/codexModelProviderService.ts
@@ -18,6 +18,8 @@ import {
 } from '../utils/apikeyFunLinks';
 import {
   queryModelProviderUsage,
+  type ModelProviderUsageField,
+  type ModelProviderUsageQuery,
   type ModelProviderUsageSummary,
 } from './modelProviderUsageService';
 import { moveCodexProviderApiKey } from '../utils/codexModelProviderApiKeyMove';
@@ -30,12 +32,15 @@ export interface CodexModelProviderApiKey {
   updatedAt: number;
 }
 
+export type CodexModelProviderUsageQuery = ModelProviderUsageQuery;
+
 export interface CodexModelProvider {
   id: string;
   name: string;
   baseUrl: string;
   sourceTag?: string;
   integrationType?: 'sub2api' | 'new_api';
+  usageQuery?: CodexModelProviderUsageQuery;
   modelCatalog?: string[];
   modelContextWindows?: Record<string, number>;
   supportsVision?: boolean;
@@ -73,6 +78,7 @@ interface UpsertFromCredentialInput {
   wireApi?: CodexProviderWireApi | null;
   supportsWebsockets?: boolean;
   integrationType?: 'sub2api' | 'new_api' | null;
+  usageQuery?: CodexModelProviderUsageQuery | null;
 }
 
 let providerIdCounter = 0;
@@ -185,6 +191,61 @@ function hasOwnProperty(value: object, key: string): boolean {
 
 function normalizeIntegrationType(value: unknown): 'sub2api' | 'new_api' | undefined {
   return value === 'sub2api' || value === 'new_api' ? value : undefined;
+}
+
+const MODEL_PROVIDER_USAGE_FIELDS: readonly ModelProviderUsageField[] = [
+  'isValid',
+  'status',
+  'planName',
+  'remaining',
+  'balance',
+  'unit',
+  'quotaUnlimited',
+  'quotaLimit',
+  'quotaUsed',
+  'quotaRemaining',
+  'todayRequests',
+  'todayTotalTokens',
+  'todayCost',
+  'totalRequests',
+  'totalTotalTokens',
+  'totalCost',
+];
+
+function normalizeUsageQuery(value: unknown): CodexModelProviderUsageQuery | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const source = value as Record<string, unknown>;
+  const endpoint = String(source.endpoint ?? '').trim();
+  if (!endpoint || endpoint.length > 512) return undefined;
+
+  const headers: Record<string, string> = {};
+  if (source.headers && typeof source.headers === 'object' && !Array.isArray(source.headers)) {
+    for (const [rawName, rawValue] of Object.entries(source.headers as Record<string, unknown>)) {
+      const name = rawName.trim();
+      const headerValue = String(rawValue ?? '').trim();
+      if (!name || !headerValue || name.length > 128 || headerValue.length > 2048) continue;
+      headers[name] = headerValue;
+    }
+  }
+
+  const mappings: Partial<Record<ModelProviderUsageField, string>> = {};
+  if (
+    source.mappings &&
+    typeof source.mappings === 'object' &&
+    !Array.isArray(source.mappings)
+  ) {
+    const rawMappings = source.mappings as Record<string, unknown>;
+    for (const field of MODEL_PROVIDER_USAGE_FIELDS) {
+      const mapping = String(rawMappings[field] ?? '').trim();
+      if (mapping && mapping.length <= 256) mappings[field] = mapping;
+    }
+  }
+
+  return {
+    endpoint,
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
+    ...(Object.keys(mappings).length > 0 ? { mappings } : {}),
+  };
 }
 
 function migrateApiKeyFunProviderWireApi(
@@ -322,6 +383,17 @@ function deriveProviderNameFromBaseUrl(baseUrl: string): string {
 function cloneProviders(providers: CodexModelProvider[]): CodexModelProvider[] {
   return providers.map((provider) => ({
     ...provider,
+    usageQuery: provider.usageQuery
+      ? {
+          ...provider.usageQuery,
+          headers: provider.usageQuery.headers
+            ? { ...provider.usageQuery.headers }
+            : undefined,
+          mappings: provider.usageQuery.mappings
+            ? { ...provider.usageQuery.mappings }
+            : undefined,
+        }
+      : undefined,
     modelCapabilities: provider.modelCapabilities
       ? Object.fromEntries(
           Object.entries(provider.modelCapabilities).map(([model, capability]) => [
@@ -378,6 +450,7 @@ function toValidProviderList(raw: unknown): CodexModelProvider[] {
       integrationType: normalizeIntegrationType(
         (item as { integrationType?: unknown }).integrationType,
       ),
+      usageQuery: normalizeUsageQuery((item as { usageQuery?: unknown }).usageQuery),
       modelCatalog:
         normalizeModelCatalog((item as { modelCatalog?: unknown }).modelCatalog) ??
         presetModelCatalogForBaseUrl(baseUrl),
@@ -563,6 +636,7 @@ export async function createCodexModelProvider(input: {
   supportsWebsockets?: boolean;
   enableModePreference?: CodexProviderEnableModePreference;
   integrationType?: 'sub2api' | 'new_api';
+  usageQuery?: CodexModelProviderUsageQuery;
   boundOauthAccountId?: string | null;
   initialApiKey?: string;
   initialApiKeyName?: string;
@@ -584,6 +658,7 @@ export async function createCodexModelProvider(input: {
     baseUrl,
     sourceTag: sanitizeName(input.sourceTag ?? '') || undefined,
     integrationType: normalizeIntegrationType(input.integrationType),
+    usageQuery: normalizeUsageQuery(input.usageQuery),
     modelCatalog:
       normalizeModelCatalog(input.modelCatalog) ??
       presetModelCatalogForBaseUrl(baseUrl),
@@ -634,6 +709,7 @@ export async function updateCodexModelProvider(
     supportsWebsockets?: boolean;
     enableModePreference?: CodexProviderEnableModePreference | null;
     integrationType?: 'sub2api' | 'new_api' | null;
+    usageQuery?: CodexModelProviderUsageQuery | null;
     boundOauthAccountId?: string | null;
   },
 ): Promise<CodexModelProvider> {
@@ -728,6 +804,10 @@ export async function updateCodexModelProvider(
   }
   if (patch.integrationType !== undefined) {
     provider.integrationType = normalizeIntegrationType(patch.integrationType);
+  }
+  if (patch.usageQuery !== undefined) {
+    provider.usageQuery =
+      patch.usageQuery === null ? undefined : normalizeUsageQuery(patch.usageQuery);
   }
   if (patch.boundOauthAccountId !== undefined) {
     provider.boundOauthAccountId =
@@ -909,6 +989,7 @@ export async function queryCodexModelProviderUsage(input: {
   baseUrl: string;
   apiKey: string;
   integrationType?: 'sub2api' | 'new_api' | null;
+  usageQuery?: CodexModelProviderUsageQuery | null;
 }): Promise<CodexModelProviderUsageSummary> {
   return await queryModelProviderUsage(input);
 }
@@ -959,6 +1040,7 @@ export async function upsertCodexModelProviderFromCredential(
       modelCapabilities: normalizeModelCapabilities(input.modelCapabilities),
       visionRoutingModel: sanitizeName(input.visionRoutingModel ?? '') || undefined,
       integrationType: normalizeIntegrationType(input.integrationType),
+      usageQuery: normalizeUsageQuery(input.usageQuery),
       website: sanitizeName(input.website ?? '') || undefined,
       apiKeyUrl: sanitizeName(input.apiKeyUrl ?? '') || undefined,
       wireApi,
@@ -1031,6 +1113,10 @@ export async function upsertCodexModelProviderFromCredential(
   }
   if (input.integrationType !== undefined) {
     provider.integrationType = normalizeIntegrationType(input.integrationType);
+  }
+  if (input.usageQuery !== undefined) {
+    provider.usageQuery =
+      input.usageQuery === null ? undefined : normalizeUsageQuery(input.usageQuery);
   }
   enforceDeepSeekProvider(provider);
   provider.updatedAt = Date.now();

--- a/src/services/modelProviderUsageService.test.ts
+++ b/src/services/modelProviderUsageService.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   buildUsageBaseUrlCandidates,
   formatModelProviderUsageMoney,
+  resolveModelProviderUsageMode,
   resolveNewApiQuotaSnapshot,
   type ModelProviderUsageSummary,
 } from "./modelProviderUsageService.ts";
@@ -96,4 +97,17 @@ test("new_api quota ignores malformed numeric details", () => {
 
 test("token plan percentages render without currency decimals", () => {
   assert.equal(formatModelProviderUsageMoney(72, "%"), "72%");
+});
+
+test("custom usage summaries preserve their explicit mode", () => {
+  assert.equal(
+    resolveModelProviderUsageMode(
+      summary({
+        mode: "custom",
+        remaining: 12.5,
+        unit: "CNY",
+      }),
+    ),
+    "custom",
+  );
 });

--- a/src/services/modelProviderUsageService.ts
+++ b/src/services/modelProviderUsageService.ts
@@ -4,7 +4,39 @@ export type ModelProviderUsageIntegrationType = 'sub2api' | 'new_api';
 export type ModelProviderUsageMode =
   | ModelProviderUsageIntegrationType
   | 'deepseek'
-  | 'token_plan';
+  | 'token_plan'
+  | 'custom';
+
+export type ModelProviderUsageField =
+  | 'isValid'
+  | 'status'
+  | 'planName'
+  | 'remaining'
+  | 'balance'
+  | 'unit'
+  | 'quotaUnlimited'
+  | 'quotaLimit'
+  | 'quotaUsed'
+  | 'quotaRemaining'
+  | 'todayRequests'
+  | 'todayTotalTokens'
+  | 'todayCost'
+  | 'totalRequests'
+  | 'totalTotalTokens'
+  | 'totalCost';
+
+/**
+ * A safe, declarative usage request. The backend only performs GET requests
+ * and resolves the endpoint against the provider's configured base URL.
+ * Mapping values are dot-separated JSON paths (for example `quota.remaining`).
+ * The `unit` mapping may also be a literal such as `CNY`; prefix it with `$`
+ * when it should be read from the response instead (for example `$.unit`).
+ */
+export interface ModelProviderUsageQuery {
+  endpoint: string;
+  headers?: Record<string, string>;
+  mappings?: Partial<Record<ModelProviderUsageField, string>>;
+}
 
 export interface ModelProviderModel {
   id: string;
@@ -113,6 +145,7 @@ export async function queryModelProviderUsage(input: {
   baseUrl: string;
   apiKey: string;
   integrationType?: ModelProviderUsageIntegrationType | null;
+  usageQuery?: ModelProviderUsageQuery | null;
 }): Promise<ModelProviderUsageSummary> {
   const candidates = buildUsageBaseUrlCandidates(input.baseUrl);
   let lastError: unknown = null;
@@ -122,6 +155,7 @@ export async function queryModelProviderUsage(input: {
         baseUrl,
         apiKey: input.apiKey,
         integrationType: input.integrationType ?? null,
+        usageQuery: input.usageQuery ?? null,
       });
     } catch (error) {
       lastError = error;
@@ -160,7 +194,8 @@ export function resolveModelProviderUsageMode(
     summary.mode === 'new_api' ||
     summary.mode === 'sub2api' ||
     summary.mode === 'deepseek' ||
-    summary.mode === 'token_plan'
+    summary.mode === 'token_plan' ||
+    summary.mode === 'custom'
   ) {
     return summary.mode;
   }


### PR DESCRIPTION
## Summary

- Add per-provider custom same-origin GET usage endpoints with bounded custom headers and declarative JSON-path mappings.
- Persist and render custom usage summaries across the Codex provider and account views.
- Include scoped API account model catalogs in local API model visibility.
- Add focused regression coverage for custom usage parsing, loopback upstream handling, and scoped model catalogs.

## Issue context

- Related to #1421: supports the requested custom routes and common JSON responses without executing arbitrary JavaScript.
- Related to #1677: fixes the model visibility gap for models present in the scoped API account catalog. Broader API/official switching and service-lifecycle synchronization still needs a reproducible case.
- #1660 is intentionally not included: the Codex App Goal persistence and durable-turn interface is not available in this repository.
- #1853 requires no duplicate patch: the different-port loopback fix is already present in the current release line.

## Validation

- `npm run typecheck`
- `node --test src/services/modelProviderUsageService.test.ts` (7/7)
- Focused Rust tests for custom usage (3/3), scoped model visibility (2/2), and loopback upstream handling (5/5)
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Full Rust suite: 806/819 passed; the remaining 11 failures are existing Windows file-handle, mtime-permission, and lock-isolation failures, while the changed-path tests pass in isolation.
