### PR TITLE
feat(terminal): support Ghostty launch

### DIFF
--- a/src-tauri/src/commands/claude.rs
+++ b/src-tauri/src/commands/claude.rs
@@ -187,6 +187,7 @@ pub(crate) fn execute_claude_cli_command(
     #[cfg(target_os = "macos")]
     {
         let is_iterm = terminal.to_lowercase().contains("iterm");
+        let is_ghostty = terminal.eq_ignore_ascii_case("Ghostty");
         let is_terminal_app = terminal == "system" || terminal.is_empty() || terminal == "Terminal";
         let app_name = if is_terminal_app {
             "Terminal"
@@ -223,9 +224,19 @@ pub(crate) fn execute_claude_cli_command(
                 end tell",
                 escape_applescript(command)
             )
+        } else if is_ghostty {
+            format!(
+                "tell application \"Ghostty\"
+                    activate
+                    set cfg to new surface configuration
+                    set command of cfg to \"{}\"
+                    new window with configuration cfg
+                end tell",
+                escape_applescript(command)
+            )
         } else {
             return Err(format!(
-                "当前终端暂不支持直接执行：{}。请改用 Terminal 或 iTerm2。",
+                "当前终端暂不支持直接执行：{}。请改用 Terminal、iTerm2 或 Ghostty。",
                 terminal
             ));
         };

--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -581,6 +581,20 @@ mod tests {
     }
 
     #[test]
+    fn macos_ghostty_launch_plan_uses_ghostty_applescript() {
+        let plan = build_macos_codex_terminal_launch_plan("codex --version", "Ghostty")
+            .expect("Ghostty should have a macOS launch plan");
+
+        assert_eq!(plan.program, "osascript");
+        assert_eq!(plan.terminal_name, "Ghostty");
+        assert_eq!(plan.args.len(), 2);
+        assert_eq!(plan.args[0], "-e");
+        assert!(plan.args[1].contains("tell application \"Ghostty\""));
+        assert!(plan.args[1].contains("new surface configuration"));
+        assert!(plan.args[1].contains("set command of cfg to \"codex --version\""));
+    }
+
+    #[test]
     fn launch_command_preview_does_not_require_an_initialized_profile() {
         let context = CodexLaunchContext {
             user_data_dir: "/path/that/does/not/exist/codex-home".to_string(),
@@ -940,6 +954,7 @@ fn build_macos_codex_terminal_launch_plan(
 ) -> Result<CodexTerminalLaunchPlan, String> {
     let normalized = terminal.trim();
     let is_iterm = normalized.to_ascii_lowercase().contains("iterm");
+    let is_ghostty = normalized.eq_ignore_ascii_case("Ghostty");
     let is_terminal_app =
         normalized.is_empty() || normalized == "system" || normalized == "Terminal";
     let (terminal_name, script) = if is_iterm {
@@ -966,6 +981,19 @@ fn build_macos_codex_terminal_launch_plan(
                 escape_applescript(command)
             ),
         )
+    } else if is_ghostty {
+        (
+            "Ghostty",
+            format!(
+                "tell application \"Ghostty\"
+                    activate
+                    set cfg to new surface configuration
+                    set command of cfg to \"{}\"
+                    new window with configuration cfg
+                end tell",
+                escape_applescript(command)
+            ),
+        )
     } else if is_terminal_app {
         (
             "Terminal.app",
@@ -979,7 +1007,7 @@ fn build_macos_codex_terminal_launch_plan(
         )
     } else {
         return Err(format!(
-            "当前终端暂不支持直接执行：{}。请改用 Terminal 或 iTerm2。",
+            "当前终端暂不支持直接执行：{}。请改用 Terminal、iTerm2 或 Ghostty。",
             normalized
         ));
     };

--- a/src/hooks/useLaunchTerminalOptions.ts
+++ b/src/hooks/useLaunchTerminalOptions.ts
@@ -77,6 +77,7 @@ export function useLaunchTerminalOptions(enabled = true) {
       ? [
           { value: "Terminal", label: "Terminal.app" },
           { value: "iTerm2", label: "iTerm2" },
+          { value: "Ghostty", label: "Ghostty" },
         ]
       : isWindows
         ? [


### PR DESCRIPTION
## 问题

macOS 上虽然系统检测已经识别 Ghostty，但启动终端选项没有展示它，Claude 和 Codex 的直接启动逻辑也会拒绝该终端。

## 变更

- 在 macOS 启动终端选项中加入 Ghostty。
- 为 Claude CLI 和 Codex CLI 增加 Ghostty AppleScript 启动计划。
- 为 Codex 启动计划增加 Ghostty 回归测试。

## 实现依据

Ghostty 官方文档提供了 macOS AppleScript 支持、surface configuration 以及 `command` 字段：[Ghostty AppleScript 文档](https://ghostty.org/docs/features/applescript)。

## 验证

- `cargo fmt --all -- --check`：通过。
- `git diff --check upstream/main...HEAD`：通过。
- `npm run typecheck`：当前工作树缺少 `tsc`，未能执行。
- Rust 测试：当前 Windows 环境缺少 MSVC `link.exe`，未能执行。
- 未在 macOS + Ghostty 环境执行实际 GUI 回归测试；首次自动化控制可能需要 macOS Automation 权限。

Fixes #1775
