### PR TITLE
fix(codex): honor per-model image input for MiniMax provider presets

### DIFF
--- a/src/components/codex/CodexModelProviderManager.tsx
+++ b/src/components/codex/CodexModelProviderManager.tsx
@@ -1703,7 +1703,7 @@ export function CodexModelProviderManager({
           preset.modelCatalog ?? [],
         ),
         supportsVision: false,
-        visionModelText: "",
+        visionModelText: (preset.visionModelCatalog ?? []).join("\n"),
         visionRoutingModel: "",
         website: preset.website ?? "",
         apiKeyUrl: preset.apiKeyUrl ?? "",

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -261,6 +261,7 @@ import {
   COCKPIT_API_BASE_URL,
   COCKPIT_API_PROVIDER_ID,
   COCKPIT_API_PROVIDER_NAME,
+  codexApiProviderPresetVisionSupport,
   findCodexApiProviderPresetById,
   isCockpitApiProviderBaseUrl,
   resolveCodexApiProviderPresetId,
@@ -4163,6 +4164,7 @@ export function CodexAccountsPage() {
             baseUrl: normalizedBaseUrl,
             wireApi: null,
           }).wireApi,
+          apiModelVisionSupport: codexApiProviderPresetVisionSupport(preset),
           accountName: preset.name,
         };
       }

--- a/src/utils/codexProviderPresets.test.ts
+++ b/src/utils/codexProviderPresets.test.ts
@@ -3,8 +3,11 @@ import test from "node:test";
 
 import {
   DEEPSEEK_API_BASE_URL,
+  MINIMAX_API_PROVIDER_ID,
+  MINIMAX_EN_API_PROVIDER_ID,
   OPENCODE_GO_API_BASE_URL,
   OPENCODE_GO_API_PROVIDER_ID,
+  codexApiProviderPresetVisionSupport,
   findCodexApiProviderPresetByBaseUrl,
   findCodexApiProviderPresetById,
 } from "./codexProviderPresets.ts";
@@ -43,4 +46,26 @@ test("DeepSeek keeps its native Responses default", () => {
   });
 
   assert.equal(profile.wireApi, "responses");
+});
+
+test("both MiniMax presets declare image input only for the vision-capable model", () => {
+  [MINIMAX_API_PROVIDER_ID, MINIMAX_EN_API_PROVIDER_ID].forEach((presetId) => {
+    const preset = findCodexApiProviderPresetById(presetId);
+
+    assert.ok(preset);
+    assert.deepEqual(preset.modelCatalog, ["MiniMax-M3", "MiniMax-M2.7"]);
+    assert.deepEqual(preset.visionModelCatalog, ["MiniMax-M3"]);
+
+    const support = codexApiProviderPresetVisionSupport(preset);
+    assert.equal(support["minimax-m3"], true);
+    assert.equal(support["minimax-m2.7"], undefined);
+  });
+});
+
+test("presets without a declared vision catalog report no image support", () => {
+  const preset = findCodexApiProviderPresetById(OPENCODE_GO_API_PROVIDER_ID);
+
+  assert.ok(preset);
+  assert.deepEqual(codexApiProviderPresetVisionSupport(preset), {});
+  assert.deepEqual(codexApiProviderPresetVisionSupport(null), {});
 });

--- a/src/utils/codexProviderPresets.ts
+++ b/src/utils/codexProviderPresets.ts
@@ -3,6 +3,12 @@ export interface CodexApiProviderPreset {
   name: string;
   baseUrls: string[];
   modelCatalog?: string[];
+  /**
+   * Models from `modelCatalog` that accept image input. Models that are left out
+   * fall back to the provider-level default, so a preset can describe a catalog
+   * that mixes vision-capable and text-only models.
+   */
+  visionModelCatalog?: string[];
   website?: string;
   apiKeyUrl?: string;
   isOfficial?: boolean;
@@ -22,6 +28,14 @@ export const DEEPSEEK_CODEX_MODEL_CATALOG = [
 ] as const;
 export const OPENCODE_GO_API_PROVIDER_ID = "opencode_go";
 export const OPENCODE_GO_API_BASE_URL = "https://opencode.ai/zen/go/v1";
+export const MINIMAX_API_PROVIDER_ID = "minimax";
+export const MINIMAX_EN_API_PROVIDER_ID = "minimax_en";
+export const MINIMAX_CODEX_MODEL_CATALOG = [
+  "MiniMax-M3",
+  "MiniMax-M2.7",
+] as const;
+/** MiniMax models whose published input modalities include images. */
+export const MINIMAX_CODEX_VISION_MODEL_CATALOG = ["MiniMax-M3"] as const;
 /** OpenCode Go models exposed through its OpenAI-compatible chat completions API. */
 export const OPENCODE_GO_CODEX_MODEL_CATALOG = [
   "minimax-m3",
@@ -310,17 +324,19 @@ export const CODEX_API_PROVIDER_PRESETS: readonly CodexApiProviderPreset[] = [
     website: "https://longcat.chat/",
   },
   {
-    id: "minimax",
+    id: MINIMAX_API_PROVIDER_ID,
     name: "MiniMax",
     baseUrls: ["https://api.minimaxi.com/v1"],
-    modelCatalog: ["MiniMax-M3", "MiniMax-M2.7"],
+    modelCatalog: [...MINIMAX_CODEX_MODEL_CATALOG],
+    visionModelCatalog: [...MINIMAX_CODEX_VISION_MODEL_CATALOG],
     website: "https://platform.minimaxi.com/docs",
   },
   {
-    id: "minimax_en",
+    id: MINIMAX_EN_API_PROVIDER_ID,
     name: "MiniMax en",
     baseUrls: ["https://api.minimax.io/v1"],
-    modelCatalog: ["MiniMax-M3", "MiniMax-M2.7"],
+    modelCatalog: [...MINIMAX_CODEX_MODEL_CATALOG],
+    visionModelCatalog: [...MINIMAX_CODEX_VISION_MODEL_CATALOG],
     website: "https://platform.minimax.io/docs",
   },
   {
@@ -442,4 +458,19 @@ export function resolveCodexApiProviderPresetId(rawBaseUrl: string): string {
     findCodexApiProviderPresetByBaseUrl(rawBaseUrl)?.id ??
     CODEX_API_PROVIDER_CUSTOM_ID
   );
+}
+
+/**
+ * Per-model image input support declared by a preset, keyed the same way the
+ * stored provider and account capability maps are keyed (trimmed, lowercased).
+ */
+export function codexApiProviderPresetVisionSupport(
+  preset: CodexApiProviderPreset | null | undefined,
+): Record<string, boolean> {
+  const support: Record<string, boolean> = {};
+  (preset?.visionModelCatalog ?? []).forEach((model) => {
+    const key = model.trim().toLowerCase();
+    if (key) support[key] = true;
+  });
+  return support;
 }


### PR DESCRIPTION
Reason: Selecting either MiniMax Codex provider preset cleared image input support and left no way to declare that only MiniMax-M3 accepts images.

## Problem

Both MiniMax Codex presets ship a model catalog of `MiniMax-M3` and `MiniMax-M2.7`, but `CodexApiProviderPreset` had no field for input capabilities. Because the presets could not declare anything, `handleSelectProviderPreset` in `CodexModelProviderManager.tsx` reset `supportsVision`, `visionModelText` and `visionRoutingModel` on every preset pick, and the built-in preset branch of the account provider payload in `CodexAccountsPage.tsx` sent no vision fields at all. The account then normalized to `api_supports_vision = false` with an empty `api_model_vision_support`, so the local gateway treated every model in the catalog as text-only.

The two models do not share one capability, so a single provider-level switch cannot express this: `MiniMax-M3` accepts image input while `MiniMax-M2.7` is text-only.

## Changes

- `src/utils/codexProviderPresets.ts`: add an optional `visionModelCatalog` to `CodexApiProviderPreset` for the subset of `modelCatalog` that accepts image input, plus a `codexApiProviderPresetVisionSupport` helper that returns the trimmed and lowercased per-model map used by the stored provider and account capability records. Both MiniMax presets now declare `MiniMax-M3`, sharing the catalog constants so the two endpoints cannot drift.
- `src/components/codex/CodexModelProviderManager.tsx`: preset selection prefills the vision model list from the preset instead of clearing it.
- `src/pages/CodexAccountsPage.tsx`: the built-in preset payload branch forwards `apiModelVisionSupport`, matching what the managed-provider branch already does.

The provider-level default stays off, so per-model capability is what grants image input. `providerGatewayModelSupportsVision` checks the per-model map before falling back to that default, which keeps `MiniMax-M2.7` text-only. Presets that declare no `visionModelCatalog` resolve to an empty map, which normalizes exactly like the previous `undefined`, so no other preset changes behavior.

## Checks

- `npm run typecheck` — passes
- `node --test src/utils/codexProviderPresets.test.ts` — 5 tests pass, including two new cases covering the MiniMax per-model declaration and the empty-catalog fallback
- `npm run test:codex-api-key-scope` — passes
- `node scripts/check_locales.cjs` — passes
