### PR TITLE
fix(api-service): make image-generation tools account-capability aware

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	internalregistry "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	responsesconverter "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
@@ -1019,6 +1020,9 @@ func (p *requestPolicy) middleware() gin.HandlerFunc {
 			c.Set(ginUserAPIKeyKey, spec.Key)
 			ctx := context.WithValue(c.Request.Context(), clientAPIKeyContextKey, spec)
 			ctx = context.WithValue(ctx, requestKindContextKey, requestKind)
+			if isImageRequestKind(requestKind) {
+				ctx = coreauth.WithImageRequest(ctx)
+			}
 			if clientInstanceID != "" {
 				ctx = withClientInstanceID(ctx, clientInstanceID)
 			}
@@ -2555,7 +2559,6 @@ func (s *backupAccountSelector) Stop() {
 
 func (s *cockpitSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
 	_ = provider
-	_ = opts
 	auths = s.filterAuthsForAPIKeyScope(ctx, auths)
 	now := time.Now()
 	available := make([]*coreauth.Auth, 0, len(auths))
@@ -2583,8 +2586,12 @@ func (s *cockpitSelector) Pick(ctx context.Context, provider, model string, opts
 	s.mu.Unlock()
 
 	requestKind, _ := ctx.Value(requestKindContextKey).(string)
+	imageIntent := isImageRequestKind(requestKind) || helps.PayloadDeclaresImageGenerationTools(executorPayloadForIntent(opts))
+	if imageIntent {
+		available = preferImageGenerationCapable(available)
+	}
 	ordered := s.orderAuths(available, start)
-	if isImageRequestKind(requestKind) {
+	if imageIntent {
 		ordered = s.orderImageAuths(available, start)
 	} else {
 		ordered = s.prioritizeAuthsForAPIKey(ctx, ordered)
@@ -2592,7 +2599,7 @@ func (s *cockpitSelector) Pick(ctx context.Context, provider, model string, opts
 	if len(ordered) == 0 {
 		return nil, noAuthAvailableError(quotaReserveReasons)
 	}
-	if isImageRequestKind(requestKind) && s.tracker != nil {
+	if imageIntent && s.tracker != nil {
 		requestID := internallogging.GetRequestID(ctx)
 		for {
 			changed := s.tracker.imageJobChangeSignal()
@@ -2700,6 +2707,40 @@ func isImageRequestKind(requestKind string) bool {
 	default:
 		return false
 	}
+}
+
+// executorPayloadForIntent returns the most complete request payload available
+// for image-intent detection (client-declared image tool declarations).
+func executorPayloadForIntent(opts cliproxyexecutor.Options) []byte {
+	return opts.OriginalRequest
+}
+
+// preferImageGenerationCapable keeps only accounts that have not proven image
+// generation unavailable, when at least one such candidate exists. When every
+// candidate is incapable it returns the original list unchanged so a request
+// can still degrade to plain text instead of failing selection.
+func preferImageGenerationCapable(auths []*coreauth.Auth) []*coreauth.Auth {
+	if len(auths) <= 1 {
+		return auths
+	}
+	hasCapable := false
+	for _, auth := range auths {
+		if auth != nil && !auth.ImageGenerationUnavailable {
+			hasCapable = true
+			break
+		}
+	}
+	if !hasCapable {
+		return auths
+	}
+	kept := make([]*coreauth.Auth, 0, len(auths))
+	for _, auth := range auths {
+		if auth == nil || auth.ImageGenerationUnavailable {
+			continue
+		}
+		kept = append(kept, auth)
+	}
+	return kept
 }
 
 func (s *cockpitSelector) orderImageAuths(auths []*coreauth.Auth, start int) []*coreauth.Auth {
@@ -3257,6 +3298,20 @@ func stringFromAPIKey(spec *apiKeySpec, field string) string {
 	return spec.ID
 }
 
+// isImageGenerationCapabilityBody matches bodies denying image generation
+// permission (whole-body phrase match, mirror of the executor classifier).
+func isImageGenerationCapabilityBody(lower string) bool {
+	if !strings.Contains(lower, "image_generation") && !strings.Contains(lower, "image generation") {
+		return false
+	}
+	for _, verb := range []string{"not enabled", "not available", "not allowed", "not supported", "disabled"} {
+		if strings.Contains(lower, verb) {
+			return true
+		}
+	}
+	return false
+}
+
 func errorCategory(status int, body string, success bool) string {
 	if success {
 		return ""
@@ -3294,6 +3349,8 @@ func errorCategory(status int, body string, success bool) string {
 		strings.Contains(lower, "codex upstream response.failed") ||
 		strings.Contains(lower, "last_event=response.failed"):
 		return "upstream_response_failed"
+	case isImageGenerationCapabilityBody(lower):
+		return "image_generation_not_enabled"
 	case status == http.StatusUnauthorized || status == http.StatusForbidden:
 		return "auth_failed"
 	case status == http.StatusNotFound:

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -4424,3 +4424,30 @@ func TestSidecarRuntimeDoesNotSelectAccountWithExcludedModel(t *testing.T) {
 		t.Fatal("blocked auth lost a non-excluded model")
 	}
 }
+
+func TestErrorCategoryImageGenerationNotEnabled(t *testing.T) {
+	body := `{"error":{"code":"image_generation_not_enabled","message":"Image generation is not enabled for this group","type":"permission_error"}}`
+	if got := errorCategory(http.StatusForbidden, body, false); got != "image_generation_not_enabled" {
+		t.Fatalf("errorCategory = %q, want image_generation_not_enabled", got)
+	}
+	if got := errorCategory(http.StatusForbidden, `{"error":{"message":"forbidden"}}`, false); got != "auth_failed" {
+		t.Fatalf("plain 403 errorCategory = %q, want auth_failed", got)
+	}
+}
+
+func TestPreferImageGenerationCapable(t *testing.T) {
+	a1 := &coreauth.Auth{ID: "a1", ImageGenerationUnavailable: true}
+	a2 := &coreauth.Auth{ID: "a2", ImageGenerationUnavailable: false}
+	a3 := &coreauth.Auth{ID: "a3", ImageGenerationUnavailable: true}
+
+	got := preferImageGenerationCapable([]*coreauth.Auth{a1, a2, a3})
+	if len(got) != 1 || got[0].ID != "a2" {
+		t.Fatalf("expected only a2, got %v", got)
+	}
+	if got := preferImageGenerationCapable([]*coreauth.Auth{a1, a3}); len(got) != 2 {
+		t.Fatalf("all incapable should be unchanged, got %d", len(got))
+	}
+	if got := preferImageGenerationCapable([]*coreauth.Auth{a2}); len(got) != 1 {
+		t.Fatal("single auth should be unchanged")
+	}
+}

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor.go
@@ -976,9 +976,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeCodexInstructions(body, baseModel)
-	if helps.ShouldInjectImageGenerationToolForModel(e.cfg, baseModel, requestPath, opts.Headers) {
-		body = ensureImageGenerationTool(body, baseModel, auth)
-	}
+	body, imageDegraded := maybeInjectImageGenerationTool(e.cfg, body, baseModel, requestPath, opts.Headers, auth)
 	body, useFullResponses := normalizeCodexResponsesLiteRequest(body, opts.Headers, auth, true)
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2Request(ctx, opts.Headers, body, e.cfg)
@@ -1088,7 +1086,11 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		var param any
 		clientCompletedData := applyCodexIdentityExposeResponsePayload(completedData, identityState)
 		out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, clientCompletedData, &param)
-		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+		respHeaders := httpResp.Header.Clone()
+		if imageDegraded {
+			respHeaders.Set(codexImageDegradedHeader, "1")
+		}
+		resp = cliproxyexecutor.Response{Payload: out, Headers: respHeaders}
 		return resp, nil
 	}
 	err = newCodexIncompleteStreamError()
@@ -1126,9 +1128,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.DeleteBytes(body, "stream")
 	body = normalizeCodexInstructions(body, baseModel)
-	if helps.ShouldInjectImageGenerationToolForModel(e.cfg, baseModel, requestPath, opts.Headers) {
-		body = ensureImageGenerationTool(body, baseModel, auth)
-	}
+	body, imageDegraded := maybeInjectImageGenerationTool(e.cfg, body, baseModel, requestPath, opts.Headers, auth)
 	body, _ = normalizeCodexResponsesLiteRequest(body, opts.Headers, auth, false)
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2Request(ctx, opts.Headers, body, e.cfg)
@@ -1197,7 +1197,11 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	var param any
 	clientData := applyCodexIdentityExposeResponsePayload(upstreamData, identityState)
 	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, clientData, &param)
-	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+	respHeaders := httpResp.Header.Clone()
+	if imageDegraded {
+		respHeaders.Set(codexImageDegradedHeader, "1")
+	}
+	resp = cliproxyexecutor.Response{Payload: out, Headers: respHeaders}
 	return resp, nil
 }
 
@@ -1245,9 +1249,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body = normalizeCodexInstructions(body, baseModel)
-	if helps.ShouldInjectImageGenerationToolForModel(e.cfg, baseModel, requestPath, opts.Headers) {
-		body = ensureImageGenerationTool(body, baseModel, auth)
-	}
+	body, imageDegraded := maybeInjectImageGenerationTool(e.cfg, body, baseModel, requestPath, opts.Headers, auth)
 	body, useFullResponses := normalizeCodexResponsesLiteRequest(body, opts.Headers, auth, true)
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2Request(ctx, opts.Headers, body, e.cfg)
@@ -1417,7 +1419,11 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			}
 		}
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	headersOut := httpResp.Header.Clone()
+	if imageDegraded {
+		headersOut.Set(codexImageDegradedHeader, "1")
+	}
+	return &cliproxyexecutor.StreamResult{Headers: headersOut, Chunks: out}, nil
 }
 
 func isCodexStreamBootstrapMetadataEvent(eventType string) bool {
@@ -2122,6 +2128,31 @@ func classifyCodexStatusError(statusCode int, body []byte) []byte {
 	return out
 }
 
+// isImageGenerationPermissionError reports whether an upstream response means
+// the selected account lacks image-generation permission. The status gate keeps
+// quota/auth/model failures out; the phrase match runs over the WHOLE raw body
+// so relay wrappers that embed the upstream error as an escaped JSON string
+// (e.g. Sub2api) still match. Unrelated permission_error bodies do not match.
+func isImageGenerationPermissionError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest &&
+		statusCode != http.StatusForbidden &&
+		statusCode != http.StatusUnprocessableEntity {
+		return false
+	}
+	lower := strings.ToLower(string(body))
+	if !strings.Contains(lower, "image_generation") && !strings.Contains(lower, "image generation") {
+		return false
+	}
+	for _, verb := range []string{
+		"not enabled", "not available", "not allowed", "not supported", "disabled",
+	} {
+		if strings.Contains(lower, verb) {
+			return true
+		}
+	}
+	return false
+}
+
 func codexStatusErrorClassification(statusCode int, body []byte) (code string, errType string, ok bool) {
 	errorMessage := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.message").String()))
 	if errorMessage == "" {
@@ -2139,6 +2170,8 @@ func codexStatusErrorClassification(statusCode int, body []byte) (code string, e
 		return "thinking_signature_invalid", "invalid_request_error", true
 	case upstreamCode == "previous_response_not_found" || strings.Contains(lower, "previous_response_not_found") || strings.Contains(lower, "previous_response_id") && strings.Contains(lower, "not found"):
 		return "previous_response_not_found", "invalid_request_error", true
+	case isImageGenerationPermissionError(statusCode, body):
+		return "image_generation_not_enabled", "permission_error", true
 	case statusCode == http.StatusUnauthorized || upstreamType == "authentication_error" || upstreamCode == "invalid_api_key" || strings.Contains(lower, "invalid or expired token") || strings.Contains(lower, "refresh_token_reused"):
 		return "auth_unavailable", "authentication_error", true
 	default:
@@ -2273,6 +2306,44 @@ func codexResponsesLiteToolSupported(tool gjson.Result) bool {
 
 var imageGenToolJSON = []byte(`{"type":"image_generation","output_format":"png"}`)
 var imageGenToolArrayJSON = []byte(`[{"type":"image_generation","output_format":"png"}]`)
+
+// codexImageDegradedHeader marks responses where the gateway skipped the hosted
+// image_generation tool because the selected account proved the capability
+// unavailable (learned from an upstream permission error).
+const codexImageDegradedHeader = "x-agtools-image-degraded"
+
+// setImageDegradedHeader attaches the degraded marker to the given headers and
+// returns them (allocating a map when degraded and the input is nil).
+func setImageDegradedHeader(headers http.Header, degraded bool) http.Header {
+	if !degraded {
+		return headers
+	}
+	if headers == nil {
+		headers = http.Header{}
+	}
+	headers.Set(codexImageDegradedHeader, "1")
+	return headers
+}
+
+// maybeInjectImageGenerationTool injects the hosted image_generation tool into
+// chat/responses payloads unless the selected account has proven the capability
+// unavailable. The bool reports an automatic degradation (skipped because of the
+// learned account capability, not because of a manual header override).
+func maybeInjectImageGenerationTool(cfg *config.Config, body []byte, model, requestPath string, headers http.Header, auth *cliproxyauth.Auth) ([]byte, bool) {
+	if !helps.ShouldInjectImageGenerationToolForModel(cfg, model, requestPath, headers) {
+		return body, false
+	}
+	if auth != nil && auth.ImageGenerationUnavailable {
+		// The account proved image generation unavailable: degrade the request
+		// to plain text, including stripping client-declared image tools and
+		// their tool_choice so the upstream cannot reject the whole request.
+		if stripped := helps.StripImageGenerationCapabilities(body); stripped != nil {
+			return stripped, true
+		}
+		return body, true
+	}
+	return ensureImageGenerationTool(body, model, auth), false
+}
 
 func isCodexFreePlanAuth(auth *cliproxyauth.Auth) bool {
 	if auth == nil || auth.Attributes == nil {

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_image_capability_test.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_image_capability_test.go
@@ -1,0 +1,175 @@
+package executor
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestIsImageGenerationPermissionError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       bool
+	}{
+		{
+			name:       "sub2api nested permission error",
+			statusCode: http.StatusForbidden,
+			body:       `{"error":{"code":"auth_failed","message":"{\"error\":{\"message\":\"Image generation is not enabled for this group\",\"type\":\"permission_error\"}}","type":"invalid_request_error"}}`,
+			want:       true,
+		},
+		{
+			name:       "direct permission error",
+			statusCode: http.StatusForbidden,
+			body:       `{"error":{"message":"Image generation is not enabled for this group","type":"permission_error"}}`,
+			want:       true,
+		},
+		{
+			name:       "underscore variant",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":{"message":"image_generation is disabled for this plan"}}`,
+			want:       true,
+		},
+		{
+			name:       "unrelated permission error",
+			statusCode: http.StatusForbidden,
+			body:       `{"error":{"message":"Search is not enabled for this group","type":"permission_error"}}`,
+			want:       false,
+		},
+		{
+			name:       "quota 403",
+			statusCode: http.StatusForbidden,
+			body:       `{"error":{"message":"usage limit exceeded","type":"insufficient_quota"}}`,
+			want:       false,
+		},
+		{
+			name:       "auth 401",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"message":"Image generation is not enabled for this group"}}`,
+			want:       false,
+		},
+		{
+			name:       "server error with same message",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"error":{"message":"Image generation is not enabled for this group"}}`,
+			want:       false,
+		},
+		{
+			name:       "model not available 403",
+			statusCode: http.StatusForbidden,
+			body:       `{"error":{"code":"model_not_available","message":"The requested model is not available"}}`,
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isImageGenerationPermissionError(tt.statusCode, []byte(tt.body)); got != tt.want {
+				t.Fatalf("isImageGenerationPermissionError(%d, %s) = %v, want %v", tt.statusCode, tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewCodexStatusErrClassifiesImagePermission(t *testing.T) {
+	body := []byte(`{"error":{"code":"auth_failed","message":"{\"error\":{\"message\":\"Image generation is not enabled for this group\",\"type\":\"permission_error\"}}","type":"invalid_request_error"}}`)
+
+	err := newCodexStatusErr(http.StatusForbidden, body)
+	if got := err.StatusCode(); got != http.StatusForbidden {
+		t.Fatalf("status code = %d, want 403", got)
+	}
+	if !strings.Contains(err.Error(), "image_generation_not_enabled") {
+		t.Fatalf("classified message = %s, want it to contain image_generation_not_enabled", err.Error())
+	}
+
+	code, errType, ok := codexStatusErrorClassification(http.StatusForbidden, []byte(err.Error()))
+	if !ok {
+		t.Fatalf("expected classification, msg=%s", err.Error())
+	}
+	if code != "image_generation_not_enabled" || errType != "permission_error" {
+		t.Fatalf("code=%s type=%s, want image_generation_not_enabled/permission_error", code, errType)
+	}
+}
+
+func TestMaybeInjectImageGenerationToolSkipsMarkedAuthAndFlagsDegraded(t *testing.T) {
+	baseBody := []byte(`{"model":"gpt-5.4","input":"draw an icon"}`)
+
+	marked := &cliproxyauth.Auth{ID: "a", Provider: "codex", ImageGenerationUnavailable: true}
+	body, degraded := maybeInjectImageGenerationTool(&config.Config{}, baseBody, "gpt-5.4", "/v1/responses", nil, marked)
+	if degraded != true {
+		t.Fatalf("degraded = %v, want true", degraded)
+	}
+	if string(body) != string(baseBody) {
+		t.Fatalf("body changed for marked auth: %s", body)
+	}
+
+	fresh := &cliproxyauth.Auth{ID: "b", Provider: "codex"}
+	body, degraded = maybeInjectImageGenerationTool(&config.Config{}, baseBody, "gpt-5.4", "/v1/responses", nil, fresh)
+	if degraded != false {
+		t.Fatalf("degraded = %v, want false", degraded)
+	}
+	if !strings.Contains(string(body), `"type":"image_generation"`) {
+		t.Fatalf("image tool not injected for fresh auth: %s", body)
+	}
+}
+
+func TestMaybeInjectImageGenerationToolRespectsManualHeader(t *testing.T) {
+	baseBody := []byte(`{"model":"gpt-5.4","input":"hi"}`)
+	headers := http.Header{helps.DisableImageGenerationHeader: []string{"chat"}}
+	body, degraded := maybeInjectImageGenerationTool(&config.Config{}, baseBody, "gpt-5.4", "/v1/responses", headers, nil)
+	if degraded != false || string(body) != string(baseBody) {
+		t.Fatalf("manual header should disable injection without degraded flag, body=%s degraded=%v", body, degraded)
+	}
+}
+
+func TestMaybeInjectImageGenerationToolStripsDeclaredToolsForMarkedAuth(t *testing.T) {
+	baseBody := []byte(`{"model":"gpt-5.4","input":"make an image","tool_choice":{"type":"image_generation"},"tools":[{"type":"image_generation","output_format":"png"},{"type":"function","name":"lookup"}]}`)
+
+	marked := &cliproxyauth.Auth{ID: "a", Provider: "codex", ImageGenerationUnavailable: true}
+	body, degraded := maybeInjectImageGenerationTool(&config.Config{}, baseBody, "gpt-5.4", "/v1/responses", nil, marked)
+	if degraded != true {
+		t.Fatalf("degraded = %v, want true", degraded)
+	}
+	if strings.Contains(string(body), "image_generation") {
+		t.Fatalf("declared image tool should be stripped: %s", body)
+	}
+	if !strings.Contains(string(body), "lookup") {
+		t.Fatalf("non-image tool should survive: %s", body)
+	}
+}
+
+func TestErrImageGenerationUnavailableBody(t *testing.T) {
+	err := errImageGenerationUnavailable()
+	se, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("expected statusErr, got %T", err)
+	}
+	if se.StatusCode() != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", se.StatusCode())
+	}
+	if !strings.Contains(se.Error(), "image_generation_not_enabled") {
+		t.Fatalf("body = %s, want image_generation_not_enabled", se.Error())
+	}
+}
+
+func TestSetImageDegradedHeader(t *testing.T) {
+	if got := setImageDegradedHeader(nil, false); got != nil {
+		t.Fatalf("degraded=false should leave headers untouched, got %v", got)
+	}
+	if got := setImageDegradedHeader(http.Header{}, false); len(got) != 0 {
+		t.Fatalf("degraded=false should not add headers, got %v", got)
+	}
+	got := setImageDegradedHeader(nil, true)
+	if got.Get(codexImageDegradedHeader) != "1" {
+		t.Fatalf("degraded=true should set %s=1, got %v", codexImageDegradedHeader, got)
+	}
+	existing := http.Header{"X-Existing": []string{"v"}}
+	got = setImageDegradedHeader(existing, true)
+	if got.Get(codexImageDegradedHeader) != "1" || got.Get("X-Existing") != "v" {
+		t.Fatalf("existing headers should be preserved, got %v", got)
+	}
+}

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_openai_images.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_openai_images.go
@@ -48,6 +48,16 @@ type codexImageCallResult struct {
 	Quality       string
 }
 
+// errImageGenerationUnavailable rejects explicit image endpoints when the
+// selected account has proven image generation unavailable. The code matches
+// the executor's upstream classification so diagnostics treat it consistently.
+func errImageGenerationUnavailable() error {
+	return statusErr{
+		code: http.StatusForbidden,
+		msg:  `{"error":{"code":"image_generation_not_enabled","message":"Image generation is not enabled for this group","type":"invalid_request_error"}}`,
+	}
+}
+
 func isCodexOpenAIImageRequest(opts cliproxyexecutor.Options) bool {
 	if !strings.EqualFold(strings.TrimSpace(opts.SourceFormat.String()), codexOpenAIImageSourceFormat) {
 		return false
@@ -81,6 +91,9 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 	prepared, errPrepare := codexPrepareOpenAIImageRequest(req, opts)
 	if errPrepare != nil {
 		return resp, errPrepare
+	}
+	if auth != nil && auth.ImageGenerationUnavailable {
+		return resp, errImageGenerationUnavailable()
 	}
 
 	apiKey, baseURL := codexCreds(auth)
@@ -179,6 +192,9 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 	prepared, errPrepare := codexPrepareOpenAIImageRequest(req, opts)
 	if errPrepare != nil {
 		return nil, errPrepare
+	}
+	if auth != nil && auth.ImageGenerationUnavailable {
+		return nil, errImageGenerationUnavailable()
 	}
 
 	apiKey, baseURL := codexCreds(auth)

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_websockets_executor.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_websockets_executor.go
@@ -360,9 +360,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body = normalizeCodexInstructions(body, baseModel)
-	if helps.ShouldInjectImageGenerationToolForModel(e.cfg, baseModel, requestPath, opts.Headers) {
-		body = ensureImageGenerationTool(body, baseModel, auth)
-	}
+	body, imageDegraded := maybeInjectImageGenerationTool(e.cfg, body, baseModel, requestPath, opts.Headers, auth)
 	body, useFullResponses := normalizeCodexResponsesLiteRequest(body, opts.Headers, auth, true)
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2Request(ctx, opts.Headers, body, e.cfg)
@@ -601,7 +599,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			var param any
 			clientPayload := applyCodexIdentityExposeResponsePayload(payload, identityState)
 			out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, clientBody, clientPayload, &param)
-			resp = cliproxyexecutor.Response{Payload: out}
+			resp = cliproxyexecutor.Response{Payload: out, Headers: setImageDegradedHeader(nil, imageDegraded)}
 			return resp, nil
 		}
 	}
@@ -645,9 +643,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, body, requestedModel, requestPath, opts.Headers)
 	body = normalizeCodexInstructions(body, baseModel)
-	if helps.ShouldInjectImageGenerationToolForModel(e.cfg, baseModel, requestPath, opts.Headers) {
-		body = ensureImageGenerationTool(body, baseModel, auth)
-	}
+	body, imageDegraded := maybeInjectImageGenerationTool(e.cfg, body, baseModel, requestPath, opts.Headers, auth)
 	body, useFullResponses := normalizeCodexResponsesLiteRequest(body, opts.Headers, auth, true)
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2Request(ctx, opts.Headers, body, e.cfg)
@@ -973,6 +969,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		}
 	}()
 
+	upstreamHeaders = setImageDegradedHeader(upstreamHeaders, imageDegraded)
 	return &cliproxyexecutor.StreamResult{Headers: upstreamHeaders, Chunks: out}, nil
 }
 

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/helps/payload_helpers.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/helps/payload_helpers.go
@@ -1,6 +1,7 @@
 package helps
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"reflect"
@@ -1409,4 +1410,29 @@ func matchModelPattern(pattern, model string) bool {
 		pi++
 	}
 	return pi == len(pattern)
+}
+
+// PayloadDeclaresImageGenerationTools reports whether the payload declares
+// hosted image_generation tools, image_gen namespaces, or image_gen.imagegen
+// function tools anywhere in the request metadata (tools, tool_choice,
+// additional_tools input items, nested response metadata).
+func PayloadDeclaresImageGenerationTools(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	return payloadDeclaresImageGenerationToolsWithRoot(payload, "")
+}
+
+// StripImageGenerationCapabilities removes all image-generation tool
+// declarations and the matching tool_choice from the payload. It returns nil
+// when nothing changed, so callers can keep the original payload untouched.
+func StripImageGenerationCapabilities(payload []byte) []byte {
+	if len(payload) == 0 {
+		return nil
+	}
+	out := removeImageGenerationToolsFromPayloadWithRoot(payload, "")
+	if bytes.Equal(out, payload) {
+		return nil
+	}
+	return out
 }

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/helps/payload_helpers_disable_image_generation_test.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/helps/payload_helpers_disable_image_generation_test.go
@@ -537,3 +537,62 @@ func TestApplyPayloadConfigWithRequest_PayloadConditionsSkipRule(t *testing.T) {
 		})
 	}
 }
+
+func TestStripImageGenerationCapabilities(t *testing.T) {
+	t.Run("strips hosted tool and tool_choice", func(t *testing.T) {
+		payload := []byte(`{"model":"gpt-5.4","tool_choice":{"type":"image_generation"},"tools":[{"type":"image_generation","output_format":"png"},{"type":"function","name":"f1"}]}`)
+		out := StripImageGenerationCapabilities(payload)
+		if out == nil {
+			t.Fatal("expected stripped payload, got nil")
+		}
+		if gjson.GetBytes(out, "tool_choice").Exists() {
+			t.Fatal("tool_choice should be removed")
+		}
+		if got := len(gjson.GetBytes(out, "tools").Array()); got != 1 {
+			t.Fatalf("expected 1 remaining tool, got %d", got)
+		}
+	})
+	t.Run("returns nil when nothing declared", func(t *testing.T) {
+		payload := []byte(`{"tools":[{"type":"function","name":"f1"}]}`)
+		if out := StripImageGenerationCapabilities(payload); out != nil {
+			t.Fatalf("expected nil, got %s", out)
+		}
+	})
+	t.Run("strips image_gen namespace and imagegen function", func(t *testing.T) {
+		payload := []byte(`{"tools":[{"type":"namespace","name":"image_gen"},{"type":"function","name":"image_gen.imagegen"},{"type":"function","name":"keep"}]}`)
+		out := StripImageGenerationCapabilities(payload)
+		if out == nil {
+			t.Fatal("expected stripped payload, got nil")
+		}
+		names := make([]string, 0, 2)
+		for _, tool := range gjson.GetBytes(out, "tools").Array() {
+			names = append(names, tool.Get("name").String())
+		}
+		if len(names) != 1 || names[0] != "keep" {
+			t.Fatalf("unexpected remaining tools: %v", names)
+		}
+	})
+}
+
+func TestPayloadDeclaresImageGenerationTools(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    bool
+	}{
+		{name: "hosted tool", payload: `{"tools":[{"type":"image_generation"}]}`, want: true},
+		{name: "imagegen function", payload: `{"tools":[{"type":"function","name":"image_gen.imagegen"}]}`, want: true},
+		{name: "image_gen namespace", payload: `{"tools":[{"type":"namespace","name":"image_gen"}]}`, want: true},
+		{name: "tool_choice only", payload: `{"tool_choice":{"type":"image_generation"}}`, want: true},
+		{name: "plain text request", payload: `{"tools":[{"type":"function","name":"lookup"}]}`, want: false},
+		{name: "no tools", payload: `{"model":"gpt-5.4"}`, want: false},
+		{name: "empty", payload: ``, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := PayloadDeclaresImageGenerationTools([]byte(tc.payload)); got != tc.want {
+				t.Fatalf("PayloadDeclaresImageGenerationTools = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/conductor.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/conductor.go
@@ -2286,6 +2286,15 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 	if isRequestInvalidError(err) {
 		return 0, false
 	}
+	if isImageGenerationCapabilityResultError(resultErrorFromError(err)) {
+		// The account learned that image generation is unavailable mid-request:
+		// allow exactly one immediate re-attempt so the same request can be
+		// re-selected and degrade to plain text (or rotate to another account).
+		if attempt >= 1 {
+			return 0, false
+		}
+		return 0, true
+	}
 	wait, found := m.closestCooldownWait(providers, model, attempt)
 	if found {
 		if wait > maxWait {
@@ -2320,6 +2329,20 @@ func waitForCooldown(ctx context.Context, wait time.Duration) error {
 	}
 }
 
+// imageRequestContextKey marks contexts carrying image-generation requests so
+// successful executions can clear a learned image unavailability mark.
+type imageRequestContextKey struct{}
+
+// WithImageRequest returns a context marked as an image-generation request.
+func WithImageRequest(ctx context.Context) context.Context {
+	return context.WithValue(ctx, imageRequestContextKey{}, true)
+}
+
+func imageRequestFromContext(ctx context.Context) bool {
+	value, _ := ctx.Value(imageRequestContextKey{}).(bool)
+	return value
+}
+
 // MarkResult records an execution result and notifies hooks.
 func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if result.AuthID == "" {
@@ -2344,6 +2367,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		}
 
 		if result.Success {
+			if imageRequestFromContext(ctx) {
+				auth.ImageGenerationUnavailable = false
+			}
 			if result.Model != "" {
 				state := ensureModelState(auth, result.Model)
 				resetModelState(state, now)
@@ -2361,7 +2387,12 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		} else {
 			if result.Model != "" {
-				if !isRequestScopedResultError(result.Error) {
+				if isImageGenerationCapabilityResultError(result.Error) {
+					// Only image generation is unavailable on this account;
+					// text requests keep working. Do NOT suspend the model.
+					auth.ImageGenerationUnavailable = true
+					auth.UpdatedAt = now
+				} else if !isRequestScopedResultError(result.Error) {
 					disableCooling := quotaCooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, result.Model)
 					state.Unavailable = true
@@ -2718,6 +2749,31 @@ func isRequestScopedError(err error) bool {
 	return ok && requestErr != nil && requestErr.IsRequestScoped()
 }
 
+// isImageGenerationCapabilityMessage matches upstream bodies that deny image
+// generation permission. The match runs over the whole message string so relay
+// wrappers that embed the upstream JSON as an escaped string still match.
+func isImageGenerationCapabilityMessage(message string) bool {
+	lower := strings.ToLower(strings.TrimSpace(message))
+	if lower == "" {
+		return false
+	}
+	if !strings.Contains(lower, "image_generation") && !strings.Contains(lower, "image generation") {
+		return false
+	}
+	for _, verb := range []string{
+		"not enabled", "not available", "not allowed", "not supported", "disabled",
+	} {
+		if strings.Contains(lower, verb) {
+			return true
+		}
+	}
+	return false
+}
+
+func isImageGenerationCapabilityResultError(err *Error) bool {
+	return err != nil && isImageGenerationCapabilityMessage(err.Message)
+}
+
 func resultErrorFromError(err error) *Error {
 	if err == nil {
 		return nil
@@ -2728,6 +2784,8 @@ func resultErrorFromError(err error) *Error {
 	}
 	if isRequestScopedError(err) || isRequestInvalidError(err) {
 		resultErr.Code = requestScopedErrorCode
+	} else if isImageGenerationCapabilityResultError(resultErr) {
+		resultErr.Code = "image_generation_not_enabled"
 	}
 	return resultErr
 }

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/conductor_image_capability_test.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/conductor_image_capability_test.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestMarkResultImageGenerationUnavailableSkipsModelSuspension(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	auth := &Auth{ID: "codex-sub2api", Provider: "codex", Metadata: map[string]any{"type": "codex"}}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "gpt-5.4",
+		Success:  false,
+		Error: &Error{
+			Message:    `{"error":{"code":"image_generation_not_enabled","message":"Image generation is not enabled for this group","type":"permission_error"}}`,
+			HTTPStatus: http.StatusForbidden,
+		},
+	})
+
+	updated, ok := manager.auths[auth.ID]
+	if !ok || updated == nil {
+		t.Fatalf("auth %q not found after MarkResult", auth.ID)
+	}
+	if !updated.ImageGenerationUnavailable {
+		t.Fatalf("ImageGenerationUnavailable = false, want true")
+	}
+	if updated.Unavailable {
+		t.Fatalf("auth.Unavailable = true, want false (text requests must stay allowed)")
+	}
+	if state := updated.ModelStates["gpt-5.4"]; state != nil && !state.NextRetryAfter.IsZero() {
+		t.Fatalf("ModelState.NextRetryAfter = %v, want zero (no model suspension)", state.NextRetryAfter)
+	}
+}
+
+func TestMarkResultOther403sKeepLegacyBehavior(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		message string
+	}{
+		{name: "plain forbidden", message: `{"error":{"code":"auth_failed","message":"forbidden"}}`},
+		{name: "unrelated permission error", message: `{"error":{"message":"Search is not enabled for this group","type":"permission_error"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := NewManager(nil, &RoundRobinSelector{}, nil)
+			auth := &Auth{ID: "codex-plain-" + tc.name, Provider: "codex", Metadata: map[string]any{"type": "codex"}}
+			if _, err := manager.Register(context.Background(), auth); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+			manager.MarkResult(context.Background(), Result{
+				AuthID:   auth.ID,
+				Provider: auth.Provider,
+				Model:    "gpt-5.4",
+				Success:  false,
+				Error:    &Error{Message: tc.message, HTTPStatus: http.StatusForbidden},
+			})
+			updated, ok := manager.auths[auth.ID]
+			if !ok || updated == nil {
+				t.Fatalf("auth %q not found after MarkResult", auth.ID)
+			}
+			if updated.ImageGenerationUnavailable {
+				t.Fatalf("ImageGenerationUnavailable = true, want false")
+			}
+			state := updated.ModelStates["gpt-5.4"]
+			if state == nil || state.NextRetryAfter.IsZero() {
+				t.Fatalf("ModelState.NextRetryAfter = zero, want ~30m suspension preserved")
+			}
+		})
+	}
+}
+
+func TestResultErrorFromErrorSetsImageCapabilityCode(t *testing.T) {
+	err := resultErrorFromError(errors.New(`{"error":{"code":"image_generation_not_enabled","message":"Image generation is not enabled for this group","type":"permission_error"}}`))
+	if err == nil || err.Code != "image_generation_not_enabled" {
+		t.Fatalf("result error code = %q, want image_generation_not_enabled", err.Code)
+	}
+}
+
+func TestShouldRetryAfterErrorImageCapabilityRetriesOnce(t *testing.T) {
+	var m *Manager
+	err := errors.New(`{"error":{"code":"image_generation_not_enabled","message":"Image generation is not enabled for this group","type":"permission_error"}}`)
+
+	wait, ok := m.shouldRetryAfterError(err, 0, []string{"codex"}, "gpt-5.4", time.Minute)
+	if !ok || wait != 0 {
+		t.Fatalf("attempt 0: ok=%v wait=%v, want ok=true wait=0", ok, wait)
+	}
+	if _, ok := m.shouldRetryAfterError(err, 1, []string{"codex"}, "gpt-5.4", time.Minute); ok {
+		t.Fatal("attempt 1 should not retry")
+	}
+}
+
+func TestMarkResultSuccessClearsImageUnavailableForImageRequest(t *testing.T) {
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+
+	imageAuth := &Auth{ID: "codex-recover", Provider: "codex", Metadata: map[string]any{"type": "codex"}, ImageGenerationUnavailable: true}
+	if _, err := manager.Register(context.Background(), imageAuth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	manager.MarkResult(WithImageRequest(context.Background()), Result{
+		AuthID: imageAuth.ID, Provider: imageAuth.Provider, Model: "gpt-image-2", Success: true,
+	})
+	if manager.auths[imageAuth.ID].ImageGenerationUnavailable {
+		t.Fatal("ImageGenerationUnavailable = true after image success, want false")
+	}
+
+	textAuth := &Auth{ID: "codex-no-recover", Provider: "codex", Metadata: map[string]any{"type": "codex"}, ImageGenerationUnavailable: true}
+	if _, err := manager.Register(context.Background(), textAuth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	manager.MarkResult(context.Background(), Result{
+		AuthID: textAuth.ID, Provider: textAuth.Provider, Model: "gpt-5.4", Success: true,
+	})
+	if !manager.auths[textAuth.ID].ImageGenerationUnavailable {
+		t.Fatal("plain text success should not clear the mark")
+	}
+}

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/types.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/types.go
@@ -67,6 +67,10 @@ type Auth struct {
 	Disabled bool `json:"disabled"`
 	// Unavailable flags transient provider unavailability (e.g. quota exceeded).
 	Unavailable bool `json:"unavailable"`
+	// ImageGenerationUnavailable marks that the upstream account rejected
+	// image-generation tool requests (e.g. "Image generation is not enabled").
+	// Runtime-only: learned from failures and reset on restart.
+	ImageGenerationUnavailable bool `json:"-"`
 	// ProxyURL overrides the global proxy setting for this auth if provided.
 	ProxyURL string `json:"proxy_url,omitempty"`
 	// Attributes stores provider specific metadata needed by executors (immutable configuration).

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -625,6 +625,7 @@ struct ProxyDispatchSuccess {
     upstream: reqwest::Response,
     account_id: String,
     account_email: String,
+    image_degraded: bool,
 }
 
 #[derive(Debug)]
@@ -1914,7 +1915,7 @@ async fn send_agent_identity_wakeup_request_with_base_urls(
             .get(AUTHORIZATION)
             .and_then(|value| value.to_str().ok())
             .ok_or_else(|| "Agent Identity 未生成有效 Authorization 头".to_string())?;
-        let response = send_upstream_request_with_authorization_url(
+        let (response, _) = send_upstream_request_with_authorization_url(
             "POST",
             &upstream_url,
             target,
@@ -1927,6 +1928,7 @@ async fn send_agent_identity_wakeup_request_with_base_urls(
             timeouts,
             CodexLocalAccessImageGenerationMode::Disabled,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .await?;
         let status = response.status();
@@ -2055,7 +2057,7 @@ pub async fn run_official_wakeup_chat(
         .map_err(format_transport_error)?;
         (response.account, response.status, response.body)
     } else {
-        let response = send_upstream_request(
+        let (response, _) = send_upstream_request(
             "POST",
             &upstream_target,
             &headers,
@@ -2066,6 +2068,7 @@ pub async fn run_official_wakeup_chat(
             &timeouts,
             CodexLocalAccessImageGenerationMode::Disabled,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .await
         .map_err(format_transport_error)?;
@@ -19946,7 +19949,7 @@ fn classify_gateway_probe_failure(
         (
             "图片生成能力不可用",
             "上游图片能力",
-            "如果只是普通文本对话报错，请在 API 服务里将 image_generation 改为“仅图片接口启用”或“禁用”；如果需要生图，请换用具备图片能力的 Codex 账号。",
+            "该上游账号未启用图片生成能力，本地网关已记录并在后续文本对话中自动跳过生图工具；如需生图，请换用具备图片能力的 Codex 账号，或使用 x-agtools-disable-image-generation 请求头调整。",
         )
     } else if is_quota_or_rate_limit_message(status, message) {
         (
@@ -22440,18 +22443,21 @@ fn is_image_generation_capability_error(status: StatusCode, body: &str) -> bool 
         return false;
     }
     let lower = body.to_ascii_lowercase();
-    lower.contains("image generation is not enabled")
-        || lower.contains("image_generation is not enabled")
-        || (lower.contains("image_generation") && lower.contains("not enabled"))
+    if !lower.contains("image_generation") && !lower.contains("image generation") {
+        return false;
+    }
+    ["not enabled", "not available", "not allowed", "not supported", "disabled"]
+        .iter()
+        .any(|verb| lower.contains(verb))
 }
 
 fn friendly_image_generation_capability_error(account_email: &str) -> String {
     let account_email = account_email.trim();
     if account_email.is_empty() {
-        return "当前上游账号未启用图片生成能力。请在 API 服务里将 image_generation 改为“仅图片接口启用”或“禁用”，或换用具备图片能力的账号。".to_string();
+        return "当前上游账号未启用图片生成能力，文本对话已自动跳过生图工具；如需生图，请换用具备图片能力的账号。".to_string();
     }
     format!(
-        "账号 {} 未启用图片生成能力。请在 API 服务里将 image_generation 改为“仅图片接口启用”或“禁用”，或换用具备图片能力的账号。",
+        "账号 {} 未启用图片生成能力，文本对话已自动跳过生图工具；如需生图，请换用具备图片能力的账号。",
         account_email
     )
 }
@@ -23309,10 +23315,12 @@ async fn write_chat_completions_compatible_response(
     request: &ParsedRequest,
     started_at: Instant,
     timeouts: &CodexLocalAccessTimeouts,
+    image_degraded: bool,
 ) -> Result<ResponseCapture, String> {
     let status = upstream.status();
     let status_text = status.canonical_reason().unwrap_or("OK");
-    let upstream_headers = upstream.headers().clone();
+    let mut upstream_headers = upstream.headers().clone();
+    apply_image_degraded_header(&mut upstream_headers, image_degraded);
 
     if stream_mode {
         write_chunked_response_headers(
@@ -23467,10 +23475,12 @@ async fn write_images_compatible_response(
     request: &ParsedRequest,
     started_at: Instant,
     timeouts: &CodexLocalAccessTimeouts,
+    image_degraded: bool,
 ) -> Result<ResponseCapture, String> {
     let status = upstream.status();
     let status_text = status.canonical_reason().unwrap_or("OK");
-    let upstream_headers = upstream.headers().clone();
+    let mut upstream_headers = upstream.headers().clone();
+    apply_image_degraded_header(&mut upstream_headers, image_degraded);
 
     if stream_mode {
         write_chunked_response_headers(
@@ -23613,6 +23623,15 @@ async fn write_images_compatible_response(
     Ok(response_capture)
 }
 
+fn apply_image_degraded_header(headers: &mut reqwest::header::HeaderMap, degraded: bool) {
+    if degraded {
+        headers.insert(
+            HeaderName::from_static("x-agtools-image-degraded"),
+            HeaderValue::from_static("1"),
+        );
+    }
+}
+
 async fn write_gateway_response(
     stream: &mut TcpStream,
     upstream: reqwest::Response,
@@ -23621,6 +23640,7 @@ async fn write_gateway_response(
     request: &ParsedRequest,
     started_at: Instant,
     timeouts: &CodexLocalAccessTimeouts,
+    image_degraded: bool,
 ) -> Result<ResponseCapture, String> {
     match response_adapter {
         GatewayResponseAdapter::Passthrough { request_is_stream } => {
@@ -23632,6 +23652,7 @@ async fn write_gateway_response(
                 request,
                 started_at,
                 timeouts,
+                image_degraded,
             )
             .await
         }
@@ -23650,6 +23671,7 @@ async fn write_gateway_response(
                 request,
                 started_at,
                 timeouts,
+                image_degraded,
             )
             .await
         }
@@ -23668,6 +23690,7 @@ async fn write_gateway_response(
                 request,
                 started_at,
                 timeouts,
+                image_degraded,
             )
             .await
         }
@@ -23682,10 +23705,12 @@ async fn write_upstream_response(
     request: &ParsedRequest,
     started_at: Instant,
     timeouts: &CodexLocalAccessTimeouts,
+    image_degraded: bool,
 ) -> Result<ResponseCapture, String> {
     let status = upstream.status();
     let status_text = status.canonical_reason().unwrap_or("OK");
-    let headers = upstream.headers().clone();
+    let mut headers = upstream.headers().clone();
+    apply_image_degraded_header(&mut headers, image_degraded);
     let content_type = headers
         .get(CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
@@ -23861,22 +23886,105 @@ fn should_retry_single_account_upstream_status(status: StatusCode) -> bool {
     )
 }
 
+/// 生图意图：把"已知不可生图"的账号稳定地移到候选末尾，让能生图的账号优先；
+/// 全部不可生图时保持原顺序，由后续降级路径兜底。
+fn prefer_image_generation_capable_account_ids(
+    account_ids: Vec<String>,
+    health_snapshot: &HashMap<String, RuntimeAccountHealth>,
+) -> Vec<String> {
+    if account_ids.len() <= 1 {
+        return account_ids;
+    }
+    let has_capable = account_ids.iter().any(|account_id| {
+        !matches!(
+            health_snapshot
+                .get(account_id)
+                .map(|health| health.image_generation_status),
+            Some(CodexLocalAccessImageGenerationStatus::Unavailable)
+        )
+    });
+    if !has_capable {
+        return account_ids;
+    }
+    let mut capable = Vec::new();
+    let mut incapable = Vec::new();
+    for account_id in account_ids {
+        if matches!(
+            health_snapshot
+                .get(&account_id)
+                .map(|health| health.image_generation_status),
+            Some(CodexLocalAccessImageGenerationStatus::Unavailable)
+        ) {
+            incapable.push(account_id);
+        } else {
+            capable.push(account_id);
+        }
+    }
+    capable.extend(incapable);
+    capable
+}
+
+/// 请求体是否声明了生图工具（hosted image_generation / image_gen 命名空间 /
+/// image_gen.imagegen 函数）或强制了生图 tool_choice。
+fn request_body_declares_image_tools(body: &[u8]) -> bool {
+    let Ok(value) = serde_json::from_slice::<Value>(body) else {
+        return false;
+    };
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    object
+        .get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| tools.iter().any(tool_declares_image_generation_capability))
+        || object
+            .get("tool_choice")
+            .is_some_and(tool_choice_selects_image_generation)
+}
+
+/// 轮转重试前剥离 previous_response_id，避免请求被路由到不同账号后因会话
+/// 上下文缺失而被上游拒绝。
+fn strip_previous_response_id_from_body(body: &[u8]) -> Vec<u8> {
+    let Ok(mut value) = serde_json::from_slice::<Value>(body) else {
+        return body.to_vec();
+    };
+    let changed = value
+        .as_object_mut()
+        .map(|object| object.remove("previous_response_id").is_some())
+        .unwrap_or(false);
+    if changed {
+        serde_json::to_vec(&value).unwrap_or_else(|_| body.to_vec())
+    } else {
+        body.to_vec()
+    }
+}
+
+/// 按"是否已发生生图权限轮转"调整下一个账号使用的请求体。
+fn rotation_adjusted_request_body(request_body: &[u8], strip_previous_response: bool) -> Vec<u8> {
+    if strip_previous_response {
+        strip_previous_response_id_from_body(request_body)
+    } else {
+        request_body.to_vec()
+    }
+}
+
 fn build_account_scoped_upstream_body<'a>(
     target: &str,
     body: &'a [u8],
     account: &CodexAccount,
     image_generation_mode: CodexLocalAccessImageGenerationMode,
     request_kind: CodexLocalAccessRequestKind,
-) -> Result<Cow<'a, [u8]>, String> {
+    image_generation_known_unavailable: bool,
+) -> Result<(Cow<'a, [u8]>, bool), String> {
     if !is_responses_request(target) {
-        return Ok(Cow::Borrowed(body));
+        return Ok((Cow::Borrowed(body), false));
     }
 
     let Some(mut body_value) = parse_request_body_json(body) else {
-        return Ok(Cow::Borrowed(body));
+        return Ok((Cow::Borrowed(body), false));
     };
     let Some(body_obj) = body_value.as_object_mut() else {
-        return Ok(Cow::Borrowed(body));
+        return Ok((Cow::Borrowed(body), false));
     };
     let remove_all_image_capabilities =
         !image_generation_tools_allowed(image_generation_mode, request_kind);
@@ -23887,34 +23995,46 @@ fn build_account_scoped_upstream_body<'a>(
             remove_image_generation_capabilities_from_object(body_obj)
         };
         if !changed {
-            return Ok(Cow::Borrowed(body));
+            return Ok((Cow::Borrowed(body), false));
         }
         return serde_json::to_vec(&body_value)
-            .map(Cow::Owned)
+            .map(|bytes| (Cow::Owned(bytes), false))
             .map_err(|e| format!("序列化账号级 responses 请求体失败: {}", e));
     }
 
     if has_hosted_image_generation_tool_conflict(body_obj) {
         if !remove_hosted_image_generation_tool_from_object(body_obj) {
-            return Ok(Cow::Borrowed(body));
+            return Ok((Cow::Borrowed(body), false));
         }
         return serde_json::to_vec(&body_value)
-            .map(Cow::Owned)
+            .map(|bytes| (Cow::Owned(bytes), false))
             .map_err(|e| format!("序列化账号级 responses 请求体失败: {}", e));
     }
 
     if !image_generation_tools_allowed(image_generation_mode, request_kind) {
-        return Ok(Cow::Borrowed(body));
+        return Ok((Cow::Borrowed(body), false));
+    }
+
+    if image_generation_known_unavailable {
+        // 账号健康已学习到“不可生图”：剥除客户端声明的生图工具与对应
+        // tool_choice，仅按纯文本转发（自动降级）。
+        let changed = remove_image_generation_capabilities_from_object(body_obj);
+        if changed {
+            return serde_json::to_vec(&body_value)
+                .map(|bytes| (Cow::Owned(bytes), true))
+                .map_err(|e| format!("序列化账号级 responses 请求体失败: {}", e));
+        }
+        return Ok((Cow::Borrowed(body), true));
     }
 
     if is_free_plan_type(account.plan_type.as_deref())
         || !ensure_image_generation_tool_in_object(body_obj)
     {
-        return Ok(Cow::Borrowed(body));
+        return Ok((Cow::Borrowed(body), false));
     }
 
     serde_json::to_vec(&body_value)
-        .map(Cow::Owned)
+        .map(|bytes| (Cow::Owned(bytes), false))
         .map_err(|e| format!("序列化账号级 responses 请求体失败: {}", e))
 }
 
@@ -23929,7 +24049,8 @@ async fn send_upstream_request(
     timeouts: &CodexLocalAccessTimeouts,
     image_generation_mode: CodexLocalAccessImageGenerationMode,
     request_kind: CodexLocalAccessRequestKind,
-) -> Result<reqwest::Response, String> {
+    image_generation_known_unavailable: bool,
+) -> Result<(reqwest::Response, bool), String> {
     let url = build_upstream_url(account, target)?;
     let upstream_token = account_upstream_token(account)?;
     let authorization = format!("Bearer {}", upstream_token);
@@ -23946,6 +24067,7 @@ async fn send_upstream_request(
         timeouts,
         image_generation_mode,
         request_kind,
+        image_generation_known_unavailable,
     )
     .await
 }
@@ -23963,16 +24085,18 @@ async fn send_upstream_request_with_authorization_url(
     timeouts: &CodexLocalAccessTimeouts,
     image_generation_mode: CodexLocalAccessImageGenerationMode,
     request_kind: CodexLocalAccessRequestKind,
-) -> Result<reqwest::Response, String> {
+    image_generation_known_unavailable: bool,
+) -> Result<(reqwest::Response, bool), String> {
     let method =
         Method::from_bytes(method.as_bytes()).map_err(|e| format!("不支持的请求方法: {}", e))?;
     let client = upstream_http_client(upstream_proxy_url, connect_timeout)?;
-    let upstream_body = build_account_scoped_upstream_body(
+    let (upstream_body, image_degraded) = build_account_scoped_upstream_body(
         target,
         body,
         account,
         image_generation_mode,
         request_kind,
+        image_generation_known_unavailable,
     )?;
     let max_send_retries = timeouts.upstream_send_retry_attempts as usize;
     for retry_attempt in 0..=max_send_retries {
@@ -24038,7 +24162,7 @@ async fn send_upstream_request_with_authorization_url(
         }
 
         match request.send().await {
-            Ok(response) => return Ok(response),
+            Ok(response) => return Ok((response, image_degraded)),
             Err(error) => {
                 let should_retry =
                     retry_attempt < max_send_retries && should_retry_upstream_send_error(&error);
@@ -24421,6 +24545,12 @@ async fn proxy_request_with_account_pool(
     );
     let image_generation_mode =
         request_image_generation_mode(collection.image_generation_mode, &request.headers);
+    let image_intent =
+        request_kind_is_image(request_kind) || request_body_declares_image_tools(&request.body);
+    let health_snapshot = {
+        let runtime = gateway_runtime().lock().await;
+        runtime.account_health.clone()
+    };
     let routing_hint = build_request_routing_hint(request);
     let total = scoped_account_ids.len();
     let max_credential_attempts = max_credential_attempts_for_strategy(collection, total, strategy);
@@ -24448,6 +24578,7 @@ async fn proxy_request_with_account_pool(
     let mut last_account_email: Option<String> = None;
     let mut attempts = 0usize;
     let mut retry_round = 0usize;
+    let mut strip_previous_response_for_image_rotation = false;
     let mut earliest_cooldown_wait: Option<Duration>;
 
     loop {
@@ -24470,6 +24601,13 @@ async fn proxy_request_with_account_pool(
             strategy,
             &collection.custom_routing_rules,
         );
+        // 生图意图请求：把"已知不可生图"的账号排到候选末尾，让能生图的账号
+        // 优先承载；全部不可生图时保持原顺序（由降级路径兜底）。
+        let strategy_account_ids = if image_intent {
+            prefer_image_generation_capable_account_ids(strategy_account_ids, &health_snapshot)
+        } else {
+            strategy_account_ids
+        };
         let mut attempted_in_round = false;
         let mut round_cooldown_wait: Option<Duration> = None;
 
@@ -24572,7 +24710,10 @@ async fn proxy_request_with_account_pool(
             );
 
             let mut single_account_status_retry_attempt = 0usize;
-            let mut upstream_request_body = request.body.clone();
+            // 生图权限失败轮转后，后续账号重发时剥离 previous_response_id。
+            let mut upstream_request_body =
+                rotation_adjusted_request_body(&request.body, strip_previous_response_for_image_rotation);
+            let mut image_degraded = false;
             let mut rejected_field_retry_state = is_responses_request(&request.target)
                 .then(|| OpenAIResponsesRejectedFieldRetryState::new(&upstream_request_body));
             loop {
@@ -24589,6 +24730,24 @@ async fn proxy_request_with_account_pool(
                         single_account_status_retry_attempt
                     ),
                 );
+                let image_generation_known_unavailable = {
+                    let runtime = gateway_runtime().lock().await;
+                    matches!(
+                        runtime
+                            .account_health
+                            .get(&account.id)
+                            .map(|health| health.image_generation_status),
+                        Some(CodexLocalAccessImageGenerationStatus::Unavailable)
+                    )
+                };
+                if request_kind_is_image(request_kind) && image_generation_known_unavailable {
+                    // 显式图片接口：该账号不可生图，跳到下一个候选账号；全部
+                    // 不可用时以 403 + 友好提示收尾。
+                    last_status = StatusCode::FORBIDDEN.as_u16();
+                    last_error = friendly_image_generation_capability_error(&account.email);
+                    last_error_category = Some("image_generation_not_enabled".to_string());
+                    break;
+                }
                 let first_response = send_upstream_request(
                     &request.method,
                     &upstream_target,
@@ -24600,11 +24759,13 @@ async fn proxy_request_with_account_pool(
                     &timeouts,
                     image_generation_mode,
                     request_kind,
+                    image_generation_known_unavailable,
                 )
                 .await;
 
                 let mut response = match first_response {
-                    Ok(response) => {
+                    Ok((response, degraded)) => {
+                        image_degraded = degraded;
                         legacy_debug_log(
                             collection.debug_logs,
                             format!(
@@ -24736,10 +24897,14 @@ async fn proxy_request_with_account_pool(
                                 &timeouts,
                                 image_generation_mode,
                                 request_kind,
+                                image_generation_known_unavailable,
                             )
                             .await
                             {
-                                Ok(response) => response,
+                                Ok((response, degraded)) => {
+                                    image_degraded = degraded;
+                                    response
+                                }
                                 Err(err) => {
                                     last_status = StatusCode::BAD_GATEWAY.as_u16();
                                     log_codex_api_failure(
@@ -24816,6 +24981,7 @@ async fn proxy_request_with_account_pool(
                         upstream: response,
                         account_id: account.id.clone(),
                         account_email: account.email.clone(),
+                        image_degraded,
                     });
                 }
 
@@ -24906,6 +25072,11 @@ async fn proxy_request_with_account_pool(
                 }
 
                 if should_try_next_account(status, &body) {
+                    if category == Some("image_generation_not_enabled") {
+                        // 生图权限失败轮转：后续账号重发时剥离 previous_response_id，
+                        // 避免上下文不匹配导致 404（见 upstream_request_body 初始化）。
+                        strip_previous_response_for_image_rotation = true;
+                    }
                     last_status = status.as_u16();
                     last_error = if category == Some("image_generation_not_enabled") {
                         message.clone()
@@ -26006,17 +26177,28 @@ async fn current_websocket_image_generation_mode(
     request_image_generation_mode(collection_mode, &filter.request_headers)
 }
 
-fn filter_websocket_client_message(
+async fn filter_websocket_client_message(
     message: Message,
     account: &CodexAccount,
     image_generation_mode: CodexLocalAccessImageGenerationMode,
     responses_lite: bool,
 ) -> Result<Message, String> {
+    let image_generation_known_unavailable = {
+        let runtime = gateway_runtime().lock().await;
+        matches!(
+            runtime
+                .account_health
+                .get(&account.id)
+                .map(|health| health.image_generation_status),
+            Some(CodexLocalAccessImageGenerationStatus::Unavailable)
+        )
+    };
     fn filter_payload(
         body: &[u8],
         account: &CodexAccount,
         image_generation_mode: CodexLocalAccessImageGenerationMode,
         responses_lite: bool,
+        image_generation_known_unavailable: bool,
     ) -> Result<Option<Vec<u8>>, String> {
         let mut body_value = parse_request_body_json(body);
         let message_uses_responses_lite = responses_lite
@@ -26062,18 +26244,24 @@ fn filter_websocket_client_message(
             account,
             effective_image_generation_mode,
             CodexLocalAccessRequestKind::Text,
+            image_generation_known_unavailable,
         )?;
         match account_filtered {
-            Cow::Borrowed(_) => Ok(lite_filtered),
-            Cow::Owned(filtered) => Ok(Some(filtered)),
+            (Cow::Borrowed(_), _) => Ok(lite_filtered),
+            (Cow::Owned(filtered), _) => Ok(Some(filtered)),
         }
     }
 
     match message {
         Message::Text(text) => {
             let body = text.to_string().into_bytes();
-            let Some(filtered) =
-                filter_payload(&body, account, image_generation_mode, responses_lite)?
+            let Some(filtered) = filter_payload(
+                &body,
+                account,
+                image_generation_mode,
+                responses_lite,
+                image_generation_known_unavailable,
+            )?
             else {
                 return Ok(Message::Text(text));
             };
@@ -26087,6 +26275,7 @@ fn filter_websocket_client_message(
                 account,
                 image_generation_mode,
                 responses_lite,
+                image_generation_known_unavailable,
             )?
             else {
                 return Ok(Message::Binary(bytes));
@@ -26106,13 +26295,25 @@ async fn bridge_websocket_streams(
 ) -> Result<WebSocketBridgeResult, String> {
     let first_payload = if let Some(filter) = image_filter.as_ref() {
         let mode = current_websocket_image_generation_mode(filter).await;
+        let image_generation_known_unavailable = {
+            let runtime = gateway_runtime().lock().await;
+            matches!(
+                runtime
+                    .account_health
+                    .get(&filter.account.id)
+                    .map(|health| health.image_generation_status),
+                Some(CodexLocalAccessImageGenerationStatus::Unavailable)
+            )
+        };
         build_account_scoped_upstream_body(
             "/responses",
             &first_payload,
             &filter.account,
             mode,
             CodexLocalAccessRequestKind::Text,
+            image_generation_known_unavailable,
         )?
+        .0
         .into_owned()
     } else {
         first_payload
@@ -26169,7 +26370,8 @@ async fn bridge_websocket_streams(
                         &filter.account,
                         mode,
                         filter.responses_lite,
-                    )?;
+                    )
+                    .await?;
                 }
                 let should_close = matches!(message, Message::Close(_));
                 upstream_write
@@ -26878,6 +27080,7 @@ async fn handle_connection(
                 upstream,
                 account_id,
                 account_email,
+                image_degraded,
             } = success;
             let timeouts = collection_timeouts(&collection);
             let response_capture = match write_gateway_response(
@@ -26888,6 +27091,7 @@ async fn handle_connection(
                 &prepared_request,
                 started_at,
                 &timeouts,
+                image_degraded,
             )
             .await
             {
@@ -27362,6 +27566,7 @@ mod tests {
         open_local_access_logs_db_once, parse_codex_retry_after,
         parse_responses_payload_from_upstream, parse_websocket_upstream_error,
         pin_account_to_front_for_strategy, prepare_gateway_request,
+        prefer_image_generation_capable_account_ids,
         prepare_gateway_request_with_default_service_tier, prepare_sidecar_launch_config_in_dir,
         prepare_websocket_initial_request, profile_api_key_supports_websockets,
         profile_base_url_matches, provider_gateway_api_key_id,
@@ -27372,7 +27577,9 @@ mod tests {
         read_http_request, read_request_log_reprice_batch, recompute_time_windows,
         recover_invalid_stats_file, remove_account_refs_from_collection,
         remove_codex_local_access_config, reprice_request_logs_for_collection,
-        request_image_generation_mode, request_logs_has_column, request_ordered_account_ids,
+        request_image_generation_mode, request_body_declares_image_tools, request_logs_has_column,
+        request_ordered_account_ids,
+        rotation_adjusted_request_body,
         resolve_collection_api_key, resolve_effective_model_pricing, resolve_plan_rank,
         resolve_sidecar_upstream_base_url, resolve_sidecar_upstream_base_url_with,
         resolve_supported_model_alias, resolve_upstream_target,
@@ -27381,6 +27588,7 @@ mod tests {
         send_agent_identity_wakeup_request_with_base_urls,
         should_retry_single_account_upstream_status, should_treat_response_as_stream,
         should_try_next_account, sidecar_account_manifest_value,
+        strip_previous_response_id_from_body,
         sidecar_account_needs_background_refresh, sidecar_api_key_account_scope_values,
         sidecar_api_key_manifest_values, sidecar_api_key_priority_state_values,
         sidecar_auth_file_name, sidecar_auth_json_for_account, sidecar_auths_dir,
@@ -27400,6 +27608,7 @@ mod tests {
         AccountUsagePriority, CodexLocalAccessCollection, CodexLocalAccessGatewayMode,
         CodexLocalAccessScope, CodexModelProviderGatewayChatTestRequest, GatewayResponseAdapter,
         ParsedRequest, ResolvedLocalApiKey, ResponseUsageCollector, RoutingCandidate,
+        RuntimeAccountHealth,
         SidecarUsageDetails, SidecarUsageEvent, UsageCapture,
         BOUND_OAUTH_QUOTA_RESERVE_MAX_SNAPSHOT_AGE_SECONDS, CODEX_AUTO_REVIEW_MODEL_ID,
         CODEX_IMAGEGEN_ACTOR_HEADER, CODEX_IMAGE_MODEL_ID,
@@ -27422,7 +27631,8 @@ mod tests {
     use crate::models::codex_local_access::{
         CodexLocalAccessAccountModelRule, CodexLocalAccessApiKey,
         CodexLocalAccessClientBaseUrlHost, CodexLocalAccessCustomRoutingRule,
-        CodexLocalAccessImageGenerationMode, CodexLocalAccessProviderGateway,
+        CodexLocalAccessImageGenerationMode, CodexLocalAccessImageGenerationStatus,
+        CodexLocalAccessProviderGateway,
         CodexLocalAccessQuotaReserve, CodexLocalAccessRequestKind, CodexLocalAccessRoutingStrategy,
         CodexLocalAccessStats, CodexLocalAccessStatsWindow, CodexLocalAccessTimeouts,
         CodexLocalAccessUsageEvent, CodexTokenBreakdown,
@@ -33129,12 +33339,13 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
         );
 
         let paid_oauth_account = test_account_with_plan("plus");
-        let paid_oauth_body = build_account_scoped_upstream_body(
+        let (paid_oauth_body, _) = build_account_scoped_upstream_body(
             "/responses",
             &prepared.body,
             &paid_oauth_account,
             CodexLocalAccessImageGenerationMode::Enabled,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .expect("paid oauth body should build");
         let paid_oauth_mapped_body: Value = serde_json::from_slice(paid_oauth_body.as_ref())
@@ -33151,12 +33362,13 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
             None,
             Vec::new(),
         );
-        let api_key_body = build_account_scoped_upstream_body(
+        let (api_key_body, _) = build_account_scoped_upstream_body(
             "/responses",
             &prepared.body,
             &api_key_account,
             CodexLocalAccessImageGenerationMode::Enabled,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .expect("api key body should build");
         let api_key_mapped_body: Value =
@@ -33171,24 +33383,26 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
             .unwrap_or(false));
 
         let free_account = test_account_with_plan("free");
-        let free_body = build_account_scoped_upstream_body(
+        let (free_body, _) = build_account_scoped_upstream_body(
             "/responses",
             &prepared.body,
             &free_account,
             CodexLocalAccessImageGenerationMode::Enabled,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .expect("free body should build");
         let free_mapped_body: Value =
             serde_json::from_slice(free_body.as_ref()).expect("free body should be json");
         assert!(!has_image_generation_tool(&free_mapped_body));
 
-        let images_only_body = build_account_scoped_upstream_body(
+        let (images_only_body, _) = build_account_scoped_upstream_body(
             "/responses",
             &prepared.body,
             &api_key_account,
             CodexLocalAccessImageGenerationMode::ImagesOnly,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .expect("images-only body should build");
         let images_only_mapped_body: Value = serde_json::from_slice(images_only_body.as_ref())
@@ -33230,12 +33444,13 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
 
         let (prepared, _) = prepare_gateway_request(request).expect("request should map");
         let account = test_account_with_plan("plus");
-        let mapped = build_account_scoped_upstream_body(
+        let (mapped, _) = build_account_scoped_upstream_body(
             "/responses",
             &prepared.body,
             &account,
             CodexLocalAccessImageGenerationMode::ImagesOnly,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .expect("Responses Lite body should build");
         let parsed: Value = serde_json::from_slice(mapped.as_ref()).expect("body should be json");
@@ -33258,6 +33473,240 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
     }
 
     #[test]
+    fn skips_injection_when_account_health_marks_image_generation_unavailable() {
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            target: "/v1/responses".to_string(),
+            headers: HashMap::new(),
+            body: br#"{"model":"gpt-5.4","input":"draw an icon"}"#.to_vec(),
+        };
+        let (prepared, _) = prepare_gateway_request(request).expect("request should map");
+
+        let account = test_account_with_plan("plus");
+        let (mapped, degraded) = build_account_scoped_upstream_body(
+            "/responses",
+            &prepared.body,
+            &account,
+            CodexLocalAccessImageGenerationMode::Enabled,
+            CodexLocalAccessRequestKind::Text,
+            true,
+        )
+        .expect("body should build");
+        let parsed: Value = serde_json::from_slice(&mapped).expect("body should be json");
+        assert!(!has_image_generation_tool(&parsed));
+        assert!(degraded);
+    }
+
+    #[test]
+    fn still_injects_when_image_generation_health_is_unknown() {
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            target: "/v1/responses".to_string(),
+            headers: HashMap::new(),
+            body: br#"{"model":"gpt-5.4","input":"draw an icon"}"#.to_vec(),
+        };
+        let (prepared, _) = prepare_gateway_request(request).expect("request should map");
+
+        let account = test_account_with_plan("plus");
+        let (mapped, degraded) = build_account_scoped_upstream_body(
+            "/responses",
+            &prepared.body,
+            &account,
+            CodexLocalAccessImageGenerationMode::Enabled,
+            CodexLocalAccessRequestKind::Text,
+            false,
+        )
+        .expect("body should build");
+        let parsed: Value = serde_json::from_slice(&mapped).expect("body should be json");
+        assert!(has_image_generation_tool(&parsed));
+        assert!(!degraded);
+    }
+
+    #[test]
+    fn prefers_image_capable_accounts_when_mixed() {
+        let mut health = HashMap::new();
+        let mut mark = |id: &str, status| {
+            let mut entry = RuntimeAccountHealth::default();
+            entry.image_generation_status = status;
+            health.insert(id.to_string(), entry);
+        };
+        mark("incapable-1", CodexLocalAccessImageGenerationStatus::Unavailable);
+        mark("incapable-2", CodexLocalAccessImageGenerationStatus::Unavailable);
+
+        let ordered = prefer_image_generation_capable_account_ids(
+            vec![
+                "incapable-1".to_string(),
+                "capable-1".to_string(),
+                "incapable-2".to_string(),
+                "capable-2".to_string(),
+            ],
+            &health,
+        );
+        assert_eq!(ordered[0], "capable-1");
+        assert_eq!(ordered[1], "capable-2");
+        assert_eq!(ordered.len(), 4);
+
+        let all_incapable = prefer_image_generation_capable_account_ids(
+            vec!["incapable-1".to_string(), "incapable-2".to_string()],
+            &health,
+        );
+        assert_eq!(all_incapable, vec!["incapable-1", "incapable-2"]);
+
+        let single = prefer_image_generation_capable_account_ids(
+            vec!["incapable-1".to_string()],
+            &health,
+        );
+        assert_eq!(single, vec!["incapable-1"]);
+    }
+
+    #[test]
+    fn request_body_declares_image_tools_detects_declarations() {
+        assert!(request_body_declares_image_tools(
+            br#"{"tools":[{"type":"image_generation"}]}"#
+        ));
+        assert!(request_body_declares_image_tools(
+            br#"{"tools":[{"type":"function","name":"image_gen.imagegen"}]}"#
+        ));
+        assert!(request_body_declares_image_tools(
+            br#"{"tools":[{"type":"namespace","name":"image_gen"}]}"#
+        ));
+        assert!(request_body_declares_image_tools(
+            br#"{"tool_choice":{"type":"image_generation"}}"#
+        ));
+        assert!(!request_body_declares_image_tools(
+            br#"{"tools":[{"type":"function","name":"lookup"}]}"#
+        ));
+        assert!(!request_body_declares_image_tools(br#"{"model":"gpt-5.4"}"#));
+        assert!(!request_body_declares_image_tools(b"not json"));
+    }
+
+    #[test]
+    fn strip_previous_response_id_from_body_removes_field() {
+        let stripped = strip_previous_response_id_from_body(
+            br#"{"model":"gpt-5.4","previous_response_id":"resp_123","input":"hi"}"#,
+        );
+        let parsed: Value = serde_json::from_slice(&stripped).unwrap();
+        assert!(parsed.get("previous_response_id").is_none());
+        assert_eq!(parsed.get("input").and_then(Value::as_str), Some("hi"));
+
+        let unchanged = strip_previous_response_id_from_body(br#"{"model":"gpt-5.4"}"#);
+        let parsed: Value = serde_json::from_slice(&unchanged).unwrap();
+        assert!(parsed.get("previous_response_id").is_none());
+    }
+
+    #[test]
+    fn rotation_adjusted_request_body_strips_only_when_flagged() {
+        let body = br#"{"model":"gpt-5.4","previous_response_id":"resp_123"}"#;
+        let stripped = rotation_adjusted_request_body(body, true);
+        let parsed: Value = serde_json::from_slice(&stripped).unwrap();
+        assert!(parsed.get("previous_response_id").is_none());
+
+        let kept = rotation_adjusted_request_body(body, false);
+        let parsed: Value = serde_json::from_slice(&kept).unwrap();
+        assert_eq!(
+            parsed.get("previous_response_id").and_then(Value::as_str),
+            Some("resp_123")
+        );
+    }
+
+    #[test]
+    fn strips_declared_tools_when_health_marks_unavailable() {
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            target: "/v1/responses".to_string(),
+            headers: HashMap::new(),
+            body: br#"{"model":"gpt-5.4","input":"make an image","tool_choice":{"type":"image_generation"},"tools":[{"type":"image_generation","output_format":"png"},{"type":"function","name":"lookup"}]}"#
+                .to_vec(),
+        };
+        let (prepared, _) = prepare_gateway_request(request).expect("request should map");
+
+        let account = test_account_with_plan("plus");
+        let (mapped, degraded) = build_account_scoped_upstream_body(
+            "/responses",
+            &prepared.body,
+            &account,
+            CodexLocalAccessImageGenerationMode::Enabled,
+            CodexLocalAccessRequestKind::Text,
+            true,
+        )
+        .expect("body should build");
+        let parsed: Value = serde_json::from_slice(&mapped).expect("body should be json");
+        assert!(degraded);
+        assert!(!has_image_generation_tool(&parsed));
+        assert!(parsed.get("tool_choice").is_none());
+        assert!(parsed
+            .get("tools")
+            .and_then(Value::as_array)
+            .is_some_and(|tools| {
+                tools
+                    .iter()
+                    .any(|tool| tool.get("name").and_then(Value::as_str) == Some("lookup"))
+            }));
+    }
+
+    #[test]
+    fn unavailable_account_without_declared_tools_keeps_body_and_flags_degraded() {
+        let request = ParsedRequest {
+            method: "POST".to_string(),
+            target: "/v1/responses".to_string(),
+            headers: HashMap::new(),
+            body: br#"{"model":"gpt-5.4","input":"hello","tools":[{"type":"function","name":"lookup"}]}"#
+                .to_vec(),
+        };
+        let (prepared, _) = prepare_gateway_request(request).expect("request should map");
+
+        let account = test_account_with_plan("plus");
+        let (mapped, degraded) = build_account_scoped_upstream_body(
+            "/responses",
+            &prepared.body,
+            &account,
+            CodexLocalAccessImageGenerationMode::Enabled,
+            CodexLocalAccessRequestKind::Text,
+            true,
+        )
+        .expect("body should build");
+        assert!(degraded);
+        let parsed: Value = serde_json::from_slice(&mapped).expect("body should be json");
+        assert!(parsed
+            .get("tools")
+            .and_then(Value::as_array)
+            .is_some_and(|tools| {
+                tools
+                    .iter()
+                    .any(|tool| tool.get("name").and_then(Value::as_str) == Some("lookup"))
+            }));
+        assert!(!has_image_generation_tool(&parsed));
+    }
+
+    #[test]
+    fn image_capability_matcher_rejects_unrelated_403() {
+        assert!(!is_image_generation_capability_error(
+            StatusCode::FORBIDDEN,
+            r#"{"error":{"message":"usage limit reached"}}"#
+        ));
+        assert!(!is_image_generation_capability_error(
+            StatusCode::FORBIDDEN,
+            r#"{"error":{"message":"Search is not enabled for this group","type":"permission_error"}}"#
+        ));
+        assert!(!is_image_generation_capability_error(
+            StatusCode::FORBIDDEN,
+            r#"{"error":{"code":"model_not_available","message":"The image_generation model was removed"}}"#
+        ));
+        assert!(is_image_generation_capability_error(
+            StatusCode::FORBIDDEN,
+            r#"{"error":{"code":"auth_failed","message":"{\"error\":{\"message\":\"Image generation is not enabled for this group\",\"type\":\"permission_error\"}}","type":"invalid_request_error"}}"#
+        ));
+        assert!(is_image_generation_capability_error(
+            StatusCode::FORBIDDEN,
+            r#"{"error":{"message":"image generation is not available for this plan"}}"#
+        ));
+        assert!(is_image_generation_capability_error(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"image_generation is disabled for this account"}}"#
+        ));
+    }
+
+    #[test]
     fn disabled_image_generation_mode_removes_declared_tool_and_choice() {
         let account = test_account_with_plan("plus");
         let body = br#"{
@@ -33270,12 +33719,13 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
             ]
         }"#;
 
-        let mapped_body = build_account_scoped_upstream_body(
+        let (mapped_body, _) = build_account_scoped_upstream_body(
             "/responses",
             body,
             &account,
             CodexLocalAccessImageGenerationMode::Disabled,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .expect("disabled body should build");
         let parsed: Value =
@@ -33318,12 +33768,13 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
             }
         }"#;
 
-        let mapped_body = build_account_scoped_upstream_body(
+        let (mapped_body, _) = build_account_scoped_upstream_body(
             "/responses",
             body,
             &account,
             CodexLocalAccessImageGenerationMode::Disabled,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .expect("disabled Responses Lite body should build");
         let parsed: Value =
@@ -33361,8 +33812,8 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
         );
     }
 
-    #[test]
-    fn websocket_followup_messages_apply_the_same_image_generation_filter() {
+    #[tokio::test]
+    async fn websocket_followup_messages_apply_the_same_image_generation_filter() {
         let account = test_account_with_plan("plus");
         let payload = r#"{"type":"response.create","response":{"tools":[{"type":"namespace","name":"image_gen"},{"type":"function","name":"keep"}]}}"#;
 
@@ -33376,6 +33827,7 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
                 CodexLocalAccessImageGenerationMode::Disabled,
                 false,
             )
+            .await
             .expect("WebSocket follow-up payload should filter");
             let parsed = match filtered {
                 Message::Text(text) => serde_json::from_str::<Value>(&text).unwrap(),
@@ -33391,8 +33843,8 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
         }
     }
 
-    #[test]
-    fn websocket_followup_messages_filter_responses_lite_tools() {
+    #[tokio::test]
+    async fn websocket_followup_messages_filter_responses_lite_tools() {
         let account = test_account_with_plan("plus");
         let payload = r#"{
             "type":"response.create",
@@ -33420,6 +33872,7 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
                 CodexLocalAccessImageGenerationMode::Enabled,
                 false,
             )
+            .await
             .expect("Responses Lite WebSocket follow-up payload should filter");
             let parsed = match filtered {
                 Message::Text(text) => serde_json::from_str::<Value>(&text).unwrap(),
@@ -33458,12 +33911,13 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
             ]
         }"#;
 
-        let mapped_body = build_account_scoped_upstream_body(
+        let (mapped_body, _) = build_account_scoped_upstream_body(
             "/responses",
             body,
             &account,
             CodexLocalAccessImageGenerationMode::Enabled,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .expect("oauth body should build");
         let parsed: Value =
@@ -33495,12 +33949,13 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
             ]
         }"#;
 
-        let mapped_body = build_account_scoped_upstream_body(
+        let (mapped_body, _) = build_account_scoped_upstream_body(
             "/responses",
             body,
             &account,
             CodexLocalAccessImageGenerationMode::Enabled,
             CodexLocalAccessRequestKind::Text,
+            false,
         )
         .expect("oauth body should build");
         let parsed: Value =


### PR DESCRIPTION
## 问题

账号池加入不支持图片生成的中转站账号（如 Sub2api）后，本地网关默认会把 `image_generation` 工具注入到普通文本请求里。上游因为账号组没有生图权限，直接拒绝了整个请求：

```json
403 {"error":{"message":"Image generation is not enabled for this group","type":"permission_error"}}
```

结果是 `/v1/responses`、`/v1/chat/completions` 和内置对话测试全部不可用——哪怕消息只是纯文本。v1.3.4 已经移除了 `image_generation` 的禁用开关，但错误提示还在引导用户去改一个界面里不存在的设置（#1176 也提过这一点，本次一并修正了文案）。

## 思路

与其像全局开关那样"一刀切"关掉生图（能生图的账号也会失去对话内生图的能力），不如让网关**记住每个账号的生图能力，按账号下菜**：

- 账号第一次被上游明确告知"没有生图权限"之后，网关会记下来。之后这个账号的文本请求自动不再带生图工具，纯文本照常可用；
- 能生图的账号不受任何影响，依然可以在对话里让模型画图；
- 明确要生图的请求，会优先去找能生图的账号；实在没有才体面降级。

## 变更

- **精确认定**：只认"生图权限缺失"这一种错误（状态码 + 报文内容双重匹配），配额、鉴权、模型等其他 403 不会被误伤；
- **按账号学习**：标记只保存在内存里，不落盘、不挂起账号（文本流量不受影响），重启后重新学习一次即可，成功生图后自动恢复；
- **自动降级**：在不能生图的账号上，网关会主动剥掉生图工具声明（包括客户端自己带上的）再按纯文本转发，并在响应头带 `x-agtools-image-degraded: 1` 告诉客户端；
- **能力优先选号**：`/v1/images/*` 或携带生图工具声明的请求，优先路由到能生图的账号；
- **换号重试**：遇到生图权限 403 会自动换下一个账号重发一次；
- **明确报错**：显式图片接口命中无能力账号时，本地直接返回 `403 image_generation_not_enabled`，不再透传中转站晦涩错误；
- **文案修正**：错误提示改为描述自动降级行为，不再指向已删除的设置。

覆盖 Go sidecar（executor / auth / helps / main）与 Rust legacy 网关两条链路，双侧对称，均带单元测试。无新增配置项、无 UI 变更；手动请求头 `x-agtools-disable-image-generation` 的语义保持不变且始终优先。

## 验证

- `go test ./internal/runtime/executor/... ./sdk/cliproxy/auth/... .`：全部通过；
- `cargo test --lib codex_local_access::tests`（MSVC）：237 通过 / 1 失败——失败项 `builds_upstream_websocket_url_from_custom_base_url` 读取本机全局代理配置，属环境性既有失败，与本改动无关；
- 真机端到端（Sub2api 账号实测）：纯文本首请求 403 一次（学习）→ 重试成功且响应头带降级标记；带生图工具声明的对话请求自动剥工具降级成功；`/v1/images/generations` 返回本地明确的 403。

Fixes #1940