### PR TITLE
fix(codex): preserve provider wire API metadata

### DIFF
--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -7201,7 +7201,8 @@ export function CodexAccountsPage() {
             supportsVision: providerPayload.sponsorTemplate?.supportsVision,
             website: providerPayload.sponsorTemplate?.website,
             apiKeyUrl: providerPayload.sponsorTemplate?.apiKeyUrl,
-            wireApi: providerPayload.sponsorTemplate?.wireApi,
+            wireApi: providerPayload.apiWireApi,
+            supportsWebsockets: providerPayload.apiSupportsWebsockets,
             integrationType: providerPayload.sponsorTemplate?.integrationType,
           });
           finalProviderPayload = {

--- a/src/services/codexModelProviderService.ts
+++ b/src/services/codexModelProviderService.ts
@@ -1,8 +1,9 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { CodexAccount } from '../types/codex';
-import type {
-  CodexProviderEnableModePreference,
-  CodexProviderWireApi,
+import {
+  resolveCodexModelProviderWireApi,
+  type CodexProviderEnableModePreference,
+  type CodexProviderWireApi,
 } from '../utils/codexProviderGateway';
 import type { CodexLocalAccessTestResult } from '../types/codexLocalAccess';
 import {
@@ -369,7 +370,10 @@ function toValidProviderList(raw: unknown): CodexModelProvider[] {
     const boundOauthAccountId = normalizeBoundOauthAccountId(
       (item as { boundOauthAccountId?: unknown }).boundOauthAccountId,
     );
-    const wireApi = normalizeWireApi((item as { wireApi?: unknown }).wireApi);
+    const wireApi = resolveCodexModelProviderWireApi(
+      baseUrl,
+      normalizeWireApi((item as { wireApi?: unknown }).wireApi),
+    );
     providers.push({
       id: String((item as { id?: unknown }).id ?? createProviderId()),
       name,
@@ -435,10 +439,21 @@ function hasLegacySupportsWebsocketsProvider(raw: unknown): boolean {
   });
 }
 
+function hasMissingWireApiProvider(raw: unknown): boolean {
+  if (!Array.isArray(raw)) return false;
+  return raw.some(
+    (item) =>
+      Boolean(item) &&
+      typeof item === 'object' &&
+      !hasOwnProperty(item, 'wireApi'),
+  );
+}
+
 async function loadProvidersFromDisk(): Promise<{
   providers: CodexModelProvider[];
   removedImageGenerationSetting: boolean;
   migratedSupportsWebsockets: boolean;
+  migratedWireApi: boolean;
 }> {
   const raw = await invoke<string>('load_codex_model_providers');
   const parsed = JSON.parse(raw);
@@ -446,6 +461,7 @@ async function loadProvidersFromDisk(): Promise<{
     providers: toValidProviderList(parsed),
     removedImageGenerationSetting: hasRemovedImageGenerationSetting(parsed),
     migratedSupportsWebsockets: hasLegacySupportsWebsocketsProvider(parsed),
+    migratedWireApi: hasMissingWireApiProvider(parsed),
   };
 }
 
@@ -461,6 +477,7 @@ async function ensureProvidersLoaded(): Promise<CodexModelProvider[]> {
     providers: [],
     removedImageGenerationSetting: false,
     migratedSupportsWebsockets: false,
+    migratedWireApi: false,
   }));
   const loadedProviders = loadResult.providers;
   let loaded = loadedProviders.filter((provider) => {
@@ -481,7 +498,8 @@ async function ensureProvidersLoaded(): Promise<CodexModelProvider[]> {
     migration.changed ||
     migratedDeepSeek ||
     loadResult.removedImageGenerationSetting ||
-    loadResult.migratedSupportsWebsockets
+    loadResult.migratedSupportsWebsockets ||
+    loadResult.migratedWireApi
   ) {
     await saveProvidersToDisk(loaded).catch(() => { });
   }
@@ -944,7 +962,7 @@ export async function upsertCodexModelProviderFromCredential(
 
   if (!provider) {
     const now = Date.now();
-    const wireApi = normalizeWireApi(input.wireApi);
+    const wireApi = resolveCodexModelProviderWireApi(apiBaseUrl, input.wireApi);
     provider = {
       id: createProviderId(),
       name:
@@ -1020,7 +1038,10 @@ export async function upsertCodexModelProviderFromCredential(
     provider.apiKeyUrl = sanitizeName(input.apiKeyUrl ?? '') || undefined;
   }
   if (input.wireApi !== undefined) {
-    provider.wireApi = normalizeWireApi(input.wireApi);
+    provider.wireApi = resolveCodexModelProviderWireApi(
+      provider.baseUrl,
+      input.wireApi,
+    );
   }
   if (input.supportsWebsockets !== undefined || input.wireApi !== undefined) {
     provider.supportsWebsockets = normalizeSupportsWebsockets(

--- a/src/utils/codexProviderGateway.ts
+++ b/src/utils/codexProviderGateway.ts
@@ -128,6 +128,13 @@ export function resolveCodexProviderCapabilityProfile(input: {
   };
 }
 
+export function resolveCodexModelProviderWireApi(
+  baseUrl: string,
+  wireApi?: CodexProviderWireApi | null,
+): CodexProviderWireApi {
+  return resolveCodexProviderCapabilityProfile({ baseUrl, wireApi }).wireApi;
+}
+
 export function resolveCodexProviderEnableMode(
   profile: CodexProviderCapabilityProfile,
   preference: CodexProviderEnableModePreference = "auto",

--- a/src/utils/codexProviderPresets.test.ts
+++ b/src/utils/codexProviderPresets.test.ts
@@ -8,7 +8,10 @@ import {
   findCodexApiProviderPresetByBaseUrl,
   findCodexApiProviderPresetById,
 } from "./codexProviderPresets.ts";
-import { resolveCodexProviderCapabilityProfile } from "./codexProviderGateway.ts";
+import {
+  resolveCodexModelProviderWireApi,
+  resolveCodexProviderCapabilityProfile,
+} from "./codexProviderGateway.ts";
 
 test("OpenRouter preset includes the current Luna Pro model id", () => {
   const preset = findCodexApiProviderPresetByBaseUrl(
@@ -34,6 +37,20 @@ test("OpenCode Go preset exposes DeepSeek models and its chat-completions transp
   });
   assert.equal(profile.wireApi, "chat_completions");
   assert.equal(profile.requiresGateway, true);
+});
+
+test("OpenCode Go provider storage infers chat completions when wire API is missing", () => {
+  assert.equal(
+    resolveCodexModelProviderWireApi(OPENCODE_GO_API_BASE_URL, null),
+    "chat_completions",
+  );
+});
+
+test("explicit provider wire API overrides preset inference", () => {
+  assert.equal(
+    resolveCodexModelProviderWireApi(OPENCODE_GO_API_BASE_URL, "responses"),
+    "responses",
+  );
 });
 
 test("DeepSeek keeps its native Responses default", () => {


### PR DESCRIPTION
## Summary
- Preserve the provider wire API and WebSocket capability selected in the Codex account flow.
- Infer and persist `chat_completions` for legacy provider records that do not have `wireApi`.
- Keep explicit provider protocol choices higher priority than URL inference.

## Validation
- `node --test src/utils/codexProviderPresets.test.ts`
- `npm run typecheck` (verified on the source worktree)