### PR TITLE
refactor(accounts): 三处重复的视图模式归一化逻辑合并为共享实现

### DIFF
--- a/src/hooks/useProviderAccountsPage.ts
+++ b/src/hooks/useProviderAccountsPage.ts
@@ -199,13 +199,21 @@ export interface ProviderAccountBase {
 
 const DEFAULT_SORT_BY = 'created_at';
 const DEFAULT_SORT_DIRECTION: SortDirection = 'desc';
-const DEFAULT_VIEW_MODE: ViewMode = 'grid';
+/**
+ * Single source of truth for the account pages' persisted view mode.
+ * `compact` is a legacy value written by older Claude builds and still resolves
+ * to `list`; every other unknown value falls back to the default.
+ */
+export const DEFAULT_VIEW_MODE: ViewMode = 'grid';
+
+export const normalizeViewMode = (value: unknown): ViewMode => {
+  if (value === 'grid' || value === 'list') return value;
+  if (value === 'compact') return 'list';
+  return DEFAULT_VIEW_MODE;
+};
 
 const normalizeSortDirection = (value: string | null): SortDirection =>
   value === 'asc' ? 'asc' : DEFAULT_SORT_DIRECTION;
-
-const normalizeViewMode = (value: string | null): ViewMode =>
-  value === 'list' ? 'list' : DEFAULT_VIEW_MODE;
 
 const FILTER_FIELD_VIEW_MODE = 'view_mode';
 const FILTER_FIELD_FILTER_TYPE = 'filter_type';

--- a/src/pages/ClaudeAccountsPage.tsx
+++ b/src/pages/ClaudeAccountsPage.tsx
@@ -54,6 +54,11 @@ import { useEscClose } from '../hooks/useEscClose';
 import { useEnterConfirm } from '../hooks/useEnterConfirm';
 import { useExportJsonModal } from '../hooks/useExportJsonModal';
 import { useLaunchTerminalOptions } from '../hooks/useLaunchTerminalOptions';
+import {
+  DEFAULT_VIEW_MODE,
+  normalizeViewMode,
+  type ViewMode,
+} from '../hooks/useProviderAccountsPage';
 import { getProviderCurrentAccountId, type ProviderCurrentPlatform } from '../services/providerCurrentAccountService';
 import {
   isModelProviderUsageUnavailableError,
@@ -221,7 +226,6 @@ function getClaudeDesktopLoginProgressDetail(
   return t('claude.desktopOAuth.progress.hint', '首次准备完成后，后续会直接复用本地缓存。');
 }
 
-type ViewMode = 'grid' | 'list';
 type AddTab = 'desktop' | 'desktopGateway' | 'oauth' | 'apikey' | 'import';
 type ClaudeSubPlatform = 'desktop' | 'cli';
 type ClaudePageSection = ClaudeSubPlatform | 'instances';
@@ -332,13 +336,10 @@ function formatDate(timestamp: number): string {
 
 function readInitialViewMode(): ViewMode {
   try {
-    const value = localStorage.getItem(CLAUDE_ACCOUNTS_VIEW_MODE_KEY);
-    if (value === 'grid' || value === 'list') return value;
-    if (value === 'compact') return 'list';
+    return normalizeViewMode(localStorage.getItem(CLAUDE_ACCOUNTS_VIEW_MODE_KEY));
   } catch {
-    // ignore storage failures
+    return DEFAULT_VIEW_MODE;
   }
-  return 'grid';
 }
 
 function readClaudeApiKeyUsageCache(): Record<string, ClaudeApiKeyUsageState> {

--- a/src/pages/QoderAccountsPage.tsx
+++ b/src/pages/QoderAccountsPage.tsx
@@ -39,6 +39,11 @@ import { SingleSelectFilterDropdown } from '../components/SingleSelectFilterDrop
 import { useEscClose } from '../hooks/useEscClose';
 import { useEnterConfirm } from '../hooks/useEnterConfirm';
 import {
+  DEFAULT_VIEW_MODE,
+  normalizeViewMode,
+  type ViewMode,
+} from '../hooks/useProviderAccountsPage';
+import {
   PlatformOverviewTab,
   PlatformOverviewTabsHeader,
 } from '../components/platform/PlatformOverviewTabsHeader';
@@ -99,7 +104,6 @@ const QODER_FILTER_FIELD_TAG_FILTER = 'tag_filter';
 const QODER_FILTER_FIELD_GROUP_BY_TAG = 'group_by_tag';
 const UNTAGGED_KEY = '__untagged__';
 
-type ViewMode = 'grid' | 'list';
 type SortBy = 'created_at' | 'plan' | 'quota';
 type SortDirection = 'asc' | 'desc';
 
@@ -136,10 +140,6 @@ function writeBooleanStorage(key: string, value: boolean) {
   } catch {
     // ignore
   }
-}
-
-function normalizeQoderViewMode(value: unknown): ViewMode {
-  return value === 'list' ? 'list' : 'grid';
 }
 
 function normalizeQoderSortBy(value: unknown): SortBy {
@@ -257,14 +257,14 @@ export function QoderAccountsPage() {
   );
   const [viewMode, setViewMode] = useState<ViewMode>(() =>
     initialFilterPersistenceEnabled
-      ? normalizeQoderViewMode(
+      ? normalizeViewMode(
           readAccountsOverviewFilterField<unknown>(
             QODER_FILTER_PERSISTENCE_SCOPE,
             QODER_FILTER_FIELD_VIEW_MODE,
-            'grid',
+            DEFAULT_VIEW_MODE,
           ),
         )
-      : 'grid',
+      : DEFAULT_VIEW_MODE,
   );
   const [searchQuery, setSearchQuery] = useState('');
   const [filterTypes, setFilterTypes] = useState<string[]>(() =>


### PR DESCRIPTION
## 问题

`useProviderAccountsPage`、`ClaudeAccountsPage`、`QoderAccountsPage` 各自维护一份 `ViewMode` 联合类型和「持久化值 → grid/list」的归一化函数，三份拷贝逻辑相同。默认值与历史遗留值（`compact`）的处理规则散落在三处，改一处容易漏两处。

## 改法

从 `useProviderAccountsPage` 导出 `DEFAULT_VIEW_MODE` 与 `normalizeViewMode`，三个调用点统一复用，让默认值和遗留值处理只存在一份。

对所有可观察到的持久化值**行为不变**：默认仍是 `grid`，历史遗留的 `compact` 仍解析为 `list`。唯一的差异是 provider hook 与 Qoder 现在也会把 `compact` 映射为 `list`——但这两处从不写入该值，不存在能走到这条路径的持久化状态。

## 验证

- 行为等价重构，无界面变化。
- `tsc --noEmit` 通过。
