### PR TITLE
perf(render): MFA 倒计时仅在展示 TOTP 时运行，消除空闲状态的每秒整页重渲染

### DIFF
--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -749,10 +749,16 @@ export function AccountsPage({ onNavigate }: AccountsPageProps) {
     }
   }, [t])
 
+  // The countdown is only ever rendered next to a live TOTP token, so ticking it
+  // unconditionally re-rendered this whole page once a second for nothing.
+  const mfaCountdownActive = activeAccountNoteForm.twoFactorSecret.trim().length > 0
+
   useEffect(() => {
+    if (!mfaCountdownActive) return
+    setMfaTimeRemaining(getMfaTimeRemaining())
     const timer = window.setInterval(() => setMfaTimeRemaining(getMfaTimeRemaining()), 1000)
     return () => window.clearInterval(timer)
-  }, [])
+  }, [mfaCountdownActive])
 
   const [displayGroups, setDisplayGroups] = useState<DisplayGroup[]>([])
   const [displayGroupsLoaded, setDisplayGroupsLoaded] = useState(false)

--- a/src/pages/CodexAccountsPage.tsx
+++ b/src/pages/CodexAccountsPage.tsx
@@ -1430,12 +1430,20 @@ export function CodexAccountsPage() {
     set: setAccountNoteError,
   } = useModalErrorState();
 
+  // The countdown is only ever rendered next to a live TOTP token, so ticking it
+  // unconditionally re-rendered this whole page once a second for nothing.
+  const mfaCountdownActive =
+    editingAccountNoteForm.twoFactorSecret.trim().length > 0 ||
+    pendingOAuthNoteForm.twoFactorSecret.trim().length > 0;
+
   useEffect(() => {
+    if (!mfaCountdownActive) return;
+    setMfaTimeRemaining(getMfaTimeRemaining());
     const timer = window.setInterval(() => {
       setMfaTimeRemaining(getMfaTimeRemaining());
     }, 1000);
     return () => window.clearInterval(timer);
-  }, []);
+  }, [mfaCountdownActive]);
 
   // Use the common hook WITHOUT oauthService since Codex uses Tauri event-based OAuth
   // Codex batch-delete confirm is wired after confirmCodexDelete is defined.


### PR DESCRIPTION
## 问题

两个账号页（`CodexAccountsPage`、`AccountsPage`）的 MFA 倒计时 `setInterval` 无条件每秒执行一次 `setState`，每次都触发整页重渲染——CodexAccountsPage 约 2.1 万行、464 个 hooks。

空闲状态 CPU profile 显示：Codex 页空闲占用 **1.47%**，对照仪表盘只有 0.08%，其中仅 i18n 查找就占了浪费量的约五分之一。而这个倒计时只在账号备注弹层的 TOTP 动态码旁边才会渲染——绝大多数时间它在为不存在的界面走表。

## 改法

给定时器加门控：只在 2FA 密钥非空（即倒计时真的在展示）时才启动；重新激活时先立即同步一次剩余秒数。剩余时间用墙钟计算（`getMfaTimeRemaining()`），暂停后恢复不会停留在旧秒数。

## 验证

- 同环境 CPU profile：Codex 页空闲占用 **1.47% → 0.30%**。
- `tsc --noEmit` 通过。
