### PR TITLE
优化 Codex 账号卡片布局、备注标题与批量选择

### DIFF
--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -1719,6 +1719,7 @@ pub async fn update_codex_account_api_model_mappings(
 #[tauri::command]
 pub async fn update_codex_account_note(
     account_id: String,
+    note_title: Option<String>,
     note: Option<String>,
     two_factor_secret: Option<String>,
     account_password: Option<String>,
@@ -1729,6 +1730,7 @@ pub async fn update_codex_account_note(
     codex_account::update_account_note(
         &account_id,
         codex_account::CodexAccountNoteUpdate {
+            note_title,
             note,
             two_factor_secret,
             account_password,
@@ -1742,6 +1744,7 @@ pub async fn update_codex_account_note(
 #[tauri::command]
 pub async fn create_pending_codex_oauth_account(
     email: String,
+    note_title: Option<String>,
     note: Option<String>,
     two_factor_secret: Option<String>,
     account_password: Option<String>,
@@ -1751,6 +1754,7 @@ pub async fn create_pending_codex_oauth_account(
     codex_account::create_pending_oauth_account(
         email,
         codex_account::CodexAccountNoteUpdate {
+            note_title,
             note,
             two_factor_secret,
             account_password,

--- a/src-tauri/src/models/codex.rs
+++ b/src-tauri/src/models/codex.rs
@@ -161,6 +161,13 @@ pub struct CodexAccount {
     pub account_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub account_structure: Option<String>,
+    #[serde(
+        default,
+        alias = "accountNoteTitle",
+        alias = "noteTitle",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub account_note_title: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub account_note: Option<String>,
     /// Codex OAuth 设备指纹收敛模式。未设置时按 `off` 处理。
@@ -483,6 +490,7 @@ impl CodexAccount {
             agent_identity: None,
             account_name: None,
             account_structure: None,
+            account_note_title: None,
             account_note: None,
             codex_fingerprint_mode: None,
             codex_cli_only: false,

--- a/src-tauri/src/modules/codex_account.rs
+++ b/src-tauri/src/modules/codex_account.rs
@@ -5008,6 +5008,12 @@ fn apply_compat_account_metadata(
         .or_else(|| account.account_name.clone());
     account.account_structure = read_json_string(value, &["account_structure", "accountStructure"])
         .or_else(|| account.account_structure.clone());
+    account.account_note_title = read_json_string(
+        value,
+        &["account_note_title", "accountNoteTitle", "noteTitle"],
+    )
+    .and_then(normalize_account_note_title)
+    .or_else(|| account.account_note_title.clone());
     account.account_note = read_json_string(value, &["account_note", "accountNote"])
         .or_else(|| account.account_note.clone());
     account.codex_fingerprint_mode =
@@ -5051,6 +5057,11 @@ fn apply_compat_account_metadata(
 fn apply_api_key_import_metadata(account: &mut CodexAccount, value: &serde_json::Value) {
     if let Some(account_name) = read_json_string(value, &["account_name", "accountName"]) {
         account.account_name = Some(account_name);
+    }
+    if let Some(note_title) =
+        read_json_string(value, &["account_note_title", "accountNoteTitle", "noteTitle"])
+    {
+        account.account_note_title = normalize_account_note_title(note_title);
     }
     if let Some(account_note) = read_json_string(value, &["account_note", "accountNote"]) {
         account.account_note = Some(account_note);
@@ -8170,6 +8181,10 @@ fn import_account_struct(account: CodexAccount) -> Result<CodexAccount, String> 
             imported.tags = Some(tags);
             changed = true;
         }
+        if let Some(note_title) = account.account_note_title {
+            imported.account_note_title = normalize_account_note_title(note_title);
+            changed = true;
+        }
         if let Some(note) = account.account_note {
             imported.account_note = Some(note);
             changed = true;
@@ -8216,6 +8231,10 @@ fn import_account_struct(account: CodexAccount) -> Result<CodexAccount, String> 
             api_acc.tags = Some(tags);
             changed = true;
         }
+        if let Some(note_title) = account.account_note_title {
+            api_acc.account_note_title = normalize_account_note_title(note_title);
+            changed = true;
+        }
         if let Some(note) = account.account_note {
             api_acc.account_note = Some(note);
             changed = true;
@@ -8249,6 +8268,10 @@ fn import_account_struct(account: CodexAccount) -> Result<CodexAccount, String> 
 
     if let Some(tags) = account.tags {
         imported.tags = Some(tags);
+        changed = true;
+    }
+    if let Some(note_title) = account.account_note_title {
+        imported.account_note_title = normalize_account_note_title(note_title);
         changed = true;
     }
     if let Some(note) = account.account_note {
@@ -8312,6 +8335,7 @@ struct CodexAccessTokenImportHints {
     organization_id: Option<String>,
     account_name: Option<String>,
     account_structure: Option<String>,
+    account_note_title: Option<String>,
     account_note: Option<String>,
     two_factor_secret: Option<String>,
     account_password: Option<String>,
@@ -8338,6 +8362,10 @@ enum CodexJsonImportCandidate {
 
 fn codex_account_note_update_from_value(value: &serde_json::Value) -> CodexAccountNoteUpdate {
     CodexAccountNoteUpdate {
+        note_title: read_json_string(
+            value,
+            &["account_note_title", "accountNoteTitle", "noteTitle"],
+        ),
         note: read_json_string(
             value,
             &["account_note", "accountNote", "note", "notes", "remark"],
@@ -8369,7 +8397,8 @@ fn codex_account_note_update_from_value(value: &serde_json::Value) -> CodexAccou
 }
 
 fn has_codex_account_note_update(update: &CodexAccountNoteUpdate) -> bool {
-    update.note.is_some()
+    update.note_title.is_some()
+        || update.note.is_some()
         || update.two_factor_secret.is_some()
         || update.account_password.is_some()
         || update.phone_number.is_some()
@@ -8380,6 +8409,9 @@ fn merge_codex_account_note_update(
     mut primary: CodexAccountNoteUpdate,
     fallback: CodexAccountNoteUpdate,
 ) -> CodexAccountNoteUpdate {
+    if primary.note_title.is_none() {
+        primary.note_title = fallback.note_title;
+    }
     if primary.note.is_none() {
         primary.note = fallback.note;
     }
@@ -8402,6 +8434,7 @@ fn codex_account_note_update_from_hints(
     hints: &CodexAccessTokenImportHints,
 ) -> CodexAccountNoteUpdate {
     CodexAccountNoteUpdate {
+        note_title: hints.account_note_title.clone(),
         note: hints.account_note.clone(),
         two_factor_secret: hints.two_factor_secret.clone(),
         account_password: hints.account_password.clone(),
@@ -8510,6 +8543,8 @@ fn pending_oauth_account_from_value(value: &serde_json::Value) -> Option<CodexAc
     // carries pending metadata. This avoids silently importing malformed auth files.
     if authorization_status == CODEX_AUTHORIZATION_STATUS_PENDING
         || has_codex_account_note_details(&account)
+        || obj.contains_key("account_note_title")
+        || obj.contains_key("accountNoteTitle")
         || obj.contains_key("account_note")
         || obj.contains_key("accountNote")
     {
@@ -8521,7 +8556,12 @@ fn pending_oauth_account_from_value(value: &serde_json::Value) -> Option<CodexAc
 
 fn has_codex_account_note_details(account: &CodexAccount) -> bool {
     account
-        .account_note
+        .account_note_title
+        .as_deref()
+        .and_then(|value| normalize_optional_ref(Some(value)))
+        .is_some()
+        || account
+            .account_note
         .as_deref()
         .and_then(|value| normalize_optional_ref(Some(value)))
         .is_some()
@@ -8549,6 +8589,7 @@ fn has_codex_account_note_details(account: &CodexAccount) -> bool {
 
 fn codex_account_note_update_from_account(account: &CodexAccount) -> CodexAccountNoteUpdate {
     CodexAccountNoteUpdate {
+        note_title: account.account_note_title.clone(),
         note: account.account_note.clone(),
         two_factor_secret: account.two_factor_secret.clone(),
         account_password: account.account_password.clone(),
@@ -8630,6 +8671,9 @@ fn merge_access_token_import_hints(
     }
     if primary.account_structure.is_none() {
         primary.account_structure = fallback.account_structure;
+    }
+    if primary.account_note_title.is_none() {
+        primary.account_note_title = fallback.account_note_title;
     }
     if primary.account_note.is_none() {
         primary.account_note = fallback.account_note;
@@ -8817,6 +8861,7 @@ fn extract_access_token_import_hints_from_value(
                 &["account", "type"],
             ],
         ),
+        account_note_title: note_update.note_title,
         account_note: note_update.note,
         two_factor_secret: note_update.two_factor_secret,
         account_password: note_update.account_password,
@@ -8918,6 +8963,7 @@ fn extract_codex_session_candidate_from_value(
     let session_hints_note_update = codex_account_note_update_from_hints(&session_hints);
     let session_hints_note_update =
         merge_codex_account_note_update(session_hints_note_update, note_update.clone());
+    session_hints.account_note_title = session_hints_note_update.note_title;
     session_hints.account_note = session_hints_note_update.note;
     session_hints.two_factor_secret = session_hints_note_update.two_factor_secret;
     session_hints.account_password = session_hints_note_update.account_password;
@@ -9049,6 +9095,7 @@ fn extract_codex_import_candidate_from_value(
             hints_note_update,
             codex_account_note_update_from_value(value),
         );
+        hints.account_note_title = hints_note_update.note_title;
         hints.account_note = hints_note_update.note;
         hints.two_factor_secret = hints_note_update.two_factor_secret;
         hints.account_password = hints_note_update.account_password;
@@ -9323,6 +9370,7 @@ fn try_parse_pending_oauth_delimited_line(line: &str) -> Option<(String, CodexAc
     Some((
         email.to_string(),
         CodexAccountNoteUpdate {
+            note_title: None,
             note: None,
             two_factor_secret: normalize_optional_ref(Some(two_factor)),
             account_password: normalize_optional_ref(Some(password)),
@@ -10177,6 +10225,7 @@ fn preview_account_from_access_token(
     account.organization_id = organization_id;
     account.account_name = hints.account_name;
     account.account_structure = hints.account_structure;
+    account.account_note_title = hints.account_note_title.and_then(normalize_account_note_title);
     account.account_note = hints.account_note;
     account.two_factor_secret = hints.two_factor_secret;
     account.account_password = hints.account_password;
@@ -10335,6 +10384,7 @@ async fn codex_batch_import_draft_from_value(
                     access_token: tokens.access_token,
                     hints: CodexAccessTokenImportHints {
                         account_id: account_id_hint,
+                        account_note_title: note_update.note_title,
                         account_note: note_update.note,
                         two_factor_secret: note_update.two_factor_secret,
                         account_password: note_update.account_password,
@@ -13388,6 +13438,7 @@ mod tests {
         let mut detail = load_account(&existing.id).expect("load existing account");
         detail.account_name = Some("备注账号".to_string());
         detail.account_structure = Some("个人".to_string());
+        detail.account_note_title = Some("张三的正价号".to_string());
         detail.account_note = Some("其他备注".to_string());
         detail.two_factor_secret = Some("JBSWY3DPEHPK3PXP".to_string());
         detail.account_password = Some("password-1".to_string());
@@ -13410,6 +13461,7 @@ mod tests {
         assert_eq!(reauthed.organization_id.as_deref(), Some("org-new"));
         assert_eq!(reauthed.account_name.as_deref(), Some("备注账号"));
         assert_eq!(reauthed.account_structure.as_deref(), Some("个人"));
+        assert_eq!(reauthed.account_note_title.as_deref(), Some("张三的正价号"));
         assert_eq!(reauthed.account_note.as_deref(), Some("其他备注"));
         assert_eq!(
             reauthed.two_factor_secret.as_deref(),
@@ -13419,6 +13471,7 @@ mod tests {
         assert_eq!(reauthed.phone_number.as_deref(), Some("13800000000"));
 
         let persisted = load_account(&existing.id).expect("load persisted account");
+        assert_eq!(persisted.account_note_title.as_deref(), Some("张三的正价号"));
         assert_eq!(persisted.account_note.as_deref(), Some("其他备注"));
         assert_eq!(
             persisted.two_factor_secret.as_deref(),
@@ -17329,6 +17382,7 @@ pub fn update_account_client_policy(
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct CodexAccountNoteUpdate {
+    pub note_title: Option<String>,
     pub note: Option<String>,
     pub two_factor_secret: Option<String>,
     pub account_password: Option<String>,
@@ -17336,7 +17390,22 @@ pub struct CodexAccountNoteUpdate {
     pub mail_url: Option<String>,
 }
 
+const CODEX_ACCOUNT_NOTE_TITLE_MAX_CHARS: usize = 40;
+
+fn normalize_account_note_title(value: String) -> Option<String> {
+    let single_line = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    normalize_optional_value(Some(single_line)).map(|value| {
+        value
+            .chars()
+            .take(CODEX_ACCOUNT_NOTE_TITLE_MAX_CHARS)
+            .collect()
+    })
+}
+
 fn apply_account_note_update(account: &mut CodexAccount, update: CodexAccountNoteUpdate) {
+    if let Some(note_title) = update.note_title {
+        account.account_note_title = normalize_account_note_title(note_title);
+    }
     if let Some(note) = update.note {
         account.account_note = normalize_optional_value(Some(note));
     }

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -439,6 +439,7 @@ type OAuthBindingQuotaReserveFieldErrors = {
   weeklyPercent?: string;
 };
 type CodexAccountNoteFormState = {
+  noteTitle: string;
   note: string;
   twoFactorSecret: string;
   accountPassword: string;
@@ -446,6 +447,8 @@ type CodexAccountNoteFormState = {
   mailUrl: string;
   chatgptAccountId: string;
 };
+
+const CODEX_ACCOUNT_NOTE_TITLE_MAX_LENGTH = 40;
 
 type CodexAccountNoteMailPreviewState = MailVerificationCodePreview & {
   fetchedAt: number;
@@ -463,6 +466,7 @@ type CodexAccountNoteFieldErrors = {
 };
 
 const EMPTY_CODEX_ACCOUNT_NOTE_FORM: CodexAccountNoteFormState = {
+  noteTitle: "",
   note: "",
   twoFactorSecret: "",
   accountPassword: "",
@@ -475,6 +479,7 @@ function buildCodexAccountNoteForm(
   account?: CodexAccount | null,
 ): CodexAccountNoteFormState {
   return {
+    noteTitle: account?.account_note_title ?? "",
     note: account?.account_note ?? "",
     twoFactorSecret: account?.two_factor_secret ?? "",
     accountPassword: account?.account_password ?? "",
@@ -486,7 +491,8 @@ function buildCodexAccountNoteForm(
 
 function hasCodexAccountNoteDetails(account?: CodexAccount | null): boolean {
   return Boolean(
-    account?.account_note?.trim() ||
+    account?.account_note_title?.trim() ||
+      account?.account_note?.trim() ||
       account?.two_factor_secret?.trim() ||
       account?.account_password?.trim() ||
       account?.phone_number?.trim() ||
@@ -498,7 +504,8 @@ function hasCodexAccountNoteFormDetails(
   form?: CodexAccountNoteFormState | null,
 ): boolean {
   return Boolean(
-    form?.note.trim() ||
+    form?.noteTitle.trim() ||
+      form?.note.trim() ||
       form?.twoFactorSecret.trim() ||
       form?.accountPassword.trim() ||
       form?.phoneNumber.trim() ||
@@ -508,6 +515,7 @@ function hasCodexAccountNoteFormDetails(
 
 function getCodexAccountNoteTitle(account: CodexAccount, fallback: string): string {
   return (
+    account.account_note_title?.trim() ||
     account.account_note?.trim() ||
     account.two_factor_secret?.trim() ||
     account.account_password?.trim() ||
@@ -3391,6 +3399,7 @@ export function CodexAccountsPage() {
       const normalizedTwoFactorSecret =
         parsedTwoFactorSecret?.secret ?? rawTwoFactorSecret;
       const noteUpdate = {
+        noteTitle: activeAccountNoteForm.noteTitle,
         note: activeAccountNoteForm.note,
         twoFactorSecret: normalizedTwoFactorSecret,
         accountPassword: activeAccountNoteForm.accountPassword,
@@ -9027,26 +9036,19 @@ export function CodexAccountsPage() {
     [],
   );
 
-  const accountIdLabel = t("kiro.account.userId", "User ID");
-
   const accountMetaMap = useMemo(() => {
     const map = new Map<
       string,
       {
-        chatgptAccountId: string;
-        signedInWithText: string;
-        userId: string;
+        loginMethodText: string;
         accountContextText: string;
       }
     >();
-    const noneText = t("common.none", "暂无");
 
     accounts.forEach((account) => {
       if (isCodexApiKeyAccount(account)) {
         map.set(account.id, {
-          chatgptAccountId: t("common.none", "暂无"),
-          signedInWithText: "",
-          userId: "",
+          loginMethodText: "",
           accountContextText: "",
         });
         return;
@@ -9077,18 +9079,8 @@ export function CodexAccountsPage() {
       const loginProvider =
         formatCodexLoginProvider(metadata.authProvider) ||
         t("kiro.account.providerUnknown", "Unknown");
-      const userId =
-        (metadata.userId || account.user_id || "").trim() || noneText;
-      const signedInWithText = t("kiro.account.signedInWith", {
-        provider: loginProvider,
-        defaultValue: "Signed in with {{provider}}",
-      });
       map.set(account.id, {
-        chatgptAccountId:
-          (metadata.chatgptAccountId || account.account_id || "").trim() ||
-          noneText,
-        signedInWithText,
-        userId,
+        loginMethodText: loginProvider,
         accountContextText,
       });
     });
@@ -9099,12 +9091,7 @@ export function CodexAccountsPage() {
   const resolveAccountMeta = useCallback(
     (account: CodexAccount) =>
       accountMetaMap.get(account.id) ?? {
-        chatgptAccountId: t("common.none", "暂无"),
-        signedInWithText: t("kiro.account.signedInWith", {
-          provider: t("kiro.account.providerUnknown", "Unknown"),
-          defaultValue: "Signed in with {{provider}}",
-        }),
-        userId: t("common.none", "暂无"),
+        loginMethodText: t("kiro.account.providerUnknown", "Unknown"),
         accountContextText: "",
       },
     [accountMetaMap, t],
@@ -11030,6 +11017,7 @@ export function CodexAccountsPage() {
     ) => {
       if (isApiKeyAccount && !isNewApiAccount) return [];
       return presentation.quotaItems.filter((item) => {
+        if (item.key === "monthly_credits") return false;
         if (!showCodeReviewQuota && item.key === "code_review") return false;
         if (!showAdditionalQuota && item.key.startsWith("additional:")) {
           return false;
@@ -11050,20 +11038,17 @@ export function CodexAccountsPage() {
     const displayCount =
       availableCount ??
       creditDetails.filter(isAvailableResetCredit).length;
+    if (displayCount <= 0) return null;
+
     const isResetting = resettingResetCreditAccountId === account.id;
     const isDisabled = isResetting;
-    const titleText =
-      displayCount > 0
-        ? buildResetCreditsTitle(account, displayCount)
-        : t("codex.quota.resetCreditDetailsTitle", "重置次数明细");
+    const titleText = buildResetCreditsTitle(account, displayCount);
 
     return (
       <div className="codex-reset-credit-row inline">
         <button
           type="button"
-          className={`codex-reset-credit-pill ${
-            displayCount > 0 ? "is-available" : "is-unavailable"
-          }`}
+          className="codex-reset-credit-pill is-available"
           onClick={() => openResetCreditConfirmModal(account)}
           disabled={isDisabled}
           title={titleText}
@@ -11340,12 +11325,7 @@ export function CodexAccountsPage() {
         !isApiKeyAccount &&
         (isPendingOAuthAccount ||
           (hasQuotaError && shouldOfferReauthorizeAction(accountIssueMeta)));
-      const accountIdText =
-        meta.chatgptAccountId &&
-        meta.chatgptAccountId !== t("common.none", "暂无")
-          ? meta.chatgptAccountId
-          : meta.userId;
-      const signInLine = `${meta.signedInWithText} | ${accountIdLabel}: ${accountIdText}`;
+      const accountNoteTitleText = (account.account_note_title || "").trim();
       const apiProviderName = resolveApiProviderDisplayName(account);
       const apiProviderLine = `${t("codex.api.provider.label", "供应商")}：${apiProviderName}`;
       const apiBaseUrlText = (account.api_base_url || "").trim() || "-";
@@ -11417,7 +11397,15 @@ export function CodexAccountsPage() {
       return (
         <div
           key={groupKey ? `${groupKey}-${account.id}` : account.id}
-          className={`codex-account-card ${isCurrent ? "current" : ""} ${isSelected ? "selected" : ""} ${isPendingOAuthAccount ? "pending-auth" : ""} ${isNewApiAccount ? "new-api-exclusive" : ""} ${isQuotaAwareApiKeyAccount ? "api-key-usage-account" : ""} ${isSponsorApiKeyAccount ? "sponsor-api-account" : ""}`}
+          className={`codex-account-card ${selected.size > 0 ? "selection-mode" : ""} ${isCurrent ? "current" : ""} ${isSelected ? "selected" : ""} ${isPendingOAuthAccount ? "pending-auth" : ""} ${isNewApiAccount ? "new-api-exclusive" : ""} ${isQuotaAwareApiKeyAccount ? "api-key-usage-account" : ""} ${isSponsorApiKeyAccount ? "sponsor-api-account" : ""}`}
+          onClickCapture={(event) => {
+            if (selected.size === 0) return;
+            const target = event.target as Element;
+            if (target.closest(".card-select")) return;
+            event.preventDefault();
+            event.stopPropagation();
+            handleToggleOverviewAccount(account.id);
+          }}
         >
           <div className="card-top">
             <div className="card-select">
@@ -11477,70 +11465,82 @@ export function CodexAccountsPage() {
               {displayPlanLabel}
             </span>
           </div>
-          {(meta.accountContextText ||
-            isInLocalAccess ||
-            canAddToLocalAccess ||
-            (!isApiKeyAccount && hasCodexAccountNoteDetails(account)) ||
-            resetCreditControls) && (
-            <div className="account-sub-line">
-              {meta.accountContextText && (
+          {!isApiKeyAccount &&
+            (meta.accountContextText ||
+              meta.loginMethodText ||
+              isInLocalAccess ||
+              canAddToLocalAccess) && (
+              <div className="account-sub-line codex-account-context-line">
                 <span
-                  className="codex-login-subline"
-                  title={meta.accountContextText}
+                  className="codex-account-context-summary"
+                  title={[meta.accountContextText, meta.loginMethodText]
+                    .filter(Boolean)
+                    .join(" | ")}
                 >
-                  Team Name：{meta.accountContextText}
+                  {meta.accountContextText && (
+                    <span className="codex-account-team-name">
+                      Team：{meta.accountContextText}
+                    </span>
+                  )}
+                  {meta.loginMethodText && (
+                    <span className="codex-account-login-method">
+                      {meta.loginMethodText}
+                    </span>
+                  )}
                 </span>
-              )}
-              {isInLocalAccess && (
-                <button
-                  type="button"
-                  className="group-account-badge codex-local-access-inline-remove"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    void handleRemoveLocalAccessAccount(account.id);
-                  }}
-                  disabled={addingLocalAccessAccountId !== null}
-                  title={t(
-                    "codex.localAccess.removeAction",
-                    "移除 API 服务",
-                  )}
-                  aria-label={t(
-                    "codex.localAccess.removeAction",
-                    "移除 API 服务",
-                  )}
-                >
-                  {addingLocalAccessAccountId === account.id ? (
-                    <RefreshCw size={11} className="loading-spinner" />
-                  ) : (
+                {isInLocalAccess && (
+                  <button
+                    type="button"
+                    className="group-account-badge codex-local-access-inline-remove"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      void handleRemoveLocalAccessAccount(account.id);
+                    }}
+                    disabled={addingLocalAccessAccountId !== null}
+                    title={t(
+                      "codex.localAccess.removeAction",
+                      "移除 API 服务",
+                    )}
+                    aria-label={t(
+                      "codex.localAccess.removeAction",
+                      "移除 API 服务",
+                    )}
+                  >
+                    {addingLocalAccessAccountId === account.id ? (
+                      <RefreshCw size={11} className="loading-spinner" />
+                    ) : (
+                      <Link2 size={11} />
+                    )}
+                    {t("codex.localAccess.removeAction", "移除 API 服务")}
+                  </button>
+                )}
+                {!isInLocalAccess && canAddToLocalAccess && (
+                  <button
+                    type="button"
+                    className="group-account-badge codex-local-access-inline-add"
+                    onClick={() => void handleAddLocalAccessAccount(account.id)}
+                    disabled={addingLocalAccessAccountId !== null}
+                    title={t(
+                      "codex.localAccess.entryAction",
+                      "添加至 API 服务",
+                    )}
+                  >
                     <Link2 size={11} />
-                  )}
-                  {t("codex.localAccess.removeAction", "移除 API 服务")}
-                </button>
-              )}
-              {!isInLocalAccess && canAddToLocalAccess && (
-                <button
-                  type="button"
-                  className="group-account-badge codex-local-access-inline-add"
-                  onClick={() => void handleAddLocalAccessAccount(account.id)}
-                  disabled={addingLocalAccessAccountId !== null}
-                  title={t(
-                    "codex.localAccess.entryAction",
-                    "添加至 API 服务",
-                  )}
-                >
-                  <Link2 size={11} />
-                  {t("codex.localAccess.entryAction", "添加至 API 服务")}
-                </button>
-              )}
-              {!isApiKeyAccount && renderAccountNoteButton(account)}
-              {resetCreditControls}
-            </div>
-          )}
+                    {t("codex.localAccess.entryAction", "添加至 API 服务")}
+                  </button>
+                )}
+              </div>
+            )}
           {!isApiKeyAccount && (
-            <div className="account-sub-line">
-              <span className="codex-login-subline" title={signInLine}>
-                {meta.signedInWithText} | {accountIdLabel}:{" "}
-                {maskAccountText(accountIdText)}
+            <div className="account-sub-line codex-account-note-line">
+              <span
+                className={`codex-account-note-preview ${accountNoteTitleText ? "" : "is-empty"}`}
+                title={
+                  accountNoteTitleText ||
+                  t("codex.accountNote.emptyTitle", "填写账号备注")
+                }
+              >
+                {accountNoteTitleText || t("common.none", "暂无")}
               </span>
             </div>
           )}
@@ -11694,7 +11694,10 @@ export function CodexAccountsPage() {
           )}
           <div className="codex-card-bottom">
             <span className="card-date">{formatDate(account.created_at)}</span>
-            {renderAccountSpeedSelect(account)}
+            <div className="codex-card-bottom-controls">
+              {resetCreditControls}
+              {renderAccountSpeedSelect(account)}
+            </div>
             <div className="card-footer">
               <div className="card-actions">
                 <button
@@ -12649,12 +12652,7 @@ export function CodexAccountsPage() {
         !isApiKeyAccount &&
         (isPendingOAuthAccount ||
           (hasQuotaError && shouldOfferReauthorizeAction(accountIssueMeta)));
-      const accountIdText =
-        meta.chatgptAccountId &&
-        meta.chatgptAccountId !== t("common.none", "暂无")
-          ? meta.chatgptAccountId
-          : meta.userId;
-      const signInLine = `${meta.signedInWithText} | ${accountIdLabel}: ${accountIdText}`;
+      const accountNoteTitleText = (account.account_note_title || "").trim();
       const apiProviderName = resolveApiProviderDisplayName(account);
       const apiProviderLine = `${t("codex.api.provider.label", "供应商")}：${apiProviderName}`;
       const apiBaseUrlText = (account.api_base_url || "").trim() || "-";
@@ -12761,19 +12759,29 @@ export function CodexAccountsPage() {
                 )}
                 {renderAccountSpeedSelect(account, true)}
               </div>
-              {(meta.accountContextText ||
-                isInLocalAccess ||
-                (!isApiKeyAccount && hasCodexAccountNoteDetails(account)) ||
-                resetCreditControls) && (
-                <div className="account-sub-line codex-account-meta-inline">
-                  {meta.accountContextText && (
-                    <span
-                      className="codex-login-subline"
-                      title={meta.accountContextText}
-                    >
-                      Team Name：{meta.accountContextText}
-                    </span>
-                  )}
+              {!isApiKeyAccount &&
+                (meta.accountContextText ||
+                  meta.loginMethodText ||
+                  isInLocalAccess ||
+                  resetCreditControls) && (
+                <div className="account-sub-line codex-account-meta-inline codex-account-context-line">
+                  <span
+                    className="codex-account-context-summary"
+                    title={[meta.accountContextText, meta.loginMethodText]
+                      .filter(Boolean)
+                      .join(" | ")}
+                  >
+                    {meta.accountContextText && (
+                      <span className="codex-account-team-name">
+                        Team：{meta.accountContextText}
+                      </span>
+                    )}
+                    {meta.loginMethodText && (
+                      <span className="codex-account-login-method">
+                        {meta.loginMethodText}
+                      </span>
+                    )}
+                  </span>
                   {isInLocalAccess && (
                     <button
                       type="button"
@@ -12800,15 +12808,19 @@ export function CodexAccountsPage() {
                       {t("codex.localAccess.removeAction", "移除 API 服务")}
                     </button>
                   )}
-                  {!isApiKeyAccount && renderAccountNoteButton(account)}
                   {resetCreditControls}
                 </div>
               )}
               {!isApiKeyAccount && (
-                <div className="account-sub-line codex-account-meta-inline">
-                  <span className="codex-login-subline" title={signInLine}>
-                    {meta.signedInWithText} | {accountIdLabel}:{" "}
-                    {maskAccountText(accountIdText)}
+                <div className="account-sub-line codex-account-meta-inline codex-account-note-line">
+                  <span
+                    className={`codex-account-note-preview ${accountNoteTitleText ? "" : "is-empty"}`}
+                    title={
+                      accountNoteTitleText ||
+                      t("codex.accountNote.emptyTitle", "填写账号备注")
+                    }
+                  >
+                    {accountNoteTitleText || t("common.none", "暂无")}
                   </span>
                 </div>
               )}
@@ -19253,6 +19265,28 @@ export function CodexAccountsPage() {
                         )}
                       </button>
                     </div>
+                  </label>
+                  <label className="codex-account-note-field">
+                    <span>
+                      {t("codex.accountNote.noteTitleLabel", "备注标题")}
+                    </span>
+                    <input
+                      className="codex-account-note-input"
+                      type="text"
+                      value={activeAccountNoteForm.noteTitle}
+                      onChange={(event) => {
+                        updateActiveAccountNoteForm({
+                          noteTitle: event.target.value,
+                        });
+                      }}
+                      placeholder={t(
+                        "codex.accountNote.noteTitlePlaceholder",
+                        "例如：日抛号、15 元购入、张三正价号",
+                      )}
+                      maxLength={CODEX_ACCOUNT_NOTE_TITLE_MAX_LENGTH}
+                      autoComplete="off"
+                      disabled={activeAccountNoteSaving}
+                    />
                   </label>
                   <label className="codex-account-note-field">
                     <span>

--- a/src/styles/pages/codex.css
+++ b/src/styles/pages/codex.css
@@ -2746,6 +2746,10 @@
   transform: translateY(-2px);
 }
 
+.codex-account-card.selection-mode {
+  cursor: pointer;
+}
+
 .codex-account-card.current {
   border-color: var(--primary);
   box-shadow:
@@ -2813,6 +2817,7 @@
 .codex-account-card .account-email {
   flex: 1;
   min-width: 0;
+  max-width: none;
   font-family: var(--font-sans);
   font-weight: 600;
   font-size: 14px;
@@ -4233,6 +4238,82 @@
 
 .codex-account-card .codex-card-bottom > .codex-speed-select {
   justify-self: end;
+}
+
+.codex-account-card > .account-sub-line {
+  min-width: 0;
+  flex-wrap: nowrap;
+}
+
+.codex-account-card > .account-sub-line > .codex-login-subline {
+  flex: 1 1 auto;
+}
+
+.codex-account-card > .account-sub-line > button {
+  flex-shrink: 0;
+}
+
+.codex-accounts-page .codex-account-context-line,
+.codex-accounts-page .codex-account-note-line {
+  min-width: 0;
+  flex-wrap: nowrap;
+}
+
+.codex-accounts-page .codex-account-context-summary {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.codex-accounts-page .codex-account-team-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.codex-accounts-page .codex-account-login-method {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 18%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted) 7%, transparent);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.codex-accounts-page .codex-account-note-preview {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.codex-accounts-page .codex-account-note-preview.is-empty {
+  color: var(--text-muted);
+}
+
+.codex-account-card .codex-card-bottom-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
 }
 
 .codex-account-card .card-footer {

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -71,6 +71,7 @@ export interface CodexAccount {
   agent_identity?: CodexAgentIdentity;
   account_name?: string;
   account_structure?: string;
+  account_note_title?: string;
   account_note?: string;
   codex_fingerprint_mode?: CodexFingerprintMode;
   codex_cli_only?: boolean;
@@ -95,6 +96,7 @@ export interface CodexAccount {
 }
 
 export interface CodexAccountNoteUpdate {
+  noteTitle?: string;
   note?: string;
   twoFactorSecret?: string;
   accountPassword?: string;


### PR DESCRIPTION
## 改动概览

- 精简账号卡片：隐藏月度 credits、用户 ID 和无可用次数的重置按钮，并将重置入口移至卡片底部。
- 优化信息布局：Team 与登录方式同行显示，长 Team 名称自动省略，同时增加邮箱名称的显示空间。
- 新增单行“备注标题”（最多 40 字符），用于卡片和列表摘要，并支持保存、导入及重新授权时保留。
- 改进批量选择：已有账号被选中后，点击卡片任意位置即可切换选中状态，避免误触卡片内操作。

## 验证

- 使用不同套餐、标签、登录方式及长 Team 名称的模拟账号完成浏览器预览验证。
- 已验证重置按钮、备注标题、卡片布局和批量选择交互。
- `git diff --check` 通过。