### PR TITLE
fix(antigravity): align switch targets with installed products

### DIFF
--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -551,6 +551,35 @@ pub async fn switch_account(
 ) -> Result<models::Account, String> {
     let runtime_target = normalize_antigravity_runtime_target(runtime_target.as_deref());
     let user_config = modules::config::get_user_config();
+    if user_config.antigravity_switch_sync_mode == "all_targets" {
+        let surfaces = modules::account::resolve_effective_antigravity_switch_surfaces(
+            &user_config.antigravity_switch_targets,
+        );
+        let result = modules::account::switch_account_configured_surfaces(
+            &account_id,
+            &surfaces,
+            "manual",
+            "tools.account.switch",
+            "all_targets",
+            None,
+        )
+        .await;
+        if let Ok(account) = &result {
+            modules::websocket::broadcast_account_switched(&account.id, &account.email);
+            modules::websocket::broadcast_data_changed("switch_account_all_targets");
+        } else if let Err(error) = &result {
+            if error.starts_with("APP_PATH_NOT_FOUND:") {
+                let _ = app.emit(
+                    "app:path_missing",
+                    serde_json::json!({
+                        "app": "antigravity",
+                        "retry": { "kind": "switchAccount", "accountId": account_id }
+                    }),
+                );
+            }
+        }
+        return result;
+    }
     match resolve_antigravity_switch_flow(
         runtime_target,
         user_config.antigravity_launch_on_switch,

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -242,6 +242,10 @@ pub struct GeneralConfig {
     pub top_right_ad_visible: bool,
     /// Antigravity 切号是否启用“本地落盘 + 扩展无感”且不重启
     pub antigravity_dual_switch_no_restart_enabled: bool,
+    /// Antigravity 切号同步模式：active_only | all_targets
+    pub antigravity_switch_sync_mode: String,
+    /// 参与切号同步的产品面：desktop | ide | cli
+    pub antigravity_switch_targets: Vec<String>,
     /// 是否启用自动切号
     pub auto_switch_enabled: bool,
     /// 自动切号阈值（百分比）
@@ -1067,6 +1071,34 @@ fn resolve_antigravity_installed_version_info_quick_for_target(
     )
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AntigravityRuntimeTargetKind {
+    Legacy,
+    Ide,
+}
+
+pub fn is_antigravity_runtime_target_installed(target: AntigravityRuntimeTargetKind) -> bool {
+    let target_str = match target {
+        AntigravityRuntimeTargetKind::Legacy => "antigravity",
+        AntigravityRuntimeTargetKind::Ide => "antigravity_ide",
+    };
+    resolve_antigravity_installed_version_info_quick_for_target(Some(target_str))
+        .or_else(|| resolve_antigravity_installed_version_info_for_target(Some(target_str)))
+        .is_some()
+}
+
+/// Pick the Antigravity runtime that matches what is actually installed.
+pub fn resolve_preferred_antigravity_runtime_target() -> AntigravityRuntimeTargetKind {
+    let legacy = is_antigravity_runtime_target_installed(AntigravityRuntimeTargetKind::Legacy);
+    let ide = is_antigravity_runtime_target_installed(AntigravityRuntimeTargetKind::Ide);
+    match (legacy, ide) {
+        (true, false) => AntigravityRuntimeTargetKind::Legacy,
+        (false, true) => AntigravityRuntimeTargetKind::Ide,
+        (true, true) => AntigravityRuntimeTargetKind::Ide,
+        (false, false) => AntigravityRuntimeTargetKind::Ide,
+    }
+}
+
 fn sanitize_startup_wakeup_delay_seconds(raw: i32) -> i32 {
     raw.clamp(0, MAX_STARTUP_WAKEUP_DELAY_SECONDS)
 }
@@ -1211,6 +1243,8 @@ fn is_general_config_patch_field(key: &str) -> bool {
             | "codex_hide_relay_quota"
             | "top_right_ad_visible"
             | "antigravity_dual_switch_no_restart_enabled"
+            | "antigravity_switch_sync_mode"
+            | "antigravity_switch_targets"
             | "auto_switch_enabled"
             | "auto_switch_threshold"
             | "auto_switch_credits_enabled"
@@ -2744,6 +2778,8 @@ pub fn get_general_config(app: tauri::AppHandle) -> Result<GeneralConfig, String
         top_right_ad_visible: user_config.top_right_ad_visible,
         antigravity_dual_switch_no_restart_enabled: user_config
             .antigravity_dual_switch_no_restart_enabled,
+        antigravity_switch_sync_mode: user_config.antigravity_switch_sync_mode.clone(),
+        antigravity_switch_targets: user_config.antigravity_switch_targets.clone(),
         auto_switch_enabled: user_config.auto_switch_enabled,
         auto_switch_threshold: user_config.auto_switch_threshold,
         auto_switch_credits_enabled: user_config.auto_switch_credits_enabled,
@@ -3127,6 +3163,8 @@ pub fn save_general_config(
     codex_hide_relay_quota: Option<bool>,
     top_right_ad_visible: Option<bool>,
     antigravity_dual_switch_no_restart_enabled: Option<bool>,
+    antigravity_switch_sync_mode: Option<String>,
+    antigravity_switch_targets: Option<Vec<String>>,
     auto_switch_enabled: Option<bool>,
     auto_switch_threshold: Option<i32>,
     auto_switch_credits_enabled: Option<bool>,
@@ -3505,6 +3543,21 @@ pub fn save_general_config(
         }
         if let Some(value) = antigravity_dual_switch_no_restart_enabled {
             current.antigravity_dual_switch_no_restart_enabled = value;
+        }
+        if let Some(value) = antigravity_switch_sync_mode {
+            let normalized = value.trim().to_lowercase();
+            current.antigravity_switch_sync_mode = if normalized == "all_targets" {
+                "all_targets".to_string()
+            } else {
+                "active_only".to_string()
+            };
+        }
+        if let Some(value) = antigravity_switch_targets {
+            current.antigravity_switch_targets = value
+                .into_iter()
+                .map(|item| item.trim().to_lowercase())
+                .filter(|item| matches!(item.as_str(), "desktop" | "ide" | "cli"))
+                .collect();
         }
 
         if let Some(value) = auto_switch_enabled {

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -1827,20 +1827,25 @@ async fn run_auto_switch_if_needed_inner() -> Result<Option<Account>, String> {
         trigger_context.rule
     ));
 
-    let switched = if cfg.antigravity_dual_switch_no_restart_enabled {
-        switch_account_dual_no_restart(
-            &target.id,
-            "auto",
-            "tools.account.auto_switch",
-            "auto_switch",
-            Some(reason_snapshot),
-        )
-        .await?
-    } else {
-        let switched = switch_account_internal(&target.id).await?;
-        modules::websocket::broadcast_account_switched(&switched.id, &switched.email);
-        switched
-    };
+    let surfaces = resolve_effective_antigravity_switch_surfaces(&cfg.antigravity_switch_targets);
+    modules::logger::log_info(&format!(
+        "[AutoSwitch] 切号目标: {:?}",
+        surfaces
+            .iter()
+            .map(|surface| format!("{:?}", surface))
+            .collect::<Vec<_>>()
+    ));
+
+    let switched = switch_account_configured_surfaces(
+        &target.id,
+        &surfaces,
+        "auto",
+        "tools.account.auto_switch",
+        "auto_switch",
+        Some(reason_snapshot),
+    )
+    .await?;
+    modules::websocket::broadcast_account_switched(&switched.id, &switched.email);
     modules::websocket::broadcast_data_changed("auto_switch");
     Ok(Some(switched))
 }
@@ -2017,6 +2022,178 @@ pub async fn fetch_quota_with_fresh_token(
             Err(err)
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AntigravitySwitchSurface {
+    Desktop,
+    Ide,
+    Cli,
+}
+
+fn dedupe_antigravity_switch_surfaces(
+    surfaces: Vec<AntigravitySwitchSurface>,
+) -> Vec<AntigravitySwitchSurface> {
+    let mut result = Vec::new();
+    for surface in surfaces {
+        if !result.contains(&surface) {
+            result.push(surface);
+        }
+    }
+    result
+}
+
+pub fn resolve_effective_antigravity_switch_surfaces(
+    configured_targets: &[String],
+) -> Vec<AntigravitySwitchSurface> {
+    let parsed = dedupe_antigravity_switch_surfaces(
+        configured_targets
+            .iter()
+            .filter_map(|raw| match raw.trim().to_lowercase().as_str() {
+                "desktop" | "antigravity" | "legacy" => Some(AntigravitySwitchSurface::Desktop),
+                "ide" | "antigravity_ide" => Some(AntigravitySwitchSurface::Ide),
+                "cli" | "agy" | "antigravity_cli" => Some(AntigravitySwitchSurface::Cli),
+                _ => None,
+            })
+            .collect(),
+    );
+
+    if !parsed.is_empty() {
+        return parsed;
+    }
+
+    let mut auto = Vec::new();
+    if crate::commands::system::is_antigravity_runtime_target_installed(
+        crate::commands::system::AntigravityRuntimeTargetKind::Legacy,
+    ) {
+        auto.push(AntigravitySwitchSurface::Desktop);
+    }
+    if crate::commands::system::is_antigravity_runtime_target_installed(
+        crate::commands::system::AntigravityRuntimeTargetKind::Ide,
+    ) {
+        auto.push(AntigravitySwitchSurface::Ide);
+    }
+    if auto.is_empty() {
+        auto.push(AntigravitySwitchSurface::Ide);
+    }
+    auto
+}
+
+async fn switch_account_cli_credential_only(account_id: &str) -> Result<(), String> {
+    let account = prepare_account_for_injection(account_id).await?;
+    modules::logger::log_info("[Switch][CLI] 写入 agy / 系统凭据");
+    modules::antigravity_credential::write_antigravity_system_credential(&account)?;
+    Ok(())
+}
+
+pub async fn switch_account_configured_surfaces(
+    account_id: &str,
+    surfaces: &[AntigravitySwitchSurface],
+    trigger_type: &str,
+    trigger_source: &str,
+    reason: &str,
+    auto_switch_reason: Option<modules::antigravity_switch_history::AntigravityAutoSwitchReason>,
+) -> Result<Account, String> {
+    let cfg = modules::config::get_user_config();
+    let mut account = prepare_account_for_injection(account_id).await?;
+    set_current_account_id(account_id)?;
+    account.update_last_used();
+    save_account(&account)?;
+
+    for surface in surfaces {
+        match surface {
+            AntigravitySwitchSurface::Desktop => {
+                switch_account_legacy_internal(account_id).await?;
+            }
+            AntigravitySwitchSurface::Ide => {
+                if cfg.antigravity_dual_switch_no_restart_enabled {
+                    account = switch_account_dual_no_restart(
+                        account_id,
+                        trigger_type,
+                        trigger_source,
+                        reason,
+                        auto_switch_reason.clone(),
+                    )
+                    .await?;
+                } else {
+                    account = switch_account_internal(account_id).await?;
+                }
+            }
+            AntigravitySwitchSurface::Cli => {
+                switch_account_cli_credential_only(account_id).await?;
+            }
+        }
+    }
+
+    Ok(account)
+}
+
+/// 内部切换 Antigravity 桌面版账号（供自动切号等内部流程调用）
+pub async fn switch_account_legacy_internal(account_id: &str) -> Result<Account, String> {
+    modules::logger::log_info(&format!(
+        "[Switch][Legacy] 开始切换 Antigravity 桌面版账号: {}",
+        account_id
+    ));
+
+    modules::process::ensure_antigravity_legacy_launch_path_configured()?;
+
+    let mut account = prepare_account_for_injection(account_id).await?;
+    set_current_account_id(account_id)?;
+    account.update_last_used();
+    save_account(&account)?;
+
+    if let Err(e) = modules::antigravity_legacy_instance::update_default_settings(
+        Some(Some(account_id.to_string())),
+        None,
+        Some(false),
+    ) {
+        modules::logger::log_warn(&format!(
+            "[Switch][Legacy] 更新默认实例绑定账号失败: {}",
+            e
+        ));
+    }
+
+    let default_dir = modules::antigravity_legacy_instance::get_default_user_data_dir()?;
+    let cfg = modules::config::get_user_config();
+
+    if !cfg.antigravity_launch_on_switch {
+        modules::logger::log_info(
+            "[Switch][Legacy] 切号后自动启动已关闭，仅写入本地账号数据",
+        );
+        modules::antigravity_legacy_instance::inject_account_to_profile(&default_dir, account_id)?;
+        modules::logger::log_info(&format!(
+            "[Switch][Legacy] 本地切号完成: {}",
+            account.email
+        ));
+        return Ok(account);
+    }
+
+    let default_dir_str = default_dir.to_string_lossy().to_string();
+    modules::process::close_antigravity_legacy_instances(
+        &[default_dir_str.clone()],
+        &default_dir_str,
+        20,
+    )?;
+    let _ = modules::antigravity_legacy_instance::update_default_pid(None);
+    modules::antigravity_legacy_instance::inject_account_to_profile(&default_dir, account_id)?;
+
+    modules::logger::log_info("[Switch][Legacy] 正在启动 Antigravity 默认实例...");
+    let default_settings = modules::antigravity_legacy_instance::load_default_settings()?;
+    let extra_args = modules::process::parse_extra_args(&default_settings.extra_args);
+    match modules::process::start_antigravity_legacy_with_args("", &extra_args) {
+        Ok(pid) => {
+            let _ = modules::antigravity_legacy_instance::update_default_pid(Some(pid));
+        }
+        Err(e) => {
+            modules::logger::log_warn(&format!("[Switch][Legacy] Antigravity 启动失败: {}", e));
+        }
+    }
+
+    modules::logger::log_info(&format!(
+        "[Switch][Legacy] 账号切换完成: {}",
+        account.email
+    ));
+    Ok(account)
 }
 
 /// 内部切换账号函数（供 WebSocket 调用）

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -1827,7 +1827,7 @@ async fn run_auto_switch_if_needed_inner() -> Result<Option<Account>, String> {
         trigger_context.rule
     ));
 
-    let surfaces = resolve_effective_antigravity_switch_surfaces(&cfg.antigravity_switch_targets);
+    let surfaces = resolve_auto_switch_antigravity_surfaces(&cfg.antigravity_switch_targets);
     modules::logger::log_info(&format!(
         "[AutoSwitch] 切号目标: {:?}",
         surfaces
@@ -2046,7 +2046,37 @@ fn dedupe_antigravity_switch_surfaces(
 pub fn resolve_effective_antigravity_switch_surfaces(
     configured_targets: &[String],
 ) -> Vec<AntigravitySwitchSurface> {
-    let parsed = dedupe_antigravity_switch_surfaces(
+    let parsed = parse_configured_antigravity_switch_surfaces(configured_targets);
+    if !parsed.is_empty() {
+        return parsed;
+    }
+    detect_installed_antigravity_switch_surfaces()
+}
+
+/// Auto-switch prefers a single installed product unless the user explicitly
+/// configured `antigravity_switch_targets`.
+pub fn resolve_auto_switch_antigravity_surfaces(
+    configured_targets: &[String],
+) -> Vec<AntigravitySwitchSurface> {
+    let parsed = parse_configured_antigravity_switch_surfaces(configured_targets);
+    if !parsed.is_empty() {
+        return parsed;
+    }
+
+    match crate::commands::system::resolve_preferred_antigravity_runtime_target() {
+        crate::commands::system::AntigravityRuntimeTargetKind::Legacy => {
+            vec![AntigravitySwitchSurface::Desktop]
+        }
+        crate::commands::system::AntigravityRuntimeTargetKind::Ide => {
+            vec![AntigravitySwitchSurface::Ide]
+        }
+    }
+}
+
+fn parse_configured_antigravity_switch_surfaces(
+    configured_targets: &[String],
+) -> Vec<AntigravitySwitchSurface> {
+    dedupe_antigravity_switch_surfaces(
         configured_targets
             .iter()
             .filter_map(|raw| match raw.trim().to_lowercase().as_str() {
@@ -2056,12 +2086,10 @@ pub fn resolve_effective_antigravity_switch_surfaces(
                 _ => None,
             })
             .collect(),
-    );
+    )
+}
 
-    if !parsed.is_empty() {
-        return parsed;
-    }
-
+fn detect_installed_antigravity_switch_surfaces() -> Vec<AntigravitySwitchSurface> {
     let mut auto = Vec::new();
     if crate::commands::system::is_antigravity_runtime_target_installed(
         crate::commands::system::AntigravityRuntimeTargetKind::Legacy,
@@ -2079,10 +2107,9 @@ pub fn resolve_effective_antigravity_switch_surfaces(
     auto
 }
 
-async fn switch_account_cli_credential_only(account_id: &str) -> Result<(), String> {
-    let account = prepare_account_for_injection(account_id).await?;
+async fn switch_account_cli_credential_only(account: &Account) -> Result<(), String> {
     modules::logger::log_info("[Switch][CLI] 写入 agy / 系统凭据");
-    modules::antigravity_credential::write_antigravity_system_credential(&account)?;
+    modules::antigravity_credential::write_antigravity_system_credential(account)?;
     Ok(())
 }
 
@@ -2094,6 +2121,10 @@ pub async fn switch_account_configured_surfaces(
     reason: &str,
     auto_switch_reason: Option<modules::antigravity_switch_history::AntigravityAutoSwitchReason>,
 ) -> Result<Account, String> {
+    if surfaces.is_empty() {
+        return Err("未配置 Antigravity 切号目标".to_string());
+    }
+
     let cfg = modules::config::get_user_config();
     let mut account = prepare_account_for_injection(account_id).await?;
     set_current_account_id(account_id)?;
@@ -2120,7 +2151,7 @@ pub async fn switch_account_configured_surfaces(
                 }
             }
             AntigravitySwitchSurface::Cli => {
-                switch_account_cli_credential_only(account_id).await?;
+                switch_account_cli_credential_only(&account).await?;
             }
         }
     }

--- a/src-tauri/src/modules/config.rs
+++ b/src-tauri/src/modules/config.rs
@@ -403,6 +403,12 @@ pub struct UserConfig {
     /// Antigravity 切号是否启用“本地落盘 + 扩展无感”且不重启
     #[serde(default = "default_antigravity_dual_switch_no_restart_enabled")]
     pub antigravity_dual_switch_no_restart_enabled: bool,
+    /// Antigravity 切号同步模式：active_only=仅当前选中产品 | all_targets=同步所有已启用目标
+    #[serde(default = "default_antigravity_switch_sync_mode")]
+    pub antigravity_switch_sync_mode: String,
+    /// 参与切号同步的产品面：desktop | ide | cli（空数组=自动检测已安装产品）
+    #[serde(default = "default_antigravity_switch_targets")]
+    pub antigravity_switch_targets: Vec<String>,
     /// 是否启用自动切号
     #[serde(default = "default_auto_switch_enabled")]
     pub auto_switch_enabled: bool,
@@ -1010,6 +1016,12 @@ fn default_top_right_ad_visible() -> bool {
 fn default_antigravity_dual_switch_no_restart_enabled() -> bool {
     false
 }
+fn default_antigravity_switch_sync_mode() -> String {
+    "active_only".to_string()
+}
+fn default_antigravity_switch_targets() -> Vec<String> {
+    Vec::new()
+}
 fn default_auto_switch_enabled() -> bool {
     false
 }
@@ -1275,6 +1287,8 @@ impl Default for UserConfig {
             top_right_ad_visible: default_top_right_ad_visible(),
             antigravity_dual_switch_no_restart_enabled:
                 default_antigravity_dual_switch_no_restart_enabled(),
+            antigravity_switch_sync_mode: default_antigravity_switch_sync_mode(),
+            antigravity_switch_targets: default_antigravity_switch_targets(),
             auto_switch_enabled: default_auto_switch_enabled(),
             auto_switch_threshold: default_auto_switch_threshold(),
             auto_switch_credits_enabled: default_auto_switch_credits_enabled(),

--- a/src/components/QuickSettingsPopover.tsx
+++ b/src/components/QuickSettingsPopover.tsx
@@ -151,6 +151,8 @@ interface GeneralConfig {
   codex_local_access_entry_visible: boolean;
   codex_hide_relay_quota?: boolean;
   antigravity_dual_switch_no_restart_enabled: boolean;
+  antigravity_switch_sync_mode: string;
+  antigravity_switch_targets: string[];
   auto_switch_enabled: boolean;
   auto_switch_threshold: number;
   auto_switch_credits_enabled: boolean;
@@ -3508,6 +3510,80 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
                       {t(
                         'settings.general.antigravityDualSwitchNoRestartDesc',
                         '切号时同时执行本地落盘与扩展无感切号，不再自动重启 Antigravity IDE。'
+                      )}
+                    </div>
+
+                    <div className="qs-row">
+                      <div className="qs-row-label">
+                        <span>
+                          {t(
+                            'settings.general.antigravitySwitchSyncMode',
+                            '切号同步范围'
+                          )}
+                        </span>
+                      </div>
+                      <div className="qs-row-control">
+                        <select
+                          className="qs-select"
+                          value={config.antigravity_switch_sync_mode ?? 'active_only'}
+                          onChange={(e) =>
+                            saveConfig({ antigravity_switch_sync_mode: e.target.value })
+                          }
+                        >
+                          <option value="active_only">
+                            {t(
+                              'settings.general.antigravitySwitchSyncModeActiveOnly',
+                              '仅当前选中的产品'
+                            )}
+                          </option>
+                          <option value="all_targets">
+                            {t(
+                              'settings.general.antigravitySwitchSyncModeAllTargets',
+                              '同步所有已启用目标'
+                            )}
+                          </option>
+                        </select>
+                      </div>
+                    </div>
+
+                    {config.antigravity_switch_sync_mode === 'all_targets' && (
+                      <div className="qs-checkbox-group">
+                        {(['desktop', 'ide', 'cli'] as const).map((target) => {
+                          const enabled = (config.antigravity_switch_targets ?? []).includes(target);
+                          const label =
+                            target === 'desktop'
+                              ? 'Antigravity'
+                              : target === 'ide'
+                                ? 'Antigravity IDE'
+                                : 'agy CLI';
+                          return (
+                            <label key={target} className="qs-checkbox-row">
+                              <input
+                                type="checkbox"
+                                checked={enabled}
+                                onChange={(e) => {
+                                  const current = new Set(config.antigravity_switch_targets ?? []);
+                                  if (e.target.checked) {
+                                    current.add(target);
+                                  } else {
+                                    current.delete(target);
+                                  }
+                                  saveConfig({
+                                    antigravity_switch_targets: Array.from(current),
+                                  });
+                                }}
+                              />
+                              <span>{label}</span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    <div className="qs-hint">
+                      {t(
+                        'settings.general.antigravitySwitchTargetsHint',
+                        '未勾选具体目标时，将自动检测本机已安装的 Antigravity 产品。CLI 在 Windows 上与桌面版共用 gemini:antigravity 系统凭据。'
                       )}
                     </div>
                   </>

--- a/src/components/QuickSettingsPopover.tsx
+++ b/src/components/QuickSettingsPopover.tsx
@@ -3583,7 +3583,7 @@ export function QuickSettingsPopover({ type }: QuickSettingsPopoverProps) {
                     <div className="qs-hint">
                       {t(
                         'settings.general.antigravitySwitchTargetsHint',
-                        '未勾选具体目标时，将自动检测本机已安装的 Antigravity 产品。CLI 在 Windows 上与桌面版共用 gemini:antigravity 系统凭据。'
+                        '未勾选具体目标时：手动「同步所有目标」会检测本机已安装产品；自动切号默认只切首选已安装产品。CLI 在 Windows 上与桌面版共用 gemini:antigravity 系统凭据。'
                       )}
                     </div>
                   </>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -75,7 +75,6 @@ import {
 import { isDeepSeekAccount } from '../utils/codexDeepSeekAccess';
 import './DashboardPage.css';
 import apiKeyFunIcon from '../assets/icons/apikey-fun.png';
-import { RobotIcon } from '../components/icons/RobotIcon';
 import { CodexIcon } from '../components/icons/CodexIcon';
 import { WindsurfIcon } from '../components/icons/WindsurfIcon';
 import { KiroIcon } from '../components/icons/KiroIcon';
@@ -87,7 +86,10 @@ import { ZcodeIcon } from '../components/icons/ZcodeIcon';
 import { WorkbuddyIcon } from '../components/icons/WorkbuddyIcon';
 import { isAccountPlatform, PlatformId, PLATFORM_PAGE_MAP } from '../types/platform';
 import { getPlatformLabel, renderPlatformIcon } from '../utils/platformMeta';
-import { setAntigravityRuntimeTargetFromPlatform } from '../utils/antigravityRuntimeTarget';
+import {
+  isAntigravitySuitePlatformIds,
+  setAntigravityRuntimeTargetFromPlatform,
+} from '../utils/antigravityRuntimeTarget';
 import { useAntigravityRuntimeTarget } from '../hooks/useAntigravityRuntimeTarget';
 import { ManualHelpIconButton } from '../components/ManualHelpIconButton';
 import { AnnouncementCenter } from '../components/AnnouncementCenter';
@@ -2778,8 +2780,8 @@ export function DashboardPage({
         <div className="main-card antigravity-card" key={platformId}>
           <div className="main-card-header">
             <div className="header-title">
-              <RobotIcon className="" style={{ width: 18, height: 18 }} />
-              <h3>{getPlatformLabel(platformId, t)}</h3>
+              {renderPlatformIcon(antigravityRuntimeTarget, 18)}
+              <h3>{getPlatformLabel(antigravityRuntimeTarget, t)}</h3>
             </div>
             <div className="header-action-group">
               <button
@@ -3611,6 +3613,14 @@ export function DashboardPage({
           const label = group
             ? group.name
             : getPlatformLabel(platformId, t);
+          const displayPlatformId =
+            group && isAntigravitySuitePlatformIds(group.platformIds)
+              ? antigravityRuntimeTarget
+              : (group?.iconPlatformId ?? platformId);
+          const navigatePlatformId =
+            group && isAntigravitySuitePlatformIds(group.platformIds)
+              ? antigravityRuntimeTarget
+              : platformId;
           const iconClass =
             platformId === 'antigravity'
               ? 'success'
@@ -3629,7 +3639,7 @@ export function DashboardPage({
             <button
               className="stat-card stat-card-button"
               key={entryId}
-              onClick={() => navigateToPlatform(platformId)}
+              onClick={() => navigateToPlatform(navigatePlatformId)}
               title={
                 groupExtraCount > 0
                   ? `${t('dashboard.switchTo', '切换到此账号')} · ${groupTooltip}`
@@ -3657,7 +3667,7 @@ export function DashboardPage({
                     style={{ width: 24, height: 24 }}
                   />
                 ) : (
-                  renderPlatformIcon(group?.iconPlatformId ?? platformId, 24)
+                  renderPlatformIcon(displayPlatformId, 24)
                 )}
               </div>
               <div className="stat-info">

--- a/src/utils/antigravityRuntimeTarget.ts
+++ b/src/utils/antigravityRuntimeTarget.ts
@@ -41,6 +41,10 @@ export function setAntigravityRuntimeTarget(target: AntigravityRuntimeTarget): v
   );
 }
 
+export function isAntigravitySuitePlatformIds(platformIds: PlatformId[]): boolean {
+  return platformIds.includes('antigravity') && platformIds.includes('antigravity_ide');
+}
+
 export function setAntigravityRuntimeTargetFromPlatform(platformId: PlatformId): void {
   if (!isAntigravityRuntimeTarget(platformId)) {
     return;


### PR DESCRIPTION
## Summary

- Fix dashboard Antigravity icons/labels to follow the active runtime target instead of always showing Antigravity IDE
- Route auto-switch through installed products (desktop Antigravity when IDE is absent)
- Add configurable multi-surface account sync:
  - **active_only** (default): switch only the currently selected Antigravity product tab
  - **all_targets**: sync all enabled surfaces on manual switch
  - Targets: `desktop` | `ide` | `cli` (empty = auto-detect installed products)
- CLI target writes `gemini:antigravity` system credentials (shared with desktop Antigravity 2.x on Windows)

## Context

Fixes scenarios like #931 where users run Antigravity desktop without Antigravity IDE installed, but Cockpit defaulted to IDE paths/icons. Upstream previously merged then reverted Antigravity CLI switching (#1801); this PR keeps CLI as credential-only sync without reintroducing the reverted macOS-only flow.

## Follow-up (not in this PR)

- Native Antigravity relay for `agy` using existing `cockpit-cliproxy` Antigravity executor (similar to Codex Local Access)
- Seamless in-app switching remains IDE-extension only; desktop still requires credential-only or restart depending on settings

## Test plan

- [ ] Windows: only Antigravity desktop installed → dashboard shows desktop icon; auto-switch updates desktop account
- [ ] Quick settings → set sync mode to `all_targets`, enable desktop + CLI → manual switch updates credential without IDE restart
- [ ] IDE installed + dual no-restart enabled → IDE surface still uses seamless path when selected
