### PR TITLE
style(theme): 清理写死的蓝/橙十六进制色，改用主题变量

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -164,7 +164,7 @@
 .codex-batch-import-progress-fill {
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, #2563eb, #0ea5e9);
+  background: var(--primary);
   transition: width 180ms ease;
 }
 
@@ -306,7 +306,7 @@
 }
 
 .codex-batch-import-check-toggle input:checked + .codex-batch-import-check-switch {
-  background: #2563eb;
+  background: var(--primary);
 }
 
 .codex-batch-import-check-toggle input:checked + .codex-batch-import-check-switch::after {

--- a/src/components/CloseConfirmDialog.css
+++ b/src/components/CloseConfirmDialog.css
@@ -96,7 +96,7 @@
 }
 
 .close-option-btn.minimize .option-icon {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: var(--primary);
   color: white;
 }
 

--- a/src/components/CodexLocalAccessModal.css
+++ b/src/components/CodexLocalAccessModal.css
@@ -133,11 +133,11 @@
   height: 18px;
   padding: 10px;
   box-sizing: content-box;
-  border-radius: 14px;
-  background: linear-gradient(135deg, #2563eb 0%, #0ea5a5 100%);
+  border-radius: var(--radius-xl);
+  background: var(--primary);
   color: #fff;
   box-shadow:
-    0 14px 28px -18px rgba(29, 78, 216, 0.72),
+    0 14px 28px -18px color-mix(in srgb, var(--primary) 72%, transparent),
     inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
@@ -512,10 +512,9 @@
 }
 
 .codex-local-access-stats-range-tab.is-active {
-  color: #1d4ed8;
-  border-color: rgba(37, 99, 235, 0.24);
-  background: rgba(219, 234, 254, 0.9);
-  box-shadow: 0 8px 16px -12px rgba(37, 99, 235, 0.65);
+  color: var(--primary);
+  border-color: color-mix(in srgb, var(--primary) 24%, transparent);
+  background: var(--primary-light);
 }
 
 .codex-local-access-inline-error,
@@ -1687,11 +1686,11 @@
 }
 
 .codex-local-access-stat-card-cost {
-  color: #059669;
+  color: var(--success);
 }
 
 .codex-local-access-stat-card-latency {
-  color: #d97706;
+  color: var(--warning);
 }
 
 .codex-local-access-stat-label {
@@ -3088,13 +3087,9 @@
 }
 
 [data-theme="dark"] .codex-local-access-inline-info {
-  color: #93c5fd;
-  background: linear-gradient(
-    135deg,
-    rgba(30, 58, 138, 0.72),
-    rgba(37, 99, 235, 0.5)
-  );
-  border-color: rgba(96, 165, 250, 0.24);
+  color: var(--primary);
+  background: var(--primary-light);
+  border-color: color-mix(in srgb, var(--primary) 24%, transparent);
 }
 
 [data-theme="dark"] .codex-local-access-test-dialog {

--- a/src/styles/CompactView.module.css
+++ b/src/styles/CompactView.module.css
@@ -203,13 +203,15 @@
 }
 
 .tierPro {
-  background: linear-gradient(135deg, #1d4ed8, #0ea5a5);
-  color: white;
+  background: var(--plan-pro-bg);
+  color: var(--plan-pro-color);
+  border: 1px solid var(--plan-pro-border);
 }
 
 .tierUltra {
-  background: linear-gradient(135deg, #f97316, #f59e0b);
-  color: white;
+  background: var(--plan-ultra-bg);
+  color: var(--plan-ultra-color);
+  border: 1px solid var(--plan-ultra-border);
 }
 
 .tierFree {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -67,7 +67,7 @@
   min-width: 18px;
   height: 18px;
   padding: 0 5px;
-  background: linear-gradient(135deg, #f97316 0%, #ef4444 100%);
+  background: var(--warning-strong);
   color: white;
   font-size: 11px;
   font-weight: 700;
@@ -534,7 +534,7 @@
 }
 
 .installed-version-badge.is-missing .installed-version-dot {
-  background: #f59e0b;
+  background: var(--warning);
   box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.16);
 }
 


### PR DESCRIPTION
## 问题

若干界面元素写死了蓝/橙十六进制色（`#1d4ed8` / `#f97316` / `#2563eb` / `#3b82f6` / `#93c5fd` 等），不跟随主题变量体系：

- 紧凑悬浮视图的 PRO / ULTRA 徽章（最后一处实心色计划徽章）
- 批量导入进度条填充与开关
- 关闭确认弹窗的最小化图标
- Codex 本地访问弹窗的图标、时间范围页签、深色内联提示
- 火箭点击计数徽章、缺失版本红点
- Codex 本地访问的成本 / 延迟统计色

## 改法

统一改用已有的主题变量：计划徽章走共享的 `--plan-*` token，蓝系装饰走 `var(--primary)` + `color-mix`，提醒/状态色走 `--warning` / `--success`。浅、深两种模式下视觉与原先一致，但从此跟随主题设置。

共 5 个 CSS 文件，+22 / −25 行，纯颜色变量替换，无布局改动。

## 验证

- 浅色 / 深色两种模式实机目检，视觉一致。
- 纯 CSS 改动，不涉及构建与逻辑。
