### PR TITLE
fix(i18n): 修正账号页标题回退英文、六个平台页写死英文筛选文案、中文缩放提示缺 Ctrl

### DIFF
--- a/src/components/OverviewTabsHeader.tsx
+++ b/src/components/OverviewTabsHeader.tsx
@@ -96,7 +96,7 @@ export function OverviewTabsHeader({
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">
-            {t('settings.general.account', 'Accounts')}
+            {t('settings.general.accountManagement', 'Account')}
           </span>
           <ManualHelpIconButton className="platform-header-help" onClick={onOpenManual} />
         </div>

--- a/src/components/codebuddy-suite/CodebuddySuiteAccountsSharedView.tsx
+++ b/src/components/codebuddy-suite/CodebuddySuiteAccountsSharedView.tsx
@@ -977,7 +977,7 @@ export function CodebuddySuiteAccountsSharedView<
           <MultiSelectFilterDropdown
             options={tierFilterOptions}
             selectedValues={filterTypes}
-            allLabel={`ALL (${tierSummary.all})`}
+            allLabel={t('common.shared.filter.all', '全部 ({{count}})', { count: tierSummary.all })}
             filterLabel={t("common.shared.filterLabel", "筛选")}
             clearLabel={t("accounts.clearFilter", "清空筛选")}
             emptyLabel={t("common.none", "暂无")}

--- a/src/components/platform/PlatformOverviewTabsHeader.tsx
+++ b/src/components/platform/PlatformOverviewTabsHeader.tsx
@@ -227,7 +227,7 @@ export function PlatformOverviewTabsHeader({
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">
-            {t('settings.general.account', 'Accounts')}
+            {t('settings.general.accountManagement', 'Account')}
           </span>
           <ManualHelpIconButton className="platform-header-help" />
         </div>

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -875,7 +875,7 @@
       "themeDark": "深色 (Dark)",
       "themeSystem": "跟随系统",
       "uiScale": "界面缩放",
-      "uiScaleDesc": "调整界面缩放比例（⌘+/⌘- 缩放，⌘0 重置）",
+      "uiScaleDesc": "调整界面缩放比例（⌘+/⌘- 或 Ctrl+/Ctrl-，⌘0/Ctrl+0 重置）",
       "accountManagement": "账号管理",
       "autoRefresh": "Antigravity IDE 自动刷新配额",
       "codexAutoRefresh": "Codex 自动刷新配额",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -674,7 +674,7 @@
       "themeDark": "深色 (Dark)",
       "themeSystem": "跟隨系統",
       "uiScale": "介面縮放",
-      "uiScaleDesc": "調整介面縮放比例（⌘+/⌘- 縮放，⌘0 重設）",
+      "uiScaleDesc": "調整介面縮放比例（⌘+/⌘- 或 Ctrl+/Ctrl-，⌘0/Ctrl+0 重設）",
       "accountManagement": "帳號管理",
       "autoRefresh": "Antigravity IDE 自動刷新配額",
       "codexAutoRefresh": "Codex 自動刷新配額",

--- a/src/pages/ClaudeAccountsPage.tsx
+++ b/src/pages/ClaudeAccountsPage.tsx
@@ -2841,7 +2841,7 @@ export function ClaudeAccountsPage({ subPlatform = 'desktop' }: ClaudeAccountsPa
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">
-            {t('settings.general.account', 'Accounts')}
+            {t('settings.general.accountManagement', 'Account')}
           </span>
           <ManualHelpIconButton className="platform-header-help" />
         </div>

--- a/src/pages/CodebuddyAccountsPage.tsx
+++ b/src/pages/CodebuddyAccountsPage.tsx
@@ -614,7 +614,7 @@ export function CodebuddyAccountsPage() {
           <MultiSelectFilterDropdown
             options={tierFilterOptions}
             selectedValues={filterTypes}
-            allLabel={`ALL (${tierSummary.all})`}
+            allLabel={t('common.shared.filter.all', '全部 ({{count}})', { count: tierSummary.all })}
             filterLabel={t('common.shared.filterLabel', '筛选')}
             clearLabel={t('accounts.clearFilter', '清空筛选')}
             emptyLabel={t('common.none', '暂无')}

--- a/src/pages/CodexApiServicePage.tsx
+++ b/src/pages/CodexApiServicePage.tsx
@@ -3606,7 +3606,7 @@ export function CodexApiServicePage() {
       <div className="page-top-strip">
         <div className="page-top-strip-left">
           <span className="page-top-strip-label">
-            {t("settings.general.account", "Accounts")}
+            {t("settings.general.accountManagement", "Account")}
           </span>
           <ManualHelpIconButton className="platform-header-help" />
         </div>

--- a/src/pages/CursorAccountsPage.tsx
+++ b/src/pages/CursorAccountsPage.tsx
@@ -932,7 +932,7 @@ export function CursorAccountsPage() {
           <MultiSelectFilterDropdown
             options={tierFilterOptions}
             selectedValues={filterTypes}
-            allLabel={`ALL (${tierSummary.all})`}
+            allLabel={t('common.shared.filter.all', '全部 ({{count}})', { count: tierSummary.all })}
             filterLabel={t('common.shared.filterLabel', '筛选')}
             clearLabel={t('accounts.clearFilter', '清空筛选')}
             emptyLabel={t('common.none', '暂无')}

--- a/src/pages/KiroAccountsPage.tsx
+++ b/src/pages/KiroAccountsPage.tsx
@@ -927,7 +927,7 @@ export function KiroAccountsPage() {
           <MultiSelectFilterDropdown
             options={tierFilterOptions}
             selectedValues={filterTypes}
-            allLabel={`ALL (${tierSummary.all})`}
+            allLabel={t('common.shared.filter.all', '全部 ({{count}})', { count: tierSummary.all })}
             filterLabel={t('common.shared.filterLabel', '筛选')}
             clearLabel={t('accounts.clearFilter', '清空筛选')}
             emptyLabel={t('common.none', '暂无')}

--- a/src/pages/WindsurfAccountsPage.tsx
+++ b/src/pages/WindsurfAccountsPage.tsx
@@ -1352,7 +1352,7 @@ export function WindsurfAccountsPage() {
           <MultiSelectFilterDropdown
             options={tierFilterOptions}
             selectedValues={filterTypes}
-            allLabel={`ALL (${tierCounts.all})`}
+            allLabel={t('common.shared.filter.all', '全部 ({{count}})', { count: tierCounts.all })}
             filterLabel={t('common.shared.filterLabel', '筛选')}
             clearLabel={t('accounts.clearFilter', '清空筛选')}
             emptyLabel={t('common.none', '暂无')}

--- a/src/pages/ZedAccountsPage.tsx
+++ b/src/pages/ZedAccountsPage.tsx
@@ -1073,7 +1073,7 @@ export function ZedAccountsPage() {
           <MultiSelectFilterDropdown
             options={tierFilterOptions}
             selectedValues={filterTypes}
-            allLabel={`ALL (${accounts.length})`}
+            allLabel={t('common.shared.filter.all', '全部 ({{count}})', { count: accounts.length })}
             filterLabel={t('common.shared.filterLabel', '筛选')}
             clearLabel={t('accounts.clearFilter', '清空筛选')}
             emptyLabel={t('common.none', '暂无')}


### PR DESCRIPTION
## 问题（三处）

1. `settings.general.account` 这个翻译键**在任何语言文件里都不存在**，导致四个账号页的页头标题永远回退成英文 "Accounts"（中文等所有非英文界面都显示英文）。
2. 六个平台页把档位筛选按钮写死为英文 `ALL (n)`，没有走翻译体系（其他页面用的是共享键）。
3. zh-CN / zh-TW 的 `uiScaleDesc` 缩放提示只写了 macOS 的 Cmd 快捷键，其他所有语言都同时写了 Ctrl 变体。

## 改法

1. 页头标题改指向已有完整翻译的 `settings.general.accountManagement` 键；
2. 筛选按钮改用其他页面同款的 `common.shared.filter.all` 键；
3. 中文缩放提示补上 Ctrl 快捷键说明。

不新增任何翻译键，12 个文件各改 1 行。

## 验证

- `tsc --noEmit` 通过；zh-CN / zh-TW JSON 解析校验合法。
- 中文界面实机目检：账号页标题、筛选按钮、缩放提示均正确显示中文。
