### PR TITLE
fix(codex): Codex 快速切换服务商弹窗支持 ESC 关闭

### DIFF
--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -7330,6 +7330,8 @@ export function CodexAccountsPage() {
     setQuickSwitchError(null);
   }, [quickSwitchSubmitting]);
 
+  useEscClose(Boolean(quickSwitchAccountId), closeQuickSwitchModal);
+
   const openQuickSwitchProviderModal = useCallback(
     (account: CodexAccount) => {
       if (!isCodexApiKeyAccount(account)) return;


### PR DESCRIPTION
## 问题

Codex 账号页的「快速切换服务商」弹窗是该页面唯一没有绑定 ESC 的浮层：弹窗打开时按 ESC 没有任何反应，与页面上其他弹窗（CLI 启动、删除确认等）的行为不一致。

## 改法

复用页面里已有的 `useEscClose` 钩子，共 +2 行：

```tsx
useEscClose(Boolean(quickSwitchAccountId), closeQuickSwitchModal);
```

`closeQuickSwitchModal` 自身在提交进行中（`quickSwitchSubmitting`）会拒绝执行，因此切换请求在途时不会被 ESC 误关。

## 验证

- 实机验证：ESC 可正常关闭弹窗；切换提交进行中按 ESC 不会中断操作。
- `tsc --noEmit` 通过。
