### PR TITLE
fix: display Codex Business monthly credits

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -2358,6 +2358,10 @@
     "quota": {
       "hourly": "حصة 5 ساعات",
       "weekly": "الحصة الأسبوعية",
+      "monthlyCredits": "الأرصدة الشهرية",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} رصيد",
+      "creditBalance": "{{balance}} رصيد",
+      "unlimitedCredits": "أرصدة غير محدودة",
       "additional": "حصة إضافية",
       "reset": "إعادة ضبط",
       "weeklyBlocksHourly": "الحصة الأسبوعية 0، لذا حصة 5 ساعات غير متاحة",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "Kvóta 5 hodin",
       "weekly": "Týdenní kvóta",
+      "monthlyCredits": "Měsíční kredity",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} kreditů",
+      "creditBalance": "Zůstatek {{balance}} kreditů",
+      "unlimitedCredits": "Neomezené kredity",
       "additional": "Dodatečná kvóta",
       "reset": "Reset​",
       "weeklyBlocksHourly": "Týdenní kvóta je 0, proto není 5hodinová kvóta dostupná",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "5-Stunden-Kontingent",
       "weekly": "Wöchentliches Kontingent",
+      "monthlyCredits": "Monatliche Credits",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} Credits",
+      "creditBalance": "Guthaben {{balance}} Credits",
+      "unlimitedCredits": "Unbegrenzte Credits",
       "additional": "Zusätzliches Kontingent",
       "reset": "Zurücksetzen",
       "weeklyBlocksHourly": "Das Wochenkontingent ist 0, daher ist das 5-Stunden-Kontingent nicht verfügbar",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -3058,6 +3058,10 @@
     "quota": {
       "hourly": "5-hour quota",
       "weekly": "Weekly quota",
+      "monthlyCredits": "Monthly credits",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} credits",
+      "creditBalance": "{{balance}} credits",
+      "unlimitedCredits": "Unlimited credits",
       "additional": "Additional quota",
       "weeklyBlocksHourly": "Weekly quota is 0, so the 5-hour quota is unavailable",
       "windowStats": "Used {{tokens}} · {{cost}}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3058,6 +3058,10 @@
     "quota": {
       "hourly": "5-hour quota",
       "weekly": "Weekly quota",
+      "monthlyCredits": "Monthly credits",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} credits",
+      "creditBalance": "{{balance}} credits",
+      "unlimitedCredits": "Unlimited credits",
       "additional": "Additional quota",
       "weeklyBlocksHourly": "Weekly quota is 0, so the 5-hour quota is unavailable",
       "windowStats": "Used {{tokens}} · {{cost}}",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "Cuota de 5 horas",
       "weekly": "Cuota semanal",
+      "monthlyCredits": "Créditos mensuales",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} créditos",
+      "creditBalance": "Saldo {{balance}} créditos",
+      "unlimitedCredits": "Créditos ilimitados",
       "additional": "Cuota adicional",
       "reset": "Reinicio",
       "weeklyBlocksHourly": "La cuota semanal es 0, por eso la cuota de 5 horas no está disponible",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "Quota de 5 heures",
       "weekly": "Quota hebdomadaire",
+      "monthlyCredits": "Crédits mensuels",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} crédits",
+      "creditBalance": "Solde {{balance}} crédits",
+      "unlimitedCredits": "Crédits illimités",
       "additional": "Quota supplémentaire",
       "reset": "Réinitialiser",
       "weeklyBlocksHourly": "Le quota hebdomadaire est à 0 ; le quota de 5 heures est donc indisponible",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -2492,6 +2492,10 @@
     "quota": {
       "hourly": "Kuota 5 jam",
       "weekly": "Kuota mingguan",
+      "monthlyCredits": "Kredit bulanan",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} kredit",
+      "creditBalance": "Saldo {{balance}} kredit",
+      "unlimitedCredits": "Kredit tak terbatas",
       "additional": "Kuota tambahan",
       "reset": "Setel ulang",
       "weeklyBlocksHourly": "Kuota mingguan 0, jadi kuota 5 jam tidak tersedia",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "Quota di 5 ore",
       "weekly": "Quota settimanale",
+      "monthlyCredits": "Crediti mensili",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} crediti",
+      "creditBalance": "Saldo {{balance}} crediti",
+      "unlimitedCredits": "Crediti illimitati",
       "additional": "Quota aggiuntiva",
       "reset": "Reimposta",
       "weeklyBlocksHourly": "La quota settimanale è 0, quindi la quota di 5 ore non è disponibile",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "5 時間クォータ",
       "weekly": "週次クォータ",
+      "monthlyCredits": "月間クレジット",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} クレジット",
+      "creditBalance": "残高 {{balance}} クレジット",
+      "unlimitedCredits": "無制限クレジット",
       "additional": "追加クォータ",
       "reset": "リセット",
       "weeklyBlocksHourly": "週クォータが 0 のため、5時間クォータは利用できません",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "5시간 쿼터",
       "weekly": "주간 쿼터",
+      "monthlyCredits": "월간 크레딧",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} 크레딧",
+      "creditBalance": "잔액 {{balance}} 크레딧",
+      "unlimitedCredits": "무제한 크레딧",
       "additional": "추가 할당량",
       "reset": "재설정",
       "weeklyBlocksHourly": "주간 할당량이 0이라 5시간 할당량을 사용할 수 없습니다",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "Limit 5 godzin",
       "weekly": "Limit tygodniowy",
+      "monthlyCredits": "Miesięczne kredyty",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} kredytów",
+      "creditBalance": "Saldo {{balance}} kredytów",
+      "unlimitedCredits": "Nielimitowane kredyty",
       "additional": "Dodatkowy limit",
       "reset": "Resetuj",
       "weeklyBlocksHourly": "Limit tygodniowy wynosi 0, więc limit 5-godzinny jest niedostępny",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "Cota de 5 horas",
       "weekly": "Cota semanal",
+      "monthlyCredits": "Créditos mensais",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} créditos",
+      "creditBalance": "Saldo de {{balance}} créditos",
+      "unlimitedCredits": "Créditos ilimitados",
       "additional": "Cota adicional",
       "reset": "Redefinir",
       "weeklyBlocksHourly": "A cota semanal é 0, então a cota de 5 horas está indisponível",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "Квота 5 часов",
       "weekly": "Недельная квота",
+      "monthlyCredits": "Месячные кредиты",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} кредитов",
+      "creditBalance": "Баланс: {{balance}} кредитов",
+      "unlimitedCredits": "Безлимитные кредиты",
       "additional": "Дополнительная квота",
       "reset": "Сброс",
       "weeklyBlocksHourly": "Недельная квота равна 0, поэтому 5-часовая квота недоступна",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "5 saatlik kota",
       "weekly": "Haftalık kota",
+      "monthlyCredits": "Aylık krediler",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} kredi",
+      "creditBalance": "{{balance}} kredi bakiyesi",
+      "unlimitedCredits": "Sınırsız krediler",
       "additional": "Ek kota",
       "reset": "Sıfırla",
       "weeklyBlocksHourly": "Haftalık kota 0 olduğu için 5 saatlik kota kullanılamaz",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -2311,6 +2311,10 @@
     "quota": {
       "hourly": "Hạn mức 5 giờ",
       "weekly": "Hạn mức tuần",
+      "monthlyCredits": "Tín dụng hàng tháng",
+      "monthlyCreditsValue": "{{remaining}} / {{total}} tín dụng",
+      "creditBalance": "Số dư {{balance}} tín dụng",
+      "unlimitedCredits": "Tín dụng không giới hạn",
       "additional": "Hạn mức bổ sung",
       "reset": "Đặt lại",
       "weeklyBlocksHourly": "Hạn mức tuần là 0 nên hạn mức 5 giờ không khả dụng",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -3058,6 +3058,10 @@
     "quota": {
       "hourly": "5小时配额",
       "weekly": "周配额",
+      "monthlyCredits": "月度 credits",
+      "monthlyCreditsValue": "剩余 {{remaining}} / {{total}} credits",
+      "creditBalance": "余额 {{balance}} credits",
+      "unlimitedCredits": "无限 credits",
       "additional": "额外额度",
       "weeklyBlocksHourly": "周额度为 0，5小时额度已不可用",
       "windowStats": "已用 {{tokens}} · {{cost}}",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -2442,6 +2442,10 @@
     "quota": {
       "hourly": "5 小時配額",
       "weekly": "週配額",
+      "monthlyCredits": "每月 credits",
+      "monthlyCreditsValue": "剩餘 {{remaining}} / {{total}} credits",
+      "creditBalance": "餘額 {{balance}} credits",
+      "unlimitedCredits": "無限 credits",
       "additional": "額外額度",
       "reset": "重置",
       "weeklyBlocksHourly": "週額度為 0，因此 5 小時額度已不可用",

--- a/src/presentation/platformAccountPresentation.ts
+++ b/src/presentation/platformAccountPresentation.ts
@@ -37,6 +37,7 @@ import {
   getCodexCodeReviewQuotaMetric,
   getCodexQuotaWindowLabel,
   getCodexEffectiveQuotaPercentages,
+  getCodexMonthlyCreditUsage,
   getCodexPlanBadgePresentation,
   getCodexQuotaClass,
   getCodexQuotaWindows,
@@ -794,6 +795,52 @@ export function buildCodexAccountPresentation(
               .join("\n"),
           };
         });
+  const monthlyCreditUsage = isCodexChatCompletionsApiKeyAccount(account)
+    ? null
+    : getCodexMonthlyCreditUsage(account.quota);
+  if (monthlyCreditUsage) {
+    const total = monthlyCreditUsage.total;
+    const remaining = monthlyCreditUsage.remaining;
+    const percentage = monthlyCreditUsage.unlimited
+      ? 100
+      : monthlyCreditUsage.remainingPercent != null
+        ? monthlyCreditUsage.remainingPercent
+        : total != null && total > 0 && remaining != null
+          ? clampPercent((remaining / total) * 100)
+          : remaining != null && remaining > 0
+            ? 100
+            : 0;
+    const valueText = monthlyCreditUsage.unlimited
+      ? t("codex.quota.unlimitedCredits", "无限 credits")
+      : remaining != null && total != null
+        ? t("codex.quota.monthlyCreditsValue", {
+            remaining: formatQuotaNumber(remaining),
+            total: formatQuotaNumber(total),
+            defaultValue: "{{remaining}} / {{total}} credits",
+          })
+        : monthlyCreditUsage.balance
+          ? t("codex.quota.creditBalance", {
+              balance: monthlyCreditUsage.balance,
+              defaultValue: "{{balance}} credits",
+            })
+          : t("common.shared.quota.noData", "暂无配额数据");
+    quotaItems.push({
+      key: "monthly_credits",
+      label: t("codex.quota.monthlyCredits", "月度 credits"),
+      percentage,
+      quotaClass: getCodexQuotaClass(percentage),
+      valueText,
+      resetText: monthlyCreditUsage.resetTime
+        ? formatCodexResetTime(monthlyCreditUsage.resetTime, t)
+        : "",
+      resetAt: monthlyCreditUsage.resetTime,
+      used: monthlyCreditUsage.used,
+      total,
+      left: remaining,
+      showProgress:
+        monthlyCreditUsage.unlimited || (total != null && total > 0),
+    });
+  }
   const additionalQuotaItems =
     !isCodexChatCompletionsApiKeyAccount(account)
       ? getCodexAdditionalQuotaWindows(account.quota).map((window) => {

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -177,6 +177,16 @@ export interface CodexQuota {
   raw_data?: unknown;
 }
 
+export interface CodexMonthlyCreditUsage {
+  used?: number;
+  total?: number;
+  remaining?: number;
+  remainingPercent?: number;
+  balance?: string;
+  unlimited?: boolean;
+  resetTime?: number;
+}
+
 export interface CodexResetCredit {
   id?: string;
   status?: string;
@@ -601,9 +611,14 @@ function toBoolValue(value: unknown): boolean | undefined {
 }
 
 function toFiniteNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? value
-    : undefined;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
 }
 
 function decodeJwtPayload(token: string | undefined): JsonRecord | null {
@@ -750,6 +765,63 @@ export function getCodexCodeReviewQuotaMetric(
       ? normalizeCodeReviewWindow(secondaryWindow, "weekly")
       : null)
   );
+}
+
+export function getCodexMonthlyCreditUsage(
+  quota: CodexQuota | undefined,
+): CodexMonthlyCreditUsage | null {
+  const raw = toJsonRecord(quota?.raw_data);
+  if (!raw) return null;
+
+  const spendControl = toJsonRecord(raw.spend_control);
+  const individualLimit = toJsonRecord(spendControl?.individual_limit);
+  if (individualLimit) {
+    const total = toFiniteNumber(individualLimit.limit);
+    const used = toFiniteNumber(individualLimit.used);
+    const remaining =
+      toFiniteNumber(individualLimit.remaining) ??
+      (total != null && used != null ? Math.max(0, total - used) : undefined);
+    const remainingPercent =
+      toFiniteNumber(individualLimit.remaining_percent) ??
+      (total != null && total > 0 && remaining != null
+        ? Math.round((remaining / total) * 100)
+        : undefined);
+
+    if (
+      total != null ||
+      used != null ||
+      remaining != null ||
+      remainingPercent != null
+    ) {
+      const resetAfterSeconds = toFiniteNumber(
+        individualLimit.reset_after_seconds,
+      );
+      return {
+        used,
+        total,
+        remaining,
+        remainingPercent:
+          remainingPercent == null
+            ? undefined
+            : Math.max(0, Math.min(100, Math.round(remainingPercent))),
+        resetTime:
+          normalizeCodexUnixSeconds(individualLimit.reset_at) ??
+          (resetAfterSeconds != null && resetAfterSeconds >= 0
+            ? Math.floor(Date.now() / 1000) + resetAfterSeconds
+            : undefined),
+      };
+    }
+  }
+
+  // Older responses may expose only a credits balance without the effective limit.
+  const credits = toJsonRecord(raw.credits);
+  if (!credits) return null;
+  const unlimited = toBoolValue(credits.unlimited) ?? false;
+  const balance = toStringValue(credits.balance);
+  const remaining =
+    toFiniteNumber(credits.remaining) ?? toFiniteNumber(credits.balance);
+  if (!unlimited && balance == null && remaining == null) return null;
+  return { balance, remaining, unlimited };
 }
 
 function normalizeCodexAdditionalLimitLabel(

--- a/src/types/codexQuota.test.ts
+++ b/src/types/codexQuota.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   getCodexAdditionalQuotaWindows,
   getCodexQuotaWindowLabel,
+  getCodexMonthlyCreditUsage,
   type CodexQuota,
 } from "./codex.ts";
 
@@ -71,4 +72,52 @@ test("keeps upstream Spark-specific quota windows for the account card", () => {
       windowMinutes: 10_080,
     },
   ]);
+});
+
+test("reads Business monthly credits from the spend-control payload", () => {
+  assert.deepEqual(
+    getCodexMonthlyCreditUsage({
+      hourly_percentage: 100,
+      weekly_percentage: 100,
+      raw_data: {
+        plan_type: "business",
+        spend_control: {
+          individual_limit: {
+            limit: "25000",
+            used: "8000",
+            remaining: "17000",
+            remaining_percent: 68,
+            reset_at: 1_790_000_000,
+          },
+        },
+      },
+    }),
+    {
+      used: 8000,
+      total: 25000,
+      remaining: 17000,
+      remainingPercent: 68,
+      resetTime: 1_790_000_000,
+    },
+  );
+});
+
+test("falls back to a balance-only credits payload", () => {
+  assert.deepEqual(
+    getCodexMonthlyCreditUsage({
+      hourly_percentage: 100,
+      weekly_percentage: 100,
+      raw_data: {
+        credits: {
+          unlimited: false,
+          balance: "42",
+        },
+      },
+    }),
+    {
+      balance: "42",
+      remaining: 42,
+      unlimited: false,
+    },
+  );
 });


### PR DESCRIPTION
## 问题

Codex Business 使用月度 credits 计价，但现有额度展示没有解析对应字段，导致企业版账号无法正常显示月度 credits。

## 变更

- 从 `spend_control.individual_limit` 解析月度 credits，并兼容字符串形式的数值。
- 展示剩余值、总值、重置时间、无限额度和仅返回余额的响应。
- 在 Codex 账号视图中加入月度 credits 指标。
- 为全部 18 个语言文件补充对应文案。
- 增加 Business 限额和仅余额响应的回归测试。

## 验证

- `npm run typecheck`：通过。
- `node --test src/types/codexQuota.test.ts`：通过，4 个测试全部成功。
- `node scripts/check_locales.cjs`：通过，18 个语言文件的 key 一致。
- `npx vite build`：通过，仅有现存的大 chunk 提示。
- `git diff --check upstream/main...HEAD`：通过。
- 与最新 `upstream/main` 的合并模拟：无冲突。

Fixes #1560
