### PR TITLE
fix(macOS): sanitize sidecar launch environment

### DIFF
--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -10685,6 +10685,17 @@ fn sidecar_binary_path() -> Result<PathBuf, String> {
         })
 }
 
+fn sanitize_sidecar_command_env(command: &mut TokioCommand) {
+    #[cfg(target_os = "macos")]
+    {
+        // 避免把 Cockpit 的应用身份和 XPC 上下文传给 sidecar，导致局域网访问异常。
+        command.env_remove("__CFBundleIdentifier");
+        command.env_remove("XPC_SERVICE_NAME");
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = command;
+}
+
 fn sidecar_auth_file_name(account_id: &str) -> String {
     let mut safe = account_id
         .trim()
@@ -16288,6 +16299,7 @@ async fn ensure_gateway_matches_runtime_locked() -> Result<(), String> {
     };
 
     let mut command = TokioCommand::new(&binary);
+    sanitize_sidecar_command_env(&mut command);
     command
         .arg("--config")
         .arg(&launch_config.config_path)
@@ -18968,6 +18980,7 @@ async fn spawn_provider_gateway_sidecar(
     let bind_host = bind_host_for_collection(collection);
     let binary = sidecar_binary_path()?;
     let mut command = TokioCommand::new(&binary);
+    sanitize_sidecar_command_env(&mut command);
     command
         .arg("--config")
         .arg(&launch_config.config_path)


### PR DESCRIPTION
## 问题

macOS 应用以 `.app` 启动时，sidecar 会继承 Cockpit 的应用身份环境变量，导致 provider 测试访问局域网网关失败。

## 变更

- 为 sidecar 启动命令增加统一的 macOS 环境清理。
- 同时覆盖普通 API sidecar 和 provider 测试 sidecar。
- 移除 `__CFBundleIdentifier` 与 `XPC_SERVICE_NAME`。

## 验证

- `cargo fmt --all -- --check`：通过。
- `git diff --check upstream/main...HEAD`：通过。
- `cargo check --manifest-path src-tauri/Cargo.toml --tests`：当前 Windows 环境缺少 MSVC `link.exe`，无法完成链接。
- 未在 macOS 环境执行实际局域网网关回归测试。

Fixes #1724
