### PR TITLE
feat(codex): support Linux terminal launch

### DIFF
--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;

--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -581,6 +581,27 @@ mod tests {
     }
 
     #[test]
+    fn linux_system_terminal_launch_plan_uses_terminal_emulator_fallbacks() {
+        let plan = build_linux_codex_terminal_launch_plan("codex --version", "system");
+
+        assert_eq!(plan.program, "x-terminal-emulator");
+        assert_eq!(
+            plan.args,
+            ["-e", "bash", "-lc", "codex --version; exec bash"]
+        );
+        assert_eq!(plan.terminal_name, "系统终端");
+    }
+
+    #[test]
+    fn linux_gnome_terminal_launch_plan_uses_gnome_argument_shape() {
+        let plan = build_linux_codex_terminal_launch_plan("codex", "gnome-terminal");
+
+        assert_eq!(plan.program, "gnome-terminal");
+        assert_eq!(plan.args, ["--", "bash", "-lc", "codex; exec bash"]);
+        assert_eq!(plan.terminal_name, "gnome-terminal");
+    }
+
+    #[test]
     fn launch_command_preview_does_not_require_an_initialized_profile() {
         let context = CodexLaunchContext {
             user_data_dir: "/path/that/does/not/exist/codex-home".to_string(),
@@ -992,6 +1013,39 @@ fn build_macos_codex_terminal_launch_plan(
     })
 }
 
+#[cfg_attr(not(any(target_os = "linux", test)), allow(dead_code))]
+fn build_linux_codex_terminal_launch_plan(
+    command: &str,
+    terminal: &str,
+) -> CodexTerminalLaunchPlan {
+    let normalized = terminal.trim();
+    let use_system_terminal = normalized.is_empty() || normalized.eq_ignore_ascii_case("system");
+    let program = if use_system_terminal {
+        "x-terminal-emulator"
+    } else {
+        normalized
+    };
+    let shell_command = format!("{}; exec bash", command);
+    let args = if program.eq_ignore_ascii_case("gnome-terminal") {
+        vec!["--", "bash", "-lc", shell_command.as_str()]
+    } else {
+        vec!["-e", "bash", "-lc", shell_command.as_str()]
+    };
+    let args = args.into_iter().map(str::to_string).collect::<Vec<_>>();
+    let terminal_name = if use_system_terminal {
+        "系统终端"
+    } else {
+        program
+    };
+
+    CodexTerminalLaunchPlan {
+        program: program.to_string(),
+        display_command: format_terminal_display_command(program, &args),
+        args,
+        terminal_name: terminal_name.to_string(),
+    }
+}
+
 fn build_codex_terminal_launch_plan(
     command: &str,
     terminal: &str,
@@ -1006,18 +1060,13 @@ fn build_codex_terminal_launch_plan(
         return Ok(build_windows_codex_terminal_launch_plan(command, terminal));
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(target_os = "linux")]
     {
-        return Ok(CodexTerminalLaunchPlan {
-            program: String::new(),
-            args: Vec::new(),
-            display_command: command.to_string(),
-            terminal_name: terminal.to_string(),
-        });
+        return Ok(build_linux_codex_terminal_launch_plan(command, terminal));
     }
 
     #[allow(unreachable_code)]
-    Err("Codex CLI 终端执行仅支持 macOS 和 Windows".to_string())
+    Err("Codex CLI 终端执行仅支持 macOS、Windows 和 Linux".to_string())
 }
 
 fn resolve_codex_launch_terminal(terminal: Option<String>) -> String {
@@ -2100,6 +2149,43 @@ pub async fn codex_execute_instance_launch_command(
         return Ok(format!("已在 {} 执行 Codex CLI 命令", plan.terminal_name));
     }
 
+    #[cfg(target_os = "linux")]
+    {
+        let shell_command = format!("{}; exec bash", command);
+        let use_system_terminal = terminal.is_empty() || terminal.eq_ignore_ascii_case("system");
+        let launch_result = Command::new(&plan.program)
+            .args(&plan.args)
+            .spawn()
+            .or_else(|_| {
+                if use_system_terminal {
+                    Command::new("gnome-terminal")
+                        .args(["--", "bash", "-lc", &shell_command])
+                        .spawn()
+                } else {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "指定终端未找到",
+                    ))
+                }
+            })
+            .or_else(|_| {
+                if use_system_terminal {
+                    Command::new("konsole")
+                        .args(["-e", "bash", "-lc", &shell_command])
+                        .spawn()
+                } else {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "指定终端未找到",
+                    ))
+                }
+            })
+            .or_else(|_| Command::new("sh").args(["-lc", &command]).spawn());
+
+        launch_result.map_err(|error| format!("执行 Codex CLI 命令失败: {}", error))?;
+        return Ok(format!("已在 {} 执行 Codex CLI 命令", plan.terminal_name));
+    }
+
     #[allow(unreachable_code)]
-    Err("Codex CLI 终端执行仅支持 macOS 和 Windows".to_string())
+    Err("Codex CLI 终端执行仅支持 macOS、Windows 和 Linux".to_string())
 }


### PR DESCRIPTION
## 问题

Linux 上 Codex CLI 实例启动计划没有生成可执行的终端命令，执行路径最终返回仅支持 macOS 和 Windows。

## 变更

- 增加 Linux Codex 终端启动计划，支持默认系统终端和显式终端。
- 默认按 `x-terminal-emulator`、`gnome-terminal`、`konsole` 的顺序回退。
- 使用 `bash -lc` 启动命令，并保持终端窗口可继续交互。
- 让预览和实际执行共用同一套 Linux 计划，并新增计划参数测试。
- 为 Linux 编译路径引入终端进程启动所需的 `std::process::Command`。

## 验证

- `cargo fmt --all -- --check`：通过。
- `git diff --check upstream/main...HEAD`：通过。
- GitHub Actions `Build: ubuntu-22.04`：通过。
- GitHub Actions `Build: ubuntu-24.04-arm`：通过。
- 本地 `cargo check --manifest-path src-tauri/Cargo.toml --tests`：当前 Windows 环境缺少 MSVC `link.exe`，无法完成编译链接。
- 未在 Linux 桌面环境执行实际终端 GUI 回归测试。

Fixes #1576
