### PR TITLE
fix(ui): persist sidebar layout across app updates

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -4302,6 +4302,18 @@ pub fn save_user_memory_list(
     modules::user_memory::save_user_memory_list(&id, items)
 }
 
+#[tauri::command]
+pub fn load_ui_preferences() -> Result<modules::ui_preferences::UiPreferences, String> {
+    modules::ui_preferences::load_ui_preferences()
+}
+
+#[tauri::command]
+pub fn save_ui_preferences(
+    values: std::collections::BTreeMap<String, String>,
+) -> Result<modules::ui_preferences::UiPreferences, String> {
+    modules::ui_preferences::save_ui_preferences(values)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -766,6 +766,8 @@ pub fn run() {
             commands::system::load_user_memory,
             commands::system::mark_user_memory_dismissed,
             commands::system::save_user_memory_list,
+            commands::system::load_ui_preferences,
+            commands::system::save_ui_preferences,
             // Logs Commands
             commands::logs::logs_get_snapshot,
             commands::logs::logs_open_log_directory,

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -96,6 +96,7 @@ pub mod trae_oauth;
 pub mod trae_session_transfer;
 pub mod tray;
 pub mod tray_layout;
+pub mod ui_preferences;
 pub mod update_checker;
 pub mod user_memory;
 pub mod vscode_inject;

--- a/src-tauri/src/modules/ui_preferences.rs
+++ b/src-tauri/src/modules/ui_preferences.rs
@@ -1,0 +1,156 @@
+//! 跨版本保留的侧边栏布局。
+//! 存在数据目录，不依赖 WebView localStorage。
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+use crate::modules::account;
+use crate::modules::atomic_write::write_string_atomic;
+
+const UI_PREFERENCES_FILE: &str = "ui_preferences.json";
+
+static PREFERENCES_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiPreferences {
+    #[serde(default)]
+    pub values: BTreeMap<String, String>,
+}
+
+fn preferences_path() -> Result<PathBuf, String> {
+    Ok(account::get_data_dir()?.join(UI_PREFERENCES_FILE))
+}
+
+fn read_preferences_from_path(path: &PathBuf) -> Result<UiPreferences, String> {
+    if !path.exists() {
+        return Ok(UiPreferences::default());
+    }
+    let raw = std::fs::read_to_string(path).map_err(|error| format!("读取界面偏好失败: {error}"))?;
+    if raw.trim().is_empty() {
+        return Ok(UiPreferences::default());
+    }
+    serde_json::from_str(&raw).or_else(|_| Ok(UiPreferences::default()))
+}
+
+fn write_preferences_to_path(path: &PathBuf, preferences: &UiPreferences) -> Result<(), String> {
+    let raw = serde_json::to_string_pretty(preferences)
+        .map_err(|error| format!("序列化界面偏好失败: {error}"))?;
+    write_string_atomic(path, &raw)
+}
+
+pub fn load_ui_preferences() -> Result<UiPreferences, String> {
+    let _guard = PREFERENCES_LOCK
+        .lock()
+        .map_err(|_| "界面偏好锁已损坏".to_string())?;
+    read_preferences_from_path(&preferences_path()?)
+}
+
+fn apply_values(preferences: &mut UiPreferences, values: BTreeMap<String, String>) -> bool {
+    let mut changed = false;
+    for (key, value) in values {
+        if preferences.values.get(&key) != Some(&value) {
+            preferences.values.insert(key, value);
+            changed = true;
+        }
+    }
+    changed
+}
+
+pub fn save_ui_preferences(values: BTreeMap<String, String>) -> Result<UiPreferences, String> {
+    let _guard = PREFERENCES_LOCK
+        .lock()
+        .map_err(|_| "界面偏好锁已损坏".to_string())?;
+    let path = preferences_path()?;
+    let mut preferences = read_preferences_from_path(&path)?;
+    if apply_values(&mut preferences, values) {
+        write_preferences_to_path(&path, &preferences)?;
+    }
+    Ok(preferences)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{read_preferences_from_path, write_preferences_to_path, UiPreferences};
+    use std::collections::BTreeMap;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn roundtrip_preference_values() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("cockpit-ui-preferences-{stamp}.json"));
+        let _ = std::fs::remove_file(&path);
+
+        let empty = read_preferences_from_path(&path).expect("empty preferences");
+        assert!(empty.values.is_empty());
+
+        let mut preferences = UiPreferences::default();
+        preferences.values.insert(
+            "agtools.platform_layout.v1".to_string(),
+            "{\"sidebarEntryIds\":[\"group:codex-suite\"]}".to_string(),
+        );
+        write_preferences_to_path(&path, &preferences).expect("write");
+
+        let loaded = read_preferences_from_path(&path).expect("reload");
+        assert!(loaded
+            .values
+            .get("agtools.platform_layout.v1")
+            .unwrap()
+            .contains("group:codex-suite"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn empty_or_invalid_file_returns_default() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("cockpit-ui-preferences-bad-{stamp}.json"));
+        std::fs::write(&path, "   ").expect("write empty");
+        let empty = read_preferences_from_path(&path).expect("empty file");
+        assert!(empty.values.is_empty());
+
+        std::fs::write(&path, "{not-json").expect("write invalid");
+        let invalid = read_preferences_from_path(&path).expect("invalid file");
+        assert!(invalid.values.is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn save_merges_without_dropping_other_keys() {
+        let mut preferences = UiPreferences::default();
+        preferences
+            .values
+            .insert("agtools.platform_layout.v1".to_string(), "old".to_string());
+        preferences
+            .values
+            .insert("keep".to_string(), "yes".to_string());
+
+        assert!(super::apply_values(
+            &mut preferences,
+            BTreeMap::from([(
+                "agtools.platform_layout.v1".to_string(),
+                "next".to_string()
+            )]),
+        ));
+        assert_eq!(
+            preferences.values.get("agtools.platform_layout.v1"),
+            Some(&"next".to_string())
+        );
+        assert_eq!(preferences.values.get("keep"), Some(&"yes".to_string()));
+        assert!(!super::apply_values(
+            &mut preferences,
+            BTreeMap::from([(
+                "agtools.platform_layout.v1".to_string(),
+                "next".to_string()
+            )]),
+        ));
+    }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App";
 import { initI18n } from "./i18n";
 import { AppRuntimeGuard } from "./components/AppRuntimeGuard";
 import {
@@ -10,29 +9,34 @@ import {
   recordFrontendStage,
 } from "./utils/errorReporter";
 import { setBootSplashStage } from "./utils/bootSplash";
+import { hydrateUiPreferences } from "./utils/uiPreferences";
 
 initErrorReporter();
 recordFrontendStage("script_loaded");
 setBootSplashStage("script_loaded");
 void initI18n();
 
-const rootElement = document.getElementById("root");
-if (!rootElement) {
-  const error = new Error("Root element not found");
-  captureError(error, { source: "frontend_boot", phase: "root_lookup" });
-  throw error;
-}
+void hydrateUiPreferences().then(async () => {
+  const { default: App } = await import("./App");
 
-recordFrontendStage("react_mount_start");
-ReactDOM.createRoot(rootElement).render(
-  <React.StrictMode>
-    <AppRuntimeGuard>
-      <App />
-    </AppRuntimeGuard>
-  </React.StrictMode>,
-);
+  const rootElement = document.getElementById("root");
+  if (!rootElement) {
+    const error = new Error("Root element not found");
+    captureError(error, { source: "frontend_boot", phase: "root_lookup" });
+    throw error;
+  }
 
-window.requestAnimationFrame(() => {
-  setBootSplashStage("react_mounted");
-  markFrontendReady("react_mounted");
+  recordFrontendStage("react_mount_start");
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <AppRuntimeGuard>
+        <App />
+      </AppRuntimeGuard>
+    </React.StrictMode>,
+  );
+
+  window.requestAnimationFrame(() => {
+    setBootSplashStage("react_mounted");
+    markFrontendReady("react_mounted");
+  });
 });

--- a/src/stores/usePlatformLayoutStore.ts
+++ b/src/stores/usePlatformLayoutStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
 import { ALL_PLATFORM_IDS, PlatformId } from '../types/platform';
+import { persistPlatformLayout } from '../utils/uiPreferences';
 import { CLASSIC_SIDEBAR_ENTRY_LIMIT } from './useSideNavLayoutStore';
 
 const PLATFORM_LAYOUT_STORAGE_KEY = 'agtools.platform_layout.v1';
@@ -900,6 +901,7 @@ function normalizeEntryOrder(
 function normalizeEntryVisibilityList(
   rawEntryIds: unknown,
   orderedEntryIds: PlatformLayoutEntryId[],
+  groups: PlatformLayoutGroup[] = [],
 ): PlatformLayoutEntryId[] {
   if (!Array.isArray(rawEntryIds)) {
     return [];
@@ -909,10 +911,18 @@ function normalizeEntryVisibilityList(
   const entries: PlatformLayoutEntryId[] = [];
   for (const item of rawEntryIds) {
     if (typeof item !== 'string') continue;
-    const entryId = item as PlatformLayoutEntryId;
-    if (!orderSet.has(entryId) || seen.has(entryId)) {
+    let entryId = item as PlatformLayoutEntryId;
+    if (!orderSet.has(entryId) && item.startsWith('platform:')) {
+      const platformId = item.slice('platform:'.length);
+      const mapped = ALL_PLATFORM_IDS.includes(platformId as PlatformId)
+        ? resolveEntryIdForPlatform(platformId as PlatformId, groups)
+        : null;
+      if (!mapped || !orderSet.has(mapped)) continue;
+      entryId = mapped;
+    } else if (!orderSet.has(entryId)) {
       continue;
     }
+    if (seen.has(entryId)) continue;
     seen.add(entryId);
     entries.push(entryId);
   }
@@ -937,7 +947,7 @@ function normalizeHiddenEntryIds(
   groups: PlatformLayoutGroup[],
   legacyHiddenPlatformIds: PlatformId[],
 ): PlatformLayoutEntryId[] {
-  const normalized = normalizeEntryVisibilityList(rawHiddenEntryIds, orderedEntryIds);
+  const normalized = normalizeEntryVisibilityList(rawHiddenEntryIds, orderedEntryIds, groups);
   if (normalized.length > 0) {
     return normalized;
   }
@@ -976,7 +986,7 @@ function normalizeSidebarEntryIds(
   groups: PlatformLayoutGroup[],
   legacySidebarPlatformIds: PlatformId[],
 ): PlatformLayoutEntryId[] {
-  const normalized = normalizeEntryVisibilityList(rawSidebarEntryIds, orderedEntryIds);
+  const normalized = normalizeEntryVisibilityList(rawSidebarEntryIds, orderedEntryIds, groups);
   if (normalized.length > 0) {
     return normalized;
   }
@@ -1351,7 +1361,7 @@ function persist(
   >,
 ) {
   try {
-    localStorage.setItem(PLATFORM_LAYOUT_STORAGE_KEY, JSON.stringify(state));
+    persistPlatformLayout(JSON.stringify(state));
   } catch {
     // ignore persistence failures
   }

--- a/src/utils/uiPreferences.ts
+++ b/src/utils/uiPreferences.ts
@@ -1,0 +1,46 @@
+import { invoke } from '@tauri-apps/api/core';
+
+const PLATFORM_LAYOUT_KEY = 'agtools.platform_layout.v1';
+
+export interface UiPreferencesSnapshot {
+  values: Record<string, string>;
+}
+
+let hydrated = false;
+
+function readLocal(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeLocal(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // ignore quota / private-mode failures
+  }
+}
+
+export function persistPlatformLayout(value: string): void {
+  writeLocal(PLATFORM_LAYOUT_KEY, value);
+  if (!hydrated) return;
+  void invoke('save_ui_preferences', {
+    values: { [PLATFORM_LAYOUT_KEY]: value },
+  }).catch(() => undefined);
+}
+
+export async function hydrateUiPreferences(): Promise<void> {
+  try {
+    const snapshot = await invoke<UiPreferencesSnapshot>('load_ui_preferences');
+    const value = snapshot?.values?.[PLATFORM_LAYOUT_KEY];
+    if (typeof value === 'string' && readLocal(PLATFORM_LAYOUT_KEY) == null) {
+      writeLocal(PLATFORM_LAYOUT_KEY, value);
+    }
+  } catch {
+    // ignore invoke failures
+  }
+  hydrated = true;
+}


### PR DESCRIPTION
Fixes #1786

## What changed

- Persist sidebar layout to `ui_preferences.json` in the data directory, using the same atomic-write helper as account groups.
- Restore it into empty `localStorage` before the layout store loads.
- Remap leftover `platform:` sidebar ids onto current group entries.

## Validation

- `git diff --check`
