### PR TITLE
fix(floating-card): show Cursor API Usage quota bar

### DIFF
--- a/src/pages/FloatingCardWindow.tsx
+++ b/src/pages/FloatingCardWindow.tsx
@@ -1131,7 +1131,9 @@ export function FloatingCardWindow() {
   ]);
 
   const isCurrentViewed = Boolean(viewedAccount?.id && viewedAccount.id === currentAccount?.id);
-  const visibleQuotaItemLimit = selectedPlatform === 'antigravity' ? 3 : 2;
+  // Cursor's account page shows 3 primary bars (Total / Auto+Composer / API).
+  const visibleQuotaItemLimit =
+    selectedPlatform === 'antigravity' || selectedPlatform === 'cursor' ? 3 : 2;
   const visibleQuotaItems = presentation?.quotaItems.slice(0, visibleQuotaItemLimit) ?? [];
   const accountStateLabel = viewedAccount
     ? isCurrentViewed


### PR DESCRIPTION
## Summary

- Cursor 账号页会展示三条主配额：**Total Usage**、**Auto + Composer**、**API Usage**。
- 悬浮卡之前只对 Antigravity 放宽到 3 条，其余平台一律截成 2 条，所以 Cursor 的 **API Usage** 永远不会出现。
- 这次把 Cursor 也放到 3 条限额里。On-Demand 仍是第 4 条，不会挤进悬浮卡。

## Test plan

- [x] 打开 Cursor 悬浮卡，确认同时看到 Total Usage、Auto + Composer、API Usage
- [x] 切到 Codex / Copilot 等只有两条配额的平台，确认仍然只显示 2 条
- [x] 切到 Antigravity，确认仍然显示 3 条
- [x] 窗口高度能随第三条配额自动增高，内容不被裁切


Made with [Cursor](https://cursor.com)