### PR TITLE
perf(tray): 合并短窗口内的托盘菜单重建，消除重复的全平台磁盘读取

### DIFF
--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -3,8 +3,7 @@
 
 #[cfg(not(target_os = "macos"))]
 use std::collections::{HashMap, HashSet};
-#[cfg(target_os = "macos")]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 #[cfg(target_os = "macos")]
 use tauri::image::Image;
@@ -28,6 +27,17 @@ const MACOS_STATUS_ITEM_AUTOSAVE_NAME: &str = "com.jlcodes.cockpit-tools.main-tr
 
 #[cfg(target_os = "macos")]
 static MACOS_TRAY_SKIP_LOGGED: AtomicBool = AtomicBool::new(false);
+
+/// How long a rebuild request waits for its neighbours before the menu is built.
+///
+/// Long enough to swallow a quota sweep's fan-out, short enough that a tray the
+/// user opens right after switching accounts already shows the new state.
+const TRAY_MENU_COALESCE_WINDOW: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// Rebuild requests received since the pending rebuild last took a batch.
+static TRAY_MENU_REQUESTS: AtomicUsize = AtomicUsize::new(0);
+/// Whether a worker is already committed to serving the outstanding requests.
+static TRAY_MENU_REBUILD_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
 /// 单层最多直出的平台数量（超出进入“更多平台”子菜单）
 #[cfg(not(target_os = "macos"))]
@@ -3600,8 +3610,51 @@ fn handle_tray_event<R: Runtime>(tray: &TrayIcon<R>, event: TrayIconEvent) {
     }
 }
 
-/// 更新托盘菜单
+/// 请求更新托盘菜单（合并同一时间窗内的重复请求）
+///
+/// Rebuilding the menu re-reads every platform's account library from disk, so
+/// the ~120 call sites that fire on any account mutation must not each pay for
+/// one: a single quota refresh sweep touches a dozen platforms and used to queue
+/// a dozen full rebuilds. Requests are collapsed into one trailing rebuild.
 pub fn update_tray_menu<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), String> {
+    TRAY_MENU_REQUESTS.fetch_add(1, Ordering::AcqRel);
+    if TRAY_MENU_REBUILD_SCHEDULED.swap(true, Ordering::AcqRel) {
+        // A worker is already going to pick this request up.
+        return Ok(());
+    }
+    spawn_tray_menu_rebuild_worker(app.clone());
+    Ok(())
+}
+
+fn spawn_tray_menu_rebuild_worker<R: Runtime>(app: tauri::AppHandle<R>) {
+    std::thread::spawn(move || loop {
+        std::thread::sleep(TRAY_MENU_COALESCE_WINDOW);
+        let collapsed = TRAY_MENU_REQUESTS.swap(0, Ordering::AcqRel);
+        let started = std::time::Instant::now();
+        if let Err(err) = rebuild_tray_menu_now(&app) {
+            logger::log_warn(&format!("[Tray] 托盘菜单重建失败: {}", err));
+        } else {
+            logger::log_info(&format!(
+                "[Tray] 托盘菜单已更新: 合并请求={}, 耗时={}ms",
+                collapsed,
+                started.elapsed().as_millis()
+            ));
+        }
+
+        // Release the slot, then re-check: a request that landed between the
+        // swap above and this store would otherwise never be served.
+        TRAY_MENU_REBUILD_SCHEDULED.store(false, Ordering::Release);
+        if TRAY_MENU_REQUESTS.load(Ordering::Acquire) == 0 {
+            return;
+        }
+        if TRAY_MENU_REBUILD_SCHEDULED.swap(true, Ordering::AcqRel) {
+            // Someone else claimed the slot and will do the work.
+            return;
+        }
+    });
+}
+
+fn rebuild_tray_menu_now<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         crate::modules::macos_native_menu::update_status_item(app)?;
@@ -3614,7 +3667,6 @@ pub fn update_tray_menu<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Str
     if let Some(tray) = app.tray_by_id(TRAY_ID) {
         let menu = build_tray_menu(app).map_err(|e| e.to_string())?;
         tray.set_menu(Some(menu)).map_err(|e| e.to_string())?;
-        logger::log_info("[Tray] 托盘菜单已更新");
     }
     Ok(())
 }


### PR DESCRIPTION
## 问题

`update_tray_menu()` 在代码库中约有 122 处调用点，任何账号变更都会触发托盘菜单重建，而每次重建都要把全部 13 个平台的账号库从磁盘完整读一遍（`tray.rs` 内 13 处 `list_accounts()`）。

实际运行日志观测：一天内「托盘菜单已更新」出现 **4073 次**，最忙的一分钟 28 次，冷启动后 760ms 内 6 次。实测单次重建冷文件缓存约 **273ms**、热缓存 12–21ms——启动阶段这笔磁盘开销被重复支付了多次；一次配额刷新扫一圈平台就会排出十几次重建。

## 改法

把重建请求放进 **150ms 合并窗口**：窗口内的多个请求合并为一次尾沿重建，最终状态与逐次重建一致（重建总是读取最新账号数据）。日志同时报告本次合并吞掉了多少个请求、重建耗时多少，便于后续观测。

只改 `src-tauri/src/modules/tray.rs` 一个文件，不改任何调用方，无外部接口变化。

## 验证

- Windows 实机同条件 A/B（重启后 60 秒观察窗）：托盘重建 **11 次 → 6 次**；启动突发 6 次合并为 2 次（分别合并了 2 个和 4 个请求）。
- `cargo check` 通过（仅存量与本改动无关的 dead-code 警告）。
