### PR TITLE
fix(codex): treat expired subscriptions as free

### DIFF
--- a/src/types/codex.test.ts
+++ b/src/types/codex.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getCodexPlanBadgePresentation,
+  getCodexPlanFilterKey,
+} from "./codex.ts";
+import type { CodexAccount } from "./codex.ts";
+
+function account(partial: Partial<CodexAccount>): CodexAccount {
+  return {
+    id: "account-1",
+    email: "account@example.com",
+    tokens: {
+      id_token: "id-token",
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+    },
+    created_at: Date.now(),
+    last_used: Date.now(),
+    ...partial,
+  };
+}
+
+test("expired paid subscriptions are presented and grouped as free", () => {
+  const expiredPlus = account({
+    plan_type: "plus",
+    subscription_active_until: "2020-01-01T00:00:00Z",
+  });
+
+  assert.equal(getCodexPlanFilterKey(expiredPlus), "FREE");
+  assert.deepEqual(getCodexPlanBadgePresentation(expiredPlus), {
+    label: "FREE",
+    className: "free",
+  });
+});
+
+test("expired pro subscriptions no longer retain the pro multiplier badge", () => {
+  const expiredPro = account({
+    plan_type: "pro",
+    subscription_active_until: "2020-01-01T00:00:00Z",
+  });
+
+  assert.equal(getCodexPlanFilterKey(expiredPro), "FREE");
+  assert.deepEqual(getCodexPlanBadgePresentation(expiredPro), {
+    label: "FREE",
+    className: "free",
+  });
+});
+
+test("active paid subscriptions keep their paid plan", () => {
+  const activePlus = account({
+    plan_type: "plus",
+    subscription_active_until: "2100-01-01T00:00:00Z",
+  });
+
+  assert.equal(getCodexPlanFilterKey(activePlus), "PLUS");
+  assert.deepEqual(getCodexPlanBadgePresentation(activePlus), {
+    label: "PLUS",
+    className: "plus codex-plus",
+  });
+});
+
+test("paid subscriptions without a usable expiry are not downgraded", () => {
+  const missingExpiry = account({ plan_type: "plus" });
+  const invalidExpiry = account({
+    plan_type: "plus",
+    subscription_active_until: "not-a-date",
+  });
+
+  assert.equal(getCodexPlanFilterKey(missingExpiry), "PLUS");
+  assert.equal(getCodexPlanFilterKey(invalidExpiry), "PLUS");
+});
+
+test("API key and pending accounts keep their special classifications", () => {
+  const apiKeyAccount = account({
+    auth_mode: "apikey",
+    plan_type: "API_KEY",
+    subscription_active_until: "2020-01-01T00:00:00Z",
+  });
+  const pendingAccount = account({
+    authorization_status: "pending",
+    plan_type: "plus",
+    subscription_active_until: "2020-01-01T00:00:00Z",
+  });
+
+  assert.equal(getCodexPlanFilterKey(apiKeyAccount), "API_KEY");
+  assert.equal(getCodexPlanFilterKey(pendingAccount), "PENDING");
+});

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -1005,10 +1005,35 @@ function normalizeCodexPlanKey(planType?: string): string {
   return normalized;
 }
 
+function getCodexEffectivePlanKey(account: CodexAccount): string {
+  const planKey = normalizeCodexPlanKey(account.plan_type);
+  if (
+    planKey === "free" ||
+    isCodexApiKeyAccount(account) ||
+    isCodexPendingOAuthAccount(account) ||
+    isCodexAgentIdentityAccount(account) ||
+    isCodexWebSessionAccount(account)
+  ) {
+    return planKey;
+  }
+
+  const subscriptionExpiry = parseCodexSubscriptionDate(
+    account.subscription_active_until,
+  );
+  if (subscriptionExpiry && subscriptionExpiry.getTime() <= Date.now()) {
+    return "free";
+  }
+  return planKey;
+}
+
 export function isCodexExplicitFreePlanType(planType?: string): boolean {
   const normalized = (planType || "").trim();
   if (!normalized) return false;
   return normalizeCodexPlanKey(planType) === "free";
+}
+
+export function isCodexEffectiveFreePlan(account: CodexAccount): boolean {
+  return getCodexEffectivePlanKey(account) === "free";
 }
 
 function normalizeCodexAuthFilePlanType(
@@ -1044,8 +1069,9 @@ function getCodexPlanBadgeLabel(account: CodexAccount): string {
   if (isCodexApiKeyAccount(account)) {
     return "API";
   }
-  const baseLabel = getCodexPlanDisplayName(account.plan_type);
-  if (normalizeCodexPlanKey(account.plan_type) !== "pro") {
+  const effectivePlanKey = getCodexEffectivePlanKey(account);
+  const baseLabel = getCodexPlanDisplayName(effectivePlanKey);
+  if (effectivePlanKey !== "pro") {
     return baseLabel;
   }
 
@@ -1064,7 +1090,7 @@ function getCodexPlanBadgeClass(account: CodexAccount): string {
   if (isCodexNewApiAccount(account)) {
     return "api-key new-api-exclusive";
   }
-  const baseClass = normalizeCodexPlanKey(account.plan_type);
+  const baseClass = getCodexEffectivePlanKey(account);
   if (baseClass === "plus") {
     return "plus codex-plus";
   }
@@ -1113,7 +1139,7 @@ export function getCodexPlanBadgePresentationWithStyle(
 
 export function getCodexPlanFilterKey(account: CodexAccount): string {
   if (isCodexPendingOAuthAccount(account)) return "PENDING";
-  return normalizeCodexPlanKey(account.plan_type).toUpperCase();
+  return getCodexEffectivePlanKey(account).toUpperCase();
 }
 
 export function isCodexTeamLikePlan(planType?: string): boolean {

--- a/src/utils/codexLocalAccessAccounts.test.ts
+++ b/src/utils/codexLocalAccessAccounts.test.ts
@@ -72,6 +72,26 @@ test("direct add follows the API service free-account restriction", () => {
   assert.equal(canAddCodexAccountToLocalAccess(free, new Set(), false), true);
 });
 
+test("expired paid subscriptions follow the API service free-account restriction", () => {
+  const expiredPlus = account({
+    plan_type: "plus",
+    subscription_active_until: "2020-01-01T00:00:00Z",
+  });
+
+  assert.equal(
+    getCodexLocalAccessAccountIneligibleReason(expiredPlus, true),
+    "free_restricted",
+  );
+  assert.equal(
+    isCodexLocalAccessEligibleAccount(expiredPlus, true),
+    false,
+  );
+  assert.equal(
+    isCodexLocalAccessEligibleAccount(expiredPlus, false),
+    true,
+  );
+});
+
 test("Agent Identity imports are forced into API service without enabling global sync", () => {
   const regular = account({ id: "regular" });
   const agentIdentity = account({

--- a/src/utils/codexLocalAccessAccounts.ts
+++ b/src/utils/codexLocalAccessAccounts.ts
@@ -1,7 +1,7 @@
 import {
   isCodexApiKeyAccount,
   isCodexAgentIdentityAccount,
-  isCodexExplicitFreePlanType,
+  isCodexEffectiveFreePlan,
   isCodexPendingOAuthAccount,
   isCodexWebSessionAccount,
   type CodexAccount,
@@ -106,7 +106,7 @@ export function getCodexLocalAccessAccountIneligibleReason(
   if (
     restrictFreeAccounts &&
     !isCodexAgentIdentityAccount(account) &&
-    isCodexExplicitFreePlanType(account.plan_type)
+    isCodexEffectiveFreePlan(account)
   ) {
     return "free_restricted";
   }


### PR DESCRIPTION
## Summary

- 根据 `plan_type` 和 `subscription_active_until` 计算 Codex 账号的有效套餐，启动时就把已过期的 Plus/Pro 账号显示并分组为 FREE。
- 保留 API key、待授权、Agent Identity 和 ChatGPT Web Session 的特殊分类，不误降级这些账号。
- 让 Codex 本地 API 服务的免费账号限制也使用有效套餐判断，避免过期付费账号绕过或错误占用免费账号策略。
- 增加过期 Plus/Pro、有效订阅、缺失/非法有效期、特殊账号和本地 API 服务限制的回归测试。

## Root cause

应用启动时读取的账号缓存仍保留原始付费 `plan_type`，而标签、筛选分组和本地 API 服务限制直接使用该字段。手动刷新订阅后数据才被更新，所以首次打开会暂时显示 PLUS。

## Validation

- `node --test --test-isolation=none --test-concurrency=1 src/types/codex.test.ts src/utils/codexLocalAccessAccounts.test.ts src/utils/codexApiKeyAccountScope.test.ts`（19/19）
- `npm run typecheck`
- `npm run build`

## Related

Fixes #1895

Related to #1907; this branch is rebased on the current v1.3.22 `main` so the fix can be reviewed against the latest code.