### PR TITLE
fix: resolve Linux Antigravity executable paths

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -700,25 +700,6 @@ if ([string]::IsNullOrWhiteSpace($v.ProductVersion) -and [string]::IsNullOrWhite
         .or_else(|| read_antigravity_windows_uninstall_metadata(&exe_path))
 }
 
-fn antigravity_metadata_root_from_executable(path: &Path) -> Option<PathBuf> {
-    let parent = path.parent()?;
-    let is_linux_launcher = path
-        .file_name()
-        .map(|name| {
-            name.to_string_lossy()
-                .eq_ignore_ascii_case("antigravity-ide")
-        })
-        .unwrap_or(false);
-    let is_bin_directory = parent
-        .file_name()
-        .map(|name| name.to_string_lossy().eq_ignore_ascii_case("bin"))
-        .unwrap_or(false);
-    if is_linux_launcher && is_bin_directory {
-        return parent.parent().map(Path::to_path_buf);
-    }
-    Some(parent.to_path_buf())
-}
-
 fn normalize_antigravity_metadata_root(path: &Path) -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
@@ -731,13 +712,7 @@ fn normalize_antigravity_metadata_root(path: &Path) -> Option<PathBuf> {
     let normalized = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     #[cfg(not(target_os = "linux"))]
     let normalized = path.to_path_buf();
-    if normalized.is_file() {
-        return antigravity_metadata_root_from_executable(&normalized);
-    }
-    if normalized.is_dir() {
-        return Some(normalized);
-    }
-    None
+    crate::modules::process::antigravity_install_root_from_path(&normalized)
 }
 
 fn push_unique_antigravity_candidate(candidates: &mut Vec<PathBuf>, path: PathBuf) {
@@ -4233,6 +4208,51 @@ mod tests {
             .expect("read product.json from install root");
 
         assert_eq!(root, install.path());
+        assert_eq!(metadata.version, "1.2.3");
+    }
+
+    #[test]
+    fn antigravity_metadata_skips_invalid_primary_product_json() {
+        let install = MetadataTestDir::new("invalid-primary-product-json");
+        let primary = install.path().join("resources").join("app");
+        let fallback = install.path().join("app");
+        std::fs::create_dir_all(&primary).expect("create primary metadata directory");
+        std::fs::create_dir_all(&fallback).expect("create fallback metadata directory");
+        std::fs::write(primary.join("product.json"), b"not-json")
+            .expect("write invalid primary product metadata");
+        std::fs::write(
+            fallback.join("product.json"),
+            r#"{"nameShort":"Antigravity IDE","ideVersion":"9.8.7"}"#,
+        )
+        .expect("write fallback product metadata");
+
+        let metadata = read_antigravity_product_json_metadata(install.path())
+            .expect("read fallback product metadata");
+
+        assert_eq!(metadata.version, "9.8.7");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn antigravity_metadata_follows_bin_launcher_symlink_to_install_root() {
+        let install = MetadataTestDir::new("symlink-space-含");
+        write_antigravity_product_json(install.path());
+        let launcher = install.path().join("bin").join("antigravity-ide");
+        let link = install.path().join("launcher-link");
+        std::fs::create_dir_all(launcher.parent().expect("launcher parent"))
+            .expect("create launcher directory");
+        std::fs::write(&launcher, b"launcher").expect("write bin launcher");
+        std::os::unix::fs::symlink("bin/antigravity-ide", &link).expect("create launcher symlink");
+
+        let root = normalize_antigravity_metadata_root(&link)
+            .expect("resolve metadata root from symlink launcher");
+        let metadata = read_antigravity_product_json_metadata(&root)
+            .expect("read product metadata through symlink root");
+
+        assert_eq!(
+            root,
+            std::fs::canonicalize(install.path()).expect("canonicalize install")
+        );
         assert_eq!(metadata.version, "1.2.3");
     }
 

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -518,6 +518,10 @@ fn read_antigravity_product_json_metadata(root: &Path) -> Option<AntigravityInst
         let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
             continue;
         };
+        #[cfg(any(target_os = "linux", test))]
+        if antigravity_product_json_is_explicitly_unrelated(&value) {
+            continue;
+        }
         let Some(version) = json_string_field(&value, &["ideVersion", "version"]) else {
             continue;
         };
@@ -532,6 +536,55 @@ fn read_antigravity_product_json_metadata(root: &Path) -> Option<AntigravityInst
             app_path: root.to_string_lossy().to_string(),
             source: "product.json".to_string(),
         });
+    }
+    None
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn antigravity_product_json_is_explicitly_unrelated(value: &serde_json::Value) -> bool {
+    if json_string_field(value, &["ideVersion"]).is_some() {
+        return false;
+    }
+    json_string_field(
+        value,
+        &["nameShort", "nameLong", "productName", "applicationName"],
+    )
+    .is_some_and(|name| !name.to_ascii_lowercase().contains("antigravity"))
+}
+
+fn antigravity_product_json_target(root: &Path) -> Option<&'static str> {
+    for path in antigravity_product_json_candidates(root) {
+        let Ok(content) = fs::read_to_string(path) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        let has_ide_version = json_string_field(&value, &["ideVersion"]).is_some();
+        if !has_ide_version && json_string_field(&value, &["version"]).is_none() {
+            continue;
+        }
+        let product_name = json_string_field(
+            &value,
+            &["nameShort", "nameLong", "productName", "applicationName"],
+        )
+        .map(|name| name.to_ascii_lowercase());
+        if has_ide_version
+            || product_name
+                .as_deref()
+                .is_some_and(|name| name.contains("antigravity") && name.contains("ide"))
+        {
+            return Some("antigravity_ide");
+        }
+        if product_name
+            .as_deref()
+            .is_some_and(|name| name.contains("antigravity") && !name.contains("ide"))
+        {
+            return Some("antigravity");
+        }
+        // A valid but unrelated primary product.json should not prevent the
+        // fallback layout from identifying the configured Antigravity root.
+        continue;
     }
     None
 }
@@ -769,9 +822,26 @@ pub fn get_cached_antigravity_installed_version_info_for_target(
 }
 
 fn antigravity_metadata_root_matches_target(root: &Path, target: Option<&str>) -> bool {
+    antigravity_metadata_root_matches_target_with_product_metadata(
+        root,
+        target,
+        cfg!(target_os = "linux"),
+    )
+}
+
+fn antigravity_metadata_root_matches_target_with_product_metadata(
+    root: &Path,
+    target: Option<&str>,
+    prefer_product_metadata: bool,
+) -> bool {
     let Some(target) = normalize_antigravity_metadata_target(target) else {
         return true;
     };
+    if prefer_product_metadata {
+        if let Some(metadata_target) = antigravity_product_json_target(root) {
+            return metadata_target == target;
+        }
+    }
     let value = root.to_string_lossy().to_ascii_lowercase();
     match target {
         "antigravity" => {
@@ -4133,9 +4203,10 @@ pub fn save_user_memory_list(
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_codex_quota_alert_thresholds, apply_general_config_updates,
-        lock_general_config_transaction, normalize_antigravity_metadata_root,
-        read_antigravity_product_json_metadata, UserConfig,
+        antigravity_metadata_root_matches_target_with_product_metadata,
+        antigravity_product_json_target, apply_codex_quota_alert_thresholds,
+        apply_general_config_updates, lock_general_config_transaction,
+        normalize_antigravity_metadata_root, read_antigravity_product_json_metadata, UserConfig,
     };
     use std::path::{Path, PathBuf};
     use std::sync::mpsc;
@@ -4232,6 +4303,34 @@ mod tests {
         assert_eq!(metadata.version, "9.8.7");
     }
 
+    #[test]
+    fn metadata_target_skips_unrelated_primary_product_json() {
+        let install = MetadataTestDir::new("unrelated-primary-product-json");
+        let primary = install.path().join("resources").join("app");
+        let fallback = install.path().join("app");
+        std::fs::create_dir_all(&primary).expect("create primary metadata directory");
+        std::fs::create_dir_all(&fallback).expect("create fallback metadata directory");
+        std::fs::write(
+            primary.join("product.json"),
+            r#"{"nameShort":"Other IDE","version":"1.0.0"}"#,
+        )
+        .expect("write unrelated primary product metadata");
+        std::fs::write(
+            fallback.join("product.json"),
+            r#"{"nameShort":"Antigravity IDE","ideVersion":"9.8.7"}"#,
+        )
+        .expect("write fallback product metadata");
+
+        assert_eq!(
+            antigravity_product_json_target(install.path()),
+            Some("antigravity_ide")
+        );
+        let metadata = read_antigravity_product_json_metadata(install.path())
+            .expect("read fallback Antigravity metadata");
+        assert_eq!(metadata.product_name, "Antigravity IDE");
+        assert_eq!(metadata.version, "9.8.7");
+    }
+
     #[cfg(unix)]
     #[test]
     fn antigravity_metadata_follows_bin_launcher_symlink_to_install_root() {
@@ -4254,6 +4353,85 @@ mod tests {
             std::fs::canonicalize(install.path()).expect("canonicalize install")
         );
         assert_eq!(metadata.version, "1.2.3");
+    }
+
+    #[test]
+    fn configured_neutral_executable_uses_product_metadata_for_ide_target() {
+        let install = MetadataTestDir::new("neutral-configured-executable");
+        write_antigravity_product_json(install.path());
+        let executable = install.path().join("MyIDE.AppImage");
+        std::fs::write(&executable, b"launcher").expect("write neutral executable");
+
+        let root = normalize_antigravity_metadata_root(&executable)
+            .expect("resolve metadata root from neutral executable");
+        assert!(
+            antigravity_metadata_root_matches_target_with_product_metadata(
+                &root,
+                Some("antigravity_ide"),
+                true,
+            )
+        );
+        assert_eq!(
+            read_antigravity_product_json_metadata(&root)
+                .expect("read configured product metadata")
+                .version,
+            "1.2.3"
+        );
+    }
+
+    #[test]
+    fn ide_version_field_classifies_metadata_without_a_product_name() {
+        let install = MetadataTestDir::new("unnamed-product");
+        let product_dir = install.path().join("resources").join("app");
+        std::fs::create_dir_all(&product_dir).expect("create unnamed product metadata directory");
+        std::fs::write(
+            product_dir.join("product.json"),
+            r#"{"ideVersion":"2.4.6"}"#,
+        )
+        .expect("write unnamed product metadata");
+
+        assert!(
+            antigravity_metadata_root_matches_target_with_product_metadata(
+                install.path(),
+                Some("antigravity_ide"),
+                true,
+            )
+        );
+        assert!(
+            !antigravity_metadata_root_matches_target_with_product_metadata(
+                install.path(),
+                Some("antigravity"),
+                true,
+            )
+        );
+    }
+
+    #[test]
+    fn product_metadata_takes_precedence_over_install_directory_spelling() {
+        let parent = MetadataTestDir::new("metadata-target-precedence");
+        let install = parent.path().join("antigravity-ide");
+        let product_dir = install.join("resources").join("app");
+        std::fs::create_dir_all(&product_dir).expect("create legacy product metadata directory");
+        std::fs::write(
+            product_dir.join("product.json"),
+            r#"{"nameShort":"Antigravity","version":"3.2.1"}"#,
+        )
+        .expect("write legacy product metadata");
+
+        assert!(
+            antigravity_metadata_root_matches_target_with_product_metadata(
+                &install,
+                Some("antigravity"),
+                true,
+            )
+        );
+        assert!(
+            !antigravity_metadata_root_matches_target_with_product_metadata(
+                &install,
+                Some("antigravity_ide"),
+                true,
+            )
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -700,6 +700,25 @@ if ([string]::IsNullOrWhiteSpace($v.ProductVersion) -and [string]::IsNullOrWhite
         .or_else(|| read_antigravity_windows_uninstall_metadata(&exe_path))
 }
 
+fn antigravity_metadata_root_from_executable(path: &Path) -> Option<PathBuf> {
+    let parent = path.parent()?;
+    let is_linux_launcher = path
+        .file_name()
+        .map(|name| {
+            name.to_string_lossy()
+                .eq_ignore_ascii_case("antigravity-ide")
+        })
+        .unwrap_or(false);
+    let is_bin_directory = parent
+        .file_name()
+        .map(|name| name.to_string_lossy().eq_ignore_ascii_case("bin"))
+        .unwrap_or(false);
+    if is_linux_launcher && is_bin_directory {
+        return parent.parent().map(Path::to_path_buf);
+    }
+    Some(parent.to_path_buf())
+}
+
 fn normalize_antigravity_metadata_root(path: &Path) -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
@@ -708,11 +727,15 @@ fn normalize_antigravity_metadata_root(path: &Path) -> Option<PathBuf> {
         }
     }
 
-    if path.is_file() {
-        return path.parent().map(Path::to_path_buf);
+    #[cfg(target_os = "linux")]
+    let normalized = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    #[cfg(not(target_os = "linux"))]
+    let normalized = path.to_path_buf();
+    if normalized.is_file() {
+        return antigravity_metadata_root_from_executable(&normalized);
     }
-    if path.is_dir() {
-        return Some(path.to_path_buf());
+    if normalized.is_dir() {
+        return Some(normalized);
     }
     None
 }
@@ -849,6 +872,15 @@ fn antigravity_metadata_candidates(
             let path = PathBuf::from(path);
             if path.exists() {
                 push_unique_antigravity_candidate(&mut candidates, path);
+            }
+        }
+
+        if normalize_antigravity_metadata_target(target) != Some("antigravity") {
+            if let Some(home) = dirs::home_dir() {
+                let user_local_share = home.join(".local/share/antigravity-ide");
+                if user_local_share.exists() {
+                    push_unique_antigravity_candidate(&mut candidates, user_local_share);
+                }
             }
         }
     }
@@ -4127,11 +4159,82 @@ pub fn save_user_memory_list(
 mod tests {
     use super::{
         apply_codex_quota_alert_thresholds, apply_general_config_updates,
-        lock_general_config_transaction, UserConfig,
+        lock_general_config_transaction, normalize_antigravity_metadata_root,
+        read_antigravity_product_json_metadata, UserConfig,
     };
+    use std::path::{Path, PathBuf};
     use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
+
+    struct MetadataTestDir(PathBuf);
+
+    impl MetadataTestDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "cockpit-tools-antigravity-metadata-{}-{}",
+                std::process::id(),
+                name
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).expect("create metadata test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for MetadataTestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_antigravity_product_json(root: &Path) {
+        let product_dir = root.join("resources").join("app");
+        std::fs::create_dir_all(&product_dir).expect("create product metadata directory");
+        std::fs::write(
+            product_dir.join("product.json"),
+            r#"{"nameShort":"Antigravity IDE","ideVersion":"1.2.3"}"#,
+        )
+        .expect("write product metadata");
+    }
+
+    #[test]
+    fn antigravity_metadata_uses_install_root_for_root_executable() {
+        let install = MetadataTestDir::new("root-executable");
+        write_antigravity_product_json(install.path());
+        let executable = install.path().join("antigravity-ide");
+        std::fs::write(&executable, b"launcher").expect("write root executable");
+
+        let root = normalize_antigravity_metadata_root(&executable)
+            .expect("resolve metadata root from executable");
+        let metadata = read_antigravity_product_json_metadata(&root)
+            .expect("read product.json from install root");
+
+        assert_eq!(root, install.path());
+        assert_eq!(metadata.version, "1.2.3");
+    }
+
+    #[test]
+    fn antigravity_metadata_uses_install_root_for_bin_launcher() {
+        let install = MetadataTestDir::new("bin-launcher");
+        write_antigravity_product_json(install.path());
+        let executable = install.path().join("bin").join("antigravity-ide");
+        std::fs::create_dir_all(executable.parent().expect("launcher parent"))
+            .expect("create launcher directory");
+        std::fs::write(&executable, b"launcher").expect("write bin launcher");
+
+        let root = normalize_antigravity_metadata_root(&executable)
+            .expect("resolve metadata root from bin launcher");
+        let metadata = read_antigravity_product_json_metadata(&root)
+            .expect("read product.json from install root");
+
+        assert_eq!(root, install.path());
+        assert_eq!(metadata.version, "1.2.3");
+    }
 
     #[test]
     fn general_config_transaction_lock_serializes_side_effecting_writes() {

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -1828,6 +1828,156 @@ mod app_path_config_guard_tests {
     }
 }
 
+#[cfg(test)]
+mod linux_antigravity_path_tests {
+    use super::{linux_antigravity_discovery_paths, resolve_linux_antigravity_exec_path};
+    use std::path::{Path, PathBuf};
+
+    struct PathTestDir(PathBuf);
+
+    impl PathTestDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "cockpit-tools-linux-antigravity-{}-{}",
+                std::process::id(),
+                name
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).expect("create path test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for PathTestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_executable(path: &Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create executable parent");
+        }
+        std::fs::write(path, b"launcher").expect("write executable");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+                .expect("mark test file executable");
+        }
+    }
+
+    #[test]
+    fn install_root_resolves_root_antigravity_executable() {
+        let install = PathTestDir::new("root-layout");
+        let executable = install.path().join("antigravity-ide");
+        write_executable(&executable);
+
+        assert_eq!(
+            resolve_linux_antigravity_exec_path(install.path()).expect("resolve root layout"),
+            executable
+        );
+    }
+
+    #[test]
+    fn install_root_resolves_bin_antigravity_launcher() {
+        let install = PathTestDir::new("bin-layout");
+        let executable = install.path().join("bin").join("antigravity-ide");
+        write_executable(&executable);
+
+        assert_eq!(
+            resolve_linux_antigravity_exec_path(install.path()).expect("resolve bin layout"),
+            executable
+        );
+    }
+
+    #[test]
+    fn configured_executable_file_is_preserved() {
+        let install = PathTestDir::new("custom-file");
+        let executable = install.path().join("custom-antigravity-launcher");
+        write_executable(&executable);
+
+        assert_eq!(
+            resolve_linux_antigravity_exec_path(&executable).expect("keep configured executable"),
+            executable
+        );
+    }
+
+    #[test]
+    fn directory_without_supported_executable_is_rejected() {
+        let install = PathTestDir::new("empty-layout");
+
+        let error = resolve_linux_antigravity_exec_path(install.path())
+            .expect_err("reject directory without a launcher");
+
+        assert!(error.contains("antigravity-ide"));
+        assert!(error.contains("bin"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_executable_linux_launcher_is_rejected() {
+        let install = PathTestDir::new("non-executable");
+        let executable = install.path().join("antigravity-ide");
+        std::fs::write(&executable, b"launcher").expect("write non-executable launcher");
+
+        let error = resolve_linux_antigravity_exec_path(&executable)
+            .expect_err("reject launcher without an executable bit");
+
+        assert!(error.contains("not executable"));
+    }
+
+    #[test]
+    fn discovery_includes_user_local_share_install_root() {
+        let home = Path::new("/home/cockpit-test");
+
+        let candidates = linux_antigravity_discovery_paths(Some(home));
+
+        assert!(candidates.contains(&home.join(".local/share/antigravity-ide")));
+    }
+
+    #[test]
+    fn legacy_linux_layout_uses_the_shared_antigravity_resolver() {
+        let install = PathTestDir::new("legacy-layout");
+        let executable = install.path().join("bin").join("antigravity-ide");
+        write_executable(&executable);
+
+        assert_eq!(
+            resolve_linux_antigravity_exec_path(install.path())
+                .expect("resolve legacy Linux layout"),
+            executable
+        );
+    }
+}
+
+#[cfg(all(test, unix))]
+mod canonical_path_comparison_tests {
+    use super::normalize_path_for_compare;
+
+    #[test]
+    fn canonicalized_symlink_and_target_paths_compare_equal() {
+        let root =
+            std::env::temp_dir().join(format!("cockpit-tools-path-compare-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("create comparison test directory");
+        let target = root.join("antigravity-ide");
+        let link = root.join("antigravity-link");
+        std::fs::write(&target, b"launcher").expect("write comparison target");
+        std::os::unix::fs::symlink(&target, &link).expect("create comparison symlink");
+
+        assert_eq!(
+            normalize_path_for_compare(&target.to_string_lossy()),
+            normalize_path_for_compare(&link.to_string_lossy())
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn is_legacy_antigravity_macos_path(path: &str) -> bool {
     let lower = path.trim().to_ascii_lowercase();
@@ -2181,6 +2331,72 @@ fn resolve_windows_antigravity_ide_custom_path(path_str: &str) -> Option<std::pa
     None
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn linux_antigravity_discovery_paths(home: Option<&Path>) -> Vec<std::path::PathBuf> {
+    let mut candidates = vec![
+        std::path::PathBuf::from("/usr/bin/antigravity-ide"),
+        std::path::PathBuf::from("/opt/antigravity-ide"),
+        std::path::PathBuf::from("/usr/share/antigravity-ide"),
+    ];
+    if let Some(home) = home {
+        candidates.push(home.join(".local/bin/antigravity-ide"));
+        candidates.push(home.join(".local/share/antigravity-ide"));
+    }
+    candidates
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn is_linux_executable_file(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        return metadata.permissions().mode() & 0o111 != 0;
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn resolve_linux_antigravity_exec_path(path: &Path) -> Result<std::path::PathBuf, String> {
+    if path.is_file() {
+        if is_linux_executable_file(path) {
+            return Ok(path.to_path_buf());
+        }
+        return Err(format!(
+            "Linux Antigravity executable is not executable: {}",
+            path.display()
+        ));
+    }
+
+    if path.is_dir() {
+        for relative in ["antigravity-ide", "bin/antigravity-ide"] {
+            let candidate = path.join(relative);
+            if is_linux_executable_file(&candidate) {
+                return Ok(candidate);
+            }
+        }
+        return Err(format!(
+            "Linux Antigravity install directory does not contain an executable antigravity-ide or bin/antigravity-ide: {}",
+            path.display()
+        ));
+    }
+
+    Err(format!(
+        "Linux Antigravity path does not exist: {}",
+        path.display()
+    ))
+}
+
 pub fn detect_antigravity_exec_path() -> Option<std::path::PathBuf> {
     if let Some(path) = find_antigravity_process_exe() {
         return Some(path);
@@ -2232,21 +2448,10 @@ pub fn detect_antigravity_exec_path() -> Option<std::path::PathBuf> {
 
     #[cfg(target_os = "linux")]
     {
-        let candidates = [
-            "/usr/bin/antigravity-ide",
-            "/opt/antigravity-ide/antigravity-ide",
-            "/usr/share/antigravity-ide/antigravity-ide",
-        ];
-        for candidate in candidates {
-            let path = std::path::PathBuf::from(candidate);
-            if path.exists() {
-                return Some(path);
-            }
-        }
-        if let Some(home) = dirs::home_dir() {
-            let user_local = home.join(".local/bin/antigravity-ide");
-            if user_local.exists() {
-                return Some(user_local);
+        let home = dirs::home_dir();
+        for candidate in linux_antigravity_discovery_paths(home.as_deref()) {
+            if let Ok(executable) = resolve_linux_antigravity_exec_path(&candidate) {
+                return Some(executable);
             }
         }
     }
@@ -3817,7 +4022,22 @@ fn resolve_antigravity_launch_path() -> Result<std::path::PathBuf, String> {
             }
         }
 
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(exec) = resolve_macos_exec_path(&custom, "Electron") {
+                return Ok(exec);
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let custom_path = Path::new(&custom);
+            if custom_path.exists() {
+                return resolve_linux_antigravity_exec_path(custom_path);
+            }
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
         {
             if let Some(exec) = resolve_macos_exec_path(&custom, "Electron") {
                 return Ok(exec);
@@ -3856,7 +4076,15 @@ fn resolve_antigravity_legacy_launch_path() -> Result<std::path::PathBuf, String
             }
         }
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        {
+            let custom_path = Path::new(&custom);
+            if custom_path.exists() {
+                return resolve_linux_antigravity_exec_path(custom_path);
+            }
+        }
+
+        #[cfg(all(not(target_os = "macos"), not(target_os = "linux")))]
         {
             let custom_path = std::path::PathBuf::from(&custom);
             let lower = custom.to_ascii_lowercase();

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -1,7 +1,7 @@
 use crate::modules::config;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -1830,7 +1830,10 @@ mod app_path_config_guard_tests {
 
 #[cfg(test)]
 mod linux_antigravity_path_tests {
-    use super::{linux_antigravity_discovery_paths, resolve_linux_antigravity_exec_path};
+    use super::{
+        antigravity_install_root_from_path, first_linux_antigravity_executable,
+        linux_antigravity_discovery_paths, resolve_linux_antigravity_exec_path,
+    };
     use std::path::{Path, PathBuf};
 
     struct PathTestDir(PathBuf);
@@ -1896,6 +1899,32 @@ mod linux_antigravity_path_tests {
     }
 
     #[test]
+    fn install_root_prefers_root_launcher_when_both_layouts_exist() {
+        let install = PathTestDir::new("both-layouts-space-含");
+        let root_executable = install.path().join("antigravity-ide");
+        let bin_executable = install.path().join("bin").join("antigravity-ide");
+        write_executable(&root_executable);
+        write_executable(&bin_executable);
+
+        assert_eq!(
+            resolve_linux_antigravity_exec_path(install.path()).expect("resolve root launcher"),
+            root_executable
+        );
+    }
+
+    #[test]
+    fn bin_directory_resolves_to_install_root() {
+        let install = PathTestDir::new("bin-directory");
+        let bin = install.path().join("bin");
+        write_executable(&bin.join("antigravity-ide"));
+
+        assert_eq!(
+            antigravity_install_root_from_path(&bin).expect("resolve bin directory root"),
+            install.path().to_path_buf()
+        );
+    }
+
+    #[test]
     fn configured_executable_file_is_preserved() {
         let install = PathTestDir::new("custom-file");
         let executable = install.path().join("custom-antigravity-launcher");
@@ -1918,6 +1947,31 @@ mod linux_antigravity_path_tests {
         assert!(error.contains("bin"));
     }
 
+    #[test]
+    fn missing_path_is_rejected_without_falling_back_to_current_directory() {
+        let install = PathTestDir::new("missing-path");
+        let missing = install.path().join("does-not-exist");
+
+        let error = resolve_linux_antigravity_exec_path(&missing)
+            .expect_err("reject missing launcher path");
+
+        assert!(error.contains("does not exist"));
+    }
+
+    #[test]
+    fn discovery_skips_invalid_candidate_before_valid_executable() {
+        let install = PathTestDir::new("candidate-fallback");
+        let invalid = install.path().join("invalid-directory");
+        let executable = install.path().join("valid launcher");
+        std::fs::create_dir_all(&invalid).expect("create invalid candidate directory");
+        write_executable(&executable);
+
+        assert_eq!(
+            first_linux_antigravity_executable([invalid, executable.clone()]),
+            Some(executable)
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn non_executable_linux_launcher_is_rejected() {
@@ -1929,6 +1983,26 @@ mod linux_antigravity_path_tests {
             .expect_err("reject launcher without an executable bit");
 
         assert!(error.contains("not executable"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_executable_root_launcher_falls_back_to_executable_bin_launcher() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let install = PathTestDir::new("non-executable-root-fallback");
+        let root_executable = install.path().join("antigravity-ide");
+        let bin_executable = install.path().join("bin").join("antigravity-ide");
+        std::fs::write(&root_executable, b"launcher").expect("write root launcher");
+        std::fs::set_permissions(&root_executable, std::fs::Permissions::from_mode(0o644))
+            .expect("remove root launcher execute bits");
+        write_executable(&bin_executable);
+
+        assert_eq!(
+            resolve_linux_antigravity_exec_path(install.path())
+                .expect("fall back to executable bin launcher"),
+            bin_executable
+        );
     }
 
     #[test]
@@ -1951,6 +2025,36 @@ mod linux_antigravity_path_tests {
                 .expect("resolve legacy Linux layout"),
             executable
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_symlink_to_executable_is_preserved() {
+        let install = PathTestDir::new("relative-link-space-含");
+        let target = install.path().join("real launcher");
+        let link = install.path().join("launcher-link");
+        write_executable(&target);
+        std::os::unix::fs::symlink(target.file_name().expect("target name"), &link)
+            .expect("create relative executable symlink");
+
+        assert_eq!(
+            resolve_linux_antigravity_exec_path(&link).expect("resolve symlink launcher"),
+            link
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn broken_symlink_is_rejected() {
+        let install = PathTestDir::new("broken-link");
+        let link = install.path().join("broken-launcher");
+        std::os::unix::fs::symlink("missing-launcher", &link)
+            .expect("create broken launcher symlink");
+
+        let error =
+            resolve_linux_antigravity_exec_path(&link).expect_err("reject broken launcher symlink");
+
+        assert!(error.contains("does not exist"));
     }
 }
 
@@ -2397,6 +2501,54 @@ fn resolve_linux_antigravity_exec_path(path: &Path) -> Result<std::path::PathBuf
     ))
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn first_linux_antigravity_executable(
+    candidates: impl IntoIterator<Item = PathBuf>,
+) -> Option<PathBuf> {
+    candidates
+        .into_iter()
+        .find_map(|candidate| resolve_linux_antigravity_exec_path(&candidate).ok())
+}
+
+fn antigravity_install_root_from_executable(path: &Path) -> Option<PathBuf> {
+    let parent = path.parent()?;
+    let is_linux_launcher = path
+        .file_name()
+        .map(|name| {
+            name.to_string_lossy()
+                .eq_ignore_ascii_case("antigravity-ide")
+        })
+        .unwrap_or(false);
+    let is_bin_directory = parent
+        .file_name()
+        .map(|name| name.to_string_lossy().eq_ignore_ascii_case("bin"))
+        .unwrap_or(false);
+    if is_linux_launcher && is_bin_directory {
+        return parent.parent().map(Path::to_path_buf);
+    }
+    Some(parent.to_path_buf())
+}
+
+pub(crate) fn antigravity_install_root_from_path(path: &Path) -> Option<PathBuf> {
+    if path.is_file() {
+        return antigravity_install_root_from_executable(path);
+    }
+    if path.is_dir() {
+        #[cfg(any(target_os = "linux", test))]
+        {
+            let is_bin_directory = path
+                .file_name()
+                .map(|name| name.to_string_lossy().eq_ignore_ascii_case("bin"))
+                .unwrap_or(false);
+            if is_bin_directory && path.join("antigravity-ide").is_file() {
+                return path.parent().map(Path::to_path_buf);
+            }
+        }
+        return Some(path.to_path_buf());
+    }
+    None
+}
+
 pub fn detect_antigravity_exec_path() -> Option<std::path::PathBuf> {
     if let Some(path) = find_antigravity_process_exe() {
         return Some(path);
@@ -2449,10 +2601,10 @@ pub fn detect_antigravity_exec_path() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "linux")]
     {
         let home = dirs::home_dir();
-        for candidate in linux_antigravity_discovery_paths(home.as_deref()) {
-            if let Ok(executable) = resolve_linux_antigravity_exec_path(&candidate) {
-                return Some(executable);
-            }
+        if let Some(executable) =
+            first_linux_antigravity_executable(linux_antigravity_discovery_paths(home.as_deref()))
+        {
+            return Some(executable);
         }
     }
 
@@ -2511,15 +2663,14 @@ pub fn detect_antigravity_legacy_exec_path() -> Option<std::path::PathBuf> {
 
     #[cfg(target_os = "linux")]
     {
-        for candidate in [
+        let candidates = [
             "/usr/bin/antigravity",
             "/opt/antigravity/antigravity",
             "/usr/share/antigravity/antigravity",
-        ] {
-            let path = std::path::PathBuf::from(candidate);
-            if path.exists() {
-                return Some(path);
-            }
+        ]
+        .map(PathBuf::from);
+        if let Some(executable) = first_linux_antigravity_executable(candidates) {
+            return Some(executable);
         }
     }
 
@@ -4877,6 +5028,66 @@ fn is_helper_command_line(cmdline_lower: &str) -> bool {
         || cmdline_lower.contains("/resources/app/extensions/")
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn is_linux_antigravity_process_candidate(
+    cmdline_lower: &str,
+    exe_path_lower: &str,
+    expected_executable_match: bool,
+) -> bool {
+    if !expected_executable_match
+        && !cmdline_lower.contains("antigravity-ide")
+        && !exe_path_lower.contains("antigravity-ide")
+    {
+        return false;
+    }
+    if cmdline_lower.contains("tools") || exe_path_lower.contains("tools") {
+        return false;
+    }
+    !is_helper_command_line(cmdline_lower)
+}
+
+#[cfg(test)]
+mod linux_antigravity_process_candidate_tests {
+    use super::is_linux_antigravity_process_candidate;
+
+    #[test]
+    fn exact_custom_executable_match_is_a_main_process_candidate() {
+        assert!(is_linux_antigravity_process_candidate(
+            "/opt/Custom AG/Antigravity.AppImage --reuse-window",
+            "/opt/custom ag/antigravity.appimage",
+            true,
+        ));
+    }
+
+    #[test]
+    fn exact_match_does_not_admit_helper_or_tools_processes() {
+        assert!(!is_linux_antigravity_process_candidate(
+            "/opt/Custom AG/Antigravity.AppImage --type=renderer",
+            "/opt/custom ag/antigravity.appimage",
+            true,
+        ));
+        assert!(!is_linux_antigravity_process_candidate(
+            "/opt/Antigravity Tools/antigravity-ide",
+            "/opt/antigravity tools/antigravity-ide",
+            true,
+        ));
+    }
+
+    #[test]
+    fn standard_signature_still_matches_without_expected_path_match() {
+        assert!(is_linux_antigravity_process_candidate(
+            "/opt/antigravity-ide/bin/antigravity-ide --reuse-window",
+            "/opt/antigravity-ide/bin/antigravity-ide",
+            false,
+        ));
+        assert!(!is_linux_antigravity_process_candidate(
+            "/opt/unrelated/app --reuse-window",
+            "/opt/unrelated/app",
+            false,
+        ));
+    }
+}
+
 #[cfg(not(target_os = "macos"))]
 fn is_antigravity_main_process(
     name: &str,
@@ -5505,8 +5716,10 @@ fn collect_antigravity_process_entries_from_sysinfo_fallback(
     result
 }
 
-#[cfg(target_os = "linux")]
-fn collect_antigravity_process_entries_from_proc() -> Vec<(u32, Option<String>)> {
+#[cfg(any(target_os = "linux", test))]
+fn collect_antigravity_process_entries_from_proc(
+    expected_launch: &str,
+) -> Vec<(u32, Option<String>)> {
     let mut result = Vec::new();
     let entries = match std::fs::read_dir("/proc") {
         Ok(value) => value,
@@ -5534,15 +5747,19 @@ fn collect_antigravity_process_entries_from_proc() -> Vec<(u32, Option<String>)>
         let cmd_lower = cmdline_str.to_lowercase();
         let exe_path = std::fs::read_link(format!("/proc/{}/exe", pid))
             .ok()
-            .and_then(|p| p.to_str().map(|s| s.to_lowercase()))
+            .and_then(|path| path.to_str().map(str::to_string))
             .unwrap_or_default();
-        if !cmd_lower.contains("antigravity-ide") && !exe_path.contains("antigravity-ide") {
-            continue;
-        }
-        if cmd_lower.contains("tools") || exe_path.contains("tools") {
-            continue;
-        }
-        if is_helper_command_line(&cmd_lower) {
+        let exe_path_lower = exe_path.to_lowercase();
+        let has_antigravity_signature =
+            cmd_lower.contains("antigravity-ide") || exe_path_lower.contains("antigravity-ide");
+        let expected_executable_match = !has_antigravity_signature
+            && !exe_path.is_empty()
+            && normalize_path_for_compare(&exe_path) == expected_launch;
+        if !is_linux_antigravity_process_candidate(
+            &cmd_lower,
+            &exe_path_lower,
+            expected_executable_match,
+        ) {
             continue;
         }
         let dir = extract_user_data_dir_from_command_line(&cmdline_str);
@@ -5594,7 +5811,10 @@ pub fn collect_antigravity_process_entries() -> Vec<(u32, Option<String>)> {
 
     #[cfg(target_os = "linux")]
     {
-        let entries = collect_antigravity_process_entries_from_proc();
+        let expected = expected_launch
+            .as_deref()
+            .expect("expected launch path must exist");
+        let entries = collect_antigravity_process_entries_from_proc(expected);
         if !entries.is_empty() {
             return filter_entries_by_expected_launch_path("AG", entries, expected_launch.clone());
         }
@@ -5736,7 +5956,10 @@ pub fn collect_antigravity_legacy_process_entries() -> Vec<(u32, Option<String>)
 
     #[cfg(target_os = "linux")]
     {
-        let entries = collect_antigravity_process_entries_from_proc()
+        let expected = expected_launch
+            .as_deref()
+            .expect("expected launch path must exist");
+        let entries = collect_antigravity_process_entries_from_proc(expected)
             .into_iter()
             .filter(|(_, dir)| {
                 dir.as_deref()

--- a/src-tauri/src/modules/process.rs
+++ b/src-tauri/src/modules/process.rs
@@ -1831,9 +1831,12 @@ mod app_path_config_guard_tests {
 #[cfg(test)]
 mod linux_antigravity_path_tests {
     use super::{
-        antigravity_install_root_from_path, first_linux_antigravity_executable,
-        linux_antigravity_discovery_paths, resolve_linux_antigravity_exec_path,
+        antigravity_executable_paths_match, antigravity_install_root_from_path,
+        first_linux_antigravity_executable, is_linux_antigravity_process_candidate,
+        linux_antigravity_discovery_paths, normalize_path_for_compare,
+        persisted_linux_antigravity_identity_matches, resolve_linux_antigravity_exec_path,
     };
+    use std::collections::HashSet;
     use std::path::{Path, PathBuf};
 
     struct PathTestDir(PathBuf);
@@ -2009,9 +2012,56 @@ mod linux_antigravity_path_tests {
     fn discovery_includes_user_local_share_install_root() {
         let home = Path::new("/home/cockpit-test");
 
-        let candidates = linux_antigravity_discovery_paths(Some(home));
+        let candidates = linux_antigravity_discovery_paths(Some(home), None);
 
         assert!(candidates.contains(&home.join(".local/share/antigravity-ide")));
+    }
+
+    #[test]
+    fn discovery_appends_path_entries_once_and_skips_empty_entries() {
+        let first = PathTestDir::new("path-first");
+        let second = PathTestDir::new("path-second");
+        let path_env = std::env::join_paths([
+            first.path().as_os_str(),
+            second.path().as_os_str(),
+            first.path().as_os_str(),
+            Path::new("").as_os_str(),
+        ])
+        .expect("build test PATH");
+
+        let candidates = linux_antigravity_discovery_paths(
+            Some(Path::new("/home/cockpit-test")),
+            Some(path_env.as_os_str()),
+        );
+        let first_candidate = first.path().join("antigravity-ide");
+        let second_candidate = second.path().join("antigravity-ide");
+        assert_eq!(
+            candidates
+                .iter()
+                .filter(|candidate| **candidate == first_candidate)
+                .count(),
+            1
+        );
+        assert_eq!(
+            candidates
+                .iter()
+                .filter(|candidate| **candidate == second_candidate)
+                .count(),
+            1
+        );
+        assert!(candidates
+            .iter()
+            .all(|candidate| candidate != Path::new("antigravity-ide")));
+        assert!(
+            candidates
+                .iter()
+                .position(|candidate| *candidate == first_candidate)
+                .expect("first PATH candidate")
+                < candidates
+                    .iter()
+                    .position(|candidate| *candidate == second_candidate)
+                    .expect("second PATH candidate")
+        );
     }
 
     #[test]
@@ -2055,6 +2105,107 @@ mod linux_antigravity_path_tests {
             resolve_linux_antigravity_exec_path(&link).expect_err("reject broken launcher symlink");
 
         assert!(error.contains("does not exist"));
+    }
+
+    #[test]
+    fn root_and_bin_launchers_match_only_within_the_same_install_root() {
+        assert!(antigravity_executable_paths_match(
+            "/opt/Antigravity Install/bin/antigravity-ide",
+            "/opt/Antigravity Install/antigravity-ide",
+        ));
+        assert!(antigravity_executable_paths_match(
+            "/opt/Antigravity Install/antigravity-ide",
+            "/opt/Antigravity Install/bin/antigravity-ide",
+        ));
+        assert!(!antigravity_executable_paths_match(
+            "/opt/Antigravity Install/bin/antigravity-ide",
+            "/opt/Other Install/antigravity-ide",
+        ));
+        assert!(!antigravity_executable_paths_match(
+            "/opt/Antigravity Install/bin/antigravity-ide",
+            "/opt/Antigravity Install/electron",
+        ));
+    }
+
+    #[test]
+    fn persisted_external_runtime_requires_a_managed_user_data_dir() {
+        let allowed = HashSet::from([normalize_path_for_compare("/work/profiles/managed")]);
+
+        assert!(persisted_linux_antigravity_identity_matches(
+            "/work/install/bin/antigravity-ide",
+            "/work/runtime/real-electron",
+            Some("/work/profiles/managed"),
+            &allowed,
+            false,
+        ));
+        assert!(!persisted_linux_antigravity_identity_matches(
+            "/work/install/bin/antigravity-ide",
+            "/work/runtime/real-electron",
+            None,
+            &allowed,
+            false,
+        ));
+        assert!(!persisted_linux_antigravity_identity_matches(
+            "/work/install/bin/antigravity-ide",
+            "/work/runtime/real-electron",
+            Some("/work/profiles/unrelated"),
+            &allowed,
+            false,
+        ));
+        assert!(persisted_linux_antigravity_identity_matches(
+            "/work/install/bin/antigravity-ide",
+            "/work/install/antigravity-ide",
+            None,
+            &allowed,
+            false,
+        ));
+        assert!(persisted_linux_antigravity_identity_matches(
+            "/work/install/bin/antigravity-ide",
+            "/work/runtime/real-electron",
+            None,
+            &allowed,
+            true,
+        ));
+    }
+
+    #[test]
+    fn exact_configured_executable_wins_over_ordinary_path_words() {
+        for word in [
+            "tools",
+            "audio",
+            "plugin-build",
+            "renderer-cache",
+            "gpu-work",
+            "utility-apps",
+            "sandbox-data",
+        ] {
+            let path = format!("/opt/{word}/Antigravity.AppImage");
+            assert!(is_linux_antigravity_process_candidate(
+                &format!("{path} --reuse-window"),
+                &path.to_ascii_lowercase(),
+                true,
+            ));
+        }
+    }
+
+    #[test]
+    fn structured_chromium_helper_arguments_are_still_rejected() {
+        for args in [
+            "--type=renderer",
+            "--type utility",
+            "--utility-sub-type=network.mojom.NetworkService",
+            "--node-ipc",
+            "--clientProcessId=42",
+        ] {
+            assert!(
+                !is_linux_antigravity_process_candidate(
+                    &format!("/opt/Custom/Antigravity.AppImage {args}"),
+                    "/opt/custom/antigravity.appimage",
+                    true,
+                ),
+                "helper argument was admitted: {args}"
+            );
+        }
     }
 }
 
@@ -2436,15 +2587,37 @@ fn resolve_windows_antigravity_ide_custom_path(path_str: &str) -> Option<std::pa
 }
 
 #[cfg(any(target_os = "linux", test))]
-fn linux_antigravity_discovery_paths(home: Option<&Path>) -> Vec<std::path::PathBuf> {
-    let mut candidates = vec![
-        std::path::PathBuf::from("/usr/bin/antigravity-ide"),
-        std::path::PathBuf::from("/opt/antigravity-ide"),
-        std::path::PathBuf::from("/usr/share/antigravity-ide"),
-    ];
+fn linux_antigravity_discovery_paths(
+    home: Option<&Path>,
+    path_env: Option<&std::ffi::OsStr>,
+) -> Vec<std::path::PathBuf> {
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+    let mut push_candidate = |candidate: PathBuf| {
+        if seen.insert(candidate.clone()) {
+            candidates.push(candidate);
+        }
+    };
+
+    for candidate in [
+        "/usr/bin/antigravity-ide",
+        "/usr/local/bin/antigravity-ide",
+        "/opt/antigravity-ide",
+        "/usr/share/antigravity-ide",
+    ] {
+        push_candidate(PathBuf::from(candidate));
+    }
     if let Some(home) = home {
-        candidates.push(home.join(".local/bin/antigravity-ide"));
-        candidates.push(home.join(".local/share/antigravity-ide"));
+        push_candidate(home.join(".local/bin/antigravity-ide"));
+        push_candidate(home.join(".local/share/antigravity-ide"));
+    }
+    if let Some(path_env) = path_env {
+        for directory in std::env::split_paths(path_env) {
+            if directory.as_os_str().is_empty() {
+                continue;
+            }
+            push_candidate(directory.join("antigravity-ide"));
+        }
     }
     candidates
 }
@@ -2458,7 +2631,25 @@ fn is_linux_executable_file(path: &Path) -> bool {
         return false;
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
+    {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let Ok(path_c) = CString::new(path.as_os_str().as_bytes()) else {
+            return false;
+        };
+        return unsafe {
+            libc::faccessat(
+                libc::AT_FDCWD,
+                path_c.as_ptr(),
+                libc::X_OK,
+                libc::AT_EACCESS,
+            ) == 0
+        };
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
     {
         use std::os::unix::fs::PermissionsExt;
         return metadata.permissions().mode() & 0o111 != 0;
@@ -2508,6 +2699,64 @@ fn first_linux_antigravity_executable(
     candidates
         .into_iter()
         .find_map(|candidate| resolve_linux_antigravity_exec_path(&candidate).ok())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_antigravity_install_root_for_match(path: &Path) -> Option<PathBuf> {
+    let file_name = path.file_name()?.to_string_lossy();
+    if !file_name.eq_ignore_ascii_case("antigravity-ide") {
+        return None;
+    }
+    let parent = path.parent()?;
+    if parent
+        .file_name()
+        .map(|name| name.to_string_lossy().eq_ignore_ascii_case("bin"))
+        .unwrap_or(false)
+    {
+        return parent.parent().map(Path::to_path_buf);
+    }
+    Some(parent.to_path_buf())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn antigravity_executable_paths_match(expected: &str, actual: &str) -> bool {
+    let expected = normalize_path_for_compare(expected);
+    let actual = normalize_path_for_compare(actual);
+    if expected.is_empty() || actual.is_empty() {
+        return false;
+    }
+    if expected == actual {
+        return true;
+    }
+
+    let Some(expected_root) = linux_antigravity_install_root_for_match(Path::new(&expected)) else {
+        return false;
+    };
+    let Some(actual_root) = linux_antigravity_install_root_for_match(Path::new(&actual)) else {
+        return false;
+    };
+    normalize_path_for_compare(&expected_root.to_string_lossy())
+        == normalize_path_for_compare(&actual_root.to_string_lossy())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn persisted_linux_antigravity_identity_matches(
+    expected_launch: &str,
+    actual_executable: &str,
+    user_data_dir: Option<&str>,
+    allowed_user_data_dirs: &HashSet<String>,
+    allow_missing_user_data_dir: bool,
+) -> bool {
+    if antigravity_executable_paths_match(expected_launch, actual_executable) {
+        return true;
+    }
+    match user_data_dir {
+        Some(value) => {
+            let normalized = normalize_path_for_compare(value);
+            !normalized.is_empty() && allowed_user_data_dirs.contains(&normalized)
+        }
+        None => allow_missing_user_data_dir,
+    }
 }
 
 fn antigravity_install_root_from_executable(path: &Path) -> Option<PathBuf> {
@@ -2601,9 +2850,9 @@ pub fn detect_antigravity_exec_path() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "linux")]
     {
         let home = dirs::home_dir();
-        if let Some(executable) =
-            first_linux_antigravity_executable(linux_antigravity_discovery_paths(home.as_deref()))
-        {
+        if let Some(executable) = first_linux_antigravity_executable(
+            linux_antigravity_discovery_paths(home.as_deref(), std::env::var_os("PATH").as_deref()),
+        ) {
             return Some(executable);
         }
     }
@@ -5029,26 +5278,214 @@ fn is_helper_command_line(cmdline_lower: &str) -> bool {
 }
 
 #[cfg(any(target_os = "linux", test))]
+fn is_linux_chromium_helper_tokens(tokens: &[String]) -> bool {
+    for token in tokens {
+        let token = token.to_ascii_lowercase();
+        if token.starts_with("--type=")
+            || token.starts_with("--utility-sub-type=")
+            || token.starts_with("--clientprocessid=")
+            || token.starts_with("--crashpad-handler")
+        {
+            return true;
+        }
+        if matches!(
+            token.as_str(),
+            "--type" | "--utility-sub-type" | "--clientprocessid" | "--node-ipc"
+        ) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_proc_cmdline_args(raw: &[u8]) -> Vec<String> {
+    raw.split(|byte| *byte == 0)
+        .filter(|arg| !arg.is_empty())
+        .map(|arg| String::from_utf8_lossy(arg).into_owned())
+        .collect()
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_antigravity_launcher_signature_from_tokens(
+    tokens: &[String],
+    exe_path_lower: &str,
+) -> bool {
+    fn token_has_launcher_component(token: &str) -> bool {
+        token
+            .split(['/', '\\'])
+            .filter(|component| !component.is_empty())
+            .any(|component| {
+                component
+                    .to_ascii_lowercase()
+                    .replace(' ', "-")
+                    .replace('_', "-")
+                    == "antigravity-ide"
+            })
+    }
+
+    let path_has_signature = Path::new(exe_path_lower)
+        .file_name()
+        .map(|name| {
+            name.to_string_lossy()
+                .eq_ignore_ascii_case("antigravity-ide")
+        })
+        .unwrap_or(false);
+    if path_has_signature {
+        return true;
+    }
+
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = &tokens[index];
+        if is_env_token(token) {
+            index += 1;
+            continue;
+        }
+        if token == "--app" || token == "--application" {
+            if let Some(value) = tokens.get(index + 1) {
+                if token_has_launcher_component(value) {
+                    return true;
+                }
+            }
+            index += 2;
+            continue;
+        }
+        let candidate = if let Some(value) = token
+            .strip_prefix("--app=")
+            .or_else(|| token.strip_prefix("--application="))
+        {
+            Some(value)
+        } else if token.starts_with("--user-data-dir")
+            || token.starts_with("--profile")
+            || token.starts_with("--extensions-dir")
+        {
+            None
+        } else if token.starts_with("--") {
+            None
+        } else {
+            Some(token.as_str())
+        };
+        if candidate.is_some_and(token_has_launcher_component) {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_antigravity_external_runtime_matches_expected_launch(
+    tokens: &[String],
+    expected_launch: &str,
+) -> bool {
+    let expected_launch = normalize_path_for_compare(expected_launch);
+    if expected_launch.is_empty() {
+        return false;
+    }
+    let expected_root = linux_antigravity_install_root_for_match(Path::new(&expected_launch))
+        .or_else(|| Path::new(&expected_launch).parent().map(Path::to_path_buf));
+    let Some(expected_root) = expected_root else {
+        return false;
+    };
+    let expected_root = normalize_path_for_compare(&expected_root.to_string_lossy());
+    if expected_root.is_empty() {
+        return false;
+    }
+
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = &tokens[index];
+        let token_lower = token.to_ascii_lowercase();
+        let app_path = if token_lower == "--app" || token_lower == "--application" {
+            index += 1;
+            tokens.get(index).map(String::as_str)
+        } else {
+            token
+                .strip_prefix("--app=")
+                .or_else(|| token.strip_prefix("--application="))
+        };
+        if let Some(app_path) = app_path {
+            let app_path = Path::new(app_path);
+            for ancestor in app_path.ancestors() {
+                let is_resources_dir = ancestor
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case("resources"));
+                if !is_resources_dir {
+                    continue;
+                }
+                if let Some(app_root) = ancestor.parent() {
+                    let app_root = normalize_path_for_compare(&app_root.to_string_lossy());
+                    if app_root == expected_root {
+                        return true;
+                    }
+                }
+                break;
+            }
+        }
+        index += 1;
+    }
+    false
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn is_linux_antigravity_process_candidate_from_tokens(
+    tokens: &[String],
+    exe_path_lower: &str,
+    expected_executable_match: bool,
+) -> bool {
+    if !expected_executable_match
+        && !linux_antigravity_launcher_signature_from_tokens(tokens, exe_path_lower)
+    {
+        return false;
+    }
+    !is_linux_chromium_helper_tokens(tokens)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn extract_user_data_dir_from_tokens(tokens: &[String]) -> Option<String> {
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = tokens[index].as_str();
+        if let Some(rest) = token.strip_prefix("--user-data-dir=") {
+            if !rest.trim().is_empty() {
+                return Some(rest.to_string());
+            }
+        }
+        if token == "--user-data-dir" {
+            if let Some(value) = tokens.get(index + 1) {
+                if !value.trim().is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+            return None;
+        }
+        index += 1;
+    }
+    None
+}
+
+#[cfg(any(target_os = "linux", test))]
 fn is_linux_antigravity_process_candidate(
     cmdline_lower: &str,
     exe_path_lower: &str,
     expected_executable_match: bool,
 ) -> bool {
-    if !expected_executable_match
-        && !cmdline_lower.contains("antigravity-ide")
-        && !exe_path_lower.contains("antigravity-ide")
-    {
-        return false;
-    }
-    if cmdline_lower.contains("tools") || exe_path_lower.contains("tools") {
-        return false;
-    }
-    !is_helper_command_line(cmdline_lower)
+    let tokens = split_command_tokens(cmdline_lower);
+    is_linux_antigravity_process_candidate_from_tokens(
+        &tokens,
+        exe_path_lower,
+        expected_executable_match,
+    )
 }
 
 #[cfg(test)]
 mod linux_antigravity_process_candidate_tests {
-    use super::is_linux_antigravity_process_candidate;
+    use super::{
+        extract_user_data_dir_from_tokens, is_linux_antigravity_process_candidate,
+        is_linux_antigravity_process_candidate_from_tokens,
+        linux_antigravity_external_runtime_matches_expected_launch, linux_proc_cmdline_args,
+    };
 
     #[test]
     fn exact_custom_executable_match_is_a_main_process_candidate() {
@@ -5060,13 +5497,13 @@ mod linux_antigravity_process_candidate_tests {
     }
 
     #[test]
-    fn exact_match_does_not_admit_helper_or_tools_processes() {
+    fn exact_match_rejects_structured_helpers_but_not_path_words() {
         assert!(!is_linux_antigravity_process_candidate(
             "/opt/Custom AG/Antigravity.AppImage --type=renderer",
             "/opt/custom ag/antigravity.appimage",
             true,
         ));
-        assert!(!is_linux_antigravity_process_candidate(
+        assert!(is_linux_antigravity_process_candidate(
             "/opt/Antigravity Tools/antigravity-ide",
             "/opt/antigravity tools/antigravity-ide",
             true,
@@ -5083,6 +5520,57 @@ mod linux_antigravity_process_candidate_tests {
         assert!(!is_linux_antigravity_process_candidate(
             "/opt/unrelated/app --reuse-window",
             "/opt/unrelated/app",
+            false,
+        ));
+    }
+
+    #[test]
+    fn external_electron_runtime_matches_an_antigravity_app_argument() {
+        assert!(is_linux_antigravity_process_candidate(
+            "/usr/bin/electron --app=\"/opt/Antigravity IDE/resources/app.asar\" --reuse-window",
+            "/usr/bin/electron",
+            false,
+        ));
+    }
+
+    #[test]
+    fn external_electron_runtime_requires_the_configured_install_root() {
+        let args = linux_proc_cmdline_args(
+            b"/usr/bin/electron\0--app=/opt/Antigravity IDE/resources/app.asar\0--reuse-window\0",
+        );
+
+        assert!(linux_antigravity_external_runtime_matches_expected_launch(
+            &args,
+            "/opt/Antigravity IDE/bin/antigravity-ide",
+        ));
+        assert!(!linux_antigravity_external_runtime_matches_expected_launch(
+            &args,
+            "/opt/Other IDE/bin/antigravity-ide",
+        ));
+    }
+
+    #[test]
+    fn proc_argv_preserves_spaces_in_runtime_and_profile_paths() {
+        let args = linux_proc_cmdline_args(
+            b"/usr/bin/electron\0--app=/opt/Antigravity IDE/resources/app.asar\0--user-data-dir=/work/profiles/managed profile\0",
+        );
+
+        assert!(is_linux_antigravity_process_candidate_from_tokens(
+            &args,
+            "/usr/bin/electron",
+            false,
+        ));
+        assert_eq!(
+            extract_user_data_dir_from_tokens(&args).as_deref(),
+            Some("/work/profiles/managed profile")
+        );
+    }
+
+    #[test]
+    fn persisted_pid_candidate_rejects_unrelated_runtime_without_launcher_signature() {
+        assert!(!is_linux_antigravity_process_candidate(
+            "/usr/bin/sleep --user-data-dir=/work/profiles/managed 60",
+            "/usr/bin/sleep",
             false,
         ));
     }
@@ -5293,12 +5781,31 @@ fn filter_entries_by_expected_launch_path(
     entries: Vec<(u32, Option<String>)>,
     expected: Option<String>,
 ) -> Vec<(u32, Option<String>)> {
+    filter_entries_by_expected_launch_path_with_options(app_label, entries, expected, false)
+}
+
+fn filter_antigravity_entries_by_expected_launch_path(
+    app_label: &str,
+    entries: Vec<(u32, Option<String>)>,
+    expected: Option<String>,
+) -> Vec<(u32, Option<String>)> {
+    filter_entries_by_expected_launch_path_with_options(app_label, entries, expected, true)
+}
+
+fn filter_entries_by_expected_launch_path_with_options(
+    app_label: &str,
+    entries: Vec<(u32, Option<String>)>,
+    expected: Option<String>,
+    allow_linux_antigravity_layout: bool,
+) -> Vec<(u32, Option<String>)> {
     if entries.is_empty() {
         return entries;
     }
     let Some(expected) = expected else {
         return Vec::new();
     };
+    #[cfg(not(target_os = "linux"))]
+    let _ = allow_linux_antigravity_layout;
     let exe_by_pid = collect_running_process_exe_by_pid();
     #[cfg(target_os = "macos")]
     let expected_app_root = normalize_macos_app_root(std::path::Path::new(&expected))
@@ -5313,6 +5820,22 @@ fn filter_entries_by_expected_launch_path(
         match exe_by_pid.get(&pid) {
             Some(actual) if actual == &expected => result.push((pid, dir)),
             Some(actual) => {
+                #[cfg(target_os = "linux")]
+                if allow_linux_antigravity_layout
+                    && antigravity_executable_paths_match(&expected, actual)
+                {
+                    result.push((pid, dir));
+                    continue;
+                }
+                #[cfg(target_os = "linux")]
+                if allow_linux_antigravity_layout
+                    && linux_antigravity_external_runtime_pid_matches_expected_launch(
+                        pid, &expected,
+                    )
+                {
+                    result.push((pid, dir));
+                    continue;
+                }
                 #[cfg(not(target_os = "macos"))]
                 let _ = actual;
                 #[cfg(target_os = "macos")]
@@ -5740,32 +6263,114 @@ fn collect_antigravity_process_entries_from_proc(
             Ok(value) => value,
             Err(_) => continue,
         };
-        if cmdline.is_empty() {
+        let args = linux_proc_cmdline_args(&cmdline);
+        if args.is_empty() {
             continue;
         }
-        let cmdline_str = String::from_utf8_lossy(&cmdline).replace('\0', " ");
-        let cmd_lower = cmdline_str.to_lowercase();
         let exe_path = std::fs::read_link(format!("/proc/{}/exe", pid))
             .ok()
             .and_then(|path| path.to_str().map(str::to_string))
             .unwrap_or_default();
         let exe_path_lower = exe_path.to_lowercase();
-        let has_antigravity_signature =
-            cmd_lower.contains("antigravity-ide") || exe_path_lower.contains("antigravity-ide");
-        let expected_executable_match = !has_antigravity_signature
-            && !exe_path.is_empty()
-            && normalize_path_for_compare(&exe_path) == expected_launch;
-        if !is_linux_antigravity_process_candidate(
-            &cmd_lower,
+        let expected_executable_match =
+            !exe_path.is_empty() && antigravity_executable_paths_match(expected_launch, &exe_path);
+        if !is_linux_antigravity_process_candidate_from_tokens(
+            &args,
             &exe_path_lower,
             expected_executable_match,
         ) {
             continue;
         }
-        let dir = extract_user_data_dir_from_command_line(&cmdline_str);
+        if !expected_executable_match
+            && !linux_antigravity_external_runtime_matches_expected_launch(&args, expected_launch)
+        {
+            continue;
+        }
+        let dir = extract_user_data_dir_from_tokens(&args);
         result.push((pid, dir));
     }
     result
+}
+
+#[cfg(target_os = "linux")]
+fn read_linux_process_entry(
+    pid: u32,
+    expected_launch: &str,
+    allowed_user_data_dirs: &HashSet<String>,
+    allow_missing_user_data_dir: bool,
+) -> Option<(u32, Option<String>)> {
+    let cmdline = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    let args = linux_proc_cmdline_args(&cmdline);
+    if args.is_empty() {
+        return None;
+    }
+    let exe_path = std::fs::read_link(format!("/proc/{pid}/exe"))
+        .ok()?
+        .to_str()?
+        .to_string();
+    if exe_path.is_empty() {
+        return None;
+    }
+    let expected_executable_match = antigravity_executable_paths_match(expected_launch, &exe_path);
+    if !is_linux_antigravity_process_candidate_from_tokens(
+        &args,
+        &exe_path.to_ascii_lowercase(),
+        expected_executable_match,
+    ) {
+        return None;
+    }
+    if !expected_executable_match
+        && !linux_antigravity_external_runtime_matches_expected_launch(&args, expected_launch)
+    {
+        return None;
+    }
+    let user_data_dir = extract_user_data_dir_from_tokens(&args);
+    if !persisted_linux_antigravity_identity_matches(
+        expected_launch,
+        &exe_path,
+        user_data_dir.as_deref(),
+        allowed_user_data_dirs,
+        allow_missing_user_data_dir,
+    ) {
+        return None;
+    }
+    Some((pid, user_data_dir))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_antigravity_external_runtime_pid_matches_expected_launch(
+    pid: u32,
+    expected_launch: &str,
+) -> bool {
+    let Ok(cmdline) = std::fs::read(format!("/proc/{pid}/cmdline")) else {
+        return false;
+    };
+    let args = linux_proc_cmdline_args(&cmdline);
+    linux_antigravity_external_runtime_matches_expected_launch(&args, expected_launch)
+}
+
+#[cfg(target_os = "linux")]
+fn append_persisted_linux_antigravity_pid(
+    entries: &mut Vec<(u32, Option<String>)>,
+    last_pid: Option<u32>,
+    expected_launch: Option<&str>,
+    allowed_user_data_dirs: &HashSet<String>,
+    allow_missing_user_data_dir: bool,
+) {
+    let (Some(pid), Some(expected_launch)) = (last_pid, expected_launch) else {
+        return;
+    };
+    if entries.iter().any(|(entry_pid, _)| *entry_pid == pid) {
+        return;
+    }
+    if let Some(entry) = read_linux_process_entry(
+        pid,
+        expected_launch,
+        allowed_user_data_dirs,
+        allow_missing_user_data_dir,
+    ) {
+        entries.push(entry);
+    }
 }
 
 pub fn collect_antigravity_process_entries() -> Vec<(u32, Option<String>)> {
@@ -5778,11 +6383,19 @@ pub fn collect_antigravity_process_entries() -> Vec<(u32, Option<String>)> {
     {
         let entries = collect_antigravity_process_entries_macos();
         if !entries.is_empty() {
-            return filter_entries_by_expected_launch_path("AG", entries, expected_launch.clone());
+            return filter_antigravity_entries_by_expected_launch_path(
+                "AG",
+                entries,
+                expected_launch.clone(),
+            );
         }
         let entries = collect_antigravity_process_entries_from_ps();
         if !entries.is_empty() {
-            return filter_entries_by_expected_launch_path("AG", entries, expected_launch.clone());
+            return filter_antigravity_entries_by_expected_launch_path(
+                "AG",
+                entries,
+                expected_launch.clone(),
+            );
         }
         // macOS 下避免回退到 sysinfo，防止触发 TCC「其他 App 数据」授权弹窗
         return Vec::new();
@@ -5816,7 +6429,11 @@ pub fn collect_antigravity_process_entries() -> Vec<(u32, Option<String>)> {
             .expect("expected launch path must exist");
         let entries = collect_antigravity_process_entries_from_proc(expected);
         if !entries.is_empty() {
-            return filter_entries_by_expected_launch_path("AG", entries, expected_launch.clone());
+            return filter_antigravity_entries_by_expected_launch_path(
+                "AG",
+                entries,
+                expected_launch.clone(),
+            );
         }
         return Vec::new();
     }
@@ -5941,7 +6558,11 @@ pub fn collect_antigravity_legacy_process_entries() -> Vec<(u32, Option<String>)
     {
         let entries = collect_antigravity_legacy_process_entries_from_ps();
         if !entries.is_empty() {
-            return filter_entries_by_expected_launch_path("AG Legacy", entries, expected_launch);
+            return filter_antigravity_entries_by_expected_launch_path(
+                "AG Legacy",
+                entries,
+                expected_launch,
+            );
         }
         return Vec::new();
     }
@@ -5966,7 +6587,11 @@ pub fn collect_antigravity_legacy_process_entries() -> Vec<(u32, Option<String>)
                     .is_some_and(|value| value.contains("Antigravity"))
             })
             .collect::<Vec<_>>();
-        return filter_entries_by_expected_launch_path("AG Legacy", entries, expected_launch);
+        return filter_antigravity_entries_by_expected_launch_path(
+            "AG Legacy",
+            entries,
+            expected_launch,
+        );
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
@@ -6475,7 +7100,25 @@ pub fn resolve_antigravity_pid_from_entries(
 }
 
 pub fn resolve_antigravity_pid(last_pid: Option<u32>, user_data_dir: Option<&str>) -> Option<u32> {
+    #[cfg(target_os = "linux")]
+    let mut entries = collect_antigravity_process_entries();
+    #[cfg(not(target_os = "linux"))]
     let entries = collect_antigravity_process_entries();
+    #[cfg(target_os = "linux")]
+    {
+        let (allowed_user_data_dirs, allow_missing_user_data_dir) =
+            resolve_antigravity_target_and_fallback(user_data_dir)
+                .map(|(target, allow_missing)| (HashSet::from([target]), allow_missing))
+                .unwrap_or_default();
+        let expected_launch = resolve_expected_antigravity_launch_path_for_match();
+        append_persisted_linux_antigravity_pid(
+            &mut entries,
+            last_pid,
+            expected_launch.as_deref(),
+            &allowed_user_data_dirs,
+            allow_missing_user_data_dir,
+        );
+    }
     resolve_antigravity_pid_from_entries(last_pid, user_data_dir, &entries)
 }
 
@@ -8361,6 +9004,65 @@ fn filter_entries_by_target_dirs(
         .collect()
 }
 
+fn collect_antigravity_process_entries_for_managed_dirs(
+    user_data_dirs: &[String],
+    default_dir: Option<&str>,
+) -> Vec<(u32, Option<String>)> {
+    #[cfg(target_os = "linux")]
+    let mut entries = collect_antigravity_process_entries();
+    #[cfg(not(target_os = "linux"))]
+    let entries = collect_antigravity_process_entries();
+
+    #[cfg(target_os = "linux")]
+    {
+        let targets: HashSet<String> = user_data_dirs
+            .iter()
+            .map(|value| normalize_path_for_compare(value))
+            .filter(|value| !value.is_empty())
+            .collect();
+        let default_target = default_dir
+            .map(normalize_path_for_compare)
+            .filter(|value| !value.is_empty());
+        let allow_missing_user_data_dir = default_target
+            .as_ref()
+            .is_some_and(|target| targets.contains(target));
+        let expected_launch = resolve_expected_antigravity_launch_path_for_match();
+        if let Ok(store) = crate::modules::instance::load_instance_store() {
+            if default_target
+                .as_ref()
+                .is_some_and(|target| targets.contains(target))
+            {
+                append_persisted_linux_antigravity_pid(
+                    &mut entries,
+                    store.default_settings.last_pid,
+                    expected_launch.as_deref(),
+                    &targets,
+                    allow_missing_user_data_dir,
+                );
+            }
+            for instance in store.instances {
+                let instance_target = normalize_path_for_compare(&instance.user_data_dir);
+                if !instance_target.is_empty() && targets.contains(&instance_target) {
+                    append_persisted_linux_antigravity_pid(
+                        &mut entries,
+                        instance.last_pid,
+                        expected_launch.as_deref(),
+                        &targets,
+                        default_target.as_ref() == Some(&instance_target),
+                    );
+                }
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (user_data_dirs, default_dir);
+    }
+
+    entries
+}
+
 fn close_managed_instances_common<CollectEntries, SelectMainPids, CollectRemainingEntries>(
     log_prefix: &str,
     start_message: &str,
@@ -8514,6 +9216,10 @@ pub fn close_antigravity_instances(
             .map(|value| summarize_text_for_process_log(value, 96))
             .unwrap_or_else(|| "-".to_string())
     ));
+    let collect_dirs = user_data_dirs.to_vec();
+    let collect_default_dir = default_dir.clone();
+    let remaining_dirs = user_data_dirs.to_vec();
+    let remaining_default_dir = default_dir.clone();
     close_managed_instances_common(
         "AG Close",
         "正在关闭受管 Antigravity IDE 实例...",
@@ -8523,13 +9229,21 @@ pub fn close_antigravity_instances(
         "无法关闭受管 Antigravity IDE 实例进程，请手动关闭后重试",
         user_data_dirs,
         timeout_secs,
-        collect_antigravity_process_entries,
+        move || {
+            collect_antigravity_process_entries_for_managed_dirs(
+                &collect_dirs,
+                collect_default_dir.as_deref(),
+            )
+        },
         |entries, target_dirs| {
             select_main_pids_by_target_dirs(entries, target_dirs, default_dir.as_deref())
         },
         |target_dirs| {
             filter_entries_by_target_dirs(
-                collect_antigravity_process_entries(),
+                collect_antigravity_process_entries_for_managed_dirs(
+                    &remaining_dirs,
+                    remaining_default_dir.as_deref(),
+                ),
                 target_dirs,
                 default_dir.as_deref(),
             )

--- a/src-tauri/src/modules/wakeup_gateway.rs
+++ b/src-tauri/src/modules/wakeup_gateway.rs
@@ -491,16 +491,80 @@ fn resolve_configured_antigravity_root(path_str: &str) -> Option<std::path::Path
         }
     }
 
-    if !resolved_path.exists() {
-        return None;
+    #[cfg(any(target_os = "linux", test))]
+    {
+        return crate::modules::process::antigravity_install_root_from_path(&resolved_path);
     }
-    if resolved_path.is_file() {
-        return resolved_path.parent().map(std::path::Path::to_path_buf);
+
+    #[cfg(not(any(target_os = "linux", test)))]
+    {
+        if resolved_path.is_file() {
+            return resolved_path.parent().map(std::path::Path::to_path_buf);
+        }
+        if resolved_path.is_dir() {
+            return Some(resolved_path);
+        }
+        None
     }
-    if resolved_path.is_dir() {
-        return Some(resolved_path);
+}
+
+#[cfg(test)]
+mod configured_antigravity_root_tests {
+    use super::resolve_configured_antigravity_root;
+    use std::path::{Path, PathBuf};
+
+    struct RootTestDir(PathBuf);
+
+    impl RootTestDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "cockpit-tools-wakeup-antigravity-root-{}-{}",
+                std::process::id(),
+                name
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).expect("create wakeup root test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
     }
-    None
+
+    impl Drop for RootTestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn bin_antigravity_launcher_resolves_install_root() {
+        let install = RootTestDir::new("bin-launcher");
+        let launcher = install.path().join("bin").join("antigravity-ide");
+        std::fs::create_dir_all(launcher.parent().expect("launcher parent"))
+            .expect("create launcher directory");
+        std::fs::write(&launcher, b"launcher").expect("write launcher");
+
+        assert_eq!(
+            resolve_configured_antigravity_root(&launcher.to_string_lossy()),
+            Some(std::fs::canonicalize(install.path()).expect("canonicalize install root"))
+        );
+    }
+
+    #[test]
+    fn bin_directory_resolves_install_root() {
+        let install = RootTestDir::new("bin-directory");
+        let bin = install.path().join("bin");
+        let launcher = bin.join("antigravity-ide");
+        std::fs::create_dir_all(&bin).expect("create bin directory");
+        std::fs::write(&launcher, b"launcher").expect("write launcher");
+
+        assert_eq!(
+            resolve_configured_antigravity_root(&bin.to_string_lossy()),
+            Some(std::fs::canonicalize(install.path()).expect("canonicalize install root"))
+        );
+    }
 }
 
 fn antigravity_extension_dir(root: &std::path::Path) -> std::path::PathBuf {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -59,6 +59,13 @@
         "installerHooks": "./windows/nsis/installer-hooks.nsh"
       }
     },
+    "linux": {
+      "deb": {
+        "depends": [
+          "libsecret-tools"
+        ]
+      }
+    },
     "icon": [
       "icons/48x48.png",
       "icons/32x32.png",


### PR DESCRIPTION
## Summary

- resolve Linux Antigravity launch paths from configured executables, `PATH`, or supported install-root layouts (`antigravity-ide` and `bin/antigravity-ide`)
- validate launchers with effective-user execute permissions and reject unsupported directories before `Command::new`
- discover user-local installs under `~/.local/share/antigravity-ide` and reuse the same resolver for IDE and legacy launches
- normalize product metadata lookup to the install root for root-level and `bin/` launchers, including symlink targets and invalid higher-priority metadata fallback
- identify native and external Electron runtimes from `/proc` executable and argv data while excluding helper processes and revalidating persisted PIDs
- normalize configured launchers to the install root used by the wakeup gateway
- declare `libsecret-tools` for Debian packages because Antigravity 2.0 credential switching invokes `secret-tool`

## Root cause

The non-macOS resolver accepted any existing path, including directories. Linux discovery omitted the reported user-local layout, while the legacy directory fallback only checked Windows executable names. Metadata lookup also treated `bin/` as the install root.

Linux lifecycle detection additionally needed to distinguish the configured launcher from external Electron runtimes and helper processes, and to validate persisted PIDs against current `/proc` identity before reuse.

Windows and macOS launch behavior is unchanged. Direct Linux executable and AppImage paths remain supported when executable by the effective user. Existing canonicalized path comparison remains unchanged and is covered by a Unix symlink regression test.

## Validation

Windows:

- `cargo fmt --all`
- `cargo fmt --all --check`
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -p cockpit-tools linux_antigravity_path_tests --lib` — 26 passed
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -p cockpit-tools modules::process --lib` — 44 passed
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -p cockpit-tools commands::system::tests --lib` — 10 passed
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test -p cockpit-tools configured_antigravity_root_tests --lib` — 2 passed
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo check -p cockpit-tools --lib` — passed
- `git diff --check`

Debian 13.6:

- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test --locked --offline -p cockpit-tools --lib linux_antigravity` — 26 passed
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test --locked --offline -p cockpit-tools --lib antigravity_metadata` — 4 passed
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo test --locked --offline -p cockpit-tools --lib metadata` — 14 passed
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo check --locked --offline -p cockpit-tools --lib` — passed
- `COCKPIT_SKIP_CLIPROXY_BUILD=1 cargo build --locked --offline -p cockpit-tools --bin cockpit-tools` — passed
- `npm run build` — passed; Vite transformed 2,201 modules
- `ldd "$CARGO_TARGET_DIR/debug/cockpit-tools"` — no unresolved libraries
- isolated Xvfb smoke with no network or published ports — 1280x800 window, frontend assets, WebKit Network/Web processes, and nonblank XWD output verified

The GUI smoke exercised Cockpit Tools and WebKit under Xvfb. It did not install or launch the proprietary Antigravity IDE on a physical Linux desktop; launcher layouts, permissions, metadata, symlinks, `/proc` identity, and lifecycle behavior are covered by native tests and probes.

Fixes #1877