### PR TITLE
fix(codex): normalize Responses Lite requests for API key upstreams

### DIFF
--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_execute.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_execute.go
@@ -20,6 +20,7 @@ import (
 )
 
 func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	opts.Headers = codexRequestHeadersWithGinResponsesLite(ctx, opts.Headers)
 	liteHeaderValue := ""
 	if opts.Headers != nil {
 		liteHeaderValue = headerValueCaseInsensitive(opts.Headers, codexResponsesLiteHeaderName)
@@ -109,6 +110,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	if !useFullResponses && liteHeaderValue != "" {
 		httpReq.Header[codexResponsesLiteHeaderName] = []string{liteHeaderValue}
 	}
+	removeCodexResponsesLiteHeaderForAPIKey(httpReq.Header, auth)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_responses_lite_test.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_responses_lite_test.go
@@ -95,7 +95,7 @@ func TestNormalizeCodexResponsesLiteRequestLeavesRegularRequestUnchanged(t *test
 	}
 }
 
-func TestNormalizeCodexResponsesLiteRequestKeepsAPIKeyImageGeneration(t *testing.T) {
+func TestNormalizeCodexResponsesLiteRequestForAPIKeyForcesParallelToolCallsFalse(t *testing.T) {
 	body := []byte(`{"parallel_tool_calls":true,"tools":[{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`)
 	headers := http.Header{codexResponsesLiteHeaderName: []string{"true"}}
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{
@@ -108,8 +108,12 @@ func TestNormalizeCodexResponsesLiteRequestKeepsAPIKeyImageGeneration(t *testing
 		t.Fatal("API key request should keep its existing Responses mode")
 	}
 
-	if string(result) != string(body) {
-		t.Fatalf("API key request changed: %s", result)
+	parallelToolCalls := gjson.GetBytes(result, "parallel_tool_calls")
+	if !parallelToolCalls.Exists() || parallelToolCalls.Bool() {
+		t.Fatalf("API key parallel_tool_calls = %s, want false: %s", parallelToolCalls.Raw, result)
+	}
+	if toolType := gjson.GetBytes(result, "tools.0.type").String(); toolType != "image_generation" {
+		t.Fatalf("API key image tool = %q, want image_generation: %s", toolType, result)
 	}
 }
 
@@ -344,7 +348,7 @@ func TestCodexExecutorExecutePreservesImageGenNamespaceOutsideResponsesLite(t *t
 	}
 }
 
-func TestCodexExecutorExecuteKeepsAPIKeyImageGenerationPathUnchanged(t *testing.T) {
+func TestCodexExecutorExecuteAPIKeyStripsResponsesLiteHeaderAndForcesParallelToolCallsFalse(t *testing.T) {
 	type capturedRequest struct {
 		header http.Header
 		body   []byte
@@ -381,21 +385,21 @@ func TestCodexExecutorExecuteKeepsAPIKeyImageGenerationPathUnchanged(t *testing.
 		Payload: payload,
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("codex"),
-		Headers:      http.Header{codexResponsesLiteHeaderName: []string{"true"}},
 	})
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
 	}
 
 	got := <-captured
-	if !codexResponsesLiteEnabled(got.header) {
-		t.Fatalf("API key request lost its existing Responses Lite header: %v", got.header)
+	if codexResponsesLiteEnabled(got.header) {
+		t.Fatalf("API key upstream retained internal Responses Lite header: %v", got.header)
 	}
 	if toolType := gjson.GetBytes(got.body, "tools.0.type").String(); toolType != "image_generation" {
 		t.Fatalf("API key image tool = %q, want image_generation: %s", toolType, got.body)
 	}
-	if !gjson.GetBytes(got.body, "parallel_tool_calls").Bool() {
-		t.Fatalf("API key parallel_tool_calls changed: %s", got.body)
+	parallelToolCalls := gjson.GetBytes(got.body, "parallel_tool_calls")
+	if !parallelToolCalls.Exists() || parallelToolCalls.Bool() {
+		t.Fatalf("API key parallel_tool_calls = %s, want false: %s", parallelToolCalls.Raw, got.body)
 	}
 }
 
@@ -412,5 +416,21 @@ func TestRemoveCodexResponsesLiteHeaderForFullResponse(t *testing.T) {
 	}
 	if got := headers.Get("X-Custom"); got != "keep-me" {
 		t.Fatalf("X-Custom = %q, want keep-me", got)
+	}
+}
+
+func TestRemoveCodexResponsesLiteHeaderForAPIKeyOnly(t *testing.T) {
+	apiKeyHeaders := http.Header{codexResponsesLiteHeaderName: []string{"true"}}
+	apiKeyAuth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test"}}
+	removeCodexResponsesLiteHeaderForAPIKey(apiKeyHeaders, apiKeyAuth)
+	if codexResponsesLiteEnabled(apiKeyHeaders) {
+		t.Fatal("API key upstream retained internal Responses Lite header")
+	}
+
+	oauthHeaders := http.Header{codexResponsesLiteHeaderName: []string{"true"}}
+	oauth := &cliproxyauth.Auth{Metadata: map[string]any{"access_token": "oauth-token"}}
+	removeCodexResponsesLiteHeaderForAPIKey(oauthHeaders, oauth)
+	if !codexResponsesLiteEnabled(oauthHeaders) {
+		t.Fatal("OAuth upstream lost Responses Lite header")
 	}
 }

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_stream.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_stream.go
@@ -22,6 +22,7 @@ import (
 )
 
 func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	opts.Headers = codexRequestHeadersWithGinResponsesLite(ctx, opts.Headers)
 	liteHeaderValue := ""
 	if opts.Headers != nil {
 		liteHeaderValue = headerValueCaseInsensitive(opts.Headers, codexResponsesLiteHeaderName)
@@ -115,6 +116,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	if !useFullResponses && liteHeaderValue != "" {
 		httpReq.Header[codexResponsesLiteHeaderName] = []string{liteHeaderValue}
 	}
+	removeCodexResponsesLiteHeaderForAPIKey(httpReq.Header, auth)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_responses_lite.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_responses_lite.go
@@ -1,16 +1,39 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/gin-gonic/gin"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
 const codexResponsesLiteHeaderName = "X-OpenAI-Internal-Codex-Responses-Lite"
+
+func codexRequestHeadersWithGinResponsesLite(ctx context.Context, headers http.Header) http.Header {
+	if strings.TrimSpace(headerValueCaseInsensitive(headers, codexResponsesLiteHeaderName)) != "" || ctx == nil {
+		return headers
+	}
+	ginCtx, ok := ctx.Value("gin").(*gin.Context)
+	if !ok || ginCtx == nil || ginCtx.Request == nil {
+		return headers
+	}
+	value := strings.TrimSpace(headerValueCaseInsensitive(ginCtx.Request.Header, codexResponsesLiteHeaderName))
+	if value == "" {
+		return headers
+	}
+	if headers == nil {
+		headers = make(http.Header)
+	} else {
+		headers = headers.Clone()
+	}
+	headers.Set(codexResponsesLiteHeaderName, value)
+	return headers
+}
 
 func codexResponsesLiteEnabled(headers http.Header) bool {
 	for name := range headers {
@@ -32,11 +55,23 @@ func removeCodexResponsesLiteHeaderForFullResponse(headers http.Header, full boo
 	}
 }
 
+// Responses Lite is an internal Codex transport hint. Do not forward it to
+// third-party API-key gateways; official OAuth requests keep the header.
+func removeCodexResponsesLiteHeaderForAPIKey(headers http.Header, auth *cliproxyauth.Auth) {
+	if !codexAuthUsesAPIKey(auth) {
+		return
+	}
+	removeCodexResponsesLiteHeaderForFullResponse(headers, true)
+}
+
 func normalizeCodexResponsesLiteRequest(body []byte, headers http.Header, auth *cliproxyauth.Auth, allowFullResponsesForImage bool) ([]byte, bool) {
-	if (!codexResponsesLiteEnabled(headers) && !isCodexResponsesLiteRequest(body, headers)) || auth == nil || codexAuthUsesAPIKey(auth) {
+	if (!codexResponsesLiteEnabled(headers) && !isCodexResponsesLiteRequest(body, headers)) || auth == nil {
 		return body, false
 	}
 	body, _ = sjson.SetBytes(body, "parallel_tool_calls", false)
+	if codexAuthUsesAPIKey(auth) {
+		return body, false
+	}
 	if allowFullResponsesForImage && codexRequestUsesImageGeneration(body) {
 		return body, true
 	}

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_websockets_execute.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_websockets_execute.go
@@ -20,6 +20,7 @@ import (
 )
 
 func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	opts.Headers = codexRequestHeadersWithGinResponsesLite(ctx, opts.Headers)
 	if errPolicy := enforceCodexClientPolicy(auth, opts.Headers, req.Payload); errPolicy != nil {
 		return resp, errPolicy
 	}
@@ -93,6 +94,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg, opts.Headers)
 	applyModelHeaderOverrides(wsHeaders, baseModel)
 	removeCodexResponsesLiteHeaderForFullResponse(wsHeaders, useFullResponses)
+	removeCodexResponsesLiteHeaderForAPIKey(wsHeaders, auth)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_websockets_stream.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_websockets_stream.go
@@ -19,6 +19,7 @@ import (
 )
 
 func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	opts.Headers = codexRequestHeadersWithGinResponsesLite(ctx, opts.Headers)
 	if errPolicy := enforceCodexClientPolicy(auth, opts.Headers, req.Payload); errPolicy != nil {
 		return nil, errPolicy
 	}
@@ -90,6 +91,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg, opts.Headers)
 	applyModelHeaderOverrides(wsHeaders, baseModel)
 	removeCodexResponsesLiteHeaderForFullResponse(wsHeaders, useFullResponses)
+	removeCodexResponsesLiteHeaderForAPIKey(wsHeaders, auth)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string


### PR DESCRIPTION
## Summary

Fix API-key Responses requests that carry the internal Codex Responses Lite signal and are rejected by compatible upstream gateways with:

`X-OpenAI-Internal-Codex-Responses-Lite requires parallel_tool_calls to be false`

The issue was reproduced on Cockpit Tools v1.3.29 through v1.3.34. The patch was developed and installed against the official v1.3.34 tag, then verified against the current `main`; the six touched executor files are unchanged between v1.3.34 and current `main`.

## Root cause

- The Responses Lite header can exist only on the Gin request context and may be absent from executor `Options.Headers`.
- `normalizeCodexResponsesLiteRequest` previously skipped API-key auth, leaving `parallel_tool_calls: true` unchanged.
- The internal Codex Responses Lite header was forwarded to third-party API-key upstreams.

That combination causes gateways which enforce Responses Lite constraints to reject the request.

## Changes

- Recover the Responses Lite header from the Gin request context when it is missing from executor options.
- Force `parallel_tool_calls` to `false` for API-key Responses Lite requests while preserving the request's existing tools and response mode.
- Strip the internal Responses Lite header before sending requests to third-party API-key upstreams.
- Preserve the existing official OAuth Responses Lite behavior.
- Apply the behavior consistently to HTTP, streaming/SSE, and WebSocket execution paths.
- Add regression coverage for API-key body normalization, Gin-only header propagation, upstream header stripping, and OAuth header preservation.

## Scope

This is intentionally limited to six Codex executor and test files. It does not change frontend, Rust application code, provider gateway configuration, model routing, account management, version metadata, or updater configuration.

## Verification

- `go test ./internal/runtime/executor -run 'ResponsesLite|ParallelToolCalls|APIKey' -count=1`
- `go test ./... -count=1` from `sidecars/cockpit-cliproxy`
- Production NSIS build and local upgrade installation of v1.3.34
- Real API requests across multiple configured API-key accounts

All targeted tests and multi-account API verification passed, and the original `unsupported_value` error no longer reproduced.

Closes #2160