### PR TITLE
fix: open macOS tray menu with either click

### DIFF
--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -3553,21 +3553,18 @@ fn handle_tray_event<R: Runtime>(tray: &TrayIcon<R>, event: TrayIconEvent) {
         } => {
             #[cfg(target_os = "macos")]
             {
-                if button == MouseButton::Left {
-                    if let Err(err) =
-                        crate::modules::floating_card_window::show_main_window(tray.app_handle())
-                    {
-                        logger::log_warn(&format!("[Tray] 左键恢复主窗口失败: {}", err));
-                    }
-                    return;
-                }
-
-                if button == MouseButton::Right && button_state == MouseButtonState::Down {
+                // Both mouse buttons should open the native status menu. This makes
+                // the quota view accessible with a trackpad, where a right click
+                // is less discoverable than a regular click.
+                if button_state == MouseButtonState::Down
+                    && matches!(button, MouseButton::Left | MouseButton::Right)
+                {
                     let app = tray.app_handle().clone();
                     let app_for_menu = app.clone();
                     let _ = app.run_on_main_thread(move || {
                         crate::modules::macos_native_menu::toggle_tray_menu(&app_for_menu, _rect);
                     });
+                    return;
                 }
             }
 


### PR DESCRIPTION
## 问题

macOS 菜单栏中的 Cockpit 图标目前只有右键才会打开原生额度菜单，左键会直接显示主窗口，对触控板用户不够友好。

## 变更

- 在 macOS 上让左键和右键都可以打开原生菜单栏额度菜单。
- 保持现有双击行为不变。
- 保持非 macOS 平台的托盘点击行为不变。

## 验证

- `rustfmt --edition 2021 --config skip_children=true --check src-tauri/src/modules/tray.rs`：通过。
- `git diff --check upstream/main...HEAD`：通过。
- 与最新 `upstream/main` 的合并模拟：无冲突。
- Rust 测试：当前 Windows 环境缺少 MSVC `link.exe`，未能执行。
- 未在 macOS 环境执行实际菜单栏点击回归测试。

Fixes #1638
