### PR TITLE
fix(api-service): disable image tools for text requests

### DIFF
--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -12552,7 +12552,8 @@ fn prepare_sidecar_launch_config_in_dir_sync(
     );
     config.insert("ws-auth".to_string(), json!(true));
     config.insert("disable-auth-auto-refresh".to_string(), json!(true));
-    // 不写 disable-image-generation：默认允许生图（绑定 OAuth 与改前一致；纯 API Key 也靠正常注入/上游能力）。
+    // 普通文本接口默认移除图片工具声明，同时保留 /v1/images/* 图片接口。
+    config.insert("disable-image-generation".to_string(), json!("chat"));
     config.insert(
         "request-retry".to_string(),
         json!(MAX_REQUEST_RETRY_ATTEMPTS as i32),
@@ -34633,6 +34634,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
         .expect("parse sidecar config");
 
         assert_eq!(config.get("disable-auth-auto-refresh"), Some(&json!(true)));
+        assert_eq!(config.get("disable-image-generation"), Some(&json!("chat")));
 
         fs::remove_dir_all(&dir).expect("cleanup temp dir");
     }
@@ -34660,10 +34662,11 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
         )
         .await
         .expect("sidecar config should build");
-        let _config: Value = serde_json::from_str(
+        let config: Value = serde_json::from_str(
             &fs::read_to_string(&launch_config.config_path).expect("read sidecar config"),
         )
         .expect("parse sidecar config");
+        assert_eq!(config.get("disable-image-generation"), Some(&json!("chat")));
 
         fs::remove_dir_all(&dir).expect("cleanup temp dir");
     }


### PR DESCRIPTION
## 问题

API 服务当前生成的 sidecar 配置没有设置 `disable-image-generation`。Go sidecar 默认会把 `image_generation` 能力带入 `/v1/responses` 和 `/v1/chat/completions`，导致不支持图片的上游对纯文本请求返回 403。

## 变更

- 为 Cockpit 生成的 sidecar 配置启用 `disable-image-generation: chat`。
- 普通文本接口会移除图片工具声明，`/v1/images/generations` 和 `/v1/images/edits` 仍保持可用。
- 为 OAuth 与绑定 OAuth API Key 两条 sidecar 配置测试增加配置断言。

## 验证

- `go test ./internal/runtime/executor/helps`：通过。
- `cargo fmt --all -- --check`：通过。
- `git diff --check upstream/main...HEAD`：通过。
- `cargo check --manifest-path src-tauri/Cargo.toml --tests`：当前 Windows 环境缺少 MSVC `link.exe`，无法完成 Rust 编译链接。
- 未连接真实的不支持图片的上游执行端到端回归。

Fixes #1940
