### PR TITLE
fix(cliproxy): 修复 Codex 接 DeepSeek 多轮对话缺失 reasoning_content 的 400 错误

### DIFF
--- a/sidecars/cockpit-cliproxy/go.mod
+++ b/sidecars/cockpit-cliproxy/go.mod
@@ -4,7 +4,11 @@ go 1.26.0
 
 require (
 	github.com/gin-gonic/gin v1.10.1
+	github.com/klauspost/compress v1.17.4
 	github.com/router-for-me/CLIProxyAPI/v7 v7.1.22
+	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/sjson v1.2.5
+	golang.org/x/sys v0.38.0
 )
 
 replace github.com/router-for-me/CLIProxyAPI/v7 => ./third_party/CLIProxyAPI
@@ -28,7 +32,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -40,10 +43,8 @@ require (
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tiktoken-go/tokenizer v0.7.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
@@ -53,7 +54,6 @@ require (
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect

--- a/sidecars/cockpit-cliproxy/main.go
+++ b/sidecars/cockpit-cliproxy/main.go
@@ -317,6 +317,9 @@ type providerGatewaySpec struct {
 	SupportsVision     bool                                      `json:"supportsVision,omitempty"`
 	ModelCapabilities  map[string]providerGatewayModelCapability `json:"modelCapabilities,omitempty"`
 	VisionRoutingModel string                                    `json:"visionRoutingModel,omitempty"`
+	// DisableThinking forces DeepSeek-style thinking mode off so clients that
+	// cannot replay reasoning_content (Codex) do not trip the upstream 400.
+	DisableThinking bool `json:"disableThinking,omitempty"`
 }
 
 type providerGatewayModelCapability struct {
@@ -5891,6 +5894,7 @@ func (s *relayServer) handleProviderGatewayRequest(c *gin.Context, gateway *prov
 			return
 		}
 		upstreamPath = "/v1/chat/completions"
+		upstreamBody = prepareProviderGatewayChatCompletionsReasoning(gateway, upstreamModel, upstreamBody)
 	} else if !sourceFormatEqual(sourceFormat, sdktranslator.FormatOpenAIResponse) {
 		writeAPIError(c, http.StatusBadRequest, "provider gateway responses wire API only accepts responses requests", "invalid_request")
 		return
@@ -5931,23 +5935,20 @@ func (s *relayServer) handleProviderGatewayRequest(c *gin.Context, gateway *prov
 		return
 	}
 
+	cacheReasoning := wireAPI == "chat_completions" && providerGatewayShouldReplayReasoning(gateway, upstreamModel)
 	if stream {
 		if wireAPI == "chat_completions" {
 			switch {
 			case sourceFormatEqual(sourceFormat, sdktranslator.FormatOpenAIResponse):
-				s.writeProviderGatewayChatStream(c, resp.Body, upstreamModel, body, upstreamBody)
+				s.writeProviderGatewayChatStream(c, resp.Body, upstreamModel, body, upstreamBody, cacheReasoning)
 			case sourceFormatEqual(sourceFormat, sdktranslator.FormatOpenAI):
-				c.Status(http.StatusOK)
-				c.Stream(func(w io.Writer) bool {
-					_, _ = io.Copy(w, resp.Body)
-					return false
-				})
+				s.writeProviderGatewayOpenAIStream(c, resp.Body, upstreamModel, cacheReasoning)
 			default:
 				alt := fixedAlt
 				if alt == "" {
 					alt = requestAlt(c)
 				}
-				s.writeProviderGatewayTranslatedChatStream(c, resp.Body, upstreamModel, body, upstreamBody, sourceFormat, alt)
+				s.writeProviderGatewayTranslatedChatStream(c, resp.Body, upstreamModel, body, upstreamBody, sourceFormat, alt, cacheReasoning)
 			}
 			return
 		}
@@ -5965,6 +5966,9 @@ func (s *relayServer) handleProviderGatewayRequest(c *gin.Context, gateway *prov
 		return
 	}
 	if wireAPI == "chat_completions" {
+		if cacheReasoning {
+			cacheReasoningFromChatCompletionsResponse(upstreamModel, payload)
+		}
 		switch {
 		case sourceFormatEqual(sourceFormat, sdktranslator.FormatOpenAIResponse):
 			payload = responsesconverter.ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(relayContext(c), upstreamModel, body, upstreamBody, payload, nil)
@@ -6022,7 +6026,7 @@ func copyProviderGatewayDiagnosticHeaders(dst http.Header, src http.Header) {
 	}
 }
 
-func (s *relayServer) writeProviderGatewayChatStream(c *gin.Context, body io.Reader, model string, originalBody []byte, chatBody []byte) {
+func (s *relayServer) writeProviderGatewayChatStream(c *gin.Context, body io.Reader, model string, originalBody []byte, chatBody []byte, cacheReasoning bool) {
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
 		writeAPIError(c, http.StatusInternalServerError, "streaming not supported", "streaming_not_supported")
@@ -6040,12 +6044,19 @@ func (s *relayServer) writeProviderGatewayChatStream(c *gin.Context, body io.Rea
 	convertedEventCount := 0
 	rawLineCount := 0
 	eventCounts := make(map[string]int)
+	acc := newChatStreamReasoningAccumulator()
+	if cacheReasoning {
+		defer acc.cache(model)
+	}
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 {
 			continue
+		}
+		if cacheReasoning {
+			acc.consume(line)
 		}
 		rawLineCount++
 		if providerGatewayStreamLineIsDone(line) {
@@ -6116,7 +6127,40 @@ func (s *relayServer) writeProviderGatewayChatStream(c *gin.Context, body io.Rea
 	)
 }
 
-func (s *relayServer) writeProviderGatewayTranslatedChatStream(c *gin.Context, body io.Reader, model string, originalBody []byte, chatBody []byte, targetFormat sdktranslator.Format, alt string) {
+func (s *relayServer) writeProviderGatewayOpenAIStream(c *gin.Context, body io.Reader, model string, cacheReasoning bool) {
+	if !cacheReasoning {
+		c.Status(http.StatusOK)
+		c.Stream(func(w io.Writer) bool {
+			_, _ = io.Copy(w, body)
+			return false
+		})
+		return
+	}
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		c.Status(http.StatusOK)
+		c.Stream(func(w io.Writer) bool {
+			_, _ = io.Copy(w, body)
+			return false
+		})
+		return
+	}
+	c.Status(http.StatusOK)
+	acc := newChatStreamReasoningAccumulator()
+	defer acc.cache(model)
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		acc.consume(line)
+		if _, err := c.Writer.Write(append(append([]byte(nil), line...), '\n')); err != nil {
+			return
+		}
+		flusher.Flush()
+	}
+}
+
+func (s *relayServer) writeProviderGatewayTranslatedChatStream(c *gin.Context, body io.Reader, model string, originalBody []byte, chatBody []byte, targetFormat sdktranslator.Format, alt string, cacheReasoning bool) {
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
 		writeAPIError(c, http.StatusInternalServerError, "streaming not supported", "streaming_not_supported")
@@ -6128,12 +6172,19 @@ func (s *relayServer) writeProviderGatewayTranslatedChatStream(c *gin.Context, b
 	c.Status(http.StatusOK)
 
 	var state any
+	acc := newChatStreamReasoningAccumulator()
+	if cacheReasoning {
+		defer acc.cache(model)
+	}
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 {
 			continue
+		}
+		if cacheReasoning {
+			acc.consume(line)
 		}
 		outputs := sdktranslator.TranslateStream(relayContext(c), sdktranslator.FormatOpenAI, targetFormat, model, originalBody, chatBody, line, &state)
 		for _, output := range outputs {

--- a/sidecars/cockpit-cliproxy/reasoning_replay.go
+++ b/sidecars/cockpit-cliproxy/reasoning_replay.go
@@ -1,0 +1,490 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	reasoningReplayCacheTTL        = 2 * time.Hour
+	reasoningReplayCacheMaxEntries = 4096
+	reasoningReplayCacheEvictBatch = 128
+	reasoningReplayPlaceholder     = "tool call"
+	reasoningReplayUnavailable     = "[reasoning unavailable]"
+)
+
+type reasoningReplayEntry struct {
+	Reasoning string
+	Model     string
+	Timestamp time.Time
+}
+
+var (
+	reasoningReplayMu      sync.Mutex
+	reasoningReplayEntries = make(map[string]reasoningReplayEntry)
+)
+
+func clearReasoningReplayCache() {
+	reasoningReplayMu.Lock()
+	reasoningReplayEntries = make(map[string]reasoningReplayEntry)
+	reasoningReplayMu.Unlock()
+}
+
+func providerGatewayShouldDisableThinking(gateway *providerGatewaySpec) bool {
+	return gateway != nil && gateway.DisableThinking
+}
+
+func providerGatewayShouldReplayReasoning(gateway *providerGatewaySpec, model string) bool {
+	if providerGatewayShouldDisableThinking(gateway) {
+		return false
+	}
+	haystack := strings.ToLower(strings.TrimSpace(model))
+	if gateway != nil {
+		haystack += " " + strings.ToLower(gateway.BaseURL)
+		haystack += " " + strings.ToLower(gateway.UpstreamModel)
+		for _, upstream := range gateway.UpstreamModels {
+			haystack += " " + strings.ToLower(upstream)
+		}
+	}
+	if haystack == "" {
+		return false
+	}
+	if strings.Contains(haystack, "deepseek-reasoner") || strings.Contains(haystack, "deepseek-r1") {
+		return false
+	}
+	return strings.Contains(haystack, "deepseek")
+}
+
+func prepareProviderGatewayChatCompletionsReasoning(gateway *providerGatewaySpec, model string, body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	if providerGatewayShouldDisableThinking(gateway) {
+		return disableChatCompletionsThinking(body)
+	}
+	if !providerGatewayShouldReplayReasoning(gateway, model) {
+		return body
+	}
+	cacheReasoningFromChatCompletionsMessages(model, body)
+	return replayReasoningIntoChatCompletions(model, body)
+}
+
+func disableChatCompletionsThinking(body []byte) []byte {
+	out, err := sjson.SetRawBytes(body, "thinking", []byte(`{"type":"disabled"}`))
+	if err != nil {
+		return body
+	}
+	out, _ = sjson.DeleteBytes(out, "reasoning_effort")
+	out, _ = sjson.DeleteBytes(out, "reasoning")
+	messages := gjson.GetBytes(out, "messages")
+	if !messages.IsArray() {
+		return out
+	}
+	for index, message := range messages.Array() {
+		if !message.Get("reasoning_content").Exists() && !message.Get("reasoning").Exists() {
+			continue
+		}
+		path := fmt.Sprintf("messages.%d", index)
+		out, _ = sjson.DeleteBytes(out, path+".reasoning_content")
+		out, _ = sjson.DeleteBytes(out, path+".reasoning")
+	}
+	return out
+}
+
+func cacheReasoningFromChatCompletionsResponse(model string, payload []byte) {
+	if len(payload) == 0 {
+		return
+	}
+	root := gjson.ParseBytes(payload)
+	choices := root.Get("choices")
+	if !choices.IsArray() {
+		cacheReasoningFromChatCompletionsMessages(model, payload)
+		return
+	}
+	for _, choice := range choices.Array() {
+		message := choice.Get("message")
+		if !message.Exists() {
+			continue
+		}
+		cacheReasoningFromAssistantMessage(model, message)
+	}
+}
+
+func cacheReasoningFromChatCompletionsMessages(model string, body []byte) {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return
+	}
+	for _, message := range messages.Array() {
+		cacheReasoningFromAssistantMessage(model, message)
+	}
+}
+
+func cacheReasoningFromAssistantMessage(model string, message gjson.Result) {
+	if strings.TrimSpace(message.Get("role").String()) != "assistant" {
+		return
+	}
+	reasoning := assistantReasoningText(message)
+	if reasoning == "" || isReasoningReplayPlaceholder(reasoning) {
+		return
+	}
+	for _, id := range assistantToolCallIDs(message) {
+		putReasoningReplay(reasoningReplayToolCallKey(id), model, reasoning)
+	}
+	if fingerprint := assistantReasoningFingerprint(message); fingerprint != "" {
+		putReasoningReplay(reasoningReplayFingerprintKey(fingerprint), model, reasoning)
+	}
+}
+
+func replayReasoningIntoChatCompletions(model string, body []byte) []byte {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return body
+	}
+	out := body
+	for index, message := range messages.Array() {
+		if strings.TrimSpace(message.Get("role").String()) != "assistant" {
+			continue
+		}
+		existing := assistantReasoningText(message)
+		if existing != "" && !isReasoningReplayPlaceholder(existing) {
+			continue
+		}
+		reasoning, ok := lookupReasoningForAssistantMessage(model, message)
+		if !ok {
+			continue
+		}
+		path := fmt.Sprintf("messages.%d.reasoning_content", index)
+		next, err := sjson.SetBytes(out, path, reasoning)
+		if err != nil {
+			continue
+		}
+		out = next
+	}
+	return out
+}
+
+func lookupReasoningForAssistantMessage(model string, message gjson.Result) (string, bool) {
+	for _, id := range assistantToolCallIDs(message) {
+		if reasoning, ok := getReasoningReplay(reasoningReplayToolCallKey(id), model); ok {
+			return reasoning, true
+		}
+	}
+	if fingerprint := assistantReasoningFingerprint(message); fingerprint != "" {
+		if reasoning, ok := getReasoningReplay(reasoningReplayFingerprintKey(fingerprint), model); ok {
+			return reasoning, true
+		}
+	}
+	return "", false
+}
+
+func assistantReasoningText(message gjson.Result) string {
+	for _, key := range []string{"reasoning_content", "reasoning"} {
+		if text := strings.TrimSpace(message.Get(key).String()); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func assistantToolCallIDs(message gjson.Result) []string {
+	toolCalls := message.Get("tool_calls")
+	if !toolCalls.IsArray() {
+		return nil
+	}
+	ids := make([]string, 0, len(toolCalls.Array()))
+	seen := make(map[string]struct{}, len(toolCalls.Array()))
+	for _, toolCall := range toolCalls.Array() {
+		id := strings.TrimSpace(toolCall.Get("id").String())
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func assistantReasoningFingerprint(message gjson.Result) string {
+	payload := map[string]any{
+		"role":    "assistant",
+		"content": canonicalizeAssistantContent(message.Get("content")),
+	}
+	if toolCalls := canonicalizeAssistantToolCalls(message.Get("tool_calls")); len(toolCalls) > 0 {
+		payload["tool_calls"] = toolCalls
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func canonicalizeAssistantContent(content gjson.Result) any {
+	if !content.Exists() || content.Type == gjson.Null {
+		return ""
+	}
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	if !content.IsArray() {
+		return content.Raw
+	}
+	parts := make([]string, 0, len(content.Array()))
+	for _, part := range content.Array() {
+		if part.Type == gjson.String {
+			if text := part.String(); text != "" {
+				parts = append(parts, text)
+			}
+			continue
+		}
+		text := part.Get("text").String()
+		if text == "" {
+			text = part.Get("content").String()
+		}
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func canonicalizeAssistantToolCalls(toolCalls gjson.Result) []map[string]any {
+	if !toolCalls.IsArray() {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(toolCalls.Array()))
+	for _, toolCall := range toolCalls.Array() {
+		out = append(out, map[string]any{
+			"type": strings.TrimSpace(toolCall.Get("type").String()),
+			"function": map[string]any{
+				"name":      strings.TrimSpace(toolCall.Get("function.name").String()),
+				"arguments": toolCall.Get("function.arguments").String(),
+			},
+		})
+	}
+	return out
+}
+
+func isReasoningReplayPlaceholder(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return true
+	}
+	switch strings.ToLower(trimmed) {
+	case reasoningReplayPlaceholder, reasoningReplayUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+func reasoningReplayToolCallKey(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	return "tc:" + id
+}
+
+func reasoningReplayFingerprintKey(fingerprint string) string {
+	fingerprint = strings.TrimSpace(fingerprint)
+	if fingerprint == "" {
+		return ""
+	}
+	return "fp:" + fingerprint
+}
+
+func putReasoningReplay(key, model, reasoning string) bool {
+	key = strings.TrimSpace(key)
+	reasoning = strings.TrimSpace(reasoning)
+	if key == "" || reasoning == "" || isReasoningReplayPlaceholder(reasoning) {
+		return false
+	}
+	now := time.Now()
+	reasoningReplayMu.Lock()
+	defer reasoningReplayMu.Unlock()
+	reasoningReplayEntries[key] = reasoningReplayEntry{
+		Reasoning: reasoning,
+		Model:     strings.TrimSpace(model),
+		Timestamp: now,
+	}
+	if len(reasoningReplayEntries) > reasoningReplayCacheMaxEntries {
+		evictOldestReasoningReplayEntries(reasoningReplayCacheEvictBatch)
+	}
+	return true
+}
+
+func getReasoningReplay(key, model string) (string, bool) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", false
+	}
+	now := time.Now()
+	reasoningReplayMu.Lock()
+	defer reasoningReplayMu.Unlock()
+	entry, ok := reasoningReplayEntries[key]
+	if !ok {
+		return "", false
+	}
+	if now.Sub(entry.Timestamp) > reasoningReplayCacheTTL {
+		delete(reasoningReplayEntries, key)
+		return "", false
+	}
+	if model != "" && entry.Model != "" && !strings.EqualFold(entry.Model, model) {
+		return "", false
+	}
+	if isReasoningReplayPlaceholder(entry.Reasoning) {
+		delete(reasoningReplayEntries, key)
+		return "", false
+	}
+	entry.Timestamp = now
+	reasoningReplayEntries[key] = entry
+	return entry.Reasoning, true
+}
+
+func evictOldestReasoningReplayEntries(count int) {
+	if count <= 0 || len(reasoningReplayEntries) == 0 {
+		return
+	}
+	type candidate struct {
+		key       string
+		timestamp time.Time
+	}
+	candidates := make([]candidate, 0, len(reasoningReplayEntries))
+	for key, entry := range reasoningReplayEntries {
+		candidates = append(candidates, candidate{key: key, timestamp: entry.Timestamp})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].timestamp.Before(candidates[j].timestamp)
+	})
+	if count > len(candidates) {
+		count = len(candidates)
+	}
+	for i := 0; i < count; i++ {
+		delete(reasoningReplayEntries, candidates[i].key)
+	}
+}
+
+type chatStreamReasoningAccumulator struct {
+	reasoning     strings.Builder
+	content       strings.Builder
+	toolCallIDs   []string
+	idByIndex     map[int]string
+	seenToolCalls map[string]struct{}
+}
+
+func newChatStreamReasoningAccumulator() *chatStreamReasoningAccumulator {
+	return &chatStreamReasoningAccumulator{
+		idByIndex:     make(map[int]string),
+		seenToolCalls: make(map[string]struct{}),
+	}
+}
+
+func (a *chatStreamReasoningAccumulator) consume(line []byte) {
+	if a == nil {
+		return
+	}
+	payload := chatCompletionsStreamPayload(line)
+	if len(payload) == 0 {
+		return
+	}
+	delta := gjson.GetBytes(payload, "choices.0.delta")
+	if !delta.Exists() {
+		message := gjson.GetBytes(payload, "choices.0.message")
+		if message.Exists() {
+			if text := assistantReasoningText(message); text != "" {
+				a.reasoning.WriteString(text)
+			}
+			if content := message.Get("content"); content.Type == gjson.String {
+				a.content.WriteString(content.String())
+			}
+			for _, id := range assistantToolCallIDs(message) {
+				a.rememberToolCallID(id)
+			}
+		}
+		return
+	}
+	if text := strings.TrimSpace(delta.Get("reasoning_content").String()); text != "" {
+		a.reasoning.WriteString(delta.Get("reasoning_content").String())
+	} else if text := strings.TrimSpace(delta.Get("reasoning").String()); text != "" {
+		a.reasoning.WriteString(delta.Get("reasoning").String())
+	}
+	if content := delta.Get("content"); content.Type == gjson.String {
+		a.content.WriteString(content.String())
+	}
+	toolCalls := delta.Get("tool_calls")
+	if !toolCalls.IsArray() {
+		return
+	}
+	for _, toolCall := range toolCalls.Array() {
+		index := int(toolCall.Get("index").Int())
+		id := strings.TrimSpace(toolCall.Get("id").String())
+		if id == "" {
+			id = a.idByIndex[index]
+		} else {
+			a.idByIndex[index] = id
+		}
+		a.rememberToolCallID(id)
+	}
+}
+
+func (a *chatStreamReasoningAccumulator) rememberToolCallID(id string) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return
+	}
+	if _, ok := a.seenToolCalls[id]; ok {
+		return
+	}
+	a.seenToolCalls[id] = struct{}{}
+	a.toolCallIDs = append(a.toolCallIDs, id)
+}
+
+func (a *chatStreamReasoningAccumulator) cache(model string) {
+	if a == nil {
+		return
+	}
+	reasoning := strings.TrimSpace(a.reasoning.String())
+	if reasoning == "" || isReasoningReplayPlaceholder(reasoning) {
+		return
+	}
+	if len(a.toolCallIDs) > 0 {
+		for _, id := range a.toolCallIDs {
+			putReasoningReplay(reasoningReplayToolCallKey(id), model, reasoning)
+		}
+		return
+	}
+	messageJSON := []byte(`{"role":"assistant"}`)
+	messageJSON, _ = sjson.SetBytes(messageJSON, "content", a.content.String())
+	messageJSON, _ = sjson.SetBytes(messageJSON, "reasoning_content", reasoning)
+	cacheReasoningFromAssistantMessage(model, gjson.ParseBytes(messageJSON))
+}
+
+func chatCompletionsStreamPayload(line []byte) []byte {
+	line = bytes.TrimSpace(line)
+	if bytes.HasPrefix(line, []byte("data:")) {
+		line = bytes.TrimSpace(line[len("data:"):])
+	}
+	if len(line) == 0 || bytes.Equal(line, []byte("[DONE]")) {
+		return nil
+	}
+	if !gjson.ValidBytes(line) {
+		return nil
+	}
+	return line
+}

--- a/sidecars/cockpit-cliproxy/reasoning_replay_test.go
+++ b/sidecars/cockpit-cliproxy/reasoning_replay_test.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/tidwall/gjson"
+)
+
+func TestProviderGatewayShouldReplayReasoning(t *testing.T) {
+	t.Parallel()
+
+	if !providerGatewayShouldReplayReasoning(&providerGatewaySpec{
+		BaseURL:       "https://api.deepseek.com",
+		UpstreamModel: "deepseek-v4-flash",
+		WireAPI:       "chat_completions",
+	}, "deepseek-v4-flash") {
+		t.Fatal("deepseek-v4-flash should replay reasoning")
+	}
+	if !providerGatewayShouldReplayReasoning(&providerGatewaySpec{
+		BaseURL:       "https://api.deepseek.com/v1",
+		UpstreamModel: "deepseek-v4-pro",
+	}, "gpt-5.4") {
+		t.Fatal("aliased DeepSeek upstream should still replay reasoning")
+	}
+	if providerGatewayShouldReplayReasoning(&providerGatewaySpec{
+		BaseURL:       "https://open.bigmodel.cn/api/paas/v4",
+		UpstreamModel: "glm-5.1",
+	}, "glm-5.1") {
+		t.Fatal("non-DeepSeek models must not inject reasoning_content")
+	}
+	if providerGatewayShouldReplayReasoning(&providerGatewaySpec{
+		BaseURL:         "https://api.deepseek.com",
+		UpstreamModel:   "deepseek-v4-flash",
+		DisableThinking: true,
+	}, "deepseek-v4-flash") {
+		t.Fatal("disableThinking should skip reasoning replay")
+	}
+	if providerGatewayShouldReplayReasoning(&providerGatewaySpec{
+		BaseURL:       "https://api.deepseek.com",
+		UpstreamModel: "deepseek-reasoner",
+	}, "deepseek-reasoner") {
+		t.Fatal("legacy deepseek-reasoner should not replay")
+	}
+}
+
+func TestReplayReasoningIntoChatCompletionsUsesToolCallCache(t *testing.T) {
+	clearReasoningReplayCache()
+	t.Cleanup(clearReasoningReplayCache)
+
+	model := "deepseek-v4-flash"
+	cacheReasoningFromChatCompletionsResponse(model, []byte(`{
+		"choices":[{
+			"message":{
+				"role":"assistant",
+				"content":"",
+				"reasoning_content":"need to write a.txt",
+				"tool_calls":[{"id":"call_abc","type":"function","function":{"name":"shell","arguments":"{}"}}]
+			}
+		}]
+	}`))
+
+	out := replayReasoningIntoChatCompletions(model, []byte(`{
+		"model":"deepseek-v4-flash",
+		"messages":[
+			{"role":"user","content":"create a.txt"},
+			{"role":"assistant","tool_calls":[{"id":"call_abc","type":"function","function":{"name":"shell","arguments":"{}"}}],"reasoning_content":"tool call"},
+			{"role":"tool","tool_call_id":"call_abc","content":"ok"}
+		]
+	}`))
+	got := gjson.GetBytes(out, "messages.1.reasoning_content").String()
+	if got != "need to write a.txt" {
+		t.Fatalf("reasoning_content = %q, want cached thought", got)
+	}
+}
+
+func TestReplayReasoningIntoChatCompletionsKeepsRealReasoning(t *testing.T) {
+	clearReasoningReplayCache()
+	t.Cleanup(clearReasoningReplayCache)
+
+	model := "deepseek-v4-pro"
+	cacheReasoningFromChatCompletionsResponse(model, []byte(`{
+		"choices":[{
+			"message":{
+				"role":"assistant",
+				"content":"done",
+				"reasoning_content":"cached thought",
+				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"read","arguments":"{}"}}]
+			}
+		}]
+	}`))
+
+	out := replayReasoningIntoChatCompletions(model, []byte(`{
+		"messages":[
+			{"role":"assistant","content":"done","reasoning_content":"client thought","tool_calls":[{"id":"call_1","type":"function","function":{"name":"read","arguments":"{}"}}]}
+		]
+	}`))
+	got := gjson.GetBytes(out, "messages.0.reasoning_content").String()
+	if got != "client thought" {
+		t.Fatalf("reasoning_content = %q, want client thought", got)
+	}
+}
+
+func TestReplayReasoningIntoChatCompletionsUsesContentFingerprint(t *testing.T) {
+	clearReasoningReplayCache()
+	t.Cleanup(clearReasoningReplayCache)
+
+	model := "deepseek-v4-pro"
+	cacheReasoningFromChatCompletionsResponse(model, []byte(`{
+		"choices":[{
+			"message":{
+				"role":"assistant",
+				"content":"the file says hello",
+				"reasoning_content":"final thought after tools"
+			}
+		}]
+	}`))
+
+	out := replayReasoningIntoChatCompletions(model, []byte(`{
+		"messages":[
+			{"role":"assistant","content":"the file says hello"}
+		]
+	}`))
+	got := gjson.GetBytes(out, "messages.0.reasoning_content").String()
+	if got != "final thought after tools" {
+		t.Fatalf("reasoning_content = %q, want fingerprint replay", got)
+	}
+}
+
+func TestCacheReasoningIgnoresPlaceholder(t *testing.T) {
+	clearReasoningReplayCache()
+	t.Cleanup(clearReasoningReplayCache)
+
+	cacheReasoningFromChatCompletionsMessages("deepseek-v4-flash", []byte(`{
+		"messages":[
+			{"role":"assistant","reasoning_content":"tool call","tool_calls":[{"id":"call_skip","type":"function","function":{"name":"shell","arguments":"{}"}}]}
+		]
+	}`))
+	if _, ok := getReasoningReplay(reasoningReplayToolCallKey("call_skip"), "deepseek-v4-flash"); ok {
+		t.Fatal("placeholder reasoning must not be cached")
+	}
+}
+
+func TestDisableChatCompletionsThinking(t *testing.T) {
+	out := disableChatCompletionsThinking([]byte(`{
+		"model":"deepseek-v4-flash",
+		"reasoning_effort":"high",
+		"reasoning":{"effort":"high"},
+		"messages":[
+			{"role":"assistant","content":"hi","reasoning_content":"thought"}
+		]
+	}`))
+	if gjson.GetBytes(out, "thinking.type").String() != "disabled" {
+		t.Fatalf("thinking.type = %q, want disabled; out=%s", gjson.GetBytes(out, "thinking.type").String(), out)
+	}
+	if gjson.GetBytes(out, "reasoning_effort").Exists() {
+		t.Fatalf("reasoning_effort should be removed; out=%s", out)
+	}
+	if gjson.GetBytes(out, "messages.0.reasoning_content").Exists() {
+		t.Fatalf("historical reasoning_content should be stripped when thinking is disabled; out=%s", out)
+	}
+}
+
+func TestChatStreamReasoningAccumulatorCachesToolCall(t *testing.T) {
+	clearReasoningReplayCache()
+	t.Cleanup(clearReasoningReplayCache)
+
+	acc := newChatStreamReasoningAccumulator()
+	acc.consume([]byte(`data: {"choices":[{"delta":{"role":"assistant","reasoning_content":"plan "}}]}`))
+	acc.consume([]byte(`data: {"choices":[{"delta":{"reasoning_content":"to call shell","tool_calls":[{"index":0,"id":"call_stream","type":"function","function":{"name":"shell","arguments":""}}]}}]}`))
+	acc.consume([]byte(`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]}}]}`))
+	acc.consume([]byte(`data: [DONE]`))
+	acc.cache("deepseek-v4-flash")
+
+	got, ok := getReasoningReplay(reasoningReplayToolCallKey("call_stream"), "deepseek-v4-flash")
+	if !ok {
+		t.Fatal("expected streamed reasoning to be cached")
+	}
+	if got != "plan to call shell" {
+		t.Fatalf("cached reasoning = %q, want concatenated stream", got)
+	}
+}
+
+func TestPrepareProviderGatewayChatCompletionsReasoningDisableThinking(t *testing.T) {
+	gateway := &providerGatewaySpec{
+		BaseURL:         "https://api.deepseek.com",
+		UpstreamModel:   "deepseek-v4-flash",
+		DisableThinking: true,
+	}
+	out := prepareProviderGatewayChatCompletionsReasoning(gateway, "deepseek-v4-flash", []byte(`{
+		"model":"deepseek-v4-flash",
+		"reasoning_effort":"medium",
+		"messages":[{"role":"user","content":"hi"}]
+	}`))
+	if gjson.GetBytes(out, "thinking.type").String() != "disabled" {
+		t.Fatalf("expected thinking disabled, out=%s", out)
+	}
+}
+
+func TestRelayServerProviderGatewayReplaysDeepSeekReasoningOnToolFollowUp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	clearReasoningReplayCache()
+	t.Cleanup(clearReasoningReplayCache)
+
+	var upstreamBodies []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamBodies = append(upstreamBodies, string(body))
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(string(body), `"role":"tool"`) {
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_2","object":"chat.completion","created":2,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"created a.txt","reasoning_content":"file is ready"},"finish_reason":"stop"}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"","reasoning_content":"I should write a.txt","tool_calls":[{"id":"call_abc","type":"function","function":{"name":"shell","arguments":"{\"command\":\"echo 123\"}"}}]},"finish_reason":"tool_calls"}]}`))
+	}))
+	defer upstream.Close()
+
+	gateway := &providerGatewaySpec{
+		BaseURL:        upstream.URL,
+		APIKey:         "deepseek-key",
+		UpstreamModel:  "deepseek-v4-flash",
+		UpstreamModels: []string{"deepseek-v4-flash"},
+		WireAPI:        "chat_completions",
+	}
+	router := newProviderGatewayTestRouter(gateway)
+
+	first := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"deepseek-v4-flash",
+		"input":[{"type":"message","role":"user","content":"create a.txt"}],
+		"stream":false
+	}`))
+	first.Header.Set("Authorization", "Bearer client-key")
+	first.Header.Set("Content-Type", "application/json")
+	firstW := httptest.NewRecorder()
+	router.ServeHTTP(firstW, first)
+	if firstW.Code != http.StatusOK {
+		t.Fatalf("first turn status=%d body=%s", firstW.Code, firstW.Body.String())
+	}
+
+	second := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"deepseek-v4-flash",
+		"input":[
+			{"type":"message","role":"user","content":"create a.txt"},
+			{"type":"function_call","call_id":"call_abc","name":"shell","arguments":"{\"command\":\"echo 123\"}"},
+			{"type":"function_call_output","call_id":"call_abc","output":"ok"}
+		],
+		"stream":false
+	}`))
+	second.Header.Set("Authorization", "Bearer client-key")
+	second.Header.Set("Content-Type", "application/json")
+	secondW := httptest.NewRecorder()
+	router.ServeHTTP(secondW, second)
+	if secondW.Code != http.StatusOK {
+		t.Fatalf("second turn status=%d body=%s", secondW.Code, secondW.Body.String())
+	}
+	if len(upstreamBodies) < 2 {
+		t.Fatalf("expected two upstream requests, got %d", len(upstreamBodies))
+	}
+	got := gjson.Get(upstreamBodies[1], "messages.#(role=assistant).reasoning_content").String()
+	if got != "I should write a.txt" {
+		t.Fatalf("follow-up reasoning_content = %q, want cached thought; body=%s", got, upstreamBodies[1])
+	}
+	if strings.Contains(upstreamBodies[1], `"reasoning_content":"tool call"`) {
+		t.Fatalf("placeholder must not be sent upstream: %s", upstreamBodies[1])
+	}
+}
+
+func TestRelayServerProviderGatewayReplaysDeepSeekReasoningFromStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	clearReasoningReplayCache()
+	t.Cleanup(clearReasoningReplayCache)
+
+	var followUpBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(body), `"role":"tool"`) {
+			followUpBody = string(body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_2","object":"chat.completion","created":2,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"done","reasoning_content":"wrap up"},"finish_reason":"stop"}]}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"reasoning_content\":\"need a file\"},\"finish_reason\":null}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_stream\",\"type\":\"function\",\"function\":{\"name\":\"shell\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	gateway := &providerGatewaySpec{
+		BaseURL:        upstream.URL,
+		APIKey:         "deepseek-key",
+		UpstreamModel:  "deepseek-v4-flash",
+		UpstreamModels: []string{"deepseek-v4-flash"},
+		WireAPI:        "chat_completions",
+	}
+	router := newProviderGatewayTestRouter(gateway)
+
+	first := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"deepseek-v4-flash",
+		"input":[{"type":"message","role":"user","content":"create a.txt"}],
+		"stream":true
+	}`))
+	first.Header.Set("Authorization", "Bearer client-key")
+	first.Header.Set("Content-Type", "application/json")
+	firstW := httptest.NewRecorder()
+	router.ServeHTTP(firstW, first)
+	if firstW.Code != http.StatusOK {
+		t.Fatalf("first turn status=%d body=%s", firstW.Code, firstW.Body.String())
+	}
+
+	second := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"deepseek-v4-flash",
+		"input":[
+			{"type":"message","role":"user","content":"create a.txt"},
+			{"type":"function_call","call_id":"call_stream","name":"shell","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_stream","output":"ok"}
+		],
+		"stream":false
+	}`))
+	second.Header.Set("Authorization", "Bearer client-key")
+	second.Header.Set("Content-Type", "application/json")
+	secondW := httptest.NewRecorder()
+	router.ServeHTTP(secondW, second)
+	if secondW.Code != http.StatusOK {
+		t.Fatalf("second turn status=%d body=%s", secondW.Code, secondW.Body.String())
+	}
+	got := gjson.Get(followUpBody, "messages.#(role=assistant).reasoning_content").String()
+	if got != "need a file" {
+		t.Fatalf("streamed reasoning was not replayed: %q body=%s", got, followUpBody)
+	}
+}
+
+func TestRelayServerProviderGatewayDisableThinkingStripsReasoningEffort(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var upstreamBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer upstream.Close()
+
+	gateway := &providerGatewaySpec{
+		BaseURL:         upstream.URL,
+		APIKey:          "deepseek-key",
+		UpstreamModel:   "deepseek-v4-flash",
+		UpstreamModels:  []string{"deepseek-v4-flash"},
+		WireAPI:         "chat_completions",
+		DisableThinking: true,
+	}
+	router := newProviderGatewayTestRouter(gateway)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"deepseek-v4-flash",
+		"reasoning":{"effort":"high"},
+		"input":"hello",
+		"stream":false
+	}`))
+	req.Header.Set("Authorization", "Bearer client-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if gjson.Get(upstreamBody, "thinking.type").String() != "disabled" {
+		t.Fatalf("expected thinking disabled, body=%s", upstreamBody)
+	}
+	if gjson.Get(upstreamBody, "reasoning_effort").Exists() {
+		t.Fatalf("reasoning_effort should be stripped, body=%s", upstreamBody)
+	}
+}
+
+func newProviderGatewayTestRouter(gateway *providerGatewaySpec) http.Handler {
+	m := &manifest{
+		APIKeys:  []apiKeySpec{{ID: "provider_gateway_account_1", Label: "Provider Gateway", Key: "client-key", Enabled: true, ProviderGateway: gateway}},
+		ModelIDs: []string{gateway.UpstreamModel},
+		apiKeyByValue: map[string]*apiKeySpec{
+			"client-key": {ID: "provider_gateway_account_1", Label: "Provider Gateway", Key: "client-key", Enabled: true, ProviderGateway: gateway},
+		},
+	}
+	return (&relayServer{
+		runtime:  &fakeRuntime{},
+		cfg:      &config.Config{},
+		manifest: m,
+		policy:   &requestPolicy{manifest: m},
+	}).router()
+}
+
+func TestAssistantReasoningFingerprintStableForTextParts(t *testing.T) {
+	stringMsg := gjson.Parse(`{"role":"assistant","content":"hello"}`)
+	partsMsg := gjson.Parse(`{"role":"assistant","content":[{"type":"text","text":"hello"}]}`)
+	if assistantReasoningFingerprint(stringMsg) != assistantReasoningFingerprint(partsMsg) {
+		t.Fatal("content fingerprint should treat string and text parts as equivalent")
+	}
+}

--- a/src-tauri/src/models/codex_local_access.rs
+++ b/src-tauri/src/models/codex_local_access.rs
@@ -396,6 +396,8 @@ pub struct CodexLocalAccessProviderGateway {
         std::collections::HashMap<String, CodexLocalAccessProviderGatewayModelCapability>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vision_routing_model: Option<String>,
+    #[serde(default)]
+    pub disable_thinking: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/modules/codex_local_access.rs
+++ b/src-tauri/src/modules/codex_local_access.rs
@@ -18047,6 +18047,7 @@ fn provider_gateway_for_account(
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(str::to_string),
+        disable_thinking: false,
     })
 }
 
@@ -29800,6 +29801,7 @@ wire_api = "responses"
                 supports_vision: false,
                 model_capabilities: HashMap::new(),
                 vision_routing_model: None,
+                disable_thinking: false,
             }),
             inherit_account_pool: Some(false),
             account_ids: vec!["deepseek-account".to_string()],
@@ -32542,6 +32544,7 @@ data: {"type":"response.completed","response":{"id":"resp_123","usage":{"input_t
                 supports_vision: false,
                 model_capabilities: HashMap::new(),
                 vision_routing_model: None,
+                disable_thinking: false,
             }),
             inherit_account_pool: false,
             account_ids: vec!["account-1".to_string()],
@@ -34682,6 +34685,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
                 supports_vision: false,
                 model_capabilities: HashMap::new(),
                 vision_routing_model: None,
+                disable_thinking: false,
             }),
             inherit_account_pool: Some(false),
             account_ids: vec!["deepseek-account".to_string()],
@@ -34743,6 +34747,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
             supports_vision: false,
             model_capabilities: HashMap::new(),
             vision_routing_model: None,
+            disable_thinking: false,
         };
         let chat_request = model_provider_chat_test_request("chat_completions");
         let chat_collection = build_model_provider_gateway_test_collection(
@@ -35471,6 +35476,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
             supports_vision: false,
             model_capabilities: HashMap::new(),
             vision_routing_model: None,
+            disable_thinking: false,
         });
         api_key.account_ids = vec![account_id.clone()];
         collection.api_keys = vec![api_key];
@@ -35522,6 +35528,7 @@ data: {"error":{"code":"server_error","type":"upstream","message":"stream aborte
             supports_vision: false,
             model_capabilities: HashMap::new(),
             vision_routing_model: None,
+            disable_thinking: false,
         });
         api_key.account_ids = vec![account_id.clone()];
         collection.api_keys = vec![api_key];


### PR DESCRIPTION
## 问题

Codex 通过 Cockpit Tools 的 provider gateway（`cockpit-cliproxy`）走 Chat Completions 接入 DeepSeek（`deepseek-v4-flash` / `deepseek-v4-pro`）时：

- 单轮对话正常
- 多轮、尤其是第一次工具调用返回后，上游报 400：

```
The reasoning_content in the thinking mode must be passed back to the API.
```

DeepSeek thinking 模式（V4 Flash/Pro 默认开启）要求：请求携带 `tools` 时，后续每一轮都必须把上一轮 assistant 的真实 `reasoning_content` 原样回传。

Codex 客户端不会在历史消息里带这个字段。gateway 之前只做协议转换并透传，缺字段时还用 `"tool call"` 占位。DeepSeek 现在会校验内容，占位符会被拒绝。

Fixes #1996

## 修复

在 gateway 层（参考 OmniRoute / OpenCode 的做法）对 DeepSeek Chat Completions 做 **reasoning 缓存与回放**：

1. 上游返回（流式 / 非流式）后，按 `tool_calls[].id`（以及无 tool call 时的消息指纹）缓存真实 `reasoning_content`
2. 下一轮请求转换完成后，把 Codex 丢掉的字段重新注入到对应 assistant 消息
3. 不缓存 `"tool call"` / `[reasoning unavailable]` 等占位符，避免污染缓存

另外保留了一个 sidecar 级逃生舱：`providerGateway.disableThinking: true` 会发送 `thinking: {type:"disabled"}` 并去掉 `reasoning_effort`。这次**没有**做到 DeepSeek 供应商设置页上，避免和 Codex 自己的 reasoning 开关冲突；默认路径仍然是回放、保留 thinking。

## 改动文件

- `sidecars/cockpit-cliproxy/reasoning_replay.go`：缓存 / 回放 / 关闭 thinking
- `sidecars/cockpit-cliproxy/main.go`：Chat Completions 网关接入（含流式）
- `sidecars/cockpit-cliproxy/reasoning_replay_test.go`：工具调用跟进、流式缓存、关闭 thinking
- `src-tauri/src/models/codex_local_access.rs` 等：gateway spec 增加 `disableThinking` 字段（默认 false）

## 测试

```
cd sidecars/cockpit-cliproxy
go test . -count=1 -run 'TestRelayServerProviderGateway|TestReplayReasoning|TestChatStreamReasoningAccumulator|TestDisableChatCompletionsThinking|TestPrepareProviderGatewayChatCompletionsReasoningDisableThinking'
```

覆盖：

- 非流式：第一轮拿到 reasoning，第二轮（工具结果回传）把真实内容而不是 `"tool call"` 发给 DeepSeek
- 流式：从 SSE 累积 reasoning，follow-up 回放
- 非 DeepSeek 模型不注入 `reasoning_content`
- `disableThinking` 会去掉 `reasoning_effort` 并写 `thinking.type=disabled`

## 使用说明

需要重新编译并替换 `cockpit-cliproxy` sidecar 后才会生效。当前 1.3.24 里的 sidecar 仍是旧逻辑。
