### PR TITLE
fix(codex): hot-reload quota model exclusions

### DIFF
--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -111,14 +112,15 @@ type manifest struct {
 	MaxConcurrentImageRequests int                 `json:"maxConcurrentImageRequests"`
 	DebugLogs                  *bool               `json:"debugLogs,omitempty"`
 
-	apiKeyByValue     map[string]*apiKeySpec
-	accountByID       map[string]*accountSpec
-	accountByAuthID   map[string]*accountSpec
-	accountByAPIKey   map[string]*accountSpec
-	accountByChatGPT  map[string]*accountSpec
-	accountByEmail    map[string]*accountSpec
-	aliasToSource     map[string]string
-	originalIndexByID map[string]int
+	apiKeyByValue          map[string]*apiKeySpec
+	accountByID            map[string]*accountSpec
+	accountByAuthID        map[string]*accountSpec
+	accountByAPIKey        map[string]*accountSpec
+	accountByChatGPT       map[string]*accountSpec
+	accountByEmail         map[string]*accountSpec
+	runtimeAccountByAuthID sync.Map
+	aliasToSource          map[string]string
+	originalIndexByID      map[string]int
 }
 
 type apiKeySpec struct {
@@ -355,6 +357,11 @@ type quotaReserveSnapshot struct {
 	WeeklyRemainingPercent       *int   `json:"weeklyRemainingPercent,omitempty"`
 	HourlyWindowPresent          *bool  `json:"hourlyWindowPresent,omitempty"`
 	WeeklyWindowPresent          *bool  `json:"weeklyWindowPresent,omitempty"`
+	// ModelExclusions is the complete effective model exclusion set for the
+	// account when non-nil. An explicit empty array authoritatively clears stale
+	// exclusions from the manifest or auth JSON. Nil is invalid and fail-closed
+	// when a state path is configured; only state-less use retains legacy input.
+	ModelExclusions []string `json:"modelExclusions"`
 }
 
 type quotaReserveStateFile struct {
@@ -2248,6 +2255,7 @@ type imageRequestSelector struct {
 // such as session affinity can reuse a cached account binding.
 type modelExclusionSelector struct {
 	manifest *manifest
+	quota    *quotaReserveStateStore
 	fallback coreauth.Selector
 }
 
@@ -2277,7 +2285,7 @@ func (s *modelExclusionSelector) Pick(ctx context.Context, provider, model strin
 	}
 	filtered := make([]*coreauth.Auth, 0, len(auths))
 	for _, auth := range auths {
-		if authModelExcluded(s.manifest, auth, model) {
+		if authModelExcluded(s.manifest, s.quota, auth, model) {
 			continue
 		}
 		filtered = append(filtered, auth)
@@ -2352,22 +2360,27 @@ func newQuotaReserveStateStore(path string, m *manifest) *quotaReserveStateStore
 }
 
 func (s *quotaReserveStateStore) load() error {
+	_, err := s.reload()
+	return err
+}
+
+func (s *quotaReserveStateStore) reload() ([]string, error) {
 	if s == nil || s.path == "" {
-		return nil
+		return nil, nil
 	}
 	content, err := os.ReadFile(s.path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	hash := sha256.Sum256(content)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.hasHash && hash == s.lastHash {
-		return nil
+		return nil, nil
 	}
 	var state quotaReserveStateFile
 	if err := json.Unmarshal(content, &state); err != nil {
-		return err
+		return nil, err
 	}
 	if state.Accounts == nil {
 		state.Accounts = make(map[string]quotaReserveSnapshot)
@@ -2376,16 +2389,23 @@ func (s *quotaReserveStateStore) load() error {
 	for accountID, snapshot := range state.Accounts {
 		accountID = strings.TrimSpace(accountID)
 		if accountID != "" {
+			snapshot.ModelExclusions = normalizeModelExclusions(snapshot.ModelExclusions)
 			normalized[accountID] = snapshot
 		}
 	}
+	previous, _ := s.snapshot.Load().(map[string]quotaReserveSnapshot)
+	changedAccountIDs := changedModelExclusionAccountIDs(previous, normalized)
 	s.snapshot.Store(normalized)
 	s.lastHash = hash
 	s.hasHash = true
-	return nil
+	return changedAccountIDs, nil
 }
 
-func (s *quotaReserveStateStore) start(ctx context.Context, emitter *eventEmitter) {
+func (s *quotaReserveStateStore) start(
+	ctx context.Context,
+	emitter *eventEmitter,
+	onModelExclusionsChanged func([]string),
+) {
 	if s == nil || s.path == "" {
 		return
 	}
@@ -2394,7 +2414,8 @@ func (s *quotaReserveStateStore) start(ctx context.Context, emitter *eventEmitte
 		defer ticker.Stop()
 		lastError := ""
 		for {
-			if err := s.load(); err != nil {
+			changedAccountIDs, err := s.reload()
+			if err != nil {
 				message := err.Error()
 				if message != lastError && emitter != nil {
 					emitter.emit(map[string]any{
@@ -2405,6 +2426,9 @@ func (s *quotaReserveStateStore) start(ctx context.Context, emitter *eventEmitte
 				lastError = message
 			} else {
 				lastError = ""
+				if len(changedAccountIDs) > 0 && onModelExclusionsChanged != nil {
+					onModelExclusionsChanged(changedAccountIDs)
+				}
 			}
 			select {
 			case <-ctx.Done():
@@ -2413,6 +2437,51 @@ func (s *quotaReserveStateStore) start(ctx context.Context, emitter *eventEmitte
 			}
 		}
 	}()
+}
+
+func normalizeModelExclusions(exclusions []string) []string {
+	if exclusions == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(exclusions))
+	normalized := make([]string, 0, len(exclusions))
+	for _, exclusion := range exclusions {
+		exclusion = strings.TrimSpace(exclusion)
+		if exclusion == "" {
+			continue
+		}
+		key := strings.ToLower(exclusion)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, key)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func changedModelExclusionAccountIDs(
+	previous map[string]quotaReserveSnapshot,
+	current map[string]quotaReserveSnapshot,
+) []string {
+	accountIDs := make(map[string]struct{}, len(previous)+len(current))
+	for accountID := range previous {
+		accountIDs[accountID] = struct{}{}
+	}
+	for accountID := range current {
+		accountIDs[accountID] = struct{}{}
+	}
+	changed := make([]string, 0)
+	for accountID := range accountIDs {
+		before := previous[accountID].ModelExclusions
+		after := current[accountID].ModelExclusions
+		if (before == nil) != (after == nil) || !slices.Equal(before, after) {
+			changed = append(changed, accountID)
+		}
+	}
+	sort.Strings(changed)
+	return changed
 }
 
 func (s *quotaReserveStateStore) forAccount(accountID string) *quotaReserveSnapshot {
@@ -2429,6 +2498,17 @@ func (s *quotaReserveStateStore) forAccount(accountID string) *quotaReserveSnaps
 		return nil
 	}
 	return &snapshot
+}
+
+func (s *quotaReserveStateStore) modelExclusionsForAccount(accountID string) ([]string, bool) {
+	snapshot := s.forAccount(accountID)
+	if s == nil || strings.TrimSpace(s.path) == "" {
+		return nil, false
+	}
+	if snapshot == nil || snapshot.ModelExclusions == nil {
+		return []string{"*"}, true
+	}
+	return append([]string(nil), snapshot.ModelExclusions...), true
 }
 
 func (s *quotaReserveSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*coreauth.Auth) (*coreauth.Auth, error) {
@@ -2564,7 +2644,7 @@ func (s *cockpitSelector) Pick(ctx context.Context, provider, model string, opts
 		if !authAvailable(auth, model, now) {
 			continue
 		}
-		if authModelExcluded(s.manifest, auth, model) {
+		if authModelExcluded(s.manifest, s.quota, auth, model) {
 			continue
 		}
 		if reason := quotaReserveBlockReasonWithState(s.accountForAuth(auth), s.quota, now); reason != "" {
@@ -2726,6 +2806,9 @@ func quotaReserveBlockReasonWithState(account *accountSpec, state *quotaReserveS
 	var snapshot *quotaReserveSnapshot
 	if account != nil && state != nil {
 		snapshot = state.forAccount(account.ID)
+		if strings.TrimSpace(state.path) != "" {
+			return quotaReserveBlockReasonWithSnapshot(account, snapshot, now)
+		}
 	}
 	if snapshot == nil {
 		snapshot = quotaReserveSnapshotFromSpec(account)
@@ -3081,24 +3164,7 @@ func (s *cockpitSelector) accountForAuth(auth *coreauth.Auth) *accountSpec {
 }
 
 func accountForAuthInManifest(m *manifest, auth *coreauth.Auth) *accountSpec {
-	if m == nil || auth == nil {
-		return nil
-	}
-	if auth.ID != "" {
-		if account := m.accountByAuthID[strings.ToLower(auth.ID)]; account != nil {
-			return account
-		}
-		base := strings.TrimSuffix(filepath.Base(auth.ID), filepath.Ext(auth.ID))
-		if account := m.accountByID[base]; account != nil {
-			return account
-		}
-	}
-	if auth.Attributes != nil {
-		if key := strings.TrimSpace(auth.Attributes["api_key"]); key != "" {
-			return m.accountByAPIKey[key]
-		}
-	}
-	return nil
+	return findManifestAccountForAuth(m, auth)
 }
 
 func (s *cockpitSelector) emitAuthSelected(ctx context.Context, auth *coreauth.Auth, provider, model string, candidateAuths, availableAuths int) {
@@ -3223,7 +3289,7 @@ func (p *usagePlugin) accountForRecord(record coreusage.Record) *accountSpec {
 		return nil
 	}
 	if record.AuthID != "" {
-		if account := p.manifest.accountByAuthID[strings.ToLower(record.AuthID)]; account != nil {
+		if account := manifestAccountByAuthID(p.manifest, record.AuthID); account != nil {
 			return account
 		}
 		base := strings.TrimSuffix(filepath.Base(record.AuthID), filepath.Ext(record.AuthID))
@@ -3396,7 +3462,7 @@ func (h *authHook) accountForAuthID(authID string) *accountSpec {
 	if authID == "" {
 		return nil
 	}
-	if account := h.manifest.accountByAuthID[strings.ToLower(authID)]; account != nil {
+	if account := manifestAccountByAuthID(h.manifest, authID); account != nil {
 		return account
 	}
 	base := strings.TrimSuffix(filepath.Base(authID), filepath.Ext(authID))
@@ -3441,7 +3507,7 @@ func buildCoreAuthSelector(cfg *config.Config, selector coreauth.Selector, m *ma
 	if m != nil {
 		selector = &backupAccountSelector{manifest: m, fallback: selector}
 		selector = &quotaReserveSelector{manifest: m, fallback: selector, quota: quota}
-		selector = &modelExclusionSelector{manifest: m, fallback: selector}
+		selector = &modelExclusionSelector{manifest: m, quota: quota, fallback: selector}
 	}
 	return selector
 }
@@ -3650,7 +3716,14 @@ func buildCodexAlphaSearchHeaders(src http.Header, auth *coreauth.Auth) http.Hea
 	return headers
 }
 
-func newSidecarRuntime(ctx context.Context, configPath string, cfg *config.Config, m *manifest, manager *coreauth.Manager) (*sidecarRuntime, error) {
+func newSidecarRuntime(
+	ctx context.Context,
+	configPath string,
+	cfg *config.Config,
+	m *manifest,
+	quota *quotaReserveStateStore,
+	manager *coreauth.Manager,
+) (*sidecarRuntime, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
 	}
@@ -3679,6 +3752,17 @@ func newSidecarRuntime(ctx context.Context, configPath string, cfg *config.Confi
 		WithHooks(cliproxy.Hooks{
 			OnAfterStart: func(*cliproxy.Service) {
 				readyOnce.Do(func() { close(readyCh) })
+			},
+			PrepareAuthUpsert: func(_ *cliproxy.Service, auth *coreauth.Auth) (*coreauth.Auth, error) {
+				return prepareManifestCodexAuthUpdate(cfg, m, auth)
+			},
+			OnAuthUpserted: func(_ *cliproxy.Service, auth *coreauth.Auth) bool {
+				if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+					return false
+				}
+				linkManifestAccountForAuth(m, auth)
+				registerManifestModelsForAuth(manager, m, quota, auth)
+				return true
 			},
 		}).
 		Build()
@@ -3716,7 +3800,7 @@ func newSidecarRuntime(ctx context.Context, configPath string, cfg *config.Confi
 		cancel()
 		return nil, err
 	}
-	if err := registerManifestCodexTokenAuths(runtimeCtx, service, cfg, m, manager); err != nil {
+	if err := registerManifestCodexTokenAuths(runtimeCtx, service, cfg, m, quota, manager); err != nil {
 		cancel()
 		return nil, err
 	}
@@ -3725,7 +3809,7 @@ func newSidecarRuntime(ctx context.Context, configPath string, cfg *config.Confi
 			continue
 		}
 		linkManifestAccountForAuth(m, auth)
-		registerManifestModelsForAuth(manager, m, auth)
+		registerManifestModelsForAuth(manager, m, quota, auth)
 	}
 	service.RebindRuntimeExecutors()
 
@@ -3761,11 +3845,62 @@ func registerConfigCodexAPIKeyAuths(ctx context.Context, service *cliproxy.Servi
 	return nil
 }
 
+func prepareManifestCodexAuthUpdate(
+	cfg *config.Config,
+	m *manifest,
+	auth *coreauth.Auth,
+) (*coreauth.Auth, error) {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return auth, nil
+	}
+	account := findManifestAccountForAuth(m, auth)
+	if account == nil || manifestAccountAuthKind(account) == "api_key" {
+		return auth, nil
+	}
+	path := ""
+	if auth.Attributes != nil {
+		path = strings.TrimSpace(auth.Attributes["path"])
+		if path == "" {
+			path = strings.TrimSpace(auth.Attributes["source"])
+		}
+	}
+	if path == "" {
+		path = strings.TrimSpace(account.AuthID)
+	}
+	if path == "" {
+		return auth, nil
+	}
+	authDir := ""
+	if cfg != nil {
+		authDir = strings.TrimSpace(cfg.AuthDir)
+	}
+	if !filepath.IsAbs(path) && authDir != "" {
+		path = filepath.Join(authDir, path)
+	}
+	prepared, err := readManifestCodexTokenAuth(account, authDir, path)
+	if err != nil {
+		return nil, err
+	}
+	prepared.ID = auth.ID
+	prepared.FileName = auth.ID
+	prepared.Prefix = auth.Prefix
+	if prepared.Attributes == nil {
+		prepared.Attributes = make(map[string]string)
+	}
+	for key, value := range auth.Attributes {
+		if _, exists := prepared.Attributes[key]; !exists {
+			prepared.Attributes[key] = value
+		}
+	}
+	return prepared, nil
+}
+
 func registerManifestCodexTokenAuths(
 	ctx context.Context,
 	service *cliproxy.Service,
 	cfg *config.Config,
 	m *manifest,
+	quota *quotaReserveStateStore,
 	manager *coreauth.Manager,
 ) error {
 	if service == nil || cfg == nil || m == nil {
@@ -3790,7 +3925,7 @@ func registerManifestCodexTokenAuths(
 			return fmt.Errorf("register codex token auth %s: %w", auth.ID, err)
 		}
 		linkManifestAccountForAuth(m, registered)
-		registerManifestModelsForAuth(manager, m, registered)
+		registerManifestModelsForAuth(manager, m, quota, registered)
 	}
 	return nil
 }
@@ -4009,23 +4144,40 @@ func ensureSidecarAuthDir(cfg *config.Config) error {
 	return nil
 }
 
+func manifestAccountByAuthID(m *manifest, authID string) *accountSpec {
+	if m == nil {
+		return nil
+	}
+	key := strings.ToLower(strings.TrimSpace(authID))
+	if key == "" {
+		return nil
+	}
+	if account := m.accountByAuthID[key]; account != nil {
+		return account
+	}
+	value, ok := m.runtimeAccountByAuthID.Load(key)
+	if !ok {
+		return nil
+	}
+	account, _ := value.(*accountSpec)
+	return account
+}
+
 func linkManifestAccountForAuth(m *manifest, auth *coreauth.Auth) {
 	if m == nil || auth == nil || strings.TrimSpace(auth.ID) == "" {
 		return
 	}
-	if m.accountByAuthID == nil {
-		m.accountByAuthID = make(map[string]*accountSpec)
+	if manifestAccountByAuthID(m, auth.ID) != nil {
+		return
+	}
+	account := findManifestAccountForAuth(m, auth)
+	if account == nil {
+		return
 	}
 	authID := strings.ToLower(strings.TrimSpace(auth.ID))
-	if _, exists := m.accountByAuthID[authID]; exists {
-		return
-	}
-	if account := findManifestAccountForAuth(m, auth); account != nil {
-		m.accountByAuthID[authID] = account
-		if base := strings.ToLower(filepath.Base(strings.TrimSpace(auth.ID))); base != "" && base != authID {
-			m.accountByAuthID[base] = account
-		}
-		return
+	m.runtimeAccountByAuthID.LoadOrStore(authID, account)
+	if base := strings.ToLower(filepath.Base(strings.TrimSpace(auth.ID))); base != "" && base != authID {
+		m.runtimeAccountByAuthID.LoadOrStore(base, account)
 	}
 }
 
@@ -4042,16 +4194,21 @@ func findManifestAccountForAuth(m *manifest, auth *coreauth.Auth) *accountSpec {
 		if candidate == "." || candidate == "" {
 			continue
 		}
-		if account := m.accountByAuthID[strings.ToLower(candidate)]; account != nil {
+		if account := manifestAccountByAuthID(m, candidate); account != nil {
+			return account
+		}
+		base := filepath.Base(candidate)
+		accountID := strings.TrimSuffix(base, filepath.Ext(base))
+		if account := m.accountByID[accountID]; account != nil {
 			return account
 		}
 	}
 	if auth.Attributes != nil {
 		if path := strings.TrimSpace(auth.Attributes["path"]); path != "" {
-			if account := m.accountByAuthID[strings.ToLower(path)]; account != nil {
+			if account := manifestAccountByAuthID(m, path); account != nil {
 				return account
 			}
-			if account := m.accountByAuthID[strings.ToLower(filepath.Base(path))]; account != nil {
+			if account := manifestAccountByAuthID(m, filepath.Base(path)); account != nil {
 				return account
 			}
 		}
@@ -4096,22 +4253,109 @@ func findManifestAccountForAuth(m *manifest, auth *coreauth.Auth) *accountSpec {
 	return nil
 }
 
-func registerManifestModelsForAuth(manager *coreauth.Manager, m *manifest, auth *coreauth.Auth) {
+func registerManifestModelsForAuth(
+	manager *coreauth.Manager,
+	m *manifest,
+	quota *quotaReserveStateStore,
+	auth *coreauth.Auth,
+) {
+	updateManifestModelsForAuth(manager, m, quota, auth, false)
+}
+
+func reconcileManifestModelsForAuthPreservingState(
+	manager *coreauth.Manager,
+	m *manifest,
+	quota *quotaReserveStateStore,
+	auth *coreauth.Auth,
+) {
+	updateManifestModelsForAuth(manager, m, quota, auth, true)
+}
+
+func updateManifestModelsForAuth(
+	manager *coreauth.Manager,
+	m *manifest,
+	quota *quotaReserveStateStore,
+	auth *coreauth.Auth,
+	preserveOverlapState bool,
+) {
 	if manager == nil || m == nil || auth == nil || strings.TrimSpace(auth.ID) == "" {
 		return
 	}
-	models := filterRegistryModelsByExcluded(manifestRegistryModels(m), excludedModelsForAuth(m, auth))
-	if len(models) == 0 {
-		cliproxy.GlobalModelRegistry().UnregisterClient(auth.ID)
-		manager.RefreshSchedulerEntry(auth.ID)
+	authID := strings.TrimSpace(auth.ID)
+	reconcileCtx := coreauth.WithSkipPersist(context.Background())
+	reconcileModelStates := manager.ReconcileRegistryModelStates
+	if preserveOverlapState {
+		reconcileModelStates = manager.PruneRegistryModelStates
+	}
+	current, exists := manager.GetByID(authID)
+	if !exists || current == nil || current.Disabled || current.Status == coreauth.StatusDisabled ||
+		!strings.EqualFold(strings.TrimSpace(current.Provider), "codex") {
+		cliproxy.GlobalModelRegistry().UnregisterClient(authID)
+		reconcileModelStates(reconcileCtx, authID)
+		manager.RefreshSchedulerEntry(authID)
 		return
 	}
-	cliproxy.GlobalModelRegistry().RegisterClient(auth.ID, "codex", models)
-	manager.ReconcileRegistryModelStates(context.Background(), auth.ID)
-	manager.RefreshSchedulerEntry(auth.ID)
+	auth = current
+	models := filterRegistryModelsByExcluded(m, manifestRegistryModels(m), excludedModelsForAuth(m, quota, auth))
+	if len(models) == 0 {
+		cliproxy.GlobalModelRegistry().UnregisterClient(authID)
+		reconcileModelStates(reconcileCtx, authID)
+		manager.RefreshSchedulerEntry(authID)
+		return
+	}
+	if preserveOverlapState {
+		cliproxy.GlobalModelRegistry().ReconcileClientModelsPreservingState(authID, "codex", models)
+	} else {
+		cliproxy.GlobalModelRegistry().RegisterClient(authID, "codex", models)
+	}
+	latest, exists := manager.GetByID(authID)
+	if !exists || latest == nil || latest.Disabled || latest.Status == coreauth.StatusDisabled ||
+		!strings.EqualFold(strings.TrimSpace(latest.Provider), "codex") {
+		cliproxy.GlobalModelRegistry().UnregisterClient(authID)
+	}
+	reconcileModelStates(reconcileCtx, authID)
+	manager.RefreshSchedulerEntry(authID)
 }
 
-func excludedModelsForAuth(m *manifest, auth *coreauth.Auth) []string {
+func refreshManifestModelsForAccounts(
+	manager *coreauth.Manager,
+	m *manifest,
+	quota *quotaReserveStateStore,
+	accountIDs []string,
+) {
+	if manager == nil || m == nil || len(accountIDs) == 0 {
+		return
+	}
+	changed := make(map[string]struct{}, len(accountIDs))
+	for _, accountID := range accountIDs {
+		if accountID = strings.TrimSpace(accountID); accountID != "" {
+			changed[accountID] = struct{}{}
+		}
+	}
+	if len(changed) == 0 {
+		return
+	}
+	for _, auth := range manager.List() {
+		if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+			continue
+		}
+		account := accountForAuthInManifest(m, auth)
+		if account == nil {
+			continue
+		}
+		if _, ok := changed[account.ID]; !ok {
+			continue
+		}
+		reconcileManifestModelsForAuthPreservingState(manager, m, quota, auth)
+	}
+}
+
+func excludedModelsForAuth(m *manifest, quota *quotaReserveStateStore, auth *coreauth.Auth) []string {
+	if account := accountForAuthInManifest(m, auth); account != nil && quota != nil {
+		if exclusions, authoritative := quota.modelExclusionsForAccount(account.ID); authoritative {
+			return exclusions
+		}
+	}
 	seen := make(map[string]struct{})
 	add := func(items []string) {
 		for _, item := range items {
@@ -4192,7 +4436,7 @@ func extractExcludedModelsFromMetadataMap(metadata map[string]any) []string {
 	}
 }
 
-func filterRegistryModelsByExcluded(models []*cliproxy.ModelInfo, excluded []string) []*cliproxy.ModelInfo {
+func filterRegistryModelsByExcluded(m *manifest, models []*cliproxy.ModelInfo, excluded []string) []*cliproxy.ModelInfo {
 	if len(models) == 0 || len(excluded) == 0 {
 		return models
 	}
@@ -4201,24 +4445,33 @@ func filterRegistryModelsByExcluded(models []*cliproxy.ModelInfo, excluded []str
 		if model == nil || strings.TrimSpace(model.ID) == "" || modelMatchesAnyRule(model.ID, excluded) {
 			continue
 		}
+		canonical := canonicalModelForClientModel(m, nil, model.ID)
+		if canonical != "" && modelMatchesAnyRule(canonical, excluded) {
+			continue
+		}
 		filtered = append(filtered, model)
 	}
 	return filtered
 }
 
-func authModelExcluded(m *manifest, auth *coreauth.Auth, model string) bool {
+func authModelExcluded(
+	m *manifest,
+	quota *quotaReserveStateStore,
+	auth *coreauth.Auth,
+	model string,
+) bool {
 	model = strings.TrimSpace(model)
 	if model == "" || auth == nil {
 		return false
 	}
-	excluded := excludedModelsForAuth(m, auth)
+	excluded := excludedModelsForAuth(m, quota, auth)
 	if len(excluded) == 0 {
 		return false
 	}
 	if modelMatchesAnyRule(model, excluded) {
 		return true
 	}
-	canonical := resolveSupportedModelAlias(m, model)
+	canonical := canonicalModelForClientModel(m, nil, model)
 	return canonical != "" && modelMatchesAnyRule(canonical, excluded)
 }
 
@@ -8412,6 +8665,7 @@ func main() {
 			"type":    "quota_reserve_state_error",
 			"message": err.Error(),
 		})
+		os.Exit(1)
 	}
 
 	usageTracker := newRequestUsageTracker()
@@ -8437,17 +8691,19 @@ func main() {
 	defer stop()
 	ctx, cancel := context.WithCancel(signalCtx)
 	defer cancel()
-	quotaState.start(ctx, emitter)
 	monitorParentProcess(ctx, *parentPID, cancel, emitter)
 
 	coreusage.RegisterPlugin(&usagePlugin{manifest: m, tracker: usageTracker})
 
-	runtime, err := newSidecarRuntime(ctx, absConfigPath, cfg, m, coreManager)
+	runtime, err := newSidecarRuntime(ctx, absConfigPath, cfg, m, quotaState, coreManager)
 	if err != nil {
 		emitter.emit(map[string]any{"type": "error", "message": err.Error()})
 		os.Exit(1)
 	}
 	defer runtime.Stop()
+	quotaState.start(ctx, emitter, func(accountIDs []string) {
+		refreshManifestModelsForAccounts(coreManager, m, quotaState, accountIDs)
+	})
 	emitter.emitStartupStage("start_http_server")
 
 	// Reuse the same coreManager so WS upgrades share OAuth pool, routing and

--- a/sidecars/cockpit-cliproxy/main_test.go
+++ b/sidecars/cockpit-cliproxy/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1425,6 +1426,185 @@ func TestQuotaReserveStateStoreHotReloadsSnapshot(t *testing.T) {
 	}
 }
 
+func TestQuotaReserveStateStoreConfiguredPathRequiresValidInitialState(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "quota-reserve.json")
+	store := newQuotaReserveStateStore(statePath, nil)
+	if err := store.load(); !os.IsNotExist(err) {
+		t.Fatalf("missing configured state error = %v, want not-exist", err)
+	}
+	if err := os.WriteFile(statePath, []byte(`{"accounts":`), 0o600); err != nil {
+		t.Fatalf("write malformed state: %v", err)
+	}
+	if err := store.load(); err == nil {
+		t.Fatal("malformed configured state should fail to load")
+	}
+	if err := newQuotaReserveStateStore("", nil).load(); err != nil {
+		t.Fatalf("state-less legacy store should not require a file: %v", err)
+	}
+}
+
+func TestQuotaReserveStateMissingSnapshotFailsClosedQuotaReserve(t *testing.T) {
+	now := time.Now()
+	hourlyThreshold := 20
+	weeklyThreshold := 10
+	hourlyRemaining := 80
+	weeklyRemaining := 80
+	windowPresent := true
+	account := &accountSpec{
+		ID:    "protected",
+		Email: "protected@example.com",
+		QuotaReserve: &quotaReserveSpec{
+			HourlyThresholdPercent:       &hourlyThreshold,
+			WeeklyThresholdPercent:       &weeklyThreshold,
+			SnapshotUpdatedAtUnixSeconds: int64PointerForTest(now.Unix()),
+			HourlyRemainingPercent:       &hourlyRemaining,
+			WeeklyRemainingPercent:       &weeklyRemaining,
+			HourlyWindowPresent:          &windowPresent,
+			WeeklyWindowPresent:          &windowPresent,
+		},
+	}
+	statePath := filepath.Join(t.TempDir(), "quota-reserve.json")
+	content, err := json.Marshal(quotaReserveStateFile{
+		Accounts: map[string]quotaReserveSnapshot{},
+	})
+	if err != nil {
+		t.Fatalf("marshal quota reserve state: %v", err)
+	}
+	if err := os.WriteFile(statePath, content, 0o600); err != nil {
+		t.Fatalf("write quota reserve state: %v", err)
+	}
+	store := newQuotaReserveStateStore(statePath, &manifest{Accounts: []accountSpec{*account}})
+	if err := store.load(); err != nil {
+		t.Fatalf("load quota reserve state: %v", err)
+	}
+	if reason := quotaReserveBlockReasonWithState(account, store, now); !strings.Contains(reason, "quota snapshot unknown") {
+		t.Fatalf("configured state missing account should fail closed, got %q", reason)
+	}
+
+	legacyStore := newQuotaReserveStateStore("", &manifest{Accounts: []accountSpec{*account}})
+	if reason := quotaReserveBlockReasonWithState(account, legacyStore, now); reason != "" {
+		t.Fatalf("state-less legacy store should retain manifest fallback, got %q", reason)
+	}
+}
+
+func TestQuotaReserveStateModelExclusionsAreAuthoritative(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "quota-reserve.json")
+	m := &manifest{
+		ExcludedModels: []string{"manifest-stale-model"},
+		Accounts: []accountSpec{{
+			ID:     "plus-account",
+			AuthID: "plus-auth.json",
+		}},
+		AccountModelRules: []accountModelRule{{
+			AccountID:      "plus-account",
+			ExcludedModels: []string{codexSparkModel},
+		}},
+	}
+	m.accountByID = map[string]*accountSpec{"plus-account": &m.Accounts[0]}
+	m.accountByAuthID = map[string]*accountSpec{"plus-auth.json": &m.Accounts[0]}
+	auth := &coreauth.Auth{
+		ID: "plus-auth.json",
+		Metadata: map[string]any{
+			"excluded_models": []string{"auth-stale-model"},
+		},
+	}
+
+	writeState := func(snapshot quotaReserveSnapshot) {
+		t.Helper()
+		content, err := json.Marshal(quotaReserveStateFile{Accounts: map[string]quotaReserveSnapshot{
+			"plus-account": snapshot,
+		}})
+		if err != nil {
+			t.Fatalf("marshal quota reserve state: %v", err)
+		}
+		if err := os.WriteFile(statePath, content, 0o600); err != nil {
+			t.Fatalf("write quota reserve state: %v", err)
+		}
+	}
+
+	writeState(quotaReserveSnapshot{ModelExclusions: []string{}})
+	store := newQuotaReserveStateStore(statePath, m)
+	changed, err := store.reload()
+	if err != nil {
+		t.Fatalf("load authoritative empty exclusions: %v", err)
+	}
+	if !slices.Equal(changed, []string{"plus-account"}) {
+		t.Fatalf("changed accounts = %#v, want plus-account", changed)
+	}
+	if excluded := excludedModelsForAuth(m, store, auth); len(excluded) != 0 {
+		t.Fatalf("explicit empty state must clear stale fallback exclusions, got %#v", excluded)
+	}
+
+	writeState(quotaReserveSnapshot{
+		HourlyRemainingPercent: intPointerForTest(75),
+		ModelExclusions:        []string{" GPT-5.7-* ", codexSparkModel, strings.ToUpper(codexSparkModel)},
+	})
+	changed, err = store.reload()
+	if err != nil {
+		t.Fatalf("load authoritative exclusions: %v", err)
+	}
+	if !slices.Equal(changed, []string{"plus-account"}) {
+		t.Fatalf("changed accounts = %#v, want plus-account", changed)
+	}
+	if !authModelExcluded(m, store, auth, codexSparkModel) {
+		t.Fatal("authoritative state should exclude Spark")
+	}
+	if !authModelExcluded(m, store, auth, "gpt-5.7-preview") {
+		t.Fatal("authoritative state wildcard should exclude gpt-5.7-preview")
+	}
+	if authModelExcluded(m, store, auth, "manifest-stale-model") {
+		t.Fatal("authoritative state must replace, not merge, stale manifest exclusions")
+	}
+
+	writeState(quotaReserveSnapshot{
+		HourlyRemainingPercent: intPointerForTest(40),
+		ModelExclusions:        []string{codexSparkModel, "gpt-5.7-*"},
+	})
+	changed, err = store.reload()
+	if err != nil {
+		t.Fatalf("load quota-only change: %v", err)
+	}
+	if len(changed) != 0 {
+		t.Fatalf("quota-only state update should not trigger registry refresh, got %#v", changed)
+	}
+
+	if err := os.WriteFile(statePath, []byte(`{"accounts":{"plus-account":{}}}`), 0o600); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+	changed, err = store.reload()
+	if err != nil {
+		t.Fatalf("load legacy state: %v", err)
+	}
+	if !slices.Equal(changed, []string{"plus-account"}) {
+		t.Fatalf("changed accounts = %#v, want plus-account", changed)
+	}
+	if excluded := excludedModelsForAuth(m, store, auth); !slices.Equal(excluded, []string{"*"}) {
+		t.Fatalf("missing authoritative field should fail closed, got %#v", excluded)
+	}
+
+	for name, content := range map[string]string{
+		"missing account": `{"accounts":{}}`,
+		"null field":      `{"accounts":{"plus-account":{"modelExclusions":null}}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(statePath, []byte(content), 0o600); err != nil {
+				t.Fatalf("write incomplete state: %v", err)
+			}
+			if err := store.load(); err != nil {
+				t.Fatalf("load incomplete state: %v", err)
+			}
+			if excluded := excludedModelsForAuth(m, store, auth); !slices.Equal(excluded, []string{"*"}) {
+				t.Fatalf("incomplete authoritative state should fail closed, got %#v", excluded)
+			}
+		})
+	}
+
+	legacyStore := newQuotaReserveStateStore("", m)
+	if excluded := excludedModelsForAuth(m, legacyStore, auth); len(excluded) != 3 {
+		t.Fatalf("state-less legacy use should retain manifest/auth behavior, got %#v", excluded)
+	}
+}
+
 func TestQuotaReserveSelectorFiltersCachedSessionAffinityAuth(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -1685,7 +1865,8 @@ func TestSidecarRuntimeRegistersConfigCodexAPIKeyAuths(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		AuthDir: authDir,
+		AuthDir:                authDir,
+		DisableAuthAutoRefresh: true,
 		CodexKey: []config.CodexKey{{
 			APIKey:  "sk-upstream",
 			BaseURL: "http://127.0.0.1:1",
@@ -1701,7 +1882,7 @@ func TestSidecarRuntimeRegistersConfigCodexAPIKeyAuths(t *testing.T) {
 	}
 	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
 
-	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager)
+	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, nil, manager)
 	if err != nil {
 		t.Fatalf("newSidecarRuntime: %v", err)
 	}
@@ -1720,7 +1901,7 @@ func TestSidecarRuntimeRegistersConfigCodexAPIKeyAuths(t *testing.T) {
 	if codexAPIKeyAuth == nil {
 		t.Fatalf("expected codex API Key auth to be registered, got %#v", manager.List())
 	}
-	if got := m.accountByAuthID[strings.ToLower(codexAPIKeyAuth.ID)]; got == nil || got.ID != "api-account" {
+	if got := manifestAccountByAuthID(m, codexAPIKeyAuth.ID); got == nil || got.ID != "api-account" {
 		t.Fatalf("expected auth to be linked to manifest account, got %#v", got)
 	}
 }
@@ -1749,7 +1930,7 @@ func TestSidecarRuntimeRegistersManifestCodexAccessTokenAuths(t *testing.T) {
 		t.Fatalf("write auth file: %v", err)
 	}
 
-	cfg := &config.Config{AuthDir: authDir}
+	cfg := &config.Config{AuthDir: authDir, DisableAuthAutoRefresh: true}
 	account := &accountSpec{
 		ID:               "token-account",
 		Email:            "token@example.com",
@@ -1769,7 +1950,7 @@ func TestSidecarRuntimeRegistersManifestCodexAccessTokenAuths(t *testing.T) {
 	}
 	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
 
-	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager)
+	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, nil, manager)
 	if err != nil {
 		t.Fatalf("newSidecarRuntime: %v", err)
 	}
@@ -1791,7 +1972,7 @@ func TestSidecarRuntimeRegistersManifestCodexAccessTokenAuths(t *testing.T) {
 	if tokenAuth.ProxyURL != "http://127.0.0.1:9" {
 		t.Fatalf("expected proxy url from auth metadata, got %q", tokenAuth.ProxyURL)
 	}
-	if got := m.accountByAuthID[strings.ToLower(tokenAuth.ID)]; got == nil || got.ID != "token-account" {
+	if got := manifestAccountByAuthID(m, tokenAuth.ID); got == nil || got.ID != "token-account" {
 		t.Fatalf("expected token auth to be linked to manifest account, got %#v", got)
 	}
 	if info := findModelInfoForTest(
@@ -1885,7 +2066,7 @@ func TestManifestRegisteredModelsPreserveReasoningEffortThroughThinkingPipeline(
 			SourceModel: "gpt-5.2",
 			Alias:       "gpt-5.2-codex",
 		}},
-	}, auth)
+	}, nil, auth)
 
 	for _, model := range []string{"gpt-5.2", "gpt-5.2-codex"} {
 		out, err := thinking.ApplyThinking(
@@ -4224,9 +4405,35 @@ func TestFilterRegistryModelsByExcludedModels(t *testing.T) {
 		{ID: "gpt-5.3-codex-spark"},
 		{ID: "gpt-5.4"},
 	}
-	filtered := filterRegistryModelsByExcluded(models, []string{"gpt-5.3-*"})
+	filtered := filterRegistryModelsByExcluded(nil, models, []string{"gpt-5.3-*"})
 	if len(filtered) != 1 || filtered[0].ID != "gpt-5.4" {
 		t.Fatalf("unexpected filtered models: %#v", filtered)
+	}
+}
+
+func TestFilterRegistryModelsByExcludedCanonicalSourceRemovesAlias(t *testing.T) {
+	const sparkAlias = "spark-worker-alias"
+	m := &manifest{
+		ModelIDs: []string{codexSparkModel, "gpt-5.4"},
+		ModelAliases: []modelAliasSpec{{
+			SourceModel: codexSparkModel,
+			Alias:       sparkAlias,
+			Fork:        true,
+		}},
+		aliasToSource: map[string]string{sparkAlias: codexSparkModel},
+	}
+	filtered := filterRegistryModelsByExcluded(m, manifestRegistryModels(m), []string{codexSparkModel})
+	seen := make(map[string]bool, len(filtered))
+	for _, model := range filtered {
+		if model != nil {
+			seen[strings.ToLower(model.ID)] = true
+		}
+	}
+	if seen[strings.ToLower(codexSparkModel)] || seen[sparkAlias] {
+		t.Fatalf("Spark source exclusion left source or alias registered: %#v", filtered)
+	}
+	if !seen["gpt-5.4"] {
+		t.Fatalf("unrelated model was removed with Spark source: %#v", filtered)
 	}
 }
 
@@ -4246,7 +4453,9 @@ func TestExcludedModelsForAuthMergesManifestAndMetadata(t *testing.T) {
 	m.accountByID = map[string]*accountSpec{"plus-account": &m.Accounts[0]}
 	m.accountByAuthID = map[string]*accountSpec{"plus-auth": &m.Accounts[0]}
 	auth := &coreauth.Auth{
-		ID: "plus-auth",
+		ID:       "plus-auth",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
 		Metadata: map[string]any{
 			"excluded_models": []string{"custom-model"},
 		},
@@ -4254,14 +4463,14 @@ func TestExcludedModelsForAuthMergesManifestAndMetadata(t *testing.T) {
 			"account_id": "plus-account",
 		},
 	}
-	excluded := excludedModelsForAuth(m, auth)
+	excluded := excludedModelsForAuth(m, nil, auth)
 	if len(excluded) != 3 {
 		t.Fatalf("expected 3 excluded patterns, got %#v", excluded)
 	}
-	if !authModelExcluded(m, auth, "gpt-5.3-codex-spark") {
+	if !authModelExcluded(m, nil, auth, "gpt-5.3-codex-spark") {
 		t.Fatal("spark should be excluded for plus auth")
 	}
-	if authModelExcluded(m, auth, "gpt-5.4") {
+	if authModelExcluded(m, nil, auth, "gpt-5.4") {
 		t.Fatal("gpt-5.4 should remain available")
 	}
 }
@@ -4286,16 +4495,214 @@ func TestRegisterManifestModelsForAuthRespectsPerAccountExclusions(t *testing.T)
 		},
 	}
 	manager := coreauth.NewManager(nil, &cockpitSelector{manifest: m}, nil)
+	registered, err := manager.Register(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	auth = registered
 	t.Cleanup(func() {
 		cliproxy.GlobalModelRegistry().UnregisterClient(auth.ID)
 	})
-	registerManifestModelsForAuth(manager, m, auth)
+	registerManifestModelsForAuth(manager, m, nil, auth)
 	models := registry.GetGlobalRegistry().GetModelsForClient(auth.ID)
 	for _, model := range models {
 		if strings.EqualFold(model.ID, codexSparkModel) {
 			t.Fatalf("spark should not be registered for excluded auth: %#v", models)
 		}
 	}
+}
+
+func TestRegisterManifestModelsForAuthDoesNotResurrectDisabledStaleSnapshot(t *testing.T) {
+	m := &manifest{
+		ModelIDs: []string{codexSparkModel, "gpt-5.4"},
+		Accounts: []accountSpec{{
+			ID:     "plus-account",
+			AuthID: "plus-auth.json",
+		}},
+	}
+	m.accountByID = map[string]*accountSpec{"plus-account": &m.Accounts[0]}
+	m.accountByAuthID = map[string]*accountSpec{"plus-auth.json": &m.Accounts[0]}
+	manager := coreauth.NewManager(nil, &cockpitSelector{manifest: m}, nil)
+	active, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:         "plus-auth.json",
+		Provider:   "codex",
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"account_id": "plus-account"},
+	})
+	if err != nil {
+		t.Fatalf("register active auth: %v", err)
+	}
+	t.Cleanup(func() {
+		cliproxy.GlobalModelRegistry().UnregisterClient(active.ID)
+	})
+	registerManifestModelsForAuth(manager, m, nil, active)
+	if len(registry.GetGlobalRegistry().GetModelsForClient(active.ID)) == 0 {
+		t.Fatal("active auth should initially have manifest models")
+	}
+
+	staleActive := active.Clone()
+	disabled := active.Clone()
+	disabled.Disabled = true
+	disabled.Status = coreauth.StatusDisabled
+	disabled, err = manager.Update(coreauth.WithSkipPersist(context.Background()), disabled)
+	if err != nil {
+		t.Fatalf("disable auth: %v", err)
+	}
+	registerManifestModelsForAuth(manager, m, nil, disabled)
+	if models := registry.GetGlobalRegistry().GetModelsForClient(active.ID); len(models) != 0 {
+		t.Fatalf("disabled auth should be unregistered, got %#v", models)
+	}
+
+	// A quota callback may still hold this clone from an earlier manager.List().
+	registerManifestModelsForAuth(manager, m, nil, staleActive)
+	if models := registry.GetGlobalRegistry().GetModelsForClient(active.ID); len(models) != 0 {
+		t.Fatalf("stale active snapshot resurrected disabled auth models: %#v", models)
+	}
+	current, ok := manager.GetByID(active.ID)
+	if !ok || current == nil || !current.Disabled || current.Status != coreauth.StatusDisabled {
+		t.Fatalf("manager disabled state changed unexpectedly: %#v, ok=%v", current, ok)
+	}
+}
+
+func TestRefreshManifestModelsForAccountsAppliesAuthoritativeState(t *testing.T) {
+	const lunaModel = "gpt-5.6-luna"
+	statePath := filepath.Join(t.TempDir(), "quota-reserve.json")
+	writeState := func(exclusions []string) {
+		t.Helper()
+		content, err := json.Marshal(quotaReserveStateFile{Accounts: map[string]quotaReserveSnapshot{
+			"plus-account": {ModelExclusions: exclusions},
+		}})
+		if err != nil {
+			t.Fatalf("marshal quota reserve state: %v", err)
+		}
+		if err := os.WriteFile(statePath, content, 0o600); err != nil {
+			t.Fatalf("write quota reserve state: %v", err)
+		}
+	}
+
+	m := &manifest{
+		ModelIDs: []string{codexSparkModel, lunaModel, "gpt-5.4"},
+		Accounts: []accountSpec{{
+			ID:     "plus-account",
+			AuthID: "plus-auth.json",
+		}},
+	}
+	m.accountByID = map[string]*accountSpec{"plus-account": &m.Accounts[0]}
+	m.accountByAuthID = map[string]*accountSpec{"plus-auth.json": &m.Accounts[0]}
+	writeState([]string{codexSparkModel})
+	store := newQuotaReserveStateStore(statePath, m)
+	if err := store.load(); err != nil {
+		t.Fatalf("load initial state: %v", err)
+	}
+
+	selector := buildCoreAuthSelector(&config.Config{}, &coreauth.RoundRobinSelector{}, m, store)
+	manager := coreauth.NewManager(nil, selector, nil)
+	auth := &coreauth.Auth{
+		ID:         "plus-auth.json",
+		Provider:   "codex",
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"account_id": "plus-account"},
+	}
+	registered, err := manager.Register(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	auth = registered
+	t.Cleanup(func() {
+		cliproxy.GlobalModelRegistry().UnregisterClient(auth.ID)
+		if stoppable, ok := selector.(coreauth.StoppableSelector); ok {
+			stoppable.Stop()
+		}
+	})
+
+	registerManifestModelsForAuth(manager, m, store, auth)
+	if info := findModelInfoForTest(
+		registry.GetGlobalRegistry().GetModelsForClient(auth.ID),
+		codexSparkModel,
+	); info != nil {
+		t.Fatalf("Spark should be absent under authoritative exclusion: %#v", info)
+	}
+	if _, err := selector.Pick(
+		context.Background(),
+		"codex",
+		codexSparkModel,
+		cliproxyexecutor.Options{},
+		manager.List(),
+	); err == nil {
+		t.Fatal("selector should reject Spark while state excludes it")
+	}
+
+	lunaRetry := time.Now().Add(10 * time.Minute).Round(time.Millisecond)
+	current, _ := manager.GetByID(auth.ID)
+	current.ModelStates = map[string]*coreauth.ModelState{
+		lunaModel: {
+			Status:         coreauth.StatusError,
+			StatusMessage:  "luna cooldown",
+			Unavailable:    true,
+			NextRetryAfter: lunaRetry,
+			Quota:          coreauth.QuotaState{Exceeded: true, BackoffLevel: 3},
+			UpdatedAt:      time.Now(),
+		},
+	}
+	if _, err := manager.Update(coreauth.WithSkipPersist(context.Background()), current); err != nil {
+		t.Fatalf("seed Luna manager state: %v", err)
+	}
+	registry.GetGlobalRegistry().SetModelQuotaExceeded(auth.ID, lunaModel)
+	registry.GetGlobalRegistry().SuspendClientModel(auth.ID, lunaModel, "cooldown")
+	assertLunaStatePreserved := func(stage string) {
+		t.Helper()
+		if count := registry.GetGlobalRegistry().GetModelCount(lunaModel); count != 0 {
+			t.Fatalf("%s cleared Luna registry cooldown/suspension: count=%d", stage, count)
+		}
+		current, ok := manager.GetByID(auth.ID)
+		if !ok || current == nil {
+			t.Fatalf("%s lost auth", stage)
+		}
+		state := current.ModelStates[lunaModel]
+		if state == nil || !state.Unavailable || state.Status != coreauth.StatusError ||
+			!state.NextRetryAfter.Equal(lunaRetry) || !state.Quota.Exceeded || state.Quota.BackoffLevel != 3 {
+			t.Fatalf("%s changed Luna manager state: %#v", stage, state)
+		}
+	}
+	assertLunaStatePreserved("before Spark delta")
+
+	writeState([]string{})
+	changed, err := store.reload()
+	if err != nil {
+		t.Fatalf("reload cleared exclusions: %v", err)
+	}
+	refreshManifestModelsForAccounts(manager, m, store, changed)
+	if info := findModelInfoForTest(
+		registry.GetGlobalRegistry().GetModelsForClient(auth.ID),
+		codexSparkModel,
+	); info == nil {
+		t.Fatal("Spark should be re-registered after authoritative exclusion is cleared")
+	}
+	assertLunaStatePreserved("after Spark add")
+	selected, err := selector.Pick(
+		context.Background(),
+		"codex",
+		codexSparkModel,
+		cliproxyexecutor.Options{},
+		manager.List(),
+	)
+	if err != nil || selected == nil || selected.ID != auth.ID {
+		t.Fatalf("Spark selection after clear = %#v, err=%v", selected, err)
+	}
+
+	writeState([]string{codexSparkModel})
+	changed, err = store.reload()
+	if err != nil {
+		t.Fatalf("reload restored exclusion: %v", err)
+	}
+	refreshManifestModelsForAccounts(manager, m, store, changed)
+	if info := findModelInfoForTest(
+		registry.GetGlobalRegistry().GetModelsForClient(auth.ID),
+		codexSparkModel,
+	); info != nil {
+		t.Fatalf("Spark should be unregistered after state exclusion returns: %#v", info)
+	}
+	assertLunaStatePreserved("after Spark remove")
 }
 
 func TestCoreAuthSelectorFiltersNewModelExclusionsBeforeSessionAffinity(t *testing.T) {
@@ -4341,7 +4748,7 @@ func TestCoreAuthSelectorFiltersNewModelExclusionsBeforeSessionAffinity(t *testi
 	}
 }
 
-func TestSidecarRuntimeDoesNotSelectAccountWithExcludedModel(t *testing.T) {
+func TestSidecarRuntimeHotReloadsExcludedModelsWithoutRestart(t *testing.T) {
 	tempDir := t.TempDir()
 	authDir := filepath.Join(tempDir, "auths")
 	if err := os.MkdirAll(authDir, 0o755); err != nil {
@@ -4354,15 +4761,47 @@ func TestSidecarRuntimeDoesNotSelectAccountWithExcludedModel(t *testing.T) {
 
 	blockedFile := "blocked-luna.json"
 	allowedFile := "allowed-luna.json"
-	if err := os.WriteFile(filepath.Join(authDir, blockedFile), []byte(`{
-  "type":"codex",
-  "email":"blocked@example.com",
-  "access_token":"blocked-token",
-  "account_id":"acct-blocked",
-  "excluded_models":["GPT-5.6-LUNA", "gpt-5.7-*"]
-}`), 0o600); err != nil {
-		t.Fatalf("write blocked auth: %v", err)
+	blockedPath := filepath.Join(authDir, blockedFile)
+	writeBlockedAuth := func(excludedModels []string, disabled bool) {
+		t.Helper()
+		payload := map[string]any{
+			"type":         "codex",
+			"email":        "blocked@example.com",
+			"access_token": "blocked-token",
+			"account_id":   "acct-blocked",
+		}
+		if len(excludedModels) > 0 {
+			payload["excluded_models"] = excludedModels
+		}
+		if disabled {
+			payload["disabled"] = true
+		}
+		data, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal blocked auth: %v", err)
+		}
+		tempFile, err := os.CreateTemp(authDir, ".blocked-auth-*")
+		if err != nil {
+			t.Fatalf("create blocked auth temp file: %v", err)
+		}
+		tempPath := tempFile.Name()
+		defer os.Remove(tempPath)
+		if err := tempFile.Chmod(0o600); err != nil {
+			tempFile.Close()
+			t.Fatalf("chmod blocked auth temp file: %v", err)
+		}
+		if _, err := tempFile.Write(data); err != nil {
+			tempFile.Close()
+			t.Fatalf("write blocked auth temp file: %v", err)
+		}
+		if err := tempFile.Close(); err != nil {
+			t.Fatalf("close blocked auth temp file: %v", err)
+		}
+		if err := os.Rename(tempPath, blockedPath); err != nil {
+			t.Fatalf("atomically replace blocked auth: %v", err)
+		}
 	}
+	writeBlockedAuth(nil, false)
 	if err := os.WriteFile(filepath.Join(authDir, allowedFile), []byte(`{
   "type":"codex",
   "email":"allowed@example.com",
@@ -4371,33 +4810,142 @@ func TestSidecarRuntimeDoesNotSelectAccountWithExcludedModel(t *testing.T) {
 }`), 0o600); err != nil {
 		t.Fatalf("write allowed auth: %v", err)
 	}
+	statePath := filepath.Join(tempDir, "quota-reserve.json")
+	writeModelExclusionState := func(blockedExclusions []string) {
+		t.Helper()
+		content, err := json.Marshal(quotaReserveStateFile{Accounts: map[string]quotaReserveSnapshot{
+			"blocked-account": {ModelExclusions: blockedExclusions},
+			"allowed-account": {ModelExclusions: []string{}},
+		}})
+		if err != nil {
+			t.Fatalf("marshal model exclusion state: %v", err)
+		}
+		tempFile, err := os.CreateTemp(tempDir, ".quota-reserve-*")
+		if err != nil {
+			t.Fatalf("create model exclusion state temp file: %v", err)
+		}
+		tempPath := tempFile.Name()
+		defer os.Remove(tempPath)
+		if err := tempFile.Chmod(0o600); err != nil {
+			tempFile.Close()
+			t.Fatalf("chmod model exclusion state temp file: %v", err)
+		}
+		if _, err := tempFile.Write(content); err != nil {
+			tempFile.Close()
+			t.Fatalf("write model exclusion state temp file: %v", err)
+		}
+		if err := tempFile.Close(); err != nil {
+			t.Fatalf("close model exclusion state temp file: %v", err)
+		}
+		if err := os.Rename(tempPath, statePath); err != nil {
+			t.Fatalf("atomically replace model exclusion state: %v", err)
+		}
+	}
+	writeModelExclusionState([]string{})
 
+	const customModel = "cockpit-runtime-custom-model"
+	const customAlias = "cockpit-runtime-custom-alias"
 	m := &manifest{
 		Accounts: []accountSpec{
 			{ID: "blocked-account", Email: "blocked@example.com", AuthID: blockedFile, AuthKind: "oauth"},
 			{ID: "allowed-account", Email: "allowed@example.com", AuthID: allowedFile, AuthKind: "oauth"},
 		},
-		ModelIDs:         []string{"gpt-5.6-luna", "gpt-5.7-preview", "gpt-5.4"},
+		ModelIDs:         []string{"gpt-5.6-luna", "gpt-5.7-preview", "gpt-5.4", customModel},
+		ModelAliases:     []modelAliasSpec{{SourceModel: "gpt-5.4", Alias: customAlias, Fork: true}},
 		accountByID:      make(map[string]*accountSpec),
 		accountByAuthID:  make(map[string]*accountSpec),
 		accountByAPIKey:  make(map[string]*accountSpec),
 		accountByChatGPT: make(map[string]*accountSpec),
 		accountByEmail:   make(map[string]*accountSpec),
+		originalIndexByID: map[string]int{
+			"blocked-account": 0,
+			"allowed-account": 1,
+		},
 	}
 	for index := range m.Accounts {
 		account := &m.Accounts[index]
 		m.accountByID[account.ID] = account
-		m.accountByAuthID[strings.ToLower(account.AuthID)] = account
 		m.accountByEmail[strings.ToLower(account.Email)] = account
 	}
+	quotaStore := newQuotaReserveStateStore(statePath, m)
+	if err := quotaStore.load(); err != nil {
+		t.Fatalf("load model exclusion state: %v", err)
+	}
 
-	cfg := &config.Config{AuthDir: authDir}
-	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m}, &authHook{manifest: m}, m, nil, newRequestUsageTracker())
-	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, manager)
+	cfg := &config.Config{AuthDir: authDir, DisableAuthAutoRefresh: true}
+	manager := buildCoreAuthManager(cfg, &cockpitSelector{manifest: m, quota: quotaStore}, &authHook{manifest: m}, m, quotaStore, newRequestUsageTracker())
+	runtime, err := newSidecarRuntime(context.Background(), configPath, cfg, m, quotaStore, manager)
 	if err != nil {
 		t.Fatalf("newSidecarRuntime: %v", err)
 	}
 	defer runtime.Stop()
+	originalService := runtime.service
+	originalManager := runtime.manager
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(blockedFile)
+		registry.GetGlobalRegistry().UnregisterClient(allowedFile)
+	})
+
+	waitFor := func(description string, condition func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if condition() {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for %s", description)
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+	modelRegistered := func(authID, modelID string) bool {
+		return findModelInfoForTest(registry.GetGlobalRegistry().GetModelsForClient(authID), modelID) != nil
+	}
+	authExcludesLuna := func() bool {
+		auth, ok := manager.GetByID(blockedFile)
+		return ok && auth != nil && modelMatchesAnyRule("gpt-5.6-luna", strings.Split(auth.Attributes["excluded_models"], ","))
+	}
+	assertManifestModels := func() {
+		t.Helper()
+		if !modelRegistered(blockedFile, customModel) || !modelRegistered(blockedFile, customAlias) {
+			t.Fatalf("watcher update lost manifest models: models=%#v", registry.GetGlobalRegistry().GetModelsForClient(blockedFile))
+		}
+	}
+
+	waitFor("initial manager and manifest model registration", func() bool {
+		_, ok := manager.GetByID(blockedFile)
+		return ok && modelRegistered(blockedFile, "gpt-5.6-luna") && modelRegistered(blockedFile, customModel) && modelRegistered(blockedFile, customAlias)
+	})
+	if len(m.accountByAuthID) != 0 {
+		t.Fatalf("runtime auth linking mutated the static manifest index: %#v", m.accountByAuthID)
+	}
+	if account := manifestAccountByAuthID(m, blockedFile); account == nil || account.ID != "blocked-account" {
+		t.Fatalf("runtime auth link = %#v, want blocked-account", account)
+	}
+
+	writeBlockedAuth([]string{"GPT-5.6-LUNA", "gpt-5.7-*"}, false)
+	waitFor("stale auth exclusions to reach manager without overriding state", func() bool {
+		return authExcludesLuna() &&
+			modelRegistered(blockedFile, "gpt-5.6-luna") &&
+			modelRegistered(blockedFile, "gpt-5.7-preview") &&
+			modelRegistered(blockedFile, customModel) &&
+			modelRegistered(blockedFile, customAlias)
+	})
+	assertManifestModels()
+
+	writeModelExclusionState([]string{"GPT-5.6-LUNA", "gpt-5.7-*"})
+	changed, err := quotaStore.reload()
+	if err != nil {
+		t.Fatalf("reload added authoritative exclusions: %v", err)
+	}
+	refreshManifestModelsForAccounts(manager, m, quotaStore, changed)
+	waitFor("authoritative state exclusions to reach registry", func() bool {
+		return !modelRegistered(blockedFile, "gpt-5.6-luna") &&
+			!modelRegistered(blockedFile, "gpt-5.7-preview") &&
+			modelRegistered(blockedFile, customModel) &&
+			modelRegistered(blockedFile, customAlias)
+	})
 
 	for attempt := 0; attempt < 8; attempt++ {
 		selected, errSelect := manager.SelectAuth(context.Background(), "codex", "gpt-5.6-luna", cliproxyexecutor.Options{})
@@ -4409,18 +4957,60 @@ func TestSidecarRuntimeDoesNotSelectAccountWithExcludedModel(t *testing.T) {
 		}
 	}
 
-	blockedAuth, ok := manager.GetByID(blockedFile)
-	if !ok || blockedAuth == nil {
-		t.Fatalf("blocked auth %q was not registered", blockedFile)
+	writeBlockedAuth(nil, false)
+	waitFor("auth exclusion removal without overriding authoritative state", func() bool {
+		return !authExcludesLuna() &&
+			!modelRegistered(blockedFile, "gpt-5.6-luna") &&
+			!modelRegistered(blockedFile, "gpt-5.7-preview") &&
+			modelRegistered(blockedFile, customModel) &&
+			modelRegistered(blockedFile, customAlias)
+	})
+	assertManifestModels()
+
+	writeModelExclusionState([]string{})
+	changed, err = quotaStore.reload()
+	if err != nil {
+		t.Fatalf("reload cleared authoritative exclusions: %v", err)
 	}
-	blockedModels := registry.GetGlobalRegistry().GetModelsForClient(blockedAuth.ID)
-	if info := findModelInfoForTest(blockedModels, "gpt-5.6-luna"); info != nil {
-		t.Fatalf("blocked auth still advertises exact excluded model: %#v", info)
+	refreshManifestModelsForAccounts(manager, m, quotaStore, changed)
+	waitFor("cleared authoritative exclusions to reach registry", func() bool {
+		return modelRegistered(blockedFile, "gpt-5.6-luna") &&
+			modelRegistered(blockedFile, "gpt-5.7-preview") &&
+			modelRegistered(blockedFile, customModel) &&
+			modelRegistered(blockedFile, customAlias)
+	})
+
+	selectedBlocked := false
+	for attempt := 0; attempt < 16; attempt++ {
+		selected, errSelect := manager.SelectAuth(context.Background(), "codex", "gpt-5.6-luna", cliproxyexecutor.Options{})
+		if errSelect != nil {
+			t.Fatalf("SelectAuth after removal attempt %d: %v", attempt, errSelect)
+		}
+		if account := accountForAuthInManifest(m, selected); account != nil && account.ID == "blocked-account" {
+			selectedBlocked = true
+			break
+		}
 	}
-	if info := findModelInfoForTest(blockedModels, "gpt-5.7-preview"); info != nil {
-		t.Fatalf("blocked auth still advertises wildcard-excluded model: %#v", info)
+	if !selectedBlocked {
+		t.Fatal("auth did not become selectable after excluded_models was removed")
 	}
-	if info := findModelInfoForTest(blockedModels, "gpt-5.4"); info == nil {
-		t.Fatal("blocked auth lost a non-excluded model")
+
+	writeBlockedAuth(nil, true)
+	waitFor("disabled auth to leave manager and registry", func() bool {
+		auth, ok := manager.GetByID(blockedFile)
+		return ok && auth != nil && auth.Disabled && auth.Status == coreauth.StatusDisabled &&
+			len(registry.GetGlobalRegistry().GetModelsForClient(blockedFile)) == 0
+	})
+	for attempt := 0; attempt < 4; attempt++ {
+		selected, errSelect := manager.SelectAuth(context.Background(), "codex", "gpt-5.6-luna", cliproxyexecutor.Options{})
+		if errSelect != nil {
+			t.Fatalf("SelectAuth after disable attempt %d: %v", attempt, errSelect)
+		}
+		if account := accountForAuthInManifest(m, selected); account == nil || account.ID != "allowed-account" {
+			t.Fatalf("SelectAuth after disable attempt %d = %#v, account=%#v", attempt, selected, account)
+		}
+	}
+	if runtime.service != originalService || runtime.manager != originalManager {
+		t.Fatal("hot auth updates must not rebuild the sidecar runtime")
 	}
 }

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/registry/model_registry.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/registry/model_registry.go
@@ -233,6 +233,22 @@ func (r *ModelRegistry) triggerModelsUnregistered(provider, clientID string) {
 //   - clientProvider: Provider name (e.g., "gemini", "claude", "openai")
 //   - models: List of models that this client can provide
 func (r *ModelRegistry) RegisterClient(clientID, clientProvider string, models []*ModelInfo) {
+	r.registerClient(clientID, clientProvider, models, false)
+}
+
+// ReconcileClientModelsPreservingState updates a client's model bindings while
+// retaining quota cooldown and suspension state for models present in both the
+// old and new sets. State for removed bindings is discarded normally.
+func (r *ModelRegistry) ReconcileClientModelsPreservingState(clientID, clientProvider string, models []*ModelInfo) {
+	r.registerClient(clientID, clientProvider, models, true)
+}
+
+func (r *ModelRegistry) registerClient(
+	clientID string,
+	clientProvider string,
+	models []*ModelInfo,
+	preserveOverlapState bool,
+) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	r.ensureAvailableModelsCacheLocked()
@@ -392,14 +408,16 @@ func (r *ModelRegistry) RegisterClient(clientID, clientProvider string, models [
 				reg.InfoByProvider[provider] = cloneModelInfo(model)
 			}
 			reg.LastUpdated = now
-			// Re-registering an existing client/model binding starts a fresh registry
-			// snapshot for that binding. Cooldown and suspension are transient
-			// scheduling state and must not survive this reconciliation step.
-			if reg.QuotaExceededClients != nil {
-				delete(reg.QuotaExceededClients, clientID)
-			}
-			if reg.SuspendedClients != nil {
-				delete(reg.SuspendedClients, clientID)
+			if !preserveOverlapState {
+				// Ordinary auth re-registration starts a fresh registry snapshot for
+				// overlapping bindings. Runtime policy deltas use the dedicated
+				// preserving path above instead.
+				if reg.QuotaExceededClients != nil {
+					delete(reg.QuotaExceededClients, clientID)
+				}
+				if reg.SuspendedClients != nil {
+					delete(reg.SuspendedClients, clientID)
+				}
 			}
 			if providerChanged && provider != "" {
 				if _, newlyAdded := addedSet[id]; newlyAdded {

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/registry/model_registry_safety_test.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/registry/model_registry_safety_test.go
@@ -56,6 +56,48 @@ func TestGetModelsForClientReturnsClones(t *testing.T) {
 	}
 }
 
+func TestReconcileClientModelsPreservingStateKeepsOverlapCooldownAndSuspension(t *testing.T) {
+	r := newTestModelRegistry()
+	clientID := "client-1"
+	luna := &ModelInfo{ID: "gpt-5.6-luna"}
+	spark := &ModelInfo{ID: "gpt-5.3-codex-spark"}
+	r.RegisterClient(clientID, "codex", []*ModelInfo{luna, spark})
+	r.SetModelQuotaExceeded(clientID, luna.ID)
+	r.SuspendClientModel(clientID, luna.ID, "cooldown")
+
+	assertLunaState := func(want bool) {
+		t.Helper()
+		r.mutex.RLock()
+		registration := r.models[luna.ID]
+		_, quotaExceeded := registration.QuotaExceededClients[clientID]
+		_, suspended := registration.SuspendedClients[clientID]
+		r.mutex.RUnlock()
+		if quotaExceeded != want || suspended != want {
+			t.Fatalf("Luna transient state: quota=%v suspended=%v, want both %v", quotaExceeded, suspended, want)
+		}
+	}
+	assertLunaState(true)
+
+	// Removing Spark is a policy delta; Luna remains an overlapping binding.
+	r.ReconcileClientModelsPreservingState(clientID, "codex", []*ModelInfo{luna})
+	assertLunaState(true)
+	if r.ClientSupportsModel(clientID, spark.ID) {
+		t.Fatal("Spark binding should be removed")
+	}
+
+	// Adding Spark back must likewise leave Luna's transient state untouched.
+	r.ReconcileClientModelsPreservingState(clientID, "codex", []*ModelInfo{luna, spark})
+	assertLunaState(true)
+	if !r.ClientSupportsModel(clientID, spark.ID) {
+		t.Fatal("Spark binding should be restored")
+	}
+
+	// Ordinary auth re-registration intentionally retains the existing reset
+	// semantics used by watcher-driven credential updates.
+	r.RegisterClient(clientID, "codex", []*ModelInfo{luna, spark})
+	assertLunaState(false)
+}
+
 func TestGetAvailableModelsByProviderReturnsClones(t *testing.T) {
 	r := newTestModelRegistry()
 	r.RegisterClient("client-1", "gemini", []*ModelInfo{{

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/auth/filestore.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/auth/filestore.go
@@ -79,7 +79,7 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		if setter, ok := auth.Storage.(metadataSetter); ok {
 			setter.SetMetadata(auth.Metadata)
 		}
-		if err = auth.Storage.SaveTokenToFile(path); err != nil {
+		if err = writeAuthFileAtomically(path, auth.Storage.SaveTokenToFile); err != nil {
 			return "", err
 		}
 	case auth.Metadata != nil:
@@ -92,22 +92,12 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 			if jsonEqual(existing, raw) {
 				return path, nil
 			}
-			file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600)
-			if errOpen != nil {
-				return "", fmt.Errorf("auth filestore: open existing failed: %w", errOpen)
-			}
-			if _, errWrite := file.Write(raw); errWrite != nil {
-				_ = file.Close()
-				return "", fmt.Errorf("auth filestore: write existing failed: %w", errWrite)
-			}
-			if errClose := file.Close(); errClose != nil {
-				return "", fmt.Errorf("auth filestore: close existing failed: %w", errClose)
-			}
-			return path, nil
 		} else if !os.IsNotExist(errRead) {
 			return "", fmt.Errorf("auth filestore: read existing failed: %w", errRead)
 		}
-		if errWrite := os.WriteFile(path, raw, 0o600); errWrite != nil {
+		if errWrite := writeAuthFileAtomically(path, func(tempPath string) error {
+			return os.WriteFile(tempPath, raw, 0o600)
+		}); errWrite != nil {
 			return "", fmt.Errorf("auth filestore: write file failed: %w", errWrite)
 		}
 	default:
@@ -124,6 +114,59 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 	}
 
 	return path, nil
+}
+
+func writeAuthFileAtomically(path string, write func(string) error) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("auth filestore: atomic write path is empty")
+	}
+	if write == nil {
+		return fmt.Errorf("auth filestore: atomic writer is nil")
+	}
+	dir := filepath.Dir(path)
+	temp, err := os.CreateTemp(dir, ".auth-*.tmp")
+	if err != nil {
+		return fmt.Errorf("auth filestore: create temp file failed: %w", err)
+	}
+	tempPath := temp.Name()
+	if err = temp.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("auth filestore: close temp file failed: %w", err)
+	}
+	defer func() { _ = os.Remove(tempPath) }()
+	if err = os.Remove(tempPath); err != nil {
+		return fmt.Errorf("auth filestore: release temp file path failed: %w", err)
+	}
+
+	if err = write(tempPath); err != nil {
+		return err
+	}
+	if _, err = os.Stat(tempPath); os.IsNotExist(err) {
+		// Token storages such as EmptyStorage deliberately perform no file I/O.
+		// Preserve that contract by leaving an existing target untouched and not
+		// creating an absent target.
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("auth filestore: stat temp file failed: %w", err)
+	}
+	if err = os.Chmod(tempPath, 0o600); err != nil {
+		return fmt.Errorf("auth filestore: chmod temp file failed: %w", err)
+	}
+	temp, err = os.OpenFile(tempPath, os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("auth filestore: reopen temp file failed: %w", err)
+	}
+	if err = temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("auth filestore: sync temp file failed: %w", err)
+	}
+	if err = temp.Close(); err != nil {
+		return fmt.Errorf("auth filestore: close synced temp file failed: %w", err)
+	}
+	if err = os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("auth filestore: replace auth file failed: %w", err)
+	}
+	return nil
 }
 
 // List enumerates all auth JSON files under the configured directory.

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/auth/filestore_disabled_test.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/auth/filestore_disabled_test.go
@@ -1,17 +1,30 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	emptyauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/empty"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 type testTokenStorage struct {
 	meta map[string]any
+}
+
+type failingTokenStorage struct{}
+
+func (*failingTokenStorage) SaveTokenToFile(authFilePath string) error {
+	if err := os.WriteFile(authFilePath, []byte(`{"partial":`), 0o600); err != nil {
+		return err
+	}
+	return errors.New("injected token write failure")
 }
 
 func (s *testTokenStorage) SetMetadata(meta map[string]any) { s.meta = meta }
@@ -60,5 +73,90 @@ func TestFileTokenStore_Save_DisabledPersistsFlagForTokenStorage(t *testing.T) {
 	}
 	if disabled, _ := meta["disabled"].(bool); !disabled {
 		t.Fatalf("disabled=%v, want true (raw=%s)", meta["disabled"], string(raw))
+	}
+}
+
+func TestFileTokenStore_SaveFailurePreservesExistingAuthFile(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "existing.json")
+	original := []byte(`{"type":"codex","access_token":"still-valid"}`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	_, err := store.Save(ctx, &cliproxyauth.Auth{
+		ID:       "existing.json",
+		Provider: "codex",
+		FileName: "existing.json",
+		Storage:  &failingTokenStorage{},
+		Metadata: map[string]any{"type": "codex"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "injected token write failure") {
+		t.Fatalf("Save() error = %v, want injected failure", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read preserved auth file: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("failed save changed live auth file: got=%s want=%s", got, original)
+	}
+}
+
+func TestFileTokenStore_EmptyStoragePreservesNoOpBehavior(t *testing.T) {
+	for _, seedExisting := range []bool{true, false} {
+		name := "absent target"
+		if seedExisting {
+			name = "existing target"
+		}
+		t.Run(name, func(t *testing.T) {
+			baseDir := t.TempDir()
+			path := filepath.Join(baseDir, "empty.json")
+			original := []byte(`{"type":"codex","access_token":"keep-me"}`)
+			if seedExisting {
+				if err := os.WriteFile(path, original, 0o600); err != nil {
+					t.Fatalf("seed auth file: %v", err)
+				}
+			}
+
+			store := NewFileTokenStore()
+			store.SetBaseDir(baseDir)
+			storage := &emptyauth.EmptyStorage{}
+			auth := &cliproxyauth.Auth{
+				ID:       "empty.json",
+				Provider: "empty",
+				FileName: "empty.json",
+				Storage:  storage,
+				Metadata: map[string]any{"type": "empty"},
+			}
+			savedPath, err := store.Save(context.Background(), auth)
+			if err != nil {
+				t.Fatalf("Save() error: %v", err)
+			}
+			if savedPath != path {
+				t.Fatalf("Save() path = %q, want %q", savedPath, path)
+			}
+			if storage.Type != "empty" {
+				t.Fatalf("EmptyStorage type = %q, want empty", storage.Type)
+			}
+			if auth.Attributes["path"] != path {
+				t.Fatalf("auth path attribute = %q, want %q", auth.Attributes["path"], path)
+			}
+
+			got, err := os.ReadFile(path)
+			if seedExisting {
+				if err != nil {
+					t.Fatalf("read preserved auth file: %v", err)
+				}
+				if !bytes.Equal(got, original) {
+					t.Fatalf("empty storage changed live auth file: got=%s want=%s", got, original)
+				}
+			} else if !os.IsNotExist(err) {
+				t.Fatalf("empty storage created absent target or returned unexpected error: data=%q err=%v", got, err)
+			}
+		})
 	}
 }

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/conductor.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/conductor.go
@@ -288,6 +288,16 @@ func (m *Manager) RefreshSchedulerEntry(authID string) {
 // models that are no longer present in the registry are pruned entirely so
 // renamed/removed models cannot keep auth-level status stale.
 func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID string) {
+	m.reconcileRegistryModelStates(ctx, authID, true)
+}
+
+// PruneRegistryModelStates removes state only for models no longer registered
+// to the auth. Runtime state for overlapping models is preserved.
+func (m *Manager) PruneRegistryModelStates(ctx context.Context, authID string) {
+	m.reconcileRegistryModelStates(ctx, authID, false)
+}
+
+func (m *Manager) reconcileRegistryModelStates(ctx context.Context, authID string, resetOverlap bool) {
 	if m == nil || authID == "" {
 		return
 	}
@@ -323,6 +333,9 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 				// status, management output, and websocket fallback checks.
 				delete(auth.ModelStates, modelKey)
 				changed = true
+				continue
+			}
+			if !resetOverlap {
 				continue
 			}
 			if state == nil {

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/conductor_update_test.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/auth/conductor_update_test.go
@@ -3,7 +3,68 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
+
+func TestManager_PruneRegistryModelStatesPreservesOverlapState(t *testing.T) {
+	clientID := "prune-overlap-state-auth"
+	luna := "gpt-5.6-luna"
+	spark := "gpt-5.3-codex-spark"
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(clientID, "codex", []*registry.ModelInfo{{ID: luna}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	nextRetry := time.Now().Add(10 * time.Minute).Round(time.Millisecond)
+	manager := NewManager(nil, nil, nil)
+	_, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       clientID,
+		Provider: "codex",
+		Status:   StatusError,
+		ModelStates: map[string]*ModelState{
+			luna: {
+				Status:         StatusError,
+				StatusMessage:  "luna cooldown",
+				Unavailable:    true,
+				NextRetryAfter: nextRetry,
+				Quota:          QuotaState{Exceeded: true, BackoffLevel: 4},
+				UpdatedAt:      time.Now(),
+			},
+			spark: {
+				Status:         StatusError,
+				StatusMessage:  "spark cooldown",
+				Unavailable:    true,
+				NextRetryAfter: nextRetry,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	manager.PruneRegistryModelStates(WithSkipPersist(context.Background()), clientID)
+	current, ok := manager.GetByID(clientID)
+	if !ok || current == nil {
+		t.Fatal("auth missing after prune")
+	}
+	if _, exists := current.ModelStates[spark]; exists {
+		t.Fatalf("removed Spark state was not pruned: %#v", current.ModelStates[spark])
+	}
+	lunaState := current.ModelStates[luna]
+	if lunaState == nil || !lunaState.Unavailable || lunaState.Status != StatusError ||
+		!lunaState.NextRetryAfter.Equal(nextRetry) || !lunaState.Quota.Exceeded || lunaState.Quota.BackoffLevel != 4 {
+		t.Fatalf("overlapping Luna state changed during prune: %#v", lunaState)
+	}
+
+	manager.ReconcileRegistryModelStates(WithSkipPersist(context.Background()), clientID)
+	current, _ = manager.GetByID(clientID)
+	lunaState = current.ModelStates[luna]
+	if lunaState == nil || lunaState.Unavailable || lunaState.Status != StatusActive ||
+		!lunaState.NextRetryAfter.IsZero() || lunaState.Quota.Exceeded || lunaState.Quota.BackoffLevel != 0 {
+		t.Fatalf("ordinary reconciliation did not reset Luna state: %#v", lunaState)
+	}
+}
 
 func TestManager_Update_PreservesModelStates(t *testing.T) {
 	m := NewManager(nil, nil, nil)

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/builder.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/builder.go
@@ -62,6 +62,16 @@ type Hooks struct {
 	// OnAfterStart is called after the service has started successfully,
 	// providing access to the service instance for additional operations.
 	OnAfterStart func(*Service)
+
+	// PrepareAuthUpsert can normalize a watcher-driven auth add/update before it
+	// is applied to the manager. Returning nil skips the update; returning an
+	// error keeps the last known-good manager entry unchanged.
+	PrepareAuthUpsert func(*Service, *coreauth.Auth) (*coreauth.Auth, error)
+
+	// OnAuthUpserted is called after a watcher-driven auth add/update has been
+	// applied to the manager, but before generic model registration. Returning
+	// true indicates that the hook fully handled registry and scheduler updates.
+	OnAuthUpserted func(*Service, *coreauth.Auth) bool
 }
 
 // NewBuilder creates a Builder with default dependencies left unset.

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/model_registry.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/model_registry.go
@@ -11,6 +11,7 @@ type ModelRegistryHook = registry.ModelRegistryHook
 // ModelRegistry describes registry operations consumed by external callers.
 type ModelRegistry interface {
 	RegisterClient(clientID, clientProvider string, models []*ModelInfo)
+	ReconcileClientModelsPreservingState(clientID, clientProvider string, models []*ModelInfo)
 	UnregisterClient(clientID string)
 	SetModelQuotaExceeded(clientID, modelID string)
 	ClearModelQuotaExceeded(clientID, modelID string)

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/service.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/sdk/cliproxy/service.go
@@ -160,6 +160,56 @@ func (s *Service) consumeAuthUpdates(ctx context.Context) {
 	}
 }
 
+func (s *Service) startWatcher(ctx context.Context) error {
+	if s == nil {
+		return fmt.Errorf("cliproxy: service is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	s.cfgMu.RLock()
+	cfg := s.cfg
+	s.cfgMu.RUnlock()
+	if cfg == nil {
+		return fmt.Errorf("cliproxy: configuration is required")
+	}
+	if cfg.Home.Enabled || s.watcher != nil {
+		return nil
+	}
+
+	watcherFactory := s.watcherFactory
+	if watcherFactory == nil {
+		watcherFactory = defaultWatcherFactory
+	}
+	reloadCallback := func(newCfg *config.Config) { s.applyConfigUpdate(newCfg) }
+	watcherWrapper, errCreate := watcherFactory(s.configPath, cfg.AuthDir, reloadCallback)
+	if errCreate != nil {
+		return fmt.Errorf("cliproxy: failed to create watcher: %w", errCreate)
+	}
+
+	s.watcher = watcherWrapper
+	s.ensureAuthUpdateQueue(ctx)
+	if s.authUpdates != nil {
+		watcherWrapper.SetAuthUpdateQueue(s.authUpdates)
+	}
+	watcherWrapper.SetConfig(cfg)
+
+	watcherCtx, watcherCancel := context.WithCancel(context.Background())
+	s.watcherCancel = watcherCancel
+	if errStart := watcherWrapper.Start(watcherCtx); errStart != nil {
+		watcherCancel()
+		s.watcherCancel = nil
+		s.watcher = nil
+		if errStop := watcherWrapper.Stop(); errStop != nil {
+			log.Debugf("failed to stop watcher after startup error: %v", errStop)
+		}
+		return fmt.Errorf("cliproxy: failed to start watcher: %w", errStart)
+	}
+	log.Info("file watcher started for config and auth directory changes")
+	return nil
+}
+
 func (s *Service) emitAuthUpdate(ctx context.Context, update watcher.AuthUpdate) {
 	if s == nil {
 		return
@@ -287,6 +337,21 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 		return
 	}
 	auth = auth.Clone()
+	if s.hooks.PrepareAuthUpsert != nil {
+		prepared, errPrepare := s.hooks.PrepareAuthUpsert(s, auth)
+		if errPrepare != nil {
+			log.Errorf("failed to prepare auth %s update: %v", auth.ID, errPrepare)
+			return
+		}
+		if prepared == nil {
+			return
+		}
+		auth = prepared.Clone()
+		if strings.TrimSpace(auth.ID) == "" {
+			log.Error("prepared auth update is missing id")
+			return
+		}
+	}
 	s.ensureExecutorsForAuth(auth)
 
 	// IMPORTANT: Update coreManager FIRST, before model registration.
@@ -318,6 +383,10 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 		auth = current
 	}
 
+	if s.hooks.OnAuthUpserted != nil && s.hooks.OnAuthUpserted(s, auth.Clone()) {
+		return
+	}
+
 	// Register models after auth is updated in coreManager.
 	// This operation may block on network calls, but the auth configuration
 	// is already effective at this point.
@@ -325,9 +394,10 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 	s.coreManager.ReconcileRegistryModelStates(ctx, auth.ID)
 
 	// Refresh the scheduler entry so that the auth's supportedModelSet is rebuilt
-	// from the now-populated global model registry. Without this, newly added auths
-	// have an empty supportedModelSet (because Register/Update upserts into the
-	// scheduler before registerModelsForAuth runs) and are invisible to the scheduler.
+	// from the now-populated global model registry. Without this, newly added
+	// auths have an empty supportedModelSet (because
+	// Register/Update upserts into the scheduler before registerModelsForAuth runs)
+	// and are invisible to the scheduler.
 	s.coreManager.RefreshSchedulerEntry(auth.ID)
 }
 
@@ -906,27 +976,8 @@ func (s *Service) Run(ctx context.Context) error {
 		s.hooks.OnAfterStart(s)
 	}
 
-	if !homeEnabled {
-		var watcherWrapper *WatcherWrapper
-		reloadCallback := func(newCfg *config.Config) { s.applyConfigUpdate(newCfg) }
-
-		watcherWrapper, errCreate := s.watcherFactory(s.configPath, s.cfg.AuthDir, reloadCallback)
-		if errCreate != nil {
-			return fmt.Errorf("cliproxy: failed to create watcher: %w", errCreate)
-		}
-		s.watcher = watcherWrapper
-		s.ensureAuthUpdateQueue(ctx)
-		if s.authUpdates != nil {
-			watcherWrapper.SetAuthUpdateQueue(s.authUpdates)
-		}
-		watcherWrapper.SetConfig(s.cfg)
-
-		watcherCtx, watcherCancel := context.WithCancel(context.Background())
-		s.watcherCancel = watcherCancel
-		if errStart := watcherWrapper.Start(watcherCtx); errStart != nil {
-			return fmt.Errorf("cliproxy: failed to start watcher: %w", errStart)
-		}
-		log.Info("file watcher started for config and auth directory changes")
+	if err := s.startWatcher(ctx); err != nil {
+		return err
 	}
 
 	// Prefer core auth manager auto refresh if available.
@@ -1851,6 +1902,9 @@ func (s *Service) StartRuntime(ctx context.Context) error {
 
 	if s.hooks.OnBeforeStart != nil {
 		s.hooks.OnBeforeStart(s.cfg)
+	}
+	if err := s.startWatcher(ctx); err != nil {
+		return err
 	}
 	if s.hooks.OnAfterStart != nil {
 		s.hooks.OnAfterStart(s)

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -234,6 +234,7 @@ static GATEWAY_STATS_MAINTENANCE_COMPLETED: AtomicBool = AtomicBool::new(false);
 static GATEWAY_COLLECTION_ACCOUNT_SANITIZE_RUNNING: AtomicBool = AtomicBool::new(false);
 static GATEWAY_COLLECTION_ACCOUNT_SANITIZE_COMPLETED: AtomicBool = AtomicBool::new(false);
 static GATEWAY_LIFECYCLE_LOCK: OnceLock<TokioMutex<()>> = OnceLock::new();
+static SIDECAR_RUNTIME_ACCOUNT_STATE_SYNC_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 static GATEWAY_LIFECYCLE_GENERATION: AtomicU64 = AtomicU64::new(1);
 static GATEWAY_LIFECYCLE_NOTIFY: OnceLock<Notify> = OnceLock::new();
 static GATEWAY_PREPARING: AtomicBool = AtomicBool::new(false);
@@ -766,6 +767,13 @@ fn lock_local_access_logs_db_write() -> Result<std::sync::MutexGuard<'static, ()
 
 fn gateway_lifecycle_lock() -> &'static TokioMutex<()> {
     GATEWAY_LIFECYCLE_LOCK.get_or_init(|| TokioMutex::new(()))
+}
+
+fn lock_sidecar_runtime_account_state_sync() -> Result<std::sync::MutexGuard<'static, ()>, String> {
+    SIDECAR_RUNTIME_ACCOUNT_STATE_SYNC_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| "API 服务 sidecar 运行时账号状态同步锁已损坏".to_string())
 }
 
 fn gateway_lifecycle_notify() -> &'static Notify {
@@ -5643,23 +5651,18 @@ fn quota_disallowed_model_patterns(account: &CodexAccount) -> Vec<String> {
             patterns.push(pattern);
         }
     }
+    patterns.sort_unstable();
     patterns
 }
 
-fn metered_feature_model_patterns_for_pool(
-    collection: &CodexLocalAccessCollection,
-    account_overrides: &HashMap<String, CodexAccount>,
+fn metered_feature_model_patterns_for_accounts<'a>(
+    accounts: impl IntoIterator<Item = &'a CodexAccount>,
 ) -> HashMap<String, String> {
-    let persisted_accounts = codex_account::list_accounts_checked().ok();
     let mut patterns = HashMap::new();
-    for account_id in effective_sidecar_account_ids(collection) {
-        let account = account_overrides.get(&account_id).or_else(|| {
-            persisted_accounts
-                .as_ref()
-                .and_then(|accounts| accounts.iter().find(|account| account.id == account_id))
-        });
+    for account in accounts {
         let Some(raw) = account
-            .and_then(|account| account.quota.as_ref())
+            .quota
+            .as_ref()
             .and_then(|quota| quota.raw_data.as_ref())
         else {
             continue;
@@ -5685,6 +5688,23 @@ fn metered_feature_model_patterns_for_pool(
     patterns
 }
 
+fn metered_feature_model_patterns_for_pool(
+    collection: &CodexLocalAccessCollection,
+    account_overrides: &HashMap<String, CodexAccount>,
+) -> HashMap<String, String> {
+    let persisted_accounts = codex_account::list_accounts_checked().ok();
+    let accounts = effective_sidecar_account_ids(collection)
+        .into_iter()
+        .filter_map(|account_id| {
+            account_overrides.get(&account_id).or_else(|| {
+                persisted_accounts
+                    .as_ref()
+                    .and_then(|accounts| accounts.iter().find(|account| account.id == account_id))
+            })
+        });
+    metered_feature_model_patterns_for_accounts(accounts)
+}
+
 fn implicit_metered_feature_exclusions(
     account: &CodexAccount,
     feature_patterns: &HashMap<String, String>,
@@ -5700,7 +5720,7 @@ fn implicit_metered_feature_exclusions(
         return Vec::new();
     };
     let present = metered_features_in_quota_raw(raw);
-    feature_patterns
+    let mut exclusions = feature_patterns
         .iter()
         .filter_map(|(feature, pattern)| {
             if present.contains(feature) {
@@ -5709,7 +5729,9 @@ fn implicit_metered_feature_exclusions(
                 Some(pattern.clone())
             }
         })
-        .collect()
+        .collect::<Vec<_>>();
+    exclusions.sort_unstable();
+    exclusions
 }
 
 fn sidecar_excluded_models_for_account(
@@ -11651,6 +11673,52 @@ fn adopt_sidecar_agent_identity_task(
     Ok(true)
 }
 
+fn complete_sidecar_account_snapshot<'a>(
+    accounts: &'a [CodexAccount],
+    collection: &CodexLocalAccessCollection,
+) -> Result<(Vec<String>, HashMap<&'a str, &'a CodexAccount>), String> {
+    let account_by_id = accounts
+        .iter()
+        .map(|account| (account.id.as_str(), account))
+        .collect::<HashMap<_, _>>();
+    let account_ids = effective_sidecar_account_ids(collection);
+    let missing_account_ids = account_ids
+        .iter()
+        .filter(|account_id| !account_by_id.contains_key(account_id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !missing_account_ids.is_empty() {
+        return Err(format!(
+            "账号快照不完整: missing={}",
+            missing_account_ids.join(",")
+        ));
+    }
+    Ok((account_ids, account_by_id))
+}
+
+fn sidecar_model_exclusions_for_accounts(
+    accounts: &[CodexAccount],
+    collection: &CodexLocalAccessCollection,
+) -> Result<HashMap<String, Vec<String>>, String> {
+    let (account_ids, account_by_id) = complete_sidecar_account_snapshot(accounts, collection)?;
+    let metered_feature_patterns = metered_feature_model_patterns_for_accounts(
+        account_ids
+            .iter()
+            .filter_map(|account_id| account_by_id.get(account_id.as_str()).copied()),
+    );
+    let mut exclusions = HashMap::new();
+    for account_id in account_ids {
+        let Some(account) = account_by_id.get(account_id.as_str()).copied() else {
+            continue;
+        };
+        exclusions.insert(
+            account.id.clone(),
+            sidecar_excluded_models_for_account(account, collection, &metered_feature_patterns),
+        );
+    }
+    Ok(exclusions)
+}
+
 fn sync_sidecar_auth_file_for_account_with_task_source(
     account: &CodexAccount,
     prefer_account_task: bool,
@@ -11778,38 +11846,247 @@ fn sidecar_quota_reserve_snapshot_value(
     }))
 }
 
-fn sidecar_quota_reserve_state_value(collection: &CodexLocalAccessCollection) -> Value {
+fn unknown_sidecar_quota_reserve_snapshot_value(
+    collection: &CodexLocalAccessCollection,
+    account_id: &str,
+) -> Option<Value> {
+    let reserve = collection.bound_oauth_quota_reserve.as_ref()?;
+    let bound_account_id =
+        normalize_optional_account_ref(collection.bound_oauth_account_id.as_deref())?;
+    if account_id != bound_account_id {
+        return None;
+    }
+
+    Some(json!({
+        "snapshotUpdatedAtUnixSeconds": Value::Null,
+        "hourlyRemainingPercent": Value::Null,
+        "weeklyRemainingPercent": Value::Null,
+        "hourlyWindowPresent": Value::Null,
+        "weeklyWindowPresent": Value::Null,
+        "hourlyThresholdPercent": reserve.hourly_percent,
+        "weeklyThresholdPercent": reserve.weekly_percent,
+    }))
+}
+
+fn sidecar_quota_reserve_state_value(
+    collection: &CodexLocalAccessCollection,
+    model_exclusions: &HashMap<String, Vec<String>>,
+) -> Value {
     let mut accounts = Map::new();
+    for account_id in effective_sidecar_account_ids(collection) {
+        let Some(excluded_models) = model_exclusions.get(&account_id) else {
+            continue;
+        };
+        let mut snapshot = codex_account::load_account(&account_id)
+            .and_then(|account| sidecar_quota_reserve_snapshot_value(collection, &account))
+            .and_then(|value| value.as_object().cloned())
+            .unwrap_or_default();
+        snapshot.insert("modelExclusions".to_string(), json!(excluded_models));
+        accounts.insert(account_id, Value::Object(snapshot));
+    }
     if let Some(account_id) =
         normalize_optional_account_ref(collection.bound_oauth_account_id.as_deref())
     {
-        if let Some(account) = codex_account::load_account(&account_id) {
-            if let Some(snapshot) = sidecar_quota_reserve_snapshot_value(collection, &account) {
-                accounts.insert(account_id, snapshot);
+        if !accounts.contains_key(&account_id) {
+            if let Some(account) = codex_account::load_account(&account_id) {
+                if let Some(snapshot) = sidecar_quota_reserve_snapshot_value(collection, &account) {
+                    accounts.insert(account_id, snapshot);
+                }
             }
         }
     }
     json!({ "accounts": accounts })
 }
 
-fn write_sidecar_quota_reserve_state(
-    collection: &CodexLocalAccessCollection,
-) -> Result<PathBuf, String> {
-    let base_dir = local_access_sidecar_dir()?;
-    write_sidecar_quota_reserve_state_in_dir(collection, &base_dir)
-}
-
 fn write_sidecar_quota_reserve_state_in_dir(
     collection: &CodexLocalAccessCollection,
+    model_exclusions: &HashMap<String, Vec<String>>,
     base_dir: &Path,
-) -> Result<PathBuf, String> {
+) -> Result<(PathBuf, bool), String> {
     std::fs::create_dir_all(&base_dir)
         .map_err(|error| format!("创建 API 服务 sidecar 目录失败: {}", error))?;
     let path = sidecar_quota_reserve_path(&base_dir);
-    let content = serde_json::to_string_pretty(&sidecar_quota_reserve_state_value(collection))
-        .map_err(|error| format!("序列化 OAuth 保留额度快照失败: {}", error))?;
-    write_string_atomic_if_changed(&path, &content)?;
-    Ok(path)
+    let content = serde_json::to_string_pretty(&sidecar_quota_reserve_state_value(
+        collection,
+        model_exclusions,
+    ))
+    .map_err(|error| format!("序列化 sidecar 运行时账号状态失败: {}", error))?;
+    let changed = write_string_atomic_if_changed(&path, &content)?;
+    Ok((path, changed))
+}
+
+fn valid_sidecar_runtime_model_exclusions(account_state: Option<&Value>) -> Option<Vec<String>> {
+    let values = account_state?
+        .as_object()?
+        .get("modelExclusions")?
+        .as_array()?;
+    let mut exclusions = Vec::with_capacity(values.len());
+    for value in values {
+        let exclusion = value.as_str()?;
+        if exclusion.trim().is_empty() {
+            return None;
+        }
+        exclusions.push(exclusion.to_string());
+    }
+    Some(exclusions)
+}
+
+fn patch_sidecar_runtime_account_state_for_incomplete_snapshot_in_dir(
+    accounts: &[CodexAccount],
+    collection: &CodexLocalAccessCollection,
+    base_dir: &Path,
+) -> Result<bool, String> {
+    std::fs::create_dir_all(base_dir)
+        .map_err(|error| format!("创建 API 服务 sidecar 目录失败: {}", error))?;
+    let path = sidecar_quota_reserve_path(base_dir);
+    let mut state = match fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str::<Value>(&content).map_err(|error| {
+            format!(
+                "解析 sidecar 运行时账号状态失败: path={}, error={}",
+                path.display(),
+                error
+            )
+        })?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            json!({ "accounts": {} })
+        }
+        Err(error) => {
+            return Err(format!(
+                "读取 sidecar 运行时账号状态失败: path={}, error={}",
+                path.display(),
+                error
+            ))
+        }
+    };
+    let state = state
+        .as_object_mut()
+        .ok_or_else(|| "sidecar 运行时账号状态不是 JSON 对象".to_string())?;
+    let accounts_value = state
+        .entry("accounts".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let state_accounts = accounts_value
+        .as_object_mut()
+        .ok_or_else(|| "sidecar 运行时账号状态 accounts 不是 JSON 对象".to_string())?;
+
+    let account_by_id = accounts
+        .iter()
+        .map(|account| (account.id.as_str(), account))
+        .collect::<HashMap<_, _>>();
+    // Metered-feature model rules are discovered across the whole pool. If any
+    // effective account is missing, every account must stay closed until a
+    // complete snapshot can authoritatively replace this state.
+    for account_id in effective_sidecar_account_ids(collection) {
+        let previous = valid_sidecar_runtime_model_exclusions(state_accounts.get(&account_id));
+        let tightened = match previous {
+            Some(mut exclusions) => {
+                if !exclusions.iter().any(|exclusion| exclusion.trim() == "*") {
+                    exclusions.push("*".to_string());
+                }
+                exclusions
+            }
+            None => vec!["*".to_string()],
+        };
+        let account_state = state_accounts
+            .entry(account_id)
+            .or_insert_with(|| Value::Object(Map::new()));
+        if !account_state.is_object() {
+            *account_state = Value::Object(Map::new());
+        }
+        account_state
+            .as_object_mut()
+            .expect("account state was normalized to an object")
+            .insert("modelExclusions".to_string(), json!(tightened));
+    }
+
+    if let Some(bound_account_id) =
+        normalize_optional_account_ref(collection.bound_oauth_account_id.as_deref())
+    {
+        if collection.bound_oauth_quota_reserve.is_some() {
+            let snapshot = account_by_id
+                .get(bound_account_id.as_str())
+                .copied()
+                .and_then(|account| {
+                    if fresh_quota_for_bound_oauth_reserve(account).is_some() {
+                        sidecar_quota_reserve_snapshot_value(collection, account)
+                    } else {
+                        unknown_sidecar_quota_reserve_snapshot_value(collection, &bound_account_id)
+                    }
+                })
+                .or_else(|| {
+                    unknown_sidecar_quota_reserve_snapshot_value(collection, &bound_account_id)
+                })
+                .ok_or_else(|| "绑定 OAuth 保留额度配置无效".to_string())?;
+            let snapshot = snapshot
+                .as_object()
+                .ok_or_else(|| "绑定 OAuth 保留额度快照不是 JSON 对象".to_string())?;
+            let bound_value = state_accounts
+                .entry(bound_account_id)
+                .or_insert_with(|| Value::Object(Map::new()));
+            if !bound_value.is_object() {
+                *bound_value = Value::Object(Map::new());
+            }
+            let bound_state = bound_value
+                .as_object_mut()
+                .expect("bound account state was normalized to an object");
+            for field in [
+                "snapshotUpdatedAtUnixSeconds",
+                "hourlyRemainingPercent",
+                "weeklyRemainingPercent",
+                "hourlyWindowPresent",
+                "weeklyWindowPresent",
+                "hourlyThresholdPercent",
+                "weeklyThresholdPercent",
+            ] {
+                if let Some(value) = snapshot.get(field) {
+                    bound_state.insert(field.to_string(), value.clone());
+                }
+            }
+        }
+    }
+
+    let content = serde_json::to_string_pretty(&Value::Object(state.clone()))
+        .map_err(|error| format!("序列化 sidecar 运行时账号状态失败: {}", error))?;
+    write_string_atomic_if_changed(&path, &content)
+}
+
+fn sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+    account_id: &str,
+    accounts: &[CodexAccount],
+    collection: &CodexLocalAccessCollection,
+    base_dir: &Path,
+) -> Result<Option<bool>, String> {
+    let account_id = account_id.trim();
+    let is_effective_account = effective_sidecar_account_ids(collection)
+        .iter()
+        .any(|candidate| candidate == account_id);
+    let is_bound_account =
+        normalize_optional_account_ref(collection.bound_oauth_account_id.as_deref()).as_deref()
+            == Some(account_id);
+    if collection_gateway_mode(collection) != CodexLocalAccessGatewayMode::Sidecar
+        || (!is_effective_account && !is_bound_account)
+    {
+        return Ok(None);
+    }
+
+    let model_exclusions = match sidecar_model_exclusions_for_accounts(accounts, collection) {
+        Ok(model_exclusions) => model_exclusions,
+        Err(error) => {
+            return match patch_sidecar_runtime_account_state_for_incomplete_snapshot_in_dir(
+                accounts, collection, base_dir,
+            ) {
+                Ok(_) => Err(format!(
+                    "{}; 已按不完整快照只收紧 sidecar 运行时账号状态",
+                    error
+                )),
+                Err(patch_error) => Err(format!(
+                    "{}; 按不完整快照收紧 sidecar 运行时账号状态失败: {}",
+                    error, patch_error
+                )),
+            };
+        }
+    };
+    write_sidecar_quota_reserve_state_in_dir(collection, &model_exclusions, base_dir)
+        .map(|(_, changed)| Some(changed))
 }
 
 fn sidecar_quota_pool_window_value(
@@ -12486,6 +12763,8 @@ fn prepare_sidecar_launch_config_in_dir_sync(
     let mut manifest_accounts = Vec::new();
     let mut codex_keys = Vec::new();
     let mut expected_auth_files = HashSet::new();
+    let mut runtime_model_exclusions = HashMap::new();
+    let state_guard = lock_sidecar_runtime_account_state_sync()?;
     let metered_feature_patterns =
         metered_feature_model_patterns_for_pool(collection, &account_overrides);
     for (index, account_id) in effective_sidecar_account_ids(collection)
@@ -12537,6 +12816,14 @@ fn prepare_sidecar_launch_config_in_dir_sync(
                 &metered_feature_patterns,
             ) {
                 codex_keys.push(config_value);
+                runtime_model_exclusions.insert(
+                    account.id.clone(),
+                    sidecar_excluded_models_for_account(
+                        &account,
+                        collection,
+                        &metered_feature_patterns,
+                    ),
+                );
                 manifest_accounts.push(sidecar_account_manifest_value(&account, None, collection));
             } else {
                 // Base-URL rejection is already logged inside resolve/config builders.
@@ -12571,6 +12858,10 @@ fn prepare_sidecar_launch_config_in_dir_sync(
             .map_err(|e| format!("序列化 sidecar Codex OAuth 认证失败: {}", e))?;
         write_string_atomic_if_changed(&auth_path, &auth_content)?;
         harden_sidecar_auth_file_permissions(&auth_path)?;
+        runtime_model_exclusions.insert(
+            account.id.clone(),
+            sidecar_excluded_models_for_account(&account, collection, &metered_feature_patterns),
+        );
         manifest_accounts.push(sidecar_account_manifest_value(
             &account,
             Some(&file_name),
@@ -12729,7 +13020,8 @@ fn prepare_sidecar_launch_config_in_dir_sync(
     write_string_atomic_if_changed(&config_path, &config_content)?;
     write_string_atomic_if_changed(&manifest_path, &manifest_content)?;
     write_sidecar_api_key_priority_state_in_dir(collection, &base_dir)?;
-    write_sidecar_quota_reserve_state_in_dir(collection, &base_dir)?;
+    write_sidecar_quota_reserve_state_in_dir(collection, &runtime_model_exclusions, &base_dir)?;
+    drop(state_guard);
     write_sidecar_quota_pool_state_in_dir(collection, &base_dir)?;
 
     Ok(SidecarLaunchConfig {
@@ -16167,30 +16459,77 @@ pub async fn reevaluate_bound_oauth_quota_reserve_after_refresh(
                         == Some(account_id)
             })
             .cloned();
-        if collection.is_some() {
+        let active_collection = runtime.collection.clone();
+        let refreshed_account_in_sidecar = active_collection.as_ref().is_some_and(|collection| {
+            collection_gateway_mode(collection) == CodexLocalAccessGatewayMode::Sidecar
+                && effective_sidecar_account_ids(collection)
+                    .iter()
+                    .any(|candidate| candidate == account_id)
+        });
+        if collection.is_some() || refreshed_account_in_sidecar {
             runtime.prepared_accounts.remove(account_id);
         }
-        (collection, runtime.collection.clone())
+        (collection, active_collection)
     };
 
     if let Some(collection) = active_collection {
         if collection_gateway_mode(&collection) == CodexLocalAccessGatewayMode::Sidecar {
+            if refresh_succeeded || matching_collection.is_some() {
+                let state_sync_result = (|| {
+                    let _state_guard = lock_sidecar_runtime_account_state_sync()?;
+                    load_collection_from_disk().and_then(|latest_collection| {
+                        let latest_collection = latest_collection.ok_or_else(|| {
+                            "API 服务配置不存在，保留现有 sidecar 运行时账号状态".to_string()
+                        })?;
+                        let base_dir = local_access_sidecar_dir()?;
+                        let accounts = match codex_account::list_accounts_checked() {
+                            Ok(accounts) => accounts,
+                            Err(error) => {
+                                return match patch_sidecar_runtime_account_state_for_incomplete_snapshot_in_dir(
+                                    &[],
+                                    &latest_collection,
+                                    &base_dir,
+                                ) {
+                                    Ok(_) => Err(format!(
+                                        "{}; 已将不可读账号快照按 fail-closed 规则写入 sidecar 运行时状态",
+                                        error
+                                    )),
+                                    Err(patch_error) => Err(format!(
+                                        "{}; 将不可读账号快照按 fail-closed 规则写入 sidecar 运行时状态失败: {}",
+                                        error, patch_error
+                                    )),
+                                };
+                            }
+                        };
+                        sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+                            account_id,
+                            &accounts,
+                            &latest_collection,
+                            &base_dir,
+                        )
+                    })
+                })();
+                match state_sync_result {
+                    Ok(Some(true)) => logger::log_codex_api_info(&format!(
+                        "[CodexLocalAccess][sidecar] 配额刷新后热同步运行时账号状态: account_id={}",
+                        account_id
+                    )),
+                    Ok(Some(false)) | Ok(None) => {}
+                    Err(error) => {
+                        if matching_collection.is_some() {
+                            let mut runtime = gateway_runtime().lock().await;
+                            runtime.last_error = Some(error.clone());
+                        }
+                        logger::log_codex_api_warn(&format!(
+                            "[CodexLocalAccess][sidecar] 配额刷新后同步运行时账号状态失败: account_id={}, error={}",
+                            account_id, error
+                        ));
+                    }
+                }
+            }
             if let Err(error) = write_sidecar_quota_pool_state(&collection) {
                 logger::log_codex_api_warn(&format!(
                     "[CodexLocalAccess] API 服务额度池快照热更新失败: {}",
-                    error
-                ));
-            }
-        }
-    }
-
-    if let Some(collection) = matching_collection {
-        if collection_gateway_mode(&collection) == CodexLocalAccessGatewayMode::Sidecar {
-            if let Err(error) = write_sidecar_quota_reserve_state(&collection) {
-                let mut runtime = gateway_runtime().lock().await;
-                runtime.last_error = Some(error.clone());
-                logger::log_codex_api_warn(&format!(
-                    "[CodexLocalAccess] 绑定 OAuth 配额快照热更新失败: {}",
                     error
                 ));
             }
@@ -27345,19 +27684,20 @@ mod tests {
         collect_local_access_profile_takeover_dirs_from_store, compare_routing_candidates,
         count_request_logs_for_model_ids, default_codex_model_ids, effective_api_key_account_ids,
         empty_stats_snapshot, extract_usage_capture, filter_bound_oauth_quota_reserve_account,
-        filter_websocket_client_message, insert_local_access_usage_event,
-        inspect_local_access_profile_attachment, inspect_local_access_profile_config,
-        is_codex_local_access_auth_text, is_codex_local_access_config_for_api_key,
-        is_codex_oauth_auth_text, is_image_generation_capability_error,
-        is_local_access_eligible_account, is_local_access_gateway_base_url,
-        is_provider_gateway_eligible_account, is_responses_completion_event,
-        is_stream_incomplete_error_message, is_upstream_response_failed_error_message,
-        legacy_stream_error_category, local_access_chat_completions_url,
-        local_access_ineligible_reason, lookup_codex_model_provider_base_url_in_dir,
-        macos_proxy_url_from_scutil_map, max_credential_attempts_for_strategy,
-        merge_collection_and_account_excluded_models, model_pricing,
-        model_provider_direct_test_client_model, model_provider_test_uses_provider_gateway,
-        normalize_account_id_list, normalize_account_model_rules, normalize_collection_api_keys,
+        filter_websocket_client_message, implicit_metered_feature_exclusions,
+        insert_local_access_usage_event, inspect_local_access_profile_attachment,
+        inspect_local_access_profile_config, is_codex_local_access_auth_text,
+        is_codex_local_access_config_for_api_key, is_codex_oauth_auth_text,
+        is_image_generation_capability_error, is_local_access_eligible_account,
+        is_local_access_gateway_base_url, is_provider_gateway_eligible_account,
+        is_responses_completion_event, is_stream_incomplete_error_message,
+        is_upstream_response_failed_error_message, legacy_stream_error_category,
+        local_access_chat_completions_url, local_access_ineligible_reason,
+        lookup_codex_model_provider_base_url_in_dir, macos_proxy_url_from_scutil_map,
+        max_credential_attempts_for_strategy, merge_collection_and_account_excluded_models,
+        model_pricing, model_provider_direct_test_client_model,
+        model_provider_test_uses_provider_gateway, normalize_account_id_list,
+        normalize_account_model_rules, normalize_collection_api_keys,
         normalize_custom_routing_rules, normalized_sidecar_error_category,
         open_local_access_logs_db_once, parse_codex_retry_after,
         parse_responses_payload_from_upstream, parse_websocket_upstream_error,
@@ -27369,8 +27709,8 @@ mod tests {
         provider_gateway_default_model_for_account,
         provider_gateway_image_generation_mode_for_account, provider_gateway_model_slots,
         provider_gateway_models_for_account, provider_model_slots_need_upstream_rewrite,
-        read_http_request, read_request_log_reprice_batch, recompute_time_windows,
-        recover_invalid_stats_file, remove_account_refs_from_collection,
+        quota_disallowed_model_patterns, read_http_request, read_request_log_reprice_batch,
+        recompute_time_windows, recover_invalid_stats_file, remove_account_refs_from_collection,
         remove_codex_local_access_config, reprice_request_logs_for_collection,
         request_image_generation_mode, request_logs_has_column, request_ordered_account_ids,
         resolve_collection_api_key, resolve_effective_model_pricing, resolve_plan_rank,
@@ -27386,9 +27726,9 @@ mod tests {
         sidecar_auth_file_name, sidecar_auth_json_for_account, sidecar_auths_dir,
         sidecar_client_api_keys, sidecar_codex_api_key_auth_id, sidecar_codex_key_config_value,
         sidecar_config_fingerprint, sidecar_local_account_usable_for_start,
-        sidecar_payload_default_service_tier, sidecar_quota_reserve_snapshot_value,
-        sidecar_routing_strategy_value, sidecar_stable_id, supported_codex_model_ids,
-        system_proxy_target_scheme, system_proxy_value_url,
+        sidecar_payload_default_service_tier, sidecar_quota_reserve_path,
+        sidecar_quota_reserve_snapshot_value, sidecar_routing_strategy_value, sidecar_stable_id,
+        supported_codex_model_ids, system_proxy_target_scheme, system_proxy_value_url,
         tool_declares_image_generation_capability, usage_event_from_row,
         validate_api_key_account_scope_update, validate_client_model_visible,
         validate_loaded_local_access_bound_oauth_account, visible_codex_model_ids_for_api_key,
@@ -27438,7 +27778,7 @@ mod tests {
     use std::{
         collections::{HashMap, HashSet},
         fs,
-        path::PathBuf,
+        path::{Path, PathBuf},
     };
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
@@ -29337,6 +29677,588 @@ wire_api = "responses"
     }
 
     #[test]
+    fn incomplete_pool_tightens_models_and_patches_bound_quota_in_one_rmw() {
+        let bound_account_id = "bound-rmw";
+        let missing_account_id = "missing-rmw";
+        let mut collection = test_local_access_collection(vec![
+            bound_account_id.to_string(),
+            missing_account_id.to_string(),
+        ]);
+        collection.bound_oauth_account_id = Some(bound_account_id.to_string());
+        collection.bound_oauth_quota_reserve = Some(CodexLocalAccessQuotaReserve {
+            hourly_percent: 20,
+            weekly_percent: 10,
+        });
+
+        let dir = make_temp_dir("codex-bound-quota-rmw");
+        let state_path = sidecar_quota_reserve_path(&dir);
+        let initial = json!({
+            "stateExtension": { "keep": true },
+            "accounts": {
+                (bound_account_id): {
+                    "snapshotUpdatedAtUnixSeconds": 1,
+                    "hourlyRemainingPercent": 99,
+                    "weeklyRemainingPercent": 98,
+                    "hourlyWindowPresent": true,
+                    "weeklyWindowPresent": true,
+                    "hourlyThresholdPercent": 1,
+                    "weeklyThresholdPercent": 1,
+                    "modelExclusions": [],
+                    "accountExtension": { "keep": "bound" }
+                },
+                (missing_account_id): {
+                    "modelExclusions": ["gpt-5.3-codex-spark"],
+                    "accountExtension": { "keep": "peer" }
+                },
+                "unrelated-rmw": {
+                    "modelExclusions": ["gpt-5.2"],
+                    "accountExtension": { "keep": "unrelated" }
+                }
+            }
+        });
+        fs::write(
+            &state_path,
+            serde_json::to_string_pretty(&initial).expect("serialize initial runtime state"),
+        )
+        .expect("write initial runtime state");
+
+        let account =
+            test_oauth_account_with_quota(bound_account_id, 75, 40, Some(true), Some(false));
+        bound_oauth_quota_refresh_failures()
+            .lock()
+            .unwrap()
+            .remove(bound_account_id);
+        let error = super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+            bound_account_id,
+            &[account.clone()],
+            &collection,
+            &dir,
+        )
+        .expect_err("incomplete pool should tighten exclusions and patch fresh bound quota");
+        assert!(error.contains(missing_account_id));
+
+        let read_state = || {
+            serde_json::from_str::<Value>(
+                &fs::read_to_string(&state_path).expect("read patched runtime state"),
+            )
+            .expect("parse patched runtime state")
+        };
+        let fresh = read_state();
+        assert_eq!(
+            fresh["accounts"][bound_account_id]["hourlyRemainingPercent"],
+            json!(75)
+        );
+        assert_eq!(
+            fresh["accounts"][bound_account_id]["weeklyRemainingPercent"],
+            json!(40)
+        );
+        assert_eq!(
+            fresh["accounts"][bound_account_id]["hourlyWindowPresent"],
+            json!(true)
+        );
+        assert_eq!(
+            fresh["accounts"][bound_account_id]["weeklyWindowPresent"],
+            json!(false)
+        );
+        assert_eq!(
+            fresh["accounts"][bound_account_id]["hourlyThresholdPercent"],
+            json!(20)
+        );
+        assert_eq!(
+            fresh["accounts"][bound_account_id]["weeklyThresholdPercent"],
+            json!(10)
+        );
+        assert_eq!(
+            fresh["accounts"][bound_account_id]["modelExclusions"],
+            json!(["*"])
+        );
+        assert_eq!(
+            fresh["accounts"][bound_account_id]["accountExtension"],
+            initial["accounts"][bound_account_id]["accountExtension"]
+        );
+        assert_eq!(
+            fresh["accounts"][missing_account_id]["modelExclusions"],
+            json!(["gpt-5.3-codex-spark", "*"])
+        );
+        assert_eq!(
+            fresh["accounts"][missing_account_id]["accountExtension"],
+            initial["accounts"][missing_account_id]["accountExtension"]
+        );
+        assert_eq!(
+            fresh["accounts"]["unrelated-rmw"],
+            initial["accounts"]["unrelated-rmw"]
+        );
+        assert_eq!(fresh["stateExtension"], initial["stateExtension"]);
+
+        bound_oauth_quota_refresh_failures()
+            .lock()
+            .unwrap()
+            .insert(bound_account_id.to_string());
+        super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+            bound_account_id,
+            &[account],
+            &collection,
+            &dir,
+        )
+        .expect_err("failed bound refresh should write an unknown quota snapshot");
+        let failed = read_state();
+        for field in [
+            "snapshotUpdatedAtUnixSeconds",
+            "hourlyRemainingPercent",
+            "weeklyRemainingPercent",
+            "hourlyWindowPresent",
+            "weeklyWindowPresent",
+        ] {
+            assert_eq!(failed["accounts"][bound_account_id][field], Value::Null);
+        }
+        assert_eq!(
+            failed["accounts"][bound_account_id]["modelExclusions"],
+            json!(["*"])
+        );
+        assert_eq!(
+            failed["accounts"][missing_account_id]["modelExclusions"],
+            json!(["gpt-5.3-codex-spark", "*"])
+        );
+
+        bound_oauth_quota_refresh_failures()
+            .lock()
+            .unwrap()
+            .remove(bound_account_id);
+        super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+            bound_account_id,
+            &[],
+            &collection,
+            &dir,
+        )
+        .expect_err("unreadable bound account should keep the unknown quota snapshot");
+        let unreadable = read_state();
+        assert_eq!(
+            unreadable["accounts"][bound_account_id]["snapshotUpdatedAtUnixSeconds"],
+            Value::Null
+        );
+        assert_eq!(
+            unreadable["accounts"][bound_account_id]["modelExclusions"],
+            json!(["*"])
+        );
+        assert_eq!(
+            unreadable["accounts"]["unrelated-rmw"],
+            initial["accounts"]["unrelated-rmw"]
+        );
+
+        fs::remove_dir_all(dir).expect("cleanup bound quota RMW state");
+    }
+
+    #[test]
+    fn incomplete_pool_blocks_all_accounts_until_complete_snapshot_replaces_state() {
+        let mut account_a = test_account_with_plan("pro");
+        account_a.id = "partial-tighten-a".to_string();
+        account_a.quota = Some(test_spark_quota(true));
+        let mut account_b = test_account_with_plan("plus");
+        account_b.id = "partial-tighten-b".to_string();
+        account_b.quota = Some(test_spark_quota(true));
+        let collection =
+            test_local_access_collection(vec![account_a.id.clone(), account_b.id.clone()]);
+        let dir = make_temp_dir("codex-partial-tighten-runtime-state");
+        super::prepare_sidecar_launch_config_in_dir_sync(
+            &collection,
+            dir.clone(),
+            HashMap::new(),
+            None,
+            HashMap::from([
+                (account_a.id.clone(), account_a.clone()),
+                (account_b.id.clone(), account_b.clone()),
+            ]),
+            None,
+        )
+        .expect("prepare initial authoritative empty exclusions");
+
+        let state_path = sidecar_quota_reserve_path(&dir);
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &account_a.id),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &account_b.id),
+            Vec::<String>::new()
+        );
+
+        account_a.quota = Some(test_spark_quota(false));
+        let error = super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+            &account_a.id,
+            &[account_a.clone()],
+            &collection,
+            &dir,
+        )
+        .expect_err("partial snapshot must tighten known and missing accounts");
+        assert!(error.contains(&account_b.id));
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &account_a.id),
+            vec!["*".to_string()]
+        );
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &account_b.id),
+            vec!["*".to_string()]
+        );
+
+        account_a.quota = Some(test_spark_quota(true));
+        super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+            &account_a.id,
+            &[account_a.clone()],
+            &collection,
+            &dir,
+        )
+        .expect_err("partial recovery must not remove an earlier exclusion");
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &account_a.id),
+            vec!["*".to_string()]
+        );
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &account_b.id),
+            vec!["*".to_string()]
+        );
+
+        assert_eq!(
+            super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+                &account_a.id,
+                &[account_a.clone(), account_b.clone()],
+                &collection,
+                &dir,
+            )
+            .expect("complete snapshot should replace stale fail-closed exclusions"),
+            Some(true)
+        );
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &account_a.id),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &account_b.id),
+            Vec::<String>::new()
+        );
+
+        fs::remove_dir_all(dir).expect("cleanup partial tighten runtime state");
+    }
+
+    #[test]
+    fn quota_refresh_runtime_state_removes_only_dynamic_spark_exclusion() {
+        let mut account = test_account_with_plan("pro");
+        account.id = "quota-runtime-state".to_string();
+        account.quota = Some(test_spark_quota(false));
+
+        let mut collection = test_local_access_collection(vec![account.id.clone()]);
+        collection.excluded_models = vec!["gpt-5.2".to_string()];
+        collection.account_model_rules = vec![CodexLocalAccessAccountModelRule {
+            account_id: account.id.clone(),
+            excluded_models: vec!["gpt-5.4-mini".to_string()],
+        }];
+
+        let dir = make_temp_dir("codex-quota-runtime-state");
+        super::prepare_sidecar_launch_config_in_dir_sync(
+            &collection,
+            dir.clone(),
+            HashMap::new(),
+            None,
+            HashMap::from([(account.id.clone(), account.clone())]),
+            None,
+        )
+        .expect("prepare sidecar state with exhausted Spark quota");
+
+        let auth_path = sidecar_auths_dir(&dir).join(sidecar_auth_file_name(&account.id));
+        let state_path = sidecar_quota_reserve_path(&dir);
+        let before = sidecar_runtime_state_model_exclusions(&state_path, &account.id);
+        assert!(before.contains(&"gpt-5.3-codex-spark".to_string()));
+        assert!(before.contains(&"gpt-5.2".to_string()));
+        assert!(before.contains(&"gpt-5.4-mini".to_string()));
+
+        let error = super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+            &account.id,
+            &[],
+            &collection,
+            &dir,
+        )
+        .expect_err("runtime state sync must reject an incomplete pool snapshot");
+        assert!(error.contains(&account.id));
+        let after_incomplete = sidecar_runtime_state_model_exclusions(&state_path, &account.id);
+        assert!(after_incomplete.contains(&"gpt-5.3-codex-spark".to_string()));
+        assert!(after_incomplete.contains(&"gpt-5.2".to_string()));
+        assert!(after_incomplete.contains(&"gpt-5.4-mini".to_string()));
+        assert!(after_incomplete.contains(&"*".to_string()));
+
+        let mut auth: Value = serde_json::from_str(
+            &fs::read_to_string(&auth_path).expect("read auth before sidecar token update"),
+        )
+        .expect("parse auth before sidecar token update");
+        auth["access_token"] = json!("sidecar-refreshed-access-token");
+        auth["refresh_token"] = json!("sidecar-refreshed-refresh-token");
+        auth["task_id"] = json!("sidecar-runtime-task");
+        fs::write(
+            &auth_path,
+            serde_json::to_string_pretty(&auth).expect("serialize sidecar-updated auth"),
+        )
+        .expect("write sidecar-updated auth");
+        let sidecar_auth = fs::read(&auth_path).expect("capture sidecar-updated auth");
+
+        account.quota = Some(test_spark_quota(true));
+        assert_eq!(
+            super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+                &account.id,
+                &[account.clone()],
+                &collection,
+                &dir,
+            )
+            .expect("hot-sync refreshed runtime state"),
+            Some(true)
+        );
+
+        let after = sidecar_runtime_state_model_exclusions(&state_path, &account.id);
+        assert!(!after.contains(&"gpt-5.3-codex-spark".to_string()));
+        assert!(after.contains(&"gpt-5.2".to_string()));
+        assert!(after.contains(&"gpt-5.4-mini".to_string()));
+        assert_eq!(
+            fs::read(&auth_path).expect("read auth after runtime state sync"),
+            sidecar_auth,
+            "quota-derived model exclusion refresh must never rewrite the auth projection"
+        );
+        assert_eq!(
+            super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+                &account.id,
+                &[account.clone()],
+                &collection,
+                &dir,
+            )
+            .expect("unchanged runtime state should not be rewritten"),
+            Some(false)
+        );
+
+        fs::remove_file(&auth_path).expect("remove auth projection");
+        assert_eq!(
+            super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+                &account.id,
+                &[account.clone()],
+                &collection,
+                &dir,
+            )
+            .expect("runtime state sync should not recreate a missing auth"),
+            Some(false)
+        );
+        assert!(!auth_path.exists());
+
+        fs::remove_dir_all(dir).expect("cleanup quota runtime state config");
+    }
+
+    #[test]
+    fn quota_refresh_runtime_state_updates_peer_metered_feature_exclusions() {
+        let quota_without_metered_features = || {
+            let mut quota = test_spark_quota(true);
+            quota.raw_data = Some(json!({ "additional_rate_limits": [] }));
+            quota
+        };
+        let mut entitled = test_account_with_plan("pro");
+        entitled.id = "quota-runtime-state-entitled".to_string();
+        entitled.quota = Some(quota_without_metered_features());
+        let mut peer = test_account_with_plan("plus");
+        peer.id = "quota-runtime-state-peer".to_string();
+        peer.quota = Some(quota_without_metered_features());
+        let collection = test_local_access_collection(vec![entitled.id.clone(), peer.id.clone()]);
+        let dir = make_temp_dir("codex-quota-runtime-state-peers");
+        super::prepare_sidecar_launch_config_in_dir_sync(
+            &collection,
+            dir.clone(),
+            HashMap::new(),
+            None,
+            HashMap::from([
+                (entitled.id.clone(), entitled.clone()),
+                (peer.id.clone(), peer.clone()),
+            ]),
+            None,
+        )
+        .expect("prepare sidecar peer runtime state");
+
+        let peer_auth_path = sidecar_auths_dir(&dir).join(sidecar_auth_file_name(&peer.id));
+        let state_path = sidecar_quota_reserve_path(&dir);
+        let peer_excludes_spark = || {
+            sidecar_runtime_state_model_exclusions(&state_path, &peer.id)
+                .iter()
+                .any(|model| model.eq_ignore_ascii_case("gpt-5.3-codex-spark"))
+        };
+        assert!(!peer_excludes_spark());
+
+        let mut incomplete_peer = peer.clone();
+        incomplete_peer.quota = Some(test_spark_quota(false));
+        let error = super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+            &peer.id,
+            &[incomplete_peer],
+            &collection,
+            &dir,
+        )
+        .expect_err("an incomplete pool snapshot must fail closed");
+        assert!(error.contains(&entitled.id));
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &entitled.id),
+            vec!["*".to_string()]
+        );
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &peer.id),
+            vec!["*".to_string()]
+        );
+
+        let mut peer_auth: Value = serde_json::from_str(
+            &fs::read_to_string(&peer_auth_path).expect("read peer auth before token refresh"),
+        )
+        .expect("parse peer auth before token refresh");
+        peer_auth["access_token"] = json!("sidecar-refreshed-access-token");
+        peer_auth["refresh_token"] = json!("sidecar-refreshed-refresh-token");
+        fs::write(
+            &peer_auth_path,
+            serde_json::to_string_pretty(&peer_auth).expect("serialize refreshed peer auth"),
+        )
+        .expect("write refreshed peer auth");
+        let sidecar_peer_auth = fs::read(&peer_auth_path).expect("capture refreshed peer auth");
+
+        entitled.quota = Some(test_spark_quota(true));
+        let accounts = vec![entitled.clone(), peer.clone()];
+        assert_eq!(
+            super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+                &entitled.id,
+                &accounts,
+                &collection,
+                &dir,
+            )
+            .expect("sync newly discovered metered feature"),
+            Some(true)
+        );
+        assert!(peer_excludes_spark());
+        assert_eq!(
+            fs::read(&peer_auth_path).expect("read peer auth after state sync"),
+            sidecar_peer_auth
+        );
+
+        entitled.quota = Some(quota_without_metered_features());
+        let accounts = vec![entitled, peer.clone()];
+        assert_eq!(
+            super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+                &peer.id,
+                &accounts,
+                &collection,
+                &dir,
+            )
+            .expect("sync removed metered feature"),
+            Some(true)
+        );
+        assert!(!peer_excludes_spark());
+        assert_eq!(
+            sidecar_runtime_state_model_exclusions(&state_path, &peer.id),
+            Vec::<String>::new(),
+            "an explicit empty list is the authoritative allow state"
+        );
+        assert_eq!(
+            fs::read(&peer_auth_path).expect("read peer auth after feature removal"),
+            sidecar_peer_auth
+        );
+
+        fs::remove_dir_all(dir).expect("cleanup peer quota runtime state");
+    }
+
+    #[test]
+    fn quota_refresh_runtime_state_preserves_agent_identity_task() {
+        let mut account = test_account_with_plan("plus");
+        account.id = "agent-quota-runtime-state".to_string();
+        account.tokens.access_token.clear();
+        account.agent_identity = Some(CodexAgentIdentity {
+            agent_runtime_id: "runtime-state".to_string(),
+            agent_private_key: "private-key-state".to_string(),
+            task_id: Some("task-old".to_string()),
+            account_id: "team-state".to_string(),
+            chatgpt_user_id: "user-state".to_string(),
+            email: Some(account.email.clone()),
+            plan_type: Some("plus".to_string()),
+            chatgpt_account_is_fedramp: false,
+        });
+        account.quota = Some(test_spark_quota(false));
+        let collection = test_local_access_collection(vec![account.id.clone()]);
+        let dir = make_temp_dir("codex-agent-quota-runtime-state");
+        super::prepare_sidecar_launch_config_in_dir_sync(
+            &collection,
+            dir.clone(),
+            HashMap::new(),
+            None,
+            HashMap::from([(account.id.clone(), account.clone())]),
+            None,
+        )
+        .expect("prepare Agent Identity sidecar auth");
+
+        let auth_path = sidecar_auths_dir(&dir).join(sidecar_auth_file_name(&account.id));
+        let mut auth: Value = serde_json::from_str(
+            &fs::read_to_string(&auth_path).expect("read Agent Identity auth"),
+        )
+        .expect("parse Agent Identity auth");
+        auth["task_id"] = json!("task-recovered");
+        fs::write(
+            &auth_path,
+            serde_json::to_string_pretty(&auth).expect("serialize recovered task auth"),
+        )
+        .expect("write recovered task auth");
+        let recovered_auth = fs::read(&auth_path).expect("capture recovered task auth");
+
+        account.quota = Some(test_spark_quota(true));
+        assert_eq!(
+            super::sync_sidecar_runtime_account_state_after_quota_refresh_in_dir(
+                &account.id,
+                &[account.clone()],
+                &collection,
+                &dir,
+            )
+            .expect("hot-sync Agent Identity runtime state"),
+            Some(true)
+        );
+        assert_eq!(
+            fs::read(&auth_path).expect("read Agent Identity auth after state sync"),
+            recovered_auth
+        );
+
+        fs::remove_dir_all(dir).expect("cleanup Agent Identity runtime state");
+    }
+
+    #[test]
+    fn quota_derived_model_exclusions_have_stable_order() {
+        let mut account = test_account_with_plan("pro");
+        let mut quota = test_spark_quota(true);
+        quota.raw_data = Some(json!({
+            "additional_rate_limits": [
+                {
+                    "limit_name": "z-model",
+                    "metered_feature": "feature_z",
+                    "rate_limit": { "allowed": false }
+                },
+                {
+                    "limit_name": "a-model",
+                    "metered_feature": "feature_a",
+                    "rate_limit": { "allowed": false }
+                }
+            ]
+        }));
+        account.quota = Some(quota);
+        assert_eq!(
+            quota_disallowed_model_patterns(&account),
+            vec!["a-model".to_string(), "z-model".to_string()]
+        );
+
+        account.quota = Some({
+            let mut quota = test_spark_quota(true);
+            quota.raw_data = Some(json!({ "additional_rate_limits": [] }));
+            quota
+        });
+        let feature_patterns = HashMap::from([
+            ("feature_z".to_string(), "z-model".to_string()),
+            ("feature_a".to_string(), "a-model".to_string()),
+        ]);
+        assert_eq!(
+            implicit_metered_feature_exclusions(&account, &feature_patterns),
+            vec!["a-model".to_string(), "z-model".to_string()]
+        );
+    }
+
+    #[test]
     fn scoped_api_key_pool_discovers_spark_entitlement_from_effective_accounts() {
         let mut plus = test_account_with_plan("plus");
         plus.id = "scoped-plus".to_string();
@@ -29417,6 +30339,23 @@ wire_api = "responses"
         fs::remove_dir_all(dir).expect("cleanup scoped sidecar config");
     }
 
+    fn sidecar_runtime_state_model_exclusions(path: &Path, account_id: &str) -> Vec<String> {
+        let state: Value = serde_json::from_str(
+            &fs::read_to_string(path).expect("read sidecar runtime account state"),
+        )
+        .expect("parse sidecar runtime account state");
+        state
+            .get("accounts")
+            .and_then(|accounts| accounts.get(account_id))
+            .and_then(|account| account.get("modelExclusions"))
+            .and_then(Value::as_array)
+            .expect("modelExclusions should be an array")
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect()
+    }
+
     fn make_temp_dir(prefix: &str) -> PathBuf {
         for _ in 0..10 {
             let dir = std::env::temp_dir().join(format!(
@@ -29444,6 +30383,29 @@ wire_api = "responses"
         );
         account.plan_type = Some(plan_type.to_string());
         account
+    }
+
+    fn test_spark_quota(allowed: bool) -> CodexQuota {
+        CodexQuota {
+            hourly_percentage: 100,
+            hourly_reset_time: None,
+            hourly_window_minutes: Some(300),
+            hourly_window_present: Some(true),
+            weekly_percentage: 100,
+            weekly_reset_time: None,
+            weekly_window_minutes: Some(10_080),
+            weekly_window_present: Some(true),
+            reset_credits_available: None,
+            reset_credits: Vec::new(),
+            reset_credits_next_expires_at: None,
+            raw_data: Some(json!({
+                "additional_rate_limits": [{
+                    "limit_name": "GPT-5.3-Codex-Spark",
+                    "metered_feature": "codex_spark",
+                    "rate_limit": { "allowed": allowed }
+                }]
+            })),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- publish quota-derived per-account model exclusions through the existing runtime state file instead of rewriting auth JSON during quota refresh
- hot-reload exclusion changes into selectors, registry, and scheduler when the embedded sidecar runs via `StartRuntime`
- fail closed for incomplete account snapshots, while allowing a complete snapshot to clear stale Spark exclusions without restarting the sidecar
- preserve unrelated model cooldown/suspension state and remove aliases whose canonical source is excluded
- make auth-file refreshes atomic and keep watcher updates manifest-aware

## Problem

When Spark quota recovered, Cockpit refreshed the account quota but left the old `excluded_models` routing state in the running sidecar. Spark workers then continued receiving `503 auth_not_found: no auth available` until the sidecar account set was manually reloaded. The embedded `StartRuntime` path also did not start the auth watcher.

## Design

`quota-reserve.json` now carries an authoritative `modelExclusions` array for every effective account. Explicit `[]` means allowed; missing/null state fails closed when a runtime-state path is configured. Rust quota refreshes update this state atomically and do not rewrite auth JSON for model-exclusion changes.

If any effective account snapshot is missing or unreadable, all effective accounts receive `*`; only a later complete snapshot may remove that temporary block. Go reloads only accounts whose exclusion semantics changed, and uses a preserving registry reconciliation so a Spark policy change does not clear Luna/Terra cooldowns.

## Verification

- Cockpit sidecar regression tests: repeated 20–50 times
- relevant Go race tests: repeated 3–10 times
- touched vendored packages: `internal/registry`, `sdk/auth`, `sdk/cliproxy`, `sdk/cliproxy/auth`, and `internal/watcher` all pass
- Windows amd64 `sdk/auth` cross-compilation passes
- `cargo check -p cockpit-tools --tests` passes
- `git diff --check` and `gofmt -d` are clean

Known unrelated local baseline failures remain outside this patch: `TestAuthHookEmitsRequestScopedResultDiagnostics` in the sidecar main package, plus Antigravity Claude signature tests when the local signature cache is disabled. Rust test linking is unavailable on this host because GTK/WebKit development libraries are not installed; test code is covered by `cargo check --tests`.

No production sidecar was replaced or restarted for this PR.