### PR TITLE
fix: treat expired Plus subscriptions as Free in backend and sidecar

### DIFF
--- a/sidecars/cockpit-cliproxy/manifest_policy.go
+++ b/sidecars/cockpit-cliproxy/manifest_policy.go
@@ -837,6 +837,16 @@ func loadManifest(path string) (*manifest, error) {
 		account.Email = strings.TrimSpace(account.Email)
 		account.AuthKind = strings.ToLower(strings.TrimSpace(account.AuthKind))
 		account.ChatGPTAccountID = strings.TrimSpace(account.ChatGPTAccountID)
+		// 修正过期的付费计划为 free
+		if account.SubscriptionExpiryMS != nil && *account.SubscriptionExpiryMS > 0 {
+			now := time.Now().UnixMilli()
+			if *account.SubscriptionExpiryMS <= now {
+				lower := strings.ToLower(strings.TrimSpace(account.PlanType))
+				if lower != "free" && lower != "api_key" && lower != "" {
+					account.PlanType = "free"
+				}
+			}
+		}
 		m.accountByID[account.ID] = account
 		m.originalIndexByID[account.ID] = i
 		if authID := strings.TrimSpace(account.AuthID); authID != "" {

--- a/src-tauri/src/modules/codex_local_access_routing_pricing.rs
+++ b/src-tauri/src/modules/codex_local_access_routing_pricing.rs
@@ -88,8 +88,22 @@ fn normalize_auth_file_plan_type(plan_type: Option<&str>) -> Option<&'static str
     }
 }
 
-fn resolve_plan_rank(account: &CodexAccount) -> Option<i32> {
+fn resolve_effective_plan_key(account: &CodexAccount) -> String {
     let plan_key = normalize_plan_key(account.plan_type.as_deref());
+    if plan_key == "free" || account.is_api_key_auth() || account.is_agent_identity_auth() {
+        return plan_key;
+    }
+    if let Some(expiry_ms) = resolve_subscription_expiry_ms(account) {
+        let now = chrono::Utc::now().timestamp_millis();
+        if expiry_ms <= now {
+            return "free".to_string();
+        }
+    }
+    plan_key
+}
+
+fn resolve_plan_rank(account: &CodexAccount) -> Option<i32> {
+    let plan_key = resolve_effective_plan_key(account);
     let auth_file_plan_type = normalize_auth_file_plan_type(account.auth_file_plan_type.as_deref())
         .or_else(|| normalize_auth_file_plan_type(account.plan_type.as_deref()));
 

--- a/src-tauri/src/modules/codex_local_access_sidecar_config.rs
+++ b/src-tauri/src/modules/codex_local_access_sidecar_config.rs
@@ -1106,6 +1106,11 @@ fn sidecar_auth_json_for_account_with_metered_feature_patterns(
     proxy_url: Option<&str>,
     metered_feature_patterns: &HashMap<String, String>,
 ) -> Value {
+    let effective_plan_type = if resolve_effective_plan_key(account) == "free" {
+        Some("free".to_string())
+    } else {
+        account.plan_type.clone()
+    };
     let account_id = account
         .account_id
         .as_deref()
@@ -1125,7 +1130,7 @@ fn sidecar_auth_json_for_account_with_metered_feature_patterns(
             "chatgpt_user_id": identity.chatgpt_user_id,
             "chatgpt_account_is_fedramp": identity.chatgpt_account_is_fedramp,
             "email": account.email,
-            "plan_type": account.plan_type,
+            "plan_type": effective_plan_type.clone(),
             "excluded_models": excluded_models,
             "disable_cooling": collection.disable_cooling,
             "websockets": collection.responses_websockets_enabled,
@@ -1145,7 +1150,7 @@ fn sidecar_auth_json_for_account_with_metered_feature_patterns(
         "refresh_owner": "cockpit_token_authority",
         "last_refresh": sidecar_account_last_refresh(account),
         "email": account.email.clone(),
-        "plan_type": account.plan_type.clone(),
+        "plan_type": effective_plan_type.clone(),
         "excluded_models": excluded_models,
         "disable_cooling": collection.disable_cooling,
         "websockets": collection.responses_websockets_enabled,
@@ -1485,6 +1490,11 @@ fn sidecar_account_manifest_value(
     auth_id: Option<&str>,
     collection: &CodexLocalAccessCollection,
 ) -> Value {
+    let effective_plan_type = if resolve_effective_plan_key(account) == "free" {
+        Some("free".to_string())
+    } else {
+        account.plan_type.clone()
+    };
     let auth_kind = if account.is_api_key_auth() {
         "api_key"
     } else if account.is_agent_identity_auth() {
@@ -1499,7 +1509,7 @@ fn sidecar_account_manifest_value(
         "email": account.email.clone(),
         "authId": auth_id,
         "authKind": auth_kind,
-        "planType": account.plan_type.as_deref(),
+        "planType": effective_plan_type.as_deref(),
         "accessTokenOnly": account_is_access_token_only(account),
         "chatgptAccountId": account.account_id.as_deref().unwrap_or_default(),
         "upstreamApiKey": account.openai_api_key.as_deref().unwrap_or_default(),


### PR DESCRIPTION
修复过期的 Plus/Pro/Team 等付费订阅账号在 API 服务页面仍被当作 Plus 处理的问题。

**根因**: Rust 后端生成 manifest 和 Go sidecar 读取 manifest 时，都直接使用了原始 `plan_type` / `PlanType`，没有检查 `subscription_active_until` 是否已过期。前端 TypeScript 虽然有 `getCodexEffectivePlanKey` 做修正，但后端逻辑没有。

**修改**:
1. Rust `codex_local_access_routing_pricing.rs`: 新增 `resolve_effective_plan_key`，过期付费计划降级为 `"free"`，`resolve_plan_rank` 使用它
2. Rust `codex_local_access_sidecar_config.rs`: 生成 manifest/auth 文件时，过期的账号 `planType` 写为 `"free"`
3. Go `manifest_policy.go`: sidecar 加载 manifest 时，根据 `subscriptionExpiryMs` 自动修正 `PlanType` 为 `"free"`