### PR TITLE
feat(trae): 支持 Trae CN 积分额度展示与每日/自动签到

### DIFF
--- a/src-tauri/src/commands/trae.rs
+++ b/src-tauri/src/commands/trae.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use tauri::{AppHandle, Emitter};
 
 use crate::models::trae::{TraeAccount, TraeOAuthStartResponse};
-use crate::modules::{logger, trae_account, trae_oauth};
+use crate::modules::{logger, trae_account, trae_auto_checkin, trae_oauth};
 
 fn resolve_trae_refresh_protection_map(
     accounts: &[TraeAccount],
@@ -512,4 +512,48 @@ pub async fn claim_trae_checkin(
     device_id: String,
 ) -> Result<trae_account::CheckinStatusResult, String> {
     trae_account::claim_trae_checkin(&account_id, &device_id).await
+}
+
+/// 获取前端与后端共用的签到设备 ID
+#[tauri::command]
+pub fn get_trae_checkin_device_id() -> Result<String, String> {
+    trae_auto_checkin::get_or_create_device_id()
+}
+
+#[tauri::command]
+pub fn get_trae_auto_checkin_config() -> Result<trae_auto_checkin::TraeAutoCheckinConfig, String> {
+    trae_auto_checkin::get_config_checked()
+}
+
+#[tauri::command]
+pub fn migrate_trae_auto_checkin_config(
+    legacy_config: trae_auto_checkin::TraeAutoCheckinConfig,
+) -> Result<trae_auto_checkin::TraeAutoCheckinConfig, String> {
+    trae_auto_checkin::migrate_config_if_missing(&legacy_config)
+}
+
+#[tauri::command]
+pub fn save_trae_auto_checkin_config(
+    config: trae_auto_checkin::TraeAutoCheckinConfig,
+) -> Result<(), String> {
+    trae_auto_checkin::save_config(&config)
+}
+
+#[tauri::command]
+pub fn get_trae_auto_checkin_logs(
+) -> Result<Vec<trae_auto_checkin::TraeAutoCheckinLogRecord>, String> {
+    trae_auto_checkin::get_logs_checked()
+}
+
+#[tauri::command]
+pub fn clear_trae_auto_checkin_logs() -> Result<(), String> {
+    trae_auto_checkin::save_logs(&[])
+}
+
+#[tauri::command]
+pub async fn run_trae_auto_checkin_now(
+    app: AppHandle,
+    force: Option<bool>,
+) -> Result<String, String> {
+    trae_auto_checkin::run_trae_auto_checkin_cycle_if_needed(&app, force.unwrap_or(false)).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -532,6 +532,7 @@ pub fn run() {
 
             apply_startup_minimized(&app.handle());
             modules::workbuddy_auto_checkin::start_auto_checkin_scheduler(app.handle().clone());
+            modules::trae_auto_checkin::start_auto_checkin_scheduler(app.handle().clone());
 
             Ok(())
         })
@@ -1205,6 +1206,13 @@ pub fn run() {
             commands::trae::inject_trae_account,
             commands::trae::get_trae_checkin_status,
             commands::trae::claim_trae_checkin,
+            commands::trae::get_trae_checkin_device_id,
+            commands::trae::get_trae_auto_checkin_config,
+            commands::trae::migrate_trae_auto_checkin_config,
+            commands::trae::save_trae_auto_checkin_config,
+            commands::trae::get_trae_auto_checkin_logs,
+            commands::trae::clear_trae_auto_checkin_logs,
+            commands::trae::run_trae_auto_checkin_now,
             // Trae Instance Commands
             commands::trae_instance::trae_get_instance_defaults,
             commands::trae_instance::trae_list_instances,

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -91,6 +91,7 @@ pub mod sync_settings;
 #[cfg(test)]
 pub mod test_support;
 pub mod trae_account;
+pub mod trae_auto_checkin;
 pub mod trae_instance;
 pub mod trae_oauth;
 pub mod trae_session_transfer;

--- a/src-tauri/src/modules/trae_account_token_injection.rs
+++ b/src-tauri/src/modules/trae_account_token_injection.rs
@@ -2734,41 +2734,28 @@ pub async fn get_trae_checkin_status(
             .map_err(|e| e.to_string())?,
     );
     headers.insert(
-        reqwest::header::ORIGIN,
-        "https://www.trae.cn"
-            .parse::<reqwest::header::HeaderValue>()
-            .map_err(|e| e.to_string())?,
-    );
-    headers.insert(
-        reqwest::header::REFERER,
-        "https://www.trae.cn/"
-            .parse::<reqwest::header::HeaderValue>()
-            .map_err(|e| e.to_string())?,
-    );
-    headers.insert(
-        "x-app-type",
-        "trae"
+        "User-Agent",
+        "Trae/1.0.0 antigravity-cockpit-tools"
             .parse::<reqwest::header::HeaderValue>()
             .map_err(|e| e.to_string())?,
     );
     headers.insert(
         reqwest::header::AUTHORIZATION,
-        format!("Bearer {}", account.access_token)
+        format!("Cloud-IDE-JWT {}", account.access_token)
             .parse::<reqwest::header::HeaderValue>()
             .map_err(|e| e.to_string())?,
     );
 
-    let mut url = "https://api.trae.cn/trae/api/v2/ug/checkin_credits/status".to_string();
     if !device_id.is_empty() {
-        url.push_str(&format!("?did={}", device_id));
         if let Ok(device_header) = reqwest::header::HeaderValue::from_bytes(device_id.as_bytes()) {
             headers.insert("x-device-id", device_header);
         }
     }
 
     let response = client
-        .get(&url)
+        .post("https://api.trae.cn/trae/api/v2/ug/checkin_credits/status")
         .headers(headers)
+        .body("{}")
         .send()
         .await
         .map_err(|e| format!("签到状态请求失败: {}", e))?;
@@ -2784,10 +2771,12 @@ pub async fn get_trae_checkin_status(
         serde_json::from_str(&body).map_err(|e| format!("解析签到状态响应失败: {}", e))?;
 
     if data.code != 0 {
-        return Err(format!(
-            "获取签到状态失败 (code={}): Token 已过期，请重新登录",
-            data.code
-        ));
+        let reason = if data.message.is_empty() {
+            "Token 已过期，请重新登录".to_string()
+        } else {
+            data.message
+        };
+        return Err(format!("获取签到状态失败 (code={}): {}", data.code, reason));
     }
 
     let message = if data.checked_in {
@@ -2832,26 +2821,14 @@ pub async fn claim_trae_checkin(
             .map_err(|e| e.to_string())?,
     );
     headers.insert(
-        reqwest::header::ORIGIN,
-        "https://www.trae.cn"
-            .parse::<reqwest::header::HeaderValue>()
-            .map_err(|e| e.to_string())?,
-    );
-    headers.insert(
-        reqwest::header::REFERER,
-        "https://www.trae.cn/"
-            .parse::<reqwest::header::HeaderValue>()
-            .map_err(|e| e.to_string())?,
-    );
-    headers.insert(
-        "x-app-type",
-        "trae"
+        "User-Agent",
+        "Trae/1.0.0 antigravity-cockpit-tools"
             .parse::<reqwest::header::HeaderValue>()
             .map_err(|e| e.to_string())?,
     );
     headers.insert(
         reqwest::header::AUTHORIZATION,
-        format!("Bearer {}", account.access_token)
+        format!("Cloud-IDE-JWT {}", account.access_token)
             .parse::<reqwest::header::HeaderValue>()
             .map_err(|e| e.to_string())?,
     );
@@ -2882,10 +2859,12 @@ pub async fn claim_trae_checkin(
         serde_json::from_str(&body).map_err(|e| format!("解析签到领取响应失败: {}", e))?;
 
     if claim_data.code != 0 {
-        return Err(format!(
-            "签到领取失败 (code={}): Token 已过期，请重新登录",
-            claim_data.code
-        ));
+        let reason = if claim_data.message.is_empty() {
+            "Token 已过期，请重新登录".to_string()
+        } else {
+            claim_data.message
+        };
+        return Err(format!("签到领取失败 (code={}): {}", claim_data.code, reason));
     }
 
     // 领取后重新查询状态

--- a/src-tauri/src/modules/trae_auto_checkin.rs
+++ b/src-tauri/src/modules/trae_auto_checkin.rs
@@ -1,0 +1,963 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Mutex, MutexGuard, OnceLock,
+};
+use std::time::{Duration, Instant};
+
+use chrono::{Local, TimeZone, Timelike};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use tokio::sync::Notify;
+
+use crate::models::trae::TraeAccount;
+use crate::modules::{config, logger, trae_account};
+
+static IS_CHECKIN_RUNNING: AtomicBool = AtomicBool::new(false);
+static STORAGE_LOCK: Mutex<()> = Mutex::new(());
+static SCHEDULER_WAKE: OnceLock<Notify> = OnceLock::new();
+
+const SCHEDULER_POLL_DELAY: Duration = Duration::from_secs(30);
+const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(5 * 60);
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(60 * 60);
+
+struct CheckinGuard;
+impl Drop for CheckinGuard {
+    fn drop(&mut self) {
+        IS_CHECKIN_RUNNING.store(false, Ordering::SeqCst);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraeAccountScheduleState {
+    pub scheduled_date: String,
+    pub scheduled_minute: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_checked_date: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraeAutoCheckinConfig {
+    pub enabled: bool,
+    pub start_time: String,
+    pub end_time: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_checked_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_schedules: Option<HashMap<String, TraeAccountScheduleState>>,
+}
+
+impl Default for TraeAutoCheckinConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            start_time: "06:00".to_string(),
+            end_time: "12:00".to_string(),
+            last_checked_date: None,
+            account_schedules: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraeAutoCheckinAccountDetail {
+    pub account_id: String,
+    pub email: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credit: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraeAutoCheckinLogRecord {
+    pub id: String,
+    pub timestamp: String,
+    pub date: String,
+    pub duration_ms: u64,
+    pub total_accounts: usize,
+    pub success_count: usize,
+    pub already_checked_count: usize,
+    pub failed_count: usize,
+    pub status: String,
+    pub details: Vec<TraeAutoCheckinAccountDetail>,
+}
+
+fn get_config_file_path() -> PathBuf {
+    config::get_shared_dir().join("trae_auto_checkin_config.json")
+}
+
+fn get_logs_file_path() -> PathBuf {
+    config::get_shared_dir().join("trae_auto_checkin_logs.json")
+}
+
+fn get_device_id_file_path() -> PathBuf {
+    config::get_shared_dir().join("trae_checkin_device_id.txt")
+}
+
+fn scheduler_wake() -> &'static Notify {
+    SCHEDULER_WAKE.get_or_init(Notify::new)
+}
+
+fn wake_scheduler() {
+    scheduler_wake().notify_one();
+}
+
+fn lock_storage() -> Result<MutexGuard<'static, ()>, String> {
+    STORAGE_LOCK
+        .lock()
+        .map_err(|_| "Trae 自动签到存储锁已损坏".to_string())
+}
+
+fn validate_time(value: &str) -> Option<i32> {
+    if value.len() != 5 || value.as_bytes().get(2) != Some(&b':') {
+        return None;
+    }
+    let hour = value.get(0..2)?.parse::<i32>().ok()?;
+    let minute = value.get(3..5)?.parse::<i32>().ok()?;
+    if (0..=23).contains(&hour) && (0..=59).contains(&minute) {
+        Some(hour * 60 + minute)
+    } else {
+        None
+    }
+}
+
+fn validate_config(config: &TraeAutoCheckinConfig) -> Result<(), String> {
+    let start = validate_time(&config.start_time)
+        .ok_or_else(|| format!("自动签到开始时间无效: {}", config.start_time))?;
+    let end = validate_time(&config.end_time)
+        .ok_or_else(|| format!("自动签到结束时间无效: {}", config.end_time))?;
+    if start > end {
+        return Err("自动签到开始时间不能晚于结束时间".to_string());
+    }
+    if let Some(schedules) = &config.account_schedules {
+        for (account_id, schedule) in schedules {
+            if !(0..=1439).contains(&schedule.scheduled_minute) {
+                return Err(format!(
+                    "账号 {} 的自动签到分钟无效: {}",
+                    account_id, schedule.scheduled_minute
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn read_config_from_path(path: &Path) -> Result<Option<TraeAutoCheckinConfig>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("读取 Trae 自动签到配置失败: {}", e))?;
+    let config = crate::modules::atomic_write::parse_json_with_auto_restore(path, &content)
+        .map_err(|e| format!("解析 Trae 自动签到配置失败: {}", e))?;
+    validate_config(&config)?;
+    Ok(Some(config))
+}
+
+fn write_config_to_path(path: &Path, config: &TraeAutoCheckinConfig) -> Result<(), String> {
+    validate_config(config)?;
+    let content = serde_json::to_string_pretty(config)
+        .map_err(|e| format!("序列化 Trae 自动签到配置失败: {}", e))?;
+    crate::modules::atomic_write::write_string_atomic(path, &content)
+        .map_err(|e| format!("保存 Trae 自动签到配置失败: {}", e))
+}
+
+pub fn get_config_checked() -> Result<TraeAutoCheckinConfig, String> {
+    let _guard = lock_storage()?;
+    Ok(read_config_from_path(&get_config_file_path())?.unwrap_or_default())
+}
+
+pub fn save_config(config: &TraeAutoCheckinConfig) -> Result<(), String> {
+    let result = save_config_without_wake(config);
+    if result.is_ok() {
+        wake_scheduler();
+    }
+    result
+}
+
+fn save_config_without_wake(config: &TraeAutoCheckinConfig) -> Result<(), String> {
+    let _guard = lock_storage()?;
+    write_config_to_path(&get_config_file_path(), config)
+}
+
+fn migrate_config_at_path(
+    path: &Path,
+    legacy_config: &TraeAutoCheckinConfig,
+) -> Result<TraeAutoCheckinConfig, String> {
+    validate_config(legacy_config)?;
+    if let Some(existing) = read_config_from_path(path)? {
+        return Ok(existing);
+    }
+    write_config_to_path(path, legacy_config)?;
+    Ok(legacy_config.clone())
+}
+
+pub fn migrate_config_if_missing(
+    legacy_config: &TraeAutoCheckinConfig,
+) -> Result<TraeAutoCheckinConfig, String> {
+    let (config, was_missing) = {
+        let _guard = lock_storage()?;
+        let path = get_config_file_path();
+        let was_missing = !path.exists();
+        let config = migrate_config_at_path(&path, legacy_config)?;
+        (config, was_missing)
+    };
+    if was_missing {
+        logger::log_info("[TraeAutoCheckin] 已完成 WebView 旧配置的一次性迁移");
+    }
+    wake_scheduler();
+    Ok(config)
+}
+
+fn read_logs_from_path(path: &Path) -> Result<Vec<TraeAutoCheckinLogRecord>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("读取 Trae 自动签到日志失败: {}", e))?;
+    crate::modules::atomic_write::parse_json_with_auto_restore(path, &content)
+        .map_err(|e| format!("解析 Trae 自动签到日志失败: {}", e))
+}
+
+fn write_logs_to_path(path: &Path, logs: &[TraeAutoCheckinLogRecord]) -> Result<(), String> {
+    let content = serde_json::to_string_pretty(logs)
+        .map_err(|e| format!("序列化 Trae 自动签到日志失败: {}", e))?;
+    crate::modules::atomic_write::write_string_atomic(path, &content)
+        .map_err(|e| format!("保存 Trae 自动签到日志失败: {}", e))
+}
+
+pub fn get_logs_checked() -> Result<Vec<TraeAutoCheckinLogRecord>, String> {
+    let _guard = lock_storage()?;
+    read_logs_from_path(&get_logs_file_path())
+}
+
+pub fn save_logs(logs: &[TraeAutoCheckinLogRecord]) -> Result<(), String> {
+    let _guard = lock_storage()?;
+    write_logs_to_path(&get_logs_file_path(), logs)
+}
+
+fn add_log_record(record: TraeAutoCheckinLogRecord) -> Result<(), String> {
+    let _guard = lock_storage()?;
+    let path = get_logs_file_path();
+    let mut logs = read_logs_from_path(&path)?;
+    if let Some(existing) = logs.iter_mut().find(|log| log.date == record.date) {
+        let mut details: HashMap<String, TraeAutoCheckinAccountDetail> = existing
+            .details
+            .drain(..)
+            .map(|detail| (detail.account_id.clone(), detail))
+            .collect();
+        for detail in record.details {
+            details.insert(detail.account_id.clone(), detail);
+        }
+
+        existing.timestamp = record.timestamp;
+        existing.duration_ms = existing.duration_ms.saturating_add(record.duration_ms);
+        existing.details = details.into_values().collect();
+        existing.success_count = existing
+            .details
+            .iter()
+            .filter(|detail| detail.status == "success")
+            .count();
+        existing.already_checked_count = existing
+            .details
+            .iter()
+            .filter(|detail| detail.status == "already_checked")
+            .count();
+        existing.failed_count = existing
+            .details
+            .iter()
+            .filter(|detail| detail.status == "failed")
+            .count();
+        existing.total_accounts = existing.details.len();
+        existing.status = if existing.total_accounts == 0 {
+            "no_accounts"
+        } else if existing.failed_count == 0 {
+            "success"
+        } else if existing.success_count > 0 || existing.already_checked_count > 0 {
+            "partial"
+        } else {
+            "failed"
+        }
+        .to_string();
+    } else {
+        logs.insert(0, record);
+    }
+
+    const THIRTY_DAYS_SECS: i64 = 30 * 24 * 60 * 60;
+    let cutoff = Local::now().timestamp() - THIRTY_DAYS_SECS;
+
+    logs.retain(|r| {
+        if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(&r.timestamp, "%Y-%m-%d %H:%M:%S") {
+            if let Some(local_dt) = Local.from_local_datetime(&ndt).single() {
+                local_dt.timestamp() >= cutoff
+            } else {
+                ndt.and_utc().timestamp() >= cutoff
+            }
+        } else {
+            true
+        }
+    });
+
+    write_logs_to_path(&path, &logs)
+}
+
+pub fn parse_time_to_minutes(time_str: &str) -> i32 {
+    let parts: Vec<&str> = time_str.split(':').collect();
+    let h = parts
+        .first()
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(0);
+    let m = parts
+        .get(1)
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(0);
+    h * 60 + m
+}
+
+pub fn get_today_date_string() -> String {
+    Local::now().format("%Y-%m-%d").to_string()
+}
+
+pub fn format_time_only() -> String {
+    Local::now().format("%H:%M:%S").to_string()
+}
+
+/// 签到积分接口仅存在于 Trae CN（api.trae.cn），只调度 CN 平台账号。
+fn list_cn_accounts() -> Result<Vec<TraeAccount>, String> {
+    Ok(trae_account::list_accounts_checked()?
+        .into_iter()
+        .filter(|account| trae_account::resolve_account_platform_kind(account).is_cn())
+        .collect())
+}
+
+/// 从本机 Trae CN 系客户端 storage.json 提取 ICDRS 数字设备 ID。
+/// 签到接口的 x-device-id 必须与客户端设备注册时一致（键名 iCubeAuthInfo://icube-dc:<did>），
+/// 否则服务端返回 9074"当前参与用户太多"拒绝领取。
+fn extract_local_icdrs_device_id() -> Option<String> {
+    use crate::modules::trae_account::{
+        get_default_trae_storage_path_for_platform, TraePlatformKind,
+    };
+
+    for platform in [TraePlatformKind::TraeSoloCn, TraePlatformKind::TraeCn] {
+        let Ok(path) = get_default_trae_storage_path_for_platform(platform) else {
+            continue;
+        };
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        const MARKER: &str = "\"iCubeAuthInfo://icube-dc:";
+        let Some(start) = content.find(MARKER) else {
+            continue;
+        };
+        let digits: String = content[start + MARKER.len()..]
+            .chars()
+            .take_while(|ch| ch.is_ascii_digit())
+            .collect();
+        if !digits.is_empty() {
+            return Some(digits);
+        }
+    }
+    None
+}
+
+/// 签到接口要求携带设备 ID：优先采用本机 Trae 客户端注册的 ICDRS 设备 ID，
+/// 无法提取时生成一次并持久化。前端手动签到与后端自动签到共用此 ID。
+pub fn get_or_create_device_id() -> Result<String, String> {
+    let path = get_device_id_file_path();
+
+    if let Some(icdrs_id) = extract_local_icdrs_device_id() {
+        let persisted = fs::read_to_string(&path)
+            .ok()
+            .map(|value| value.trim().to_string());
+        if persisted.as_deref() != Some(icdrs_id.as_str()) {
+            crate::modules::atomic_write::write_string_atomic(&path, &icdrs_id)
+                .map_err(|e| format!("保存 Trae 签到设备 ID 失败: {}", e))?;
+            logger::log_info("[TraeAutoCheckin] 已采用本机 Trae 客户端 ICDRS 设备 ID 进行签到");
+        }
+        return Ok(icdrs_id);
+    }
+
+    if let Ok(existing) = fs::read_to_string(&path) {
+        let trimmed = existing.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+    let device_id = format!(
+        "{}_{}",
+        Local::now().timestamp_millis(),
+        rand::random::<u32>()
+    );
+    crate::modules::atomic_write::write_string_atomic(&path, &device_id)
+        .map_err(|e| format!("保存 Trae 签到设备 ID 失败: {}", e))?;
+    Ok(device_id)
+}
+
+pub fn ensure_account_schedules(
+    config: &mut TraeAutoCheckinConfig,
+    accounts: &[TraeAccount],
+) -> bool {
+    let today_str = get_today_date_string();
+    let start_min = parse_time_to_minutes(&config.start_time);
+    let mut end_min = parse_time_to_minutes(&config.end_time);
+    if end_min < start_min {
+        end_min = start_min;
+    }
+    let min_range = (end_min - start_min).max(0);
+
+    let mut schedules = config.account_schedules.clone().unwrap_or_default();
+    let mut changed = false;
+
+    for account in accounts {
+        let existing = schedules.get(&account.id);
+        if let Some(sch) = existing {
+            if sch.scheduled_date == today_str
+                && sch.scheduled_minute >= start_min
+                && sch.scheduled_minute <= end_min
+            {
+                continue;
+            }
+        }
+
+        let random_offset = if min_range > 0 {
+            (rand::random::<u32>() % (min_range as u32 + 1)) as i32
+        } else {
+            0
+        };
+        let scheduled_minute = start_min + random_offset;
+
+        let last_checked = existing.and_then(|e| {
+            if e.last_checked_date.as_deref() == Some(&today_str) {
+                Some(today_str.clone())
+            } else {
+                None
+            }
+        });
+
+        schedules.insert(
+            account.id.clone(),
+            TraeAccountScheduleState {
+                scheduled_date: today_str.clone(),
+                scheduled_minute,
+                last_checked_date: last_checked,
+            },
+        );
+        changed = true;
+    }
+
+    if changed {
+        config.account_schedules = Some(schedules);
+    }
+    changed
+}
+
+fn mark_schedule_checked(
+    schedules: &mut HashMap<String, TraeAccountScheduleState>,
+    account_id: &str,
+    today: &str,
+    current_minute: i32,
+) {
+    let schedule =
+        schedules
+            .entry(account_id.to_string())
+            .or_insert_with(|| TraeAccountScheduleState {
+                scheduled_date: today.to_string(),
+                scheduled_minute: current_minute,
+                last_checked_date: None,
+            });
+    schedule.last_checked_date = Some(today.to_string());
+}
+
+pub async fn run_trae_auto_checkin_cycle_if_needed(
+    app: &AppHandle,
+    force: bool,
+) -> Result<String, String> {
+    if IS_CHECKIN_RUNNING.swap(true, Ordering::SeqCst) {
+        return Ok("already_running".to_string());
+    }
+    let _guard = CheckinGuard;
+
+    let mut config = get_config_checked()?;
+    if !config.enabled && !force {
+        return Ok("disabled".to_string());
+    }
+
+    let accounts = list_cn_accounts()?;
+    if accounts.is_empty() {
+        if force {
+            add_log_record(TraeAutoCheckinLogRecord {
+                id: format!(
+                    "log_{}_{}",
+                    Local::now().timestamp_millis(),
+                    rand::random::<u16>()
+                ),
+                timestamp: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+                date: get_today_date_string(),
+                duration_ms: 0,
+                total_accounts: 0,
+                success_count: 0,
+                already_checked_count: 0,
+                failed_count: 0,
+                status: "no_accounts".to_string(),
+                details: Vec::new(),
+            })?;
+            let _ = app.emit("trae-auto-checkin-logs-changed", ());
+        }
+        return Ok("no_accounts".to_string());
+    }
+
+    let schedule_changed = ensure_account_schedules(&mut config, &accounts);
+    if schedule_changed {
+        save_config_without_wake(&config)?;
+        let _ = app.emit("trae-auto-checkin-config-changed", ());
+    }
+
+    let today_str = get_today_date_string();
+    let now = Local::now();
+    let current_minute = (now.hour() * 60 + now.minute()) as i32;
+
+    let target_accounts: Vec<&TraeAccount> = if force {
+        accounts.iter().collect()
+    } else {
+        accounts
+            .iter()
+            .filter(|account| {
+                let sch = config
+                    .account_schedules
+                    .as_ref()
+                    .and_then(|s| s.get(&account.id));
+                match sch {
+                    Some(s) => {
+                        if s.last_checked_date.as_deref() == Some(&today_str) {
+                            return false;
+                        }
+                        s.scheduled_date == today_str && current_minute >= s.scheduled_minute
+                    }
+                    None => false,
+                }
+            })
+            .collect()
+    };
+
+    if target_accounts.is_empty() {
+        return Ok("waiting".to_string());
+    }
+
+    logger::log_info(&format!(
+        "[TraeAutoCheckin] 开始处理后台签到，目标账号数: {}",
+        target_accounts.len()
+    ));
+
+    let device_id = get_or_create_device_id()?;
+
+    let start_instant = Instant::now();
+    let start_timestamp_str = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+
+    let mut success_count = 0;
+    let mut already_checked_count = 0;
+    let mut failed_count = 0;
+    let mut retry_needed = false;
+    let mut details = Vec::new();
+    let mut new_schedules = config.account_schedules.clone().unwrap_or_default();
+    let target_account_count = target_accounts.len();
+
+    for account in target_accounts {
+        let email_display = if !account.email.trim().is_empty() {
+            account.email.clone()
+        } else {
+            account.id.clone()
+        };
+        let account_checkin_time = format_time_only();
+
+        match trae_account::get_trae_checkin_status(&account.id, &device_id).await {
+            Ok(status) if status.checked_in => {
+                already_checked_count += 1;
+                details.push(TraeAutoCheckinAccountDetail {
+                    account_id: account.id.clone(),
+                    email: email_display,
+                    status: "already_checked".to_string(),
+                    time: Some(account_checkin_time),
+                    message: Some(status.message),
+                    credit: Some(serde_json::json!(status.total_credits)),
+                });
+                mark_schedule_checked(&mut new_schedules, &account.id, &today_str, current_minute);
+            }
+            Ok(_) => {
+                match trae_account::claim_trae_checkin(&account.id, &device_id).await {
+                    Ok(result) => {
+                        success_count += 1;
+                        details.push(TraeAutoCheckinAccountDetail {
+                            account_id: account.id.clone(),
+                            email: email_display,
+                            status: "success".to_string(),
+                            time: Some(account_checkin_time),
+                            message: Some(result.message),
+                            credit: Some(serde_json::json!(result.total_credits)),
+                        });
+                        mark_schedule_checked(
+                            &mut new_schedules,
+                            &account.id,
+                            &today_str,
+                            current_minute,
+                        );
+                    }
+                    Err(err) => {
+                        // 领取失败时可能实际上已签到（如官方风控重复领取），重新查询确认。
+                        match trae_account::get_trae_checkin_status(&account.id, &device_id).await {
+                            Ok(latest_status) if latest_status.checked_in => {
+                                already_checked_count += 1;
+                                details.push(TraeAutoCheckinAccountDetail {
+                                    account_id: account.id.clone(),
+                                    email: email_display,
+                                    status: "already_checked".to_string(),
+                                    time: Some(account_checkin_time),
+                                    message: Some(latest_status.message),
+                                    credit: Some(serde_json::json!(latest_status.total_credits)),
+                                });
+                                mark_schedule_checked(
+                                    &mut new_schedules,
+                                    &account.id,
+                                    &today_str,
+                                    current_minute,
+                                );
+                            }
+                            _ => {
+                                logger::log_warn(&format!(
+                                    "[TraeAutoCheckin] 账号 {} 自动签到失败: {}",
+                                    account.id, err
+                                ));
+                                retry_needed = true;
+                                failed_count += 1;
+                                details.push(TraeAutoCheckinAccountDetail {
+                                    account_id: account.id.clone(),
+                                    email: email_display,
+                                    status: "failed".to_string(),
+                                    time: Some(account_checkin_time),
+                                    message: Some(err),
+                                    credit: None,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                logger::log_warn(&format!(
+                    "[TraeAutoCheckin] 账号 {} 签到状态检查异常: {}",
+                    account.id, err
+                ));
+                retry_needed = true;
+                failed_count += 1;
+                details.push(TraeAutoCheckinAccountDetail {
+                    account_id: account.id.clone(),
+                    email: email_display,
+                    status: "failed".to_string(),
+                    time: Some(account_checkin_time),
+                    message: Some(err),
+                    credit: None,
+                });
+            }
+        }
+    }
+
+    config.account_schedules = Some(new_schedules);
+    save_config_without_wake(&config)?;
+
+    let duration_ms = start_instant.elapsed().as_millis() as u64;
+    let overall_status = if failed_count == 0 {
+        "success"
+    } else if success_count > 0 || already_checked_count > 0 {
+        "partial"
+    } else {
+        "failed"
+    };
+
+    add_log_record(TraeAutoCheckinLogRecord {
+        id: format!(
+            "log_{}_{}",
+            Local::now().timestamp_millis(),
+            rand::random::<u16>()
+        ),
+        timestamp: start_timestamp_str,
+        date: today_str,
+        duration_ms,
+        total_accounts: target_account_count,
+        success_count,
+        already_checked_count,
+        failed_count,
+        status: overall_status.to_string(),
+        details,
+    })?;
+
+    let _ = app.emit("trae-auto-checkin-logs-changed", ());
+    let _ = app.emit("trae-auto-checkin-config-changed", ());
+
+    if retry_needed {
+        Ok("retry".to_string())
+    } else {
+        Ok("completed".to_string())
+    }
+}
+
+fn next_retry_delay(current: Duration) -> Duration {
+    current.saturating_mul(2).min(MAX_RETRY_DELAY)
+}
+
+pub fn start_auto_checkin_scheduler(app: AppHandle) {
+    let wake = scheduler_wake();
+    tauri::async_runtime::spawn(async move {
+        logger::log_info("[TraeAutoCheckin] 后台自动签到调度服务已启动");
+        // Run once as soon as the app starts. This picks up a migrated config
+        // immediately and catches schedules missed while the app was closed.
+        let mut next_delay = Duration::ZERO;
+        let mut retry_delay = INITIAL_RETRY_DELAY;
+        loop {
+            if !next_delay.is_zero() {
+                tokio::select! {
+                    _ = tokio::time::sleep(next_delay) => {}
+                    _ = wake.notified() => {
+                        next_delay = Duration::ZERO;
+                        retry_delay = INITIAL_RETRY_DELAY;
+                        continue;
+                    }
+                }
+            }
+            match run_trae_auto_checkin_cycle_if_needed(&app, false).await {
+                Ok(result) if result == "retry" => {
+                    next_delay = retry_delay;
+                    retry_delay = next_retry_delay(retry_delay);
+                    logger::log_warn(&format!(
+                        "[TraeAutoCheckin] 本轮存在失败，{} 秒后重试",
+                        next_delay.as_secs()
+                    ));
+                }
+                Ok(_) => {
+                    next_delay = SCHEDULER_POLL_DELAY;
+                    retry_delay = INITIAL_RETRY_DELAY;
+                }
+                Err(err) => {
+                    next_delay = retry_delay;
+                    retry_delay = next_retry_delay(retry_delay);
+                    logger::log_warn(&format!(
+                        "[TraeAutoCheckin] 调度异常: {}，{} 秒后重试",
+                        err,
+                        next_delay.as_secs()
+                    ));
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn make_temp_config_path(test_name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!(
+                "cockpit-trae-auto-checkin-{}-{}-{}",
+                test_name,
+                std::process::id(),
+                unique
+            ))
+            .join("trae_auto_checkin_config.json")
+    }
+
+    fn make_account(id: &str, email: &str) -> TraeAccount {
+        TraeAccount {
+            id: id.to_string(),
+            email: email.to_string(),
+            user_id: None,
+            nickname: None,
+            tags: None,
+            access_token: "token".to_string(),
+            refresh_token: None,
+            token_type: None,
+            expires_at: None,
+            plan_type: None,
+            plan_reset_at: None,
+            trae_auth_raw: None,
+            trae_profile_raw: None,
+            trae_entitlement_raw: None,
+            trae_usage_raw: None,
+            trae_server_raw: None,
+            trae_usertag_raw: None,
+            status: None,
+            status_reason: None,
+            quota_query_last_error: None,
+            quota_query_last_error_at: None,
+            usage_updated_at: None,
+            created_at: 0,
+            last_used: 0,
+        }
+    }
+
+    #[test]
+    fn test_parse_time_to_minutes() {
+        assert_eq!(parse_time_to_minutes("06:00"), 360);
+        assert_eq!(parse_time_to_minutes("12:30"), 750);
+        assert_eq!(parse_time_to_minutes("00:00"), 0);
+        assert_eq!(parse_time_to_minutes("23:59"), 1439);
+        assert_eq!(parse_time_to_minutes("invalid"), 0);
+    }
+
+    #[test]
+    fn test_ensure_account_schedules() {
+        let mut config = TraeAutoCheckinConfig {
+            enabled: true,
+            start_time: "06:00".to_string(),
+            end_time: "12:00".to_string(),
+            last_checked_date: None,
+            account_schedules: None,
+        };
+
+        let accounts = vec![
+            make_account("acc_1", "a@example.com"),
+            make_account("acc_2", "b@example.com"),
+        ];
+
+        let changed = ensure_account_schedules(&mut config, &accounts);
+        assert!(changed);
+
+        let schedules = config.account_schedules.unwrap();
+        assert_eq!(schedules.len(), 2);
+
+        let sch1 = schedules.get("acc_1").unwrap();
+        assert!(sch1.scheduled_minute >= 360 && sch1.scheduled_minute <= 720);
+
+        let sch2 = schedules.get("acc_2").unwrap();
+        assert!(sch2.scheduled_minute >= 360 && sch2.scheduled_minute <= 720);
+    }
+
+    #[test]
+    fn test_config_serde() {
+        let config = TraeAutoCheckinConfig {
+            enabled: true,
+            start_time: "08:00".to_string(),
+            end_time: "10:00".to_string(),
+            last_checked_date: Some("2026-08-31".to_string()),
+            account_schedules: None,
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"enabled\":true"));
+        assert!(json.contains("\"startTime\":\"08:00\""));
+
+        let deserialized: TraeAutoCheckinConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.start_time, "08:00");
+    }
+
+    #[test]
+    fn test_config_serde_accepts_legacy_payload_without_optional_fields() {
+        let legacy_json = r#"{"enabled":true,"startTime":"07:00","endTime":"09:00"}"#;
+        let config: TraeAutoCheckinConfig = serde_json::from_str(legacy_json).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.start_time, "07:00");
+        assert!(config.last_checked_date.is_none());
+        assert!(config.account_schedules.is_none());
+    }
+
+    #[test]
+    fn test_migration_only_writes_when_backend_config_is_missing() {
+        let path = make_temp_config_path("migration");
+        let legacy = TraeAutoCheckinConfig {
+            enabled: true,
+            start_time: "06:00".to_string(),
+            end_time: "09:00".to_string(),
+            last_checked_date: Some("2026-08-31".to_string()),
+            account_schedules: None,
+        };
+        let migrated = migrate_config_at_path(&path, &legacy).unwrap();
+        assert_eq!(migrated, legacy);
+
+        let backend = TraeAutoCheckinConfig {
+            enabled: false,
+            start_time: "08:00".to_string(),
+            end_time: "10:00".to_string(),
+            last_checked_date: Some("2026-09-01".to_string()),
+            account_schedules: None,
+        };
+        write_config_to_path(&path, &backend).unwrap();
+
+        let preserved = migrate_config_at_path(&path, &legacy).unwrap();
+        assert_eq!(preserved, backend);
+        assert_eq!(read_config_from_path(&path).unwrap(), Some(backend));
+
+        let temp_dir = path.parent().unwrap();
+        std::fs::remove_dir_all(temp_dir).unwrap();
+    }
+
+    #[test]
+    fn test_config_validation_rejects_invalid_time_and_schedule() {
+        let mut config = TraeAutoCheckinConfig {
+            enabled: true,
+            start_time: "12:00".to_string(),
+            end_time: "06:00".to_string(),
+            last_checked_date: None,
+            account_schedules: None,
+        };
+        assert!(validate_config(&config).is_err());
+
+        config.start_time = "06:00".to_string();
+        config.account_schedules = Some(HashMap::from([(
+            "acc_1".to_string(),
+            TraeAccountScheduleState {
+                scheduled_date: "2026-09-01".to_string(),
+                scheduled_minute: 1440,
+                last_checked_date: None,
+            },
+        )]));
+        assert!(validate_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_retry_delay_uses_bounded_exponential_backoff() {
+        assert_eq!(
+            next_retry_delay(INITIAL_RETRY_DELAY),
+            Duration::from_secs(10 * 60)
+        );
+        assert_eq!(
+            next_retry_delay(Duration::from_secs(45 * 60)),
+            MAX_RETRY_DELAY
+        );
+        assert_eq!(next_retry_delay(MAX_RETRY_DELAY), MAX_RETRY_DELAY);
+    }
+
+    #[test]
+    fn test_device_id_is_stable_across_reads() {
+        let dir = std::env::temp_dir().join(format!(
+            "cockpit-trae-device-id-{}-{}",
+            std::process::id(),
+            Local::now().timestamp_subsec_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        // get_or_create_device_id 读取固定 shared 路径，这里直接验证持久化语义：
+        // 同一路径两次读取返回相同值。
+        let path = dir.join("device_id.txt");
+        let first = format!(
+            "{}_{}",
+            Local::now().timestamp_millis(),
+            rand::random::<u32>()
+        );
+        crate::modules::atomic_write::write_string_atomic(&path, &first).unwrap();
+        let second = fs::read_to_string(&path).unwrap().trim().to_string();
+        assert_eq!(first, second);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,11 @@ import {
   getWorkbuddyAutoCheckinConfig,
   migrateWorkbuddyAutoCheckinConfigAsync,
 } from './services/workbuddyAutoCheckinService';
+import {
+  clearLegacyTraeAutoCheckinLogs,
+  getTraeAutoCheckinConfig,
+  migrateTraeAutoCheckinConfigAsync,
+} from './services/traeAutoCheckinService';
 import { prepareCodexLocalAccessForRestart } from './services/codexLocalAccessService';
 import { applyReducedMotion } from './utils/reducedMotion';
 import { isCodexInstanceAccountConflict } from './utils/codexInstanceLaunchConflict';
@@ -2272,6 +2277,11 @@ function MainApp() {
     clearLegacyWorkbuddyAutoCheckinLogs();
     void migrateWorkbuddyAutoCheckinConfigAsync(getWorkbuddyAutoCheckinConfig()).catch((err) => {
       console.warn('[WorkbuddyAutoCheckin] 迁移旧版自动签到配置失败:', err);
+    });
+
+    clearLegacyTraeAutoCheckinLogs();
+    void migrateTraeAutoCheckinConfigAsync(getTraeAutoCheckinConfig()).catch((err) => {
+      console.warn('[TraeAutoCheckin] 迁移旧版自动签到配置失败:', err);
     });
   }, []);
 

--- a/src/components/codebuddy-suite/TraeAutoCheckinConfigModal.tsx
+++ b/src/components/codebuddy-suite/TraeAutoCheckinConfigModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { listen } from '@tauri-apps/api/event';
 import {
   X,
   Clock,
@@ -19,7 +20,7 @@ import {
   TraeAutoCheckinConfig,
   TraeAutoCheckinLogRecord,
   parseTimeToMinutes,
-  getTraeAutoCheckinLogs,
+  getTraeAutoCheckinLogsAsync,
   clearTraeAutoCheckinLogs,
   runTraeAutoCheckinCycleIfNeeded,
   TRAE_AUTO_CHECKIN_LOGS_CHANGED_EVENT,
@@ -27,7 +28,7 @@ import {
 
 interface TraeAutoCheckinConfigModalProps {
   config: TraeAutoCheckinConfig;
-  onSave: (newConfig: TraeAutoCheckinConfig) => void;
+  onSave: (newConfig: TraeAutoCheckinConfig) => Promise<void>;
   onClose: () => void;
 }
 
@@ -45,23 +46,62 @@ export function TraeAutoCheckinConfigModal({
   const [endTime, setEndTime] = useState(config.endTime || '12:00');
   const [error, setError] = useState<string | null>(null);
 
-  const [logs, setLogs] = useState<TraeAutoCheckinLogRecord[]>(() =>
-    getTraeAutoCheckinLogs(),
-  );
+  const [logs, setLogs] = useState<TraeAutoCheckinLogRecord[]>([]);
+  const [logsLoading, setLogsLoading] = useState(true);
+  const [logsError, setLogsError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
   const [manualTesting, setManualTesting] = useState(false);
   const [expandedLogIds, setExpandedLogIds] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
-    const handleLogsChange = () => {
-      setLogs(getTraeAutoCheckinLogs());
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    let requestId = 0;
+
+    const loadLogs = async () => {
+      const currentRequestId = ++requestId;
+      setLogsLoading(true);
+      setLogsError(null);
+
+      try {
+        const nextLogs = await getTraeAutoCheckinLogsAsync();
+        if (!disposed && currentRequestId === requestId) {
+          setLogs(nextLogs);
+        }
+      } catch (err) {
+        console.warn('[TraeAutoCheckin] 读取后端签到日志失败:', err);
+        if (!disposed && currentRequestId === requestId) {
+          setLogsError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!disposed && currentRequestId === requestId) {
+          setLogsLoading(false);
+        }
+      }
     };
-    window.addEventListener(TRAE_AUTO_CHECKIN_LOGS_CHANGED_EVENT, handleLogsChange);
+
+    void loadLogs();
+    const handleLogsChange = () => {
+      void loadLogs();
+    };
+    void listen(TRAE_AUTO_CHECKIN_LOGS_CHANGED_EVENT, handleLogsChange)
+      .then((stopListening) => {
+        if (disposed) {
+          stopListening();
+        } else {
+          unlisten = stopListening;
+        }
+      })
+      .catch((err) => {
+        console.warn('[TraeAutoCheckin] 监听后端签到日志事件失败:', err);
+      });
     return () => {
-      window.removeEventListener(TRAE_AUTO_CHECKIN_LOGS_CHANGED_EVENT, handleLogsChange);
+      disposed = true;
+      unlisten?.();
     };
   }, []);
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(startTime)) {
       setError(t('workbuddy.autoCheckin.error.invalidTime', '开始时间格式错误'));
       return;
@@ -76,8 +116,20 @@ export function TraeAutoCheckinConfigModal({
       setError(t('workbuddy.autoCheckin.error.endBeforeStart', '结束时间不能早于开始时间'));
       return;
     }
+    setSaving(true);
     setError(null);
-    onSave({ enabled, startTime, endTime });
+    try {
+      await onSave({
+        ...config,
+        enabled,
+        startTime,
+        endTime,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
   };
 
   const handleManualTest = async () => {
@@ -86,6 +138,18 @@ export function TraeAutoCheckinConfigModal({
       await runTraeAutoCheckinCycleIfNeeded(true);
     } finally {
       setManualTesting(false);
+    }
+  };
+
+  const handleClearLogs = async () => {
+    if (!confirm(t('workbuddy.autoCheckin.confirmClear', '确定清空所有记录？'))) {
+      return;
+    }
+    try {
+      await clearTraeAutoCheckinLogs();
+    } catch (err) {
+      console.warn('[TraeAutoCheckin] 清空签到日志失败:', err);
+      setLogsError(err instanceof Error ? err.message : String(err));
     }
   };
 
@@ -130,7 +194,7 @@ export function TraeAutoCheckinConfigModal({
         <div className="modal-header">
           <h2>
             <Settings size={18} />
-            {t('trae.autoCheckin.title', 'TRAE SOLO CN 自动签到设置')}
+            {t('trae.autoCheckin.title', 'TRAE CN 自动签到设置')}
           </h2>
           <button className="modal-close" onClick={onClose}>
             <X size={18} />
@@ -199,11 +263,20 @@ export function TraeAutoCheckinConfigModal({
                 </div>
               </div>
 
+              <div className="setting-desc">
+                {t(
+                  'workbuddy.autoCheckin.desc',
+                  '开启后，将在所选时间段内为每个账号随机选择一个时刻自动签到（Trae CN / TraeWork 积分模式）。',
+                )}
+              </div>
+
               <div className="setting-actions">
                 <button
                   className="btn btn-primary btn-full"
-                  onClick={handleSave}
+                  onClick={() => void handleSave()}
+                  disabled={saving}
                 >
+                  {saving ? <Loader2 size={14} className="animate-spin" /> : null}
                   {t('common.save', '保存')}
                 </button>
               </div>
@@ -237,11 +310,7 @@ export function TraeAutoCheckinConfigModal({
                 {logs.length > 0 && (
                   <button
                     className="btn btn-danger btn-sm"
-                    onClick={() => {
-                      if (confirm(t('workbuddy.autoCheckin.confirmClear', '确定清空所有记录？'))) {
-                        clearTraeAutoCheckinLogs();
-                      }
-                    }}
+                    onClick={() => void handleClearLogs()}
                   >
                     <Trash2 size={14} />
                     {t('common.clear', '清空')}
@@ -249,7 +318,15 @@ export function TraeAutoCheckinConfigModal({
                 )}
               </div>
 
-              {logs.length === 0 ? (
+              {logsLoading ? (
+                <div className="history-empty">
+                  <p>{t('common.loading', '加载中...')}</p>
+                </div>
+              ) : logsError ? (
+                <div className="history-empty">
+                  <p className="checkin-error-text">{logsError}</p>
+                </div>
+              ) : logs.length === 0 ? (
                 <div className="history-empty">
                   <p>{t('workbuddy.autoCheckin.noLogs', '暂无签到记录')}</p>
                 </div>
@@ -289,6 +366,9 @@ export function TraeAutoCheckinConfigModal({
                               {detail.time && <span className="detail-time">{detail.time}</span>}
                               {detail.message && (
                                 <span className="detail-message">{detail.message}</span>
+                              )}
+                              {typeof detail.credit === 'number' && (
+                                <span className="detail-message">+{detail.credit}</span>
                               )}
                             </div>
                           ))}

--- a/src/components/codebuddy-suite/TraeCheckinModal.tsx
+++ b/src/components/codebuddy-suite/TraeCheckinModal.tsx
@@ -6,6 +6,7 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { listen } from '@tauri-apps/api/event';
 import {
   X,
   ChevronLeft,
@@ -18,11 +19,21 @@ import {
   Flame,
   Trophy,
   Ban,
+  Settings,
+  Clock,
 } from 'lucide-react';
 import { TraeAccount } from '../../types/trae';
 import { TraeCheckinStatusResult, getTraeCheckinStatus, claimTraeCheckin } from '../../services/traeService';
 import { useEscClose } from '../../hooks/useEscClose';
 import { getTraeAccountDisplayEmail } from '../../types/trae';
+import { TraeAutoCheckinConfigModal } from './TraeAutoCheckinConfigModal';
+import {
+  getTraeAutoCheckinConfig,
+  getTraeAutoCheckinConfigAsync,
+  saveTraeAutoCheckinConfigAsync,
+  TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT,
+  TraeAutoCheckinConfig,
+} from '../../services/traeAutoCheckinService';
 
 type CheckinUiState = 'loading' | 'available' | 'claimed' | 'inactive' | 'error';
 
@@ -68,6 +79,40 @@ export function TraeCheckinModal({
   const [accountStates, setAccountStates] = useState<Record<string, AccountCheckinState>>({});
   const [checkAllLoading, setCheckAllLoading] = useState(false);
   const [refreshLoading, setRefreshLoading] = useState(false);
+  const [showConfigModal, setShowConfigModal] = useState(false);
+  const [autoCheckinConfig, setAutoCheckinConfig] = useState<TraeAutoCheckinConfig>(() =>
+    getTraeAutoCheckinConfig(),
+  );
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    const handleConfigChange = () => {
+      void getTraeAutoCheckinConfigAsync().then((nextConfig) => {
+        if (!disposed) {
+          setAutoCheckinConfig(nextConfig);
+        }
+      });
+    };
+    handleConfigChange();
+    window.addEventListener(TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT, handleConfigChange);
+    void listen(TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT, handleConfigChange)
+      .then((stopListening) => {
+        if (disposed) {
+          stopListening();
+        } else {
+          unlisten = stopListening;
+        }
+      })
+      .catch((err) => {
+        console.warn('[TraeAutoCheckin] 监听后端签到配置事件失败:', err);
+      });
+    return () => {
+      disposed = true;
+      unlisten?.();
+      window.removeEventListener(TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT, handleConfigChange);
+    };
+  }, []);
 
   const updateAccountState = useCallback(
     (accountId: string, update: Partial<AccountCheckinState>) => {
@@ -208,6 +253,39 @@ export function TraeCheckinModal({
                 <Ban size={14} /> {errorCount} {t('workbuddy.checkin.errors', '异常')}
               </span>
             )}
+            <span
+              className={`checkin-stat auto-checkin-badge ${
+                autoCheckinConfig.enabled ? 'enabled' : 'disabled'
+              }`}
+              onClick={() => setShowConfigModal(true)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setShowConfigModal(true);
+                }
+              }}
+              title={
+                autoCheckinConfig.enabled
+                  ? t(
+                      'workbuddy.checkin.autoCheckinEnabledHint',
+                      '自动签到已开启：将在 {{start}} 至 {{end}} 随机签到（点击设置）',
+                      {
+                        start: autoCheckinConfig.startTime,
+                        end: autoCheckinConfig.endTime,
+                      },
+                    )
+                  : t('workbuddy.checkin.autoCheckinDisabledHint', '自动签到未开启（点击设置）')
+              }
+            >
+              <Clock size={14} />
+              {autoCheckinConfig.enabled
+                ? `${t('workbuddy.checkin.autoCheckinLabel', '自动签到')} (${
+                    autoCheckinConfig.startTime
+                  }-${autoCheckinConfig.endTime})`
+                : t('workbuddy.checkin.autoCheckinOff', '自动签到未开启')}
+            </span>
           </div>
           <div className="checkin-actions">
             <button
@@ -262,6 +340,11 @@ export function TraeCheckinModal({
                       })}
                     </span>
                   )}
+                  {state.error && (
+                    <span className="checkin-account-error" title={state.error}>
+                      <XCircle size={12} /> {state.error}
+                    </span>
+                  )}
                 </div>
 
                 <div className="checkin-account-action">
@@ -309,6 +392,31 @@ export function TraeCheckinModal({
           <div className="checkin-empty">
             <p>{t('workbuddy.checkin.noAccounts', '暂无账号')}</p>
           </div>
+        )}
+
+        <div className="modal-footer checkin-modal-footer">
+          <button
+            className="btn btn-secondary icon-only"
+            onClick={() => setShowConfigModal(true)}
+            title={t('workbuddy.checkin.autoCheckinSettings', '自动签到设置')}
+            aria-label={t('workbuddy.checkin.autoCheckinSettings', '自动签到设置')}
+          >
+            <Settings size={14} />
+          </button>
+          <button className="btn btn-secondary" onClick={onClose}>
+            {t('common.close', '关闭')}
+          </button>
+        </div>
+
+        {showConfigModal && (
+          <TraeAutoCheckinConfigModal
+            config={autoCheckinConfig}
+            onSave={async (newConfig) => {
+              await saveTraeAutoCheckinConfigAsync(newConfig);
+              setAutoCheckinConfig(newConfig);
+            }}
+            onClose={() => setShowConfigModal(false)}
+          />
         )}
       </div>
     </div>

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -5338,6 +5338,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "التسجيل اليومي"
+    },
+    "autoCheckin": {
+      "title": "إعدادات التسجيل التلقائي TRAE CN"
+    },
     "title": "إدارة حسابات Trae",
     "empty": {
       "description": "انقر على \"إضافة حساب\" لبدء إدارة حسابات Trae، أو استيرادها من بيانات Trae المحلية أو من ملف JSON.",
@@ -5357,6 +5363,9 @@
       "localDescWithPlatform": "استيراد الحساب المسجل حاليًا ومعلومات الخطة وبيانات الحصة المخزنة مؤقتًا من مجلد إعدادات {{platform}} المحلي."
     },
     "quota": {
+      "creditsLabel": "الرصيد",
+      "creditsAvailable": "الرصيد المتبقي {{remaining}} / {{total}}",
+      "statusCreditsLow": "الحالة: الرصيد على وشك النفاد",
       "usedOfTotal": "المستخدم $ {{used}} من $ {{total}}",
       "usageUnknown": "الاستخدام: --",
       "resetAt": "وقت إعادة التعيين: {{date}}",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Denní check-in"
+    },
+    "autoCheckin": {
+      "title": "Nastavení automatického check-inu TRAE CN"
+    },
     "title": "Sprava uctu Trae",
     "empty": {
       "description": "Kliknete na „Pridat ucet“ a zacnete spravovat ucty Trae, nebo je importujte z mistnich dat Trae ci ze souboru JSON.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Importuje aktuálně přihlášený účet, informace o plánu a uložená data kvóty z místního konfiguračního adresáře {{platform}}."
     },
     "quota": {
+      "creditsLabel": "Kredity",
+      "creditsAvailable": "Kredity: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Stav: kredity téměř vyčerpány",
       "usedOfTotal": "Vyuzito $ {{used}} z $ {{total}}",
       "usageUnknown": "Vyuziti: --",
       "resetAt": "Cas resetu: {{date}}",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Täglicher Check-in"
+    },
+    "autoCheckin": {
+      "title": "TRAE CN Auto-Check-in-Einstellungen"
+    },
     "title": "Trae-Kontenverwaltung",
     "empty": {
       "description": "Klicken Sie auf „Konto hinzufugen“, um Ihre Trae-Konten zu verwalten, oder importieren Sie sie aus lokalen Trae-Daten oder einer JSON-Datei.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Importiert das aktuell angemeldete Konto, Planinformationen und zwischengespeicherte Kontingentdaten aus dem lokalen {{platform}}-Konfigurationsverzeichnis."
     },
     "quota": {
+      "creditsLabel": "Guthaben",
+      "creditsAvailable": "Guthaben: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Status: Guthaben fast aufgebraucht",
       "usedOfTotal": "Verbraucht $ {{used}} von $ {{total}}",
       "usageUnknown": "Nutzung: --",
       "resetAt": "Zurucksetzung: {{date}}",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -5618,6 +5618,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Daily Check-in"
+    },
+    "autoCheckin": {
+      "title": "TRAE CN Auto Check-in Settings"
+    },
     "title": "Trae Account",
     "empty": {
       "description": "Click \"Add Account\" to start managing your Trae accounts, or import from local Trae data or a JSON file.",
@@ -5637,6 +5643,9 @@
       "localDescWithPlatform": "Import the current signed-in account, plan information, and cached quota data from the local {{platform}} configuration directory."
     },
     "quota": {
+      "creditsLabel": "Credits",
+      "creditsAvailable": "Credits left: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Status: Credits running low",
       "usedOfTotal": "${{used}} / ${{total}}",
       "usageUnknown": "Usage: --",
       "resetAt": "Subscription reset: {{date}}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5618,6 +5618,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Daily Check-in"
+    },
+    "autoCheckin": {
+      "title": "TRAE CN Auto Check-in Settings"
+    },
     "title": "Trae Account",
     "empty": {
       "description": "Click \"Add Account\" to start managing your Trae accounts, or import from local Trae data or a JSON file.",
@@ -5637,6 +5643,9 @@
       "localDescWithPlatform": "Import the current signed-in account, plan information, and cached quota data from the local {{platform}} configuration directory."
     },
     "quota": {
+      "creditsLabel": "Credits",
+      "creditsAvailable": "Credits left: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Status: Credits running low",
       "usedOfTotal": "${{used}} / ${{total}}",
       "usageUnknown": "Usage: --",
       "resetAt": "Subscription reset: {{date}}",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Registro diario"
+    },
+    "autoCheckin": {
+      "title": "Ajustes de check-in automático de TRAE CN"
+    },
     "title": "Gestion de cuentas de Trae",
     "empty": {
       "description": "Haz clic en \"Agregar cuenta\" para empezar a gestionar tus cuentas de Trae, o importalas desde datos locales de Trae o desde un archivo JSON.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Importa la cuenta iniciada, la información del plan y los datos de cuota en caché desde el directorio local de configuración de {{platform}}."
     },
     "quota": {
+      "creditsLabel": "Créditos",
+      "creditsAvailable": "Créditos: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Estado: créditos casi agotados",
       "usedOfTotal": "Usado $ {{used}} de $ {{total}}",
       "usageUnknown": "Uso: --",
       "resetAt": "Reinicio: {{date}}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Check-in quotidien"
+    },
+    "autoCheckin": {
+      "title": "Paramètres de check-in automatique TRAE CN"
+    },
     "title": "Gestion des comptes Trae",
     "empty": {
       "description": "Cliquez sur \"Ajouter un compte\" pour commencer a gerer vos comptes Trae, ou importez-les depuis les donnees locales de Trae ou un fichier JSON.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Importe le compte connecté, les informations d’abonnement et le cache de quota depuis le dossier de configuration local {{platform}}."
     },
     "quota": {
+      "creditsLabel": "Crédits",
+      "creditsAvailable": "Crédits : {{remaining}} / {{total}}",
+      "statusCreditsLow": "Statut : crédits bientôt épuisés",
       "usedOfTotal": "Utilise $ {{used}} sur $ {{total}}",
       "usageUnknown": "Utilisation : --",
       "resetAt": "Reinitialisation : {{date}}",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -5466,6 +5466,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Check-in Harian"
+    },
+    "autoCheckin": {
+      "title": "Pengaturan check-in otomatis TRAE CN"
+    },
     "title": "Akun Trae",
     "empty": {
       "description": "Klik \"Tambah Akun\" untuk mulai mengelola akun Trae Anda, atau impor dari data Trae lokal atau berkas JSON.",
@@ -5485,6 +5491,9 @@
       "localDescWithPlatform": "Mengimpor akun yang sedang masuk, informasi paket, dan data kuota cache dari direktori konfigurasi lokal {{platform}}."
     },
     "quota": {
+      "creditsLabel": "Kredit",
+      "creditsAvailable": "Kredit tersisa {{remaining}} / {{total}}",
+      "statusCreditsLow": "Status: kredit hampir habis",
       "usedOfTotal": "${{used}} / ${{total}}​",
       "usageUnknown": "Penggunaan: --",
       "resetAt": "Reset langganan: {{date}}",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Check-in giornaliero"
+    },
+    "autoCheckin": {
+      "title": "Impostazioni check-in automatico TRAE CN"
+    },
     "title": "Gestione account Trae",
     "empty": {
       "description": "Fai clic su \"Aggiungi account\" per iniziare a gestire i tuoi account Trae, oppure importali dai dati locali di Trae o da un file JSON.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Importa l’account attualmente connesso, le informazioni del piano e i dati quota in cache dalla directory di configurazione locale di {{platform}}."
     },
     "quota": {
+      "creditsLabel": "Credito",
+      "creditsAvailable": "Credito: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Stato: credito quasi esaurito",
       "usedOfTotal": "Utilizzati $ {{used}} di $ {{total}}",
       "usageUnknown": "Utilizzo: --",
       "resetAt": "Reset: {{date}}",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "デイリーチェックイン"
+    },
+    "autoCheckin": {
+      "title": "TRAE CN 自動チェックイン設定"
+    },
     "title": "Trae アカウント管理",
     "empty": {
       "description": "「アカウント追加」をクリックして Trae アカウント管理を開始するか、ローカル Trae データまたは JSON ファイルからインポートできます。",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "ローカルの {{platform}} 設定ディレクトリから、現在ログイン中のアカウント、プラン情報、キャッシュ済みクォータデータをインポートします。"
     },
     "quota": {
+      "creditsLabel": "クレジット",
+      "creditsAvailable": "クレジット残り {{remaining}} / {{total}}",
+      "statusCreditsLow": "状態：クレジットが残りわずかです",
       "usedOfTotal": "使用済み $ {{used}} / $ {{total}}",
       "usageUnknown": "利用量：--",
       "resetAt": "リセット時刻: {{date}}",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "일일 체크인"
+    },
+    "autoCheckin": {
+      "title": "TRAE CN 자동 체크인 설정"
+    },
     "title": "Trae 계정 관리",
     "empty": {
       "description": "\"계정 추가\"를 클릭해 Trae 계정 관리를 시작하거나 로컬 Trae 데이터 또는 JSON 파일에서 가져올 수 있습니다.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "로컬 {{platform}} 설정 디렉터리에서 현재 로그인된 계정, 플랜 정보, 캐시된 할당량 데이터를 가져옵니다."
     },
     "quota": {
+      "creditsLabel": "크레딧",
+      "creditsAvailable": "크레딧 잔여 {{remaining}} / {{total}}",
+      "statusCreditsLow": "상태: 크레딧이 곧 소진됩니다",
       "usedOfTotal": "사용량 $ {{used}} / $ {{total}}",
       "usageUnknown": "사용량: --",
       "resetAt": "재설정 시간: {{date}}",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Codzienne zameldowanie"
+    },
+    "autoCheckin": {
+      "title": "Ustawienia automatycznego check-in TRAE CN"
+    },
     "title": "Zarzadzanie kontami Trae",
     "empty": {
       "description": "Kliknij „Dodaj konto”, aby zaczac zarzadzac kontami Trae, albo zaimportuj je z lokalnych danych Trae lub pliku JSON.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Importuje aktualnie zalogowane konto, informacje o planie i dane limitów z pamięci podręcznej z lokalnego katalogu konfiguracji {{platform}}."
     },
     "quota": {
+      "creditsLabel": "Kredyty",
+      "creditsAvailable": "Kredyty: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Status: kredyty prawie wyczerpane",
       "usedOfTotal": "Wykorzystano $ {{used}} z $ {{total}}",
       "usageUnknown": "Zuzycie: --",
       "resetAt": "Reset: {{date}}",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Check-in diário"
+    },
+    "autoCheckin": {
+      "title": "Configurações de check-in automático do TRAE CN"
+    },
     "title": "Gerenciamento de contas Trae",
     "empty": {
       "description": "Clique em \"Adicionar conta\" para comecar a gerenciar suas contas Trae ou importe-as dos dados locais do Trae ou de um arquivo JSON.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Importa a conta conectada atual, informações do plano e dados de cota em cache do diretório local de configuração do {{platform}}."
     },
     "quota": {
+      "creditsLabel": "Créditos",
+      "creditsAvailable": "Créditos: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Status: créditos quase esgotados",
       "usedOfTotal": "Usado $ {{used}} de $ {{total}}",
       "usageUnknown": "Uso: --",
       "resetAt": "Redefinicao: {{date}}",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Ежедневный check-in"
+    },
+    "autoCheckin": {
+      "title": "Настройки автоматического check-in TRAE CN"
+    },
     "title": "Управление аккаунтами Trae",
     "empty": {
       "description": "Нажмите «Добавить аккаунт», чтобы начать управлять аккаунтами Trae, или импортируйте их из локальных данных Trae либо из JSON-файла.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Импортирует текущий вошедший аккаунт, сведения о плане и кэшированные данные квоты из локального каталога настроек {{platform}}."
     },
     "quota": {
+      "creditsLabel": "Кредиты",
+      "creditsAvailable": "Кредиты: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Статус: кредиты почти исчерпаны",
       "usedOfTotal": "Использовано $ {{used}} из $ {{total}}",
       "usageUnknown": "Использование: --",
       "resetAt": "Сброс: {{date}}",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Günlük check-in"
+    },
+    "autoCheckin": {
+      "title": "TRAE CN otomatik check-in ayarları"
+    },
     "title": "Trae hesap yonetimi",
     "empty": {
       "description": "Trae hesaplarinizi yonetmeye baslamak icin \"Hesap ekle\" dugmesine tiklayin veya yerel Trae verilerinden ya da bir JSON dosyasindan ice aktarın.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Geçerli oturum açmış hesabı, plan bilgilerini ve önbelleğe alınmış kota verilerini yerel {{platform}} yapılandırma dizininden içe aktarır."
     },
     "quota": {
+      "creditsLabel": "Kredi",
+      "creditsAvailable": "Kredi: {{remaining}} / {{total}}",
+      "statusCreditsLow": "Durum: kredi neredeyse tükendi",
       "usedOfTotal": "Kullanilan $ {{used}} / $ {{total}}",
       "usageUnknown": "Kullanim: --",
       "resetAt": "Sifirlama zamani: {{date}}",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "Điểm danh hằng ngày"
+    },
+    "autoCheckin": {
+      "title": "Cài đặt điểm danh tự động TRAE CN"
+    },
     "title": "Quan ly tai khoan Trae",
     "empty": {
       "description": "Nhan \"Them tai khoan\" de bat dau quan ly cac tai khoan Trae, hoac nhap tu du lieu Trae cuc bo hay tep JSON.",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "Nhập tài khoản đang đăng nhập, thông tin gói và dữ liệu hạn mức đã lưu cache từ thư mục cấu hình {{platform}} cục bộ."
     },
     "quota": {
+      "creditsLabel": "Tín dụng",
+      "creditsAvailable": "Tín dụng còn {{remaining}} / {{total}}",
+      "statusCreditsLow": "Trạng thái: tín dụng sắp hết",
       "usedOfTotal": "Da dung $ {{used}} / $ {{total}}",
       "usageUnknown": "Muc dung: --",
       "resetAt": "Thoi gian dat lai: {{date}}",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -5618,6 +5618,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "每日签到"
+    },
+    "autoCheckin": {
+      "title": "TRAE CN 自动签到设置"
+    },
     "title": "Trae 账号管理",
     "empty": {
       "description": "点击“添加账号”开始管理您的 Trae 账号，也可以从本机 Trae 数据或 JSON 文件导入。",
@@ -5637,6 +5643,9 @@
       "localDescWithPlatform": "支持从本机 {{platform}} 配置目录读取当前登录账号、套餐信息和配额缓存数据。"
     },
     "quota": {
+      "creditsLabel": "积分",
+      "creditsAvailable": "积分可用 {{remaining}} / {{total}}",
+      "statusCreditsLow": "状态：积分即将耗尽",
       "usedOfTotal": "${{used}} / ${{total}}",
       "usageUnknown": "用量：--",
       "resetAt": "订阅重置：{{date}}",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -5291,6 +5291,12 @@
     }
   },
   "trae": {
+    "checkin": {
+      "modalTitle": "每日簽到"
+    },
+    "autoCheckin": {
+      "title": "TRAE CN 自動簽到設定"
+    },
     "title": "Trae 帳號管理",
     "empty": {
       "description": "點擊「新增帳號」開始管理您的 Trae 帳號，也可以從本機 Trae 資料或 JSON 檔案匯入。",
@@ -5310,6 +5316,9 @@
       "localDescWithPlatform": "支援從本機 {{platform}} 設定目錄讀取目前登入帳號、方案資訊與額度快取。"
     },
     "quota": {
+      "creditsLabel": "積分",
+      "creditsAvailable": "積分可用 {{remaining}} / {{total}}",
+      "statusCreditsLow": "狀態：積分即將耗盡",
       "usedOfTotal": "已用 $ {{used}} / $ {{total}}",
       "usageUnknown": "用量：--",
       "resetAt": "重設時間：{{date}}",

--- a/src/pages/TraeAccountsPage.tsx
+++ b/src/pages/TraeAccountsPage.tsx
@@ -24,6 +24,7 @@ import {
   Eye,
   EyeOff,
   BookOpen,
+  CalendarCheck,
 } from 'lucide-react';
 import { TagEditModal } from '../components/TagEditModal';
 import { ExportJsonModal } from '../components/ExportJsonModal';
@@ -41,6 +42,7 @@ import { MultiSelectFilterDropdown, type MultiSelectFilterOption } from '../comp
 import { SingleSelectFilterDropdown } from '../components/SingleSelectFilterDropdown';
 import { TraeInstancesContent } from './TraeInstancesPage';
 import { useTraeAccountStore } from '../stores/useTraeAccountStore';
+import { TraeCheckinModal } from '../components/codebuddy-suite/TraeCheckinModal';
 import * as traeService from '../services/traeService';
 import type { TraePlatformId } from '../services/traeService';
 import type { TraeAccount } from '../types/trae';
@@ -172,6 +174,8 @@ export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps)
   const filterPersistenceScopeSeed = platformConfig.platformKey;
   const targetFilterPersistenceScope = normalizeAccountsOverviewScope(filterPersistenceScopeSeed);
   const [activeTab, setActiveTab] = useState<PlatformOverviewTab>('overview');
+  const [showCheckinModal, setShowCheckinModal] = useState(false);
+  const isCnPlatform = platformId === 'trae_cn' || platformId === 'trae_solo_cn';
   const [filterTypes, setFilterTypes] = useState<string[]>(() =>
     readAccountsOverviewFilterPersistenceEnabled(targetFilterPersistenceScope)
       ? readAccountsOverviewFilterStringArray(targetFilterPersistenceScope, FILTER_TYPES_FIELD)
@@ -607,17 +611,33 @@ export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps)
       const hasUsageRaw = account.trae_usage_raw != null || account.trae_entitlement_raw != null;
       const hasFastRequest =
         usage.usageModel === 'fast_request' && usage.fastRequestAvailable != null;
+      const hasCredits =
+        usage.usageModel === 'credits' &&
+        usage.creditsTotal != null &&
+        (usage.creditsTotal ?? 0) > 0;
       const formatFastTimes = (value: number) =>
         value === -1
           ? t('trae.quota.fastUnlimited', '无限次')
           : t('trae.quota.fastTimes', '{{count}} 次', {
               count: value,
             });
+      const formatCredits = (value: number) =>
+        Number.isInteger(value) ? String(value) : value.toFixed(1);
 
-      // CN：优先速通次数展示，无可靠剩余时不猜测（对齐社区 #1281）
+      // CN：积分计费模式优先展示（usage_summary 为权威数据），其次速通次数，
+      // 无可靠剩余时不猜测（对齐社区 #1281）
       let costText: string;
       if (isCnAccount) {
-        if (hasFastRequest) {
+        if (hasCredits) {
+          const remaining = Math.max(
+            0,
+            (usage.creditsTotal ?? 0) - (usage.creditsConsumed ?? 0),
+          );
+          costText = t('trae.quota.creditsAvailable', '积分可用 {{remaining}} / {{total}}', {
+            remaining: formatCredits(remaining),
+            total: formatCredits(usage.creditsTotal ?? 0),
+          });
+        } else if (hasFastRequest) {
           costText = t('trae.quota.fastAvailable', '速通可用 {{times}}', {
             times: formatFastTimes(usage.fastRequestAvailable ?? 0),
           });
@@ -654,11 +674,15 @@ export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps)
       const statusTone: TraeQuotaSummary['statusTone'] = !hasUsageRaw
         ? 'unknown'
         : isCnAccount
-          ? hasFastRequest
-            ? usage.usageExhausted
+          ? hasCredits
+            ? percentage != null && percentage >= 90
               ? 'warning'
               : 'normal'
-            : 'unknown'
+            : hasFastRequest
+              ? usage.usageExhausted
+                ? 'warning'
+                : 'normal'
+              : 'unknown'
           : usage.usageExhausted
             ? usage.payAsYouGoOpen && !isFreePlan
               ? 'normal'
@@ -668,7 +692,11 @@ export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps)
       const statusText = !hasUsageRaw
         ? t('trae.quota.statusUnknown', 'Status: --')
         : isCnAccount
-          ? hasFastRequest
+          ? hasCredits
+            ? percentage != null && percentage >= 90
+              ? t('trae.quota.statusCreditsLow', '状态：积分即将耗尽')
+              : t('trae.quota.statusSynced', '状态：已同步')
+            : hasFastRequest
             ? usage.usageExhausted
               ? t('trae.quota.statusExhaustedFree', 'Status: Usage exhausted, upgrade recommended')
               : t('trae.quota.statusSynced', '状态：已同步')
@@ -723,15 +751,15 @@ export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps)
           : t('trae.quota.packageEmpty', 'Package: --');
 
       return {
-        percentage: isCnAccount && !hasFastRequest && usage.usageModel !== 'usd' ? null : percentage,
+        percentage: isCnAccount && !hasCredits && !hasFastRequest && usage.usageModel !== 'usd' ? null : percentage,
         percentageText:
-          isCnAccount && !hasFastRequest && usage.usageModel !== 'usd'
+          isCnAccount && !hasCredits && !hasFastRequest && usage.usageModel !== 'usd'
             ? '--'
             : percentage == null
               ? '--'
               : `${percentage}%`,
         quotaClass: computeQuotaClass(
-          isCnAccount && !hasFastRequest && usage.usageModel !== 'usd' ? null : percentage,
+          isCnAccount && !hasCredits && !hasFastRequest && usage.usageModel !== 'usd' ? null : percentage,
         ),
         costText,
         statusText,
@@ -1392,6 +1420,17 @@ export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps)
             </div>
 
             <div className="toolbar-right">
+              {isCnPlatform && (
+                <button
+                  className="btn btn-secondary icon-only"
+                  onClick={() => setShowCheckinModal(true)}
+                  disabled={accounts.length === 0}
+                  title={t('trae.checkin.modalTitle', '每日签到')}
+                  aria-label={t('trae.checkin.modalTitle', '每日签到')}
+                >
+                  <CalendarCheck size={14} />
+                </button>
+              )}
               <button
                 className="btn btn-primary icon-only"
                 onClick={() => openAddModal('oauth')}
@@ -1957,6 +1996,14 @@ export function TraeAccountsPage({ platformId = 'trae' }: TraeAccountsPageProps)
             onClose={() => setShowTagModal(null)}
             onSave={handleSaveTags}
           />
+
+          {isCnPlatform && showCheckinModal && (
+            <TraeCheckinModal
+              accounts={accounts}
+              onClose={() => setShowCheckinModal(false)}
+              onCheckinComplete={() => { void store.fetchAccounts(); }}
+            />
+          )}
         </>
       )}
 

--- a/src/presentation/platformAccountPresentation.ts
+++ b/src/presentation/platformAccountPresentation.ts
@@ -1533,6 +1533,30 @@ export function buildTraeAccountPresentation(
   const quotaItems: UnifiedQuotaMetric[] = [];
 
   if (
+    usage.usageModel === "credits" &&
+    usage.creditsTotal != null &&
+    (usage.creditsTotal ?? 0) > 0
+  ) {
+    const creditsTotal = usage.creditsTotal ?? 0;
+    const creditsRemaining = Math.max(
+      0,
+      creditsTotal - (usage.creditsConsumed ?? 0),
+    );
+    quotaItems.push({
+      key: "credits",
+      label: t("trae.quota.creditsLabel", "积分"),
+      percentage: remainingPercent ?? 0,
+      progressPercent: remainingPercent ?? 0,
+      quotaClass: getCursorUsageQuotaClass(usedPercent ?? 0),
+      valueText: t("trae.quota.creditsAvailable", {
+        remaining: formatQuotaNumber(creditsRemaining),
+        total: formatQuotaNumber(creditsTotal),
+        defaultValue: "积分可用 {{remaining}} / {{total}}",
+      }),
+      resetText: formatMetricResetText(usage.resetAt, t),
+      showProgress: true,
+    });
+  } else if (
     remainingPercent != null ||
     usage.spentUsd != null ||
     usage.totalUsd != null ||

--- a/src/services/traeAutoCheckinService.ts
+++ b/src/services/traeAutoCheckinService.ts
@@ -1,17 +1,25 @@
 /**
- * Trae SOLO CN 自动签到服务
+ * Trae CN / TraeWork 自动签到服务
  *
- * 基于 workbuddyAutoCheckinService 模式，适配 Trae 的签到 API。
+ * 与 workbuddyAutoCheckinService 相同的架构：
+ * 配置与日志持久化在 Rust 后端（shared 目录 JSON），调度由后端
+ * `trae_auto_checkin` 调度器执行，前端仅负责配置 UI 与日志展示。
  */
 
-import { listTraeAccounts, getTraeCheckinStatus, claimTraeCheckin } from './traeService';
-import { useTraeAccountStore } from '../stores/useTraeAccountStore';
+import { invoke } from '@tauri-apps/api/core';
+
+export interface TraeAccountScheduleState {
+  scheduledDate: string;        // "YYYY-MM-DD"
+  scheduledMinute: number;      // Minutes from midnight (0..1439)
+  lastCheckedDate?: string;     // "YYYY-MM-DD" when checked in
+}
 
 export interface TraeAutoCheckinConfig {
   enabled: boolean;
   startTime: string; // HH:mm
   endTime: string;   // HH:mm
   lastCheckedDate?: string; // "YYYY-MM-DD"
+  accountSchedules?: Record<string, TraeAccountScheduleState>;
 }
 
 export const DEFAULT_TRAE_AUTO_CHECKIN_CONFIG: TraeAutoCheckinConfig = {
@@ -21,10 +29,9 @@ export const DEFAULT_TRAE_AUTO_CHECKIN_CONFIG: TraeAutoCheckinConfig = {
 };
 
 const CONFIG_KEY = 'agtools.trae.auto_checkin_config';
+const LEGACY_LOGS_KEY = 'agtools.trae.auto_checkin_logs';
 export const TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT = 'trae-auto-checkin-config-changed';
-const AUTO_CHECKIN_RETRY_DELAY_MS = 5 * 60 * 1000;
-const AUTO_CHECKIN_IDLE_RECHECK_DELAY_MS = 60 * 60 * 1000;
-const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+export const TRAE_AUTO_CHECKIN_LOGS_CHANGED_EVENT = 'trae-auto-checkin-logs-changed';
 
 export type TraeAutoCheckinCycleResult = 'disabled' | 'waiting' | 'completed' | 'retry';
 
@@ -32,7 +39,53 @@ function isValidTime(time: unknown): time is string {
   return typeof time === 'string' && /^([01]\d|2[0-3]):[0-5]\d$/.test(time);
 }
 
+/** 清理旧版 WebView localStorage 签到日志（已迁移至 Rust 后端） */
+export function clearLegacyTraeAutoCheckinLogs(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    if (localStorage.getItem(LEGACY_LOGS_KEY) !== null) {
+      localStorage.removeItem(LEGACY_LOGS_KEY);
+      console.info('[TraeAutoCheckin] 已清理废弃的 WebView 自动签到日志缓存');
+    }
+  } catch (err) {
+    console.warn('[TraeAutoCheckin] 清理废弃的自动签到日志缓存失败:', err);
+  }
+}
+
+let cachedConfig: TraeAutoCheckinConfig | null = null;
+
+function cacheConfigLocally(config: TraeAutoCheckinConfig, emitChange = false): void {
+  cachedConfig = config;
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
+    if (emitChange) {
+      window.dispatchEvent(new Event(TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT));
+    }
+  } catch (err) {
+    console.warn('[TraeAutoCheckin] 本地缓存保存失败:', err);
+  }
+}
+
+export async function getTraeAutoCheckinConfigAsync(): Promise<TraeAutoCheckinConfig> {
+  try {
+    const config = await invoke<TraeAutoCheckinConfig>('get_trae_auto_checkin_config');
+    cacheConfigLocally(config);
+    return config;
+  } catch (err) {
+    console.warn('[TraeAutoCheckin] 从 Rust 端获取配置失败，使用本地缓存或默认值:', err);
+    return getTraeAutoCheckinConfig();
+  }
+}
+
 export function getTraeAutoCheckinConfig(): TraeAutoCheckinConfig {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
   if (typeof window === 'undefined') {
     return DEFAULT_TRAE_AUTO_CHECKIN_CONFIG;
   }
@@ -42,27 +95,40 @@ export function getTraeAutoCheckinConfig(): TraeAutoCheckinConfig {
       return DEFAULT_TRAE_AUTO_CHECKIN_CONFIG;
     }
     const parsed = JSON.parse(raw);
-    return {
+    const config: TraeAutoCheckinConfig = {
       enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : false,
       startTime: isValidTime(parsed.startTime) ? parsed.startTime : '06:00',
       endTime: isValidTime(parsed.endTime) ? parsed.endTime : '12:00',
       lastCheckedDate: typeof parsed.lastCheckedDate === 'string' ? parsed.lastCheckedDate : undefined,
+      accountSchedules:
+        typeof parsed.accountSchedules === 'object' && parsed.accountSchedules !== null
+          ? parsed.accountSchedules
+          : undefined,
     };
+    cachedConfig = config;
+    return config;
   } catch {
     return DEFAULT_TRAE_AUTO_CHECKIN_CONFIG;
   }
 }
 
-export function saveTraeAutoCheckinConfig(config: TraeAutoCheckinConfig): void {
+export async function migrateTraeAutoCheckinConfigAsync(
+  legacyConfig: TraeAutoCheckinConfig,
+): Promise<TraeAutoCheckinConfig> {
+  const config = await invoke<TraeAutoCheckinConfig>('migrate_trae_auto_checkin_config', {
+    legacyConfig,
+  });
+  cacheConfigLocally(config, true);
+  return config;
+}
+
+export async function saveTraeAutoCheckinConfigAsync(config: TraeAutoCheckinConfig): Promise<void> {
   if (typeof window === 'undefined') {
+    cacheConfigLocally(config);
     return;
   }
-  try {
-    localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
-    window.dispatchEvent(new Event(TRAE_AUTO_CHECKIN_CONFIG_CHANGED_EVENT));
-  } catch (err) {
-    console.warn('[TraeAutoCheckin] 保存配置失败:', err);
-  }
+  await invoke('save_trae_auto_checkin_config', { config });
+  cacheConfigLocally(config, true);
 }
 
 export function parseTimeToMinutes(timeStr: string): number {
@@ -70,69 +136,6 @@ export function parseTimeToMinutes(timeStr: string): number {
   const h = parts[0] ?? 0;
   const m = parts[1] ?? 0;
   return h * 60 + m;
-}
-
-export function getTodayDateString(): string {
-  const now = new Date();
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
-}
-
-export function formatTimeOnly(date: Date = new Date()): string {
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-}
-
-export function formatFormattedTimestamp(date: Date = new Date()): string {
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(
-    date.getHours(),
-  )}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-}
-
-let isAutoCheckinCycleRunning = false;
-
-function getMillisecondsUntilNextLocalDay(now: Date): number {
-  const nextDay = new Date(now);
-  nextDay.setHours(24, 0, 1, 0);
-  return Math.max(1_000, nextDay.getTime() - now.getTime());
-}
-
-export function getTraeAutoCheckinNextDelayMs(
-  result?: TraeAutoCheckinCycleResult,
-  _accounts: Array<{ id: string }> = [],
-): number {
-  const config = getTraeAutoCheckinConfig();
-  if (!config.enabled) {
-    return AUTO_CHECKIN_IDLE_RECHECK_DELAY_MS;
-  }
-
-  if (result === 'retry') {
-    return AUTO_CHECKIN_RETRY_DELAY_MS;
-  }
-
-  const now = new Date();
-  const todayStr = getTodayDateString();
-  const currentMinute = now.getHours() * 60 + now.getMinutes();
-
-  if (config.lastCheckedDate === todayStr) {
-    return getMillisecondsUntilNextLocalDay(now);
-  }
-
-  const startMin = parseTimeToMinutes(config.startTime);
-  const endMin = Math.max(startMin, parseTimeToMinutes(config.endTime));
-
-  if (currentMinute < startMin) {
-    const scheduledAt = new Date(now);
-    scheduledAt.setHours(Math.floor(startMin / 60), startMin % 60, 0, 0);
-    return Math.max(1_000, scheduledAt.getTime() - now.getTime());
-  }
-
-  if (currentMinute >= endMin) {
-    return getMillisecondsUntilNextLocalDay(now);
-  }
-
-  return 1000;
 }
 
 export interface TraeAutoCheckinAccountDetail {
@@ -157,249 +160,23 @@ export interface TraeAutoCheckinLogRecord {
   details: TraeAutoCheckinAccountDetail[];
 }
 
-const LOGS_KEY = 'agtools.trae.auto_checkin_logs';
-export const TRAE_AUTO_CHECKIN_LOGS_CHANGED_EVENT = 'trae-auto-checkin-logs-changed';
-
-export function getTraeAutoCheckinLogs(): TraeAutoCheckinLogRecord[] {
-  if (typeof window === 'undefined') {
-    return [];
-  }
-  try {
-    const raw = localStorage.getItem(LOGS_KEY);
-    if (!raw) {
-      return [];
-    }
-    const parsed = JSON.parse(raw) as TraeAutoCheckinLogRecord[];
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-
-    const now = Date.now();
-    const validLogs = parsed.filter((log) => {
-      const logTime = new Date(log.timestamp.replace(' ', 'T')).getTime();
-      return !isNaN(logTime) && now - logTime <= THIRTY_DAYS_MS;
-    });
-
-    if (validLogs.length !== parsed.length) {
-      localStorage.setItem(LOGS_KEY, JSON.stringify(validLogs));
-    }
-    return validLogs;
-  } catch {
-    return [];
-  }
+export async function getTraeAutoCheckinLogsAsync(): Promise<TraeAutoCheckinLogRecord[]> {
+  return await invoke<TraeAutoCheckinLogRecord[]>('get_trae_auto_checkin_logs');
 }
 
-export function saveTraeAutoCheckinLogs(logs: TraeAutoCheckinLogRecord[]): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  try {
-    const now = Date.now();
-    const validLogs = logs.filter((log) => {
-      const logTime = new Date(log.timestamp.replace(' ', 'T')).getTime();
-      return !isNaN(logTime) && now - logTime <= THIRTY_DAYS_MS;
-    });
-    localStorage.setItem(LOGS_KEY, JSON.stringify(validLogs));
-    window.dispatchEvent(new Event(TRAE_AUTO_CHECKIN_LOGS_CHANGED_EVENT));
-  } catch (err) {
-    console.warn('[TraeAutoCheckin] 保存自动签到日志失败:', err);
-  }
-}
-
-export function addTraeAutoCheckinLog(record: TraeAutoCheckinLogRecord): void {
-  const currentLogs = getTraeAutoCheckinLogs();
-  const existingIndex = currentLogs.findIndex((l) => l.date === record.date);
-
-  if (existingIndex < 0) {
-    saveTraeAutoCheckinLogs([record, ...currentLogs]);
-    return;
-  }
-
-  const existing = currentLogs[existingIndex];
-  if (!existing) {
-    saveTraeAutoCheckinLogs([record, ...currentLogs]);
-    return;
-  }
-
-  const mergedDetailsMap = new Map<string, TraeAutoCheckinAccountDetail>();
-  for (const d of existing.details) {
-    mergedDetailsMap.set(d.accountId, d);
-  }
-  for (const d of record.details) {
-    mergedDetailsMap.set(d.accountId, d);
-  }
-
-  const mergedDetails = Array.from(mergedDetailsMap.values());
-  let successCount = 0;
-  let alreadyCheckedCount = 0;
-  let failedCount = 0;
-
-  for (const d of mergedDetails) {
-    if (d.status === 'success') successCount++;
-    else if (d.status === 'already_checked') alreadyCheckedCount++;
-    else if (d.status === 'failed') failedCount++;
-  }
-
-  const totalAccounts = mergedDetails.length;
-  const overallStatus: TraeAutoCheckinLogRecord['status'] =
-    totalAccounts === 0
-      ? 'no_accounts'
-      : failedCount === 0
-        ? 'success'
-        : successCount > 0 || alreadyCheckedCount > 0
-          ? 'partial'
-          : 'failed';
-
-  const mergedRecord: TraeAutoCheckinLogRecord = {
-    id: existing.id,
-    timestamp: record.timestamp,
-    date: record.date,
-    durationMs: existing.durationMs + record.durationMs,
-    totalAccounts,
-    successCount,
-    alreadyCheckedCount,
-    failedCount,
-    status: overallStatus,
-    details: mergedDetails,
-  };
-
-  const updatedLogs = [...currentLogs];
-  updatedLogs[existingIndex] = mergedRecord;
-  saveTraeAutoCheckinLogs(updatedLogs);
-}
-
-export function clearTraeAutoCheckinLogs(): void {
-  saveTraeAutoCheckinLogs([]);
+export async function clearTraeAutoCheckinLogs(): Promise<void> {
+  await invoke('clear_trae_auto_checkin_logs');
 }
 
 export async function runTraeAutoCheckinCycleIfNeeded(
   force = false,
 ): Promise<TraeAutoCheckinCycleResult> {
-  const config = getTraeAutoCheckinConfig();
-  if (!config.enabled && !force) {
-    return 'disabled';
-  }
-
-  if (isAutoCheckinCycleRunning) {
+  const res = await invoke<string>('run_trae_auto_checkin_now', { force });
+  if (res === 'already_running') {
     return 'waiting';
   }
-
-  isAutoCheckinCycleRunning = true;
-  const startTime = Date.now();
-  const startTimestampStr = formatFormattedTimestamp(new Date(startTime));
-  const todayStr = getTodayDateString();
-
-  try {
-    console.log('[TraeAutoCheckin] 检查签到任务...');
-    const accounts = await listTraeAccounts();
-    if (accounts.length === 0) {
-      if (force) {
-        addTraeAutoCheckinLog({
-          id: `log_${startTime}_${Math.random().toString(36).substring(2, 7)}`,
-          timestamp: startTimestampStr,
-          date: todayStr,
-          durationMs: Date.now() - startTime,
-          totalAccounts: 0,
-          successCount: 0,
-          alreadyCheckedCount: 0,
-          failedCount: 0,
-          status: 'no_accounts',
-          details: [],
-        });
-      }
-      return 'completed';
-    }
-
-    // 筛选今日需签到的账号：全部签到（简单模式，不设独立随机时间）
-    const targetAccounts = accounts;
-
-    let retryNeeded = false;
-    let successCount = 0;
-    let alreadyCheckedCount = 0;
-    let failedCount = 0;
-    let didCheckinAny = false;
-    const details: TraeAutoCheckinAccountDetail[] = [];
-
-    for (const account of targetAccounts) {
-      const emailDisplay = account.email || account.id;
-      const accountCheckinTime = formatTimeOnly(new Date());
-      try {
-        const status = await getTraeCheckinStatus(account.id);
-        if (status.checked_in) {
-          alreadyCheckedCount++;
-          details.push({
-            accountId: account.id,
-            email: emailDisplay,
-            status: 'already_checked',
-            time: accountCheckinTime,
-            message: '今日已完成签到',
-          });
-        } else {
-          console.log(`[TraeAutoCheckin] 为账号 ${emailDisplay} 执行签到...`);
-          const result = await claimTraeCheckin(account.id);
-          didCheckinAny = true;
-          successCount++;
-          details.push({
-            accountId: account.id,
-            email: emailDisplay,
-            status: 'success',
-            time: accountCheckinTime,
-            message: result.message || '签到成功',
-            credit: result.total_credits,
-          });
-        }
-      } catch (accountErr) {
-        const errMsg = accountErr instanceof Error ? accountErr.message : String(accountErr);
-        console.warn(`[TraeAutoCheckin] 账号 ${account.id} 签到异常:`, accountErr);
-        retryNeeded = true;
-        failedCount++;
-        details.push({
-          accountId: account.id,
-          email: emailDisplay,
-          status: 'failed',
-          time: accountCheckinTime,
-          message: errMsg,
-        });
-      }
-    }
-
-    // 更新最后检查日期
-    saveTraeAutoCheckinConfig({
-      ...config,
-      lastCheckedDate: todayStr,
-    });
-
-    const durationMs = Date.now() - startTime;
-    const overallStatus: TraeAutoCheckinLogRecord['status'] =
-      failedCount === 0
-        ? 'success'
-        : successCount > 0 || alreadyCheckedCount > 0
-          ? 'partial'
-          : 'failed';
-
-    addTraeAutoCheckinLog({
-      id: `log_${startTime}_${Math.random().toString(36).substring(2, 7)}`,
-      timestamp: startTimestampStr,
-      date: todayStr,
-      durationMs,
-      totalAccounts: targetAccounts.length,
-      successCount,
-      alreadyCheckedCount,
-      failedCount,
-      status: overallStatus,
-      details,
-    });
-
-    if (didCheckinAny) {
-      void useTraeAccountStore.getState().fetchAccounts().catch((err) => {
-        console.warn('[TraeAutoCheckin] 刷新账号列表失败:', err);
-      });
-    }
-    return retryNeeded ? 'retry' : 'completed';
-  } catch (err) {
-    console.error('[TraeAutoCheckin] 自动签到周期失败:', err);
-    return 'retry';
-  } finally {
-    isAutoCheckinCycleRunning = false;
+  if (res === 'disabled' || res === 'waiting' || res === 'completed' || res === 'retry') {
+    return res as TraeAutoCheckinCycleResult;
   }
+  return 'completed';
 }

--- a/src/services/traeService.ts
+++ b/src/services/traeService.ts
@@ -145,8 +145,13 @@ export interface TraeCheckinStatusResult {
 
 const TRAE_CHECKIN_DEVICE_ID_KEY = 'agtools.trae.checkin_device_id';
 
-/** 获取或生成 Trae 签到使用的设备 ID */
-export function getTraeCheckinDeviceId(): string {
+/** 获取或生成 Trae 签到使用的设备 ID（与 Rust 后端共用，避免同账号多设备） */
+export async function getTraeCheckinDeviceId(): Promise<string> {
+  try {
+    return await invoke<string>('get_trae_checkin_device_id');
+  } catch {
+    // 后端命令不可用时退回 WebView 本地生成
+  }
   if (typeof window === 'undefined') return '';
   try {
     let deviceId = localStorage.getItem(TRAE_CHECKIN_DEVICE_ID_KEY);
@@ -164,7 +169,7 @@ export function getTraeCheckinDeviceId(): string {
 export async function getTraeCheckinStatus(
   accountId: string,
 ): Promise<TraeCheckinStatusResult> {
-  const deviceId = getTraeCheckinDeviceId();
+  const deviceId = await getTraeCheckinDeviceId();
   return await invoke('get_trae_checkin_status', { accountId, deviceId });
 }
 
@@ -172,6 +177,6 @@ export async function getTraeCheckinStatus(
 export async function claimTraeCheckin(
   accountId: string,
 ): Promise<TraeCheckinStatusResult> {
-  const deviceId = getTraeCheckinDeviceId();
+  const deviceId = await getTraeCheckinDeviceId();
   return await invoke('claim_trae_checkin', { accountId, deviceId });
 }

--- a/src/types/trae.ts
+++ b/src/types/trae.ts
@@ -65,7 +65,7 @@ export type TraeUsage = {
   payAsYouGoUsd?: number | null;
   usageExhausted?: boolean | null;
   /** CN 速通额度模型（premium_model_fast_*），与国际站 USD basic 额度不同 */
-  usageModel?: 'usd' | 'fast_request' | 'unknown';
+  usageModel?: 'usd' | 'fast_request' | 'credits' | 'unknown';
   fastRequestAvailable?: number | null;
   fastRequestLimit?: number | null;
   fastRequestUsed?: number | null;
@@ -74,6 +74,10 @@ export type TraeUsage = {
   canGetExpressStatus?: number | null;
   soloParallelLimit?: number | null;
   hasSoloPackage?: boolean | null;
+  /** CN 积分计费模式（is_credits_billing）：usage_summary 汇总 */
+  isCreditsBilling?: boolean | null;
+  creditsConsumed?: number | null;
+  creditsTotal?: number | null;
 };
 
 function toRecord(value: unknown): Record<string, unknown> | null {
@@ -419,6 +423,30 @@ function getPackTimeInfo(pack: Record<string, unknown> | null) {
   };
 }
 
+function getCreditsUsageSummary(rawUsage: unknown): {
+  isCreditsBilling: boolean;
+  consumed: number | null;
+  total: number | null;
+} {
+  const root = toRecord(rawUsage);
+  const nested = root ? toRecord(root.raw) : null;
+  const source =
+    root != null && root.is_credits_billing != null
+      ? root
+      : (nested ?? root);
+  if (!source) {
+    return { isCreditsBilling: false, consumed: null, total: null };
+  }
+
+  const isCreditsBilling = toBoolean(source.is_credits_billing) === true;
+  const summary = toRecord(source.usage_summary);
+  return {
+    isCreditsBilling,
+    consumed: summary ? toNumber(summary.consumed_amount) : null,
+    total: summary ? toNumber(summary.total_amount) : null,
+  };
+}
+
 function getUsageStatusFromPackList(
   rawUsage: unknown,
   options?: { preferCnSelection?: boolean },
@@ -510,10 +538,23 @@ function getUsageStatusFromPackList(
     'Free';
   const derivedPercent = totalUsd > 0 ? (spentUsd / totalUsd) * 100 : 0;
   const fastUsage = preferCn ? getFastRequestUsage(rawUsage) : null;
+  const creditsSummary = preferCn ? getCreditsUsageSummary(rawUsage) : null;
+  const isCreditsBilling = creditsSummary?.isCreditsBilling === true;
 
   let usedPercent: number | null = Math.max(0, Math.min(100, Math.round(derivedPercent)));
   let usageModel: TraeUsage['usageModel'] = 'usd';
-  if (preferCn && fastUsage) {
+  if (preferCn && isCreditsBilling && creditsSummary?.total != null) {
+    // 积分计费模式：usage_summary.consumed_amount / total_amount 为权威数据，
+    // 优先级高于速通次数与 USD 展示。
+    usageModel = 'credits';
+    const total = creditsSummary.total;
+    if (total > 0) {
+      const consumed = creditsSummary.consumed ?? 0;
+      usedPercent = Math.max(0, Math.min(100, Math.round((consumed / total) * 100)));
+    } else {
+      usedPercent = 0;
+    }
+  } else if (preferCn && fastUsage) {
     usageModel = 'fast_request';
     if (fastUsage.limit === -1) {
       usedPercent = 0;
@@ -532,8 +573,8 @@ function getUsageStatusFromPackList(
 
   return {
     usedPercent,
-    spentUsd: usageModel === 'fast_request' ? null : spentUsd,
-    totalUsd: usageModel === 'fast_request' ? null : totalUsd,
+    spentUsd: usageModel === 'fast_request' || usageModel === 'credits' ? null : spentUsd,
+    totalUsd: usageModel === 'fast_request' || usageModel === 'credits' ? null : totalUsd,
     resetAt: toUnixSeconds(resetAtRaw),
     basicQuota,
     basicUsage,
@@ -556,6 +597,9 @@ function getUsageStatusFromPackList(
     fastRequestAvailable: fastUsage?.available ?? null,
     fastRequestLimit: fastUsage?.limit ?? null,
     fastRequestUsed: fastUsage?.used ?? null,
+    isCreditsBilling,
+    creditsConsumed: creditsSummary?.consumed ?? null,
+    creditsTotal: creditsSummary?.total ?? null,
   };
 }
 
@@ -849,8 +893,18 @@ export function getTraeUsage(account: TraeAccount): TraeUsage {
     };
   }
 
+  const creditsSummary = preferCn ? getCreditsUsageSummary(account.trae_usage_raw) : null;
+  const isCreditsBilling = creditsSummary?.isCreditsBilling === true;
+  let fallbackPercent: number | null = null;
+  if (isCreditsBilling && creditsSummary?.total != null && creditsSummary.total > 0) {
+    fallbackPercent = Math.max(
+      0,
+      Math.min(100, Math.round(((creditsSummary.consumed ?? 0) / creditsSummary.total) * 100)),
+    );
+  }
+
   return {
-    usedPercent: null,
+    usedPercent: fallbackPercent,
     spentUsd: null,
     totalUsd: null,
     resetAt: account.plan_reset_at ?? null,
@@ -868,7 +922,7 @@ export function getTraeUsage(account: TraeAccount): TraeUsage {
     payAsYouGoOpen: false,
     payAsYouGoUsd: null,
     usageExhausted: false,
-    usageModel: preferCn ? 'unknown' : 'usd',
+    usageModel: isCreditsBilling ? 'credits' : preferCn ? 'unknown' : 'usd',
     fastRequestAvailable: null,
     fastRequestLimit: null,
     fastRequestUsed: null,
@@ -876,6 +930,9 @@ export function getTraeUsage(account: TraeAccount): TraeUsage {
     canGetExpressStatus: cnDetail.canGetExpressStatus,
     soloParallelLimit: cnDetail.soloParallelLimit,
     hasSoloPackage: cnDetail.hasSoloPackage,
+    isCreditsBilling,
+    creditsConsumed: creditsSummary?.consumed ?? null,
+    creditsTotal: creditsSummary?.total ?? null,
   };
 }
 


### PR DESCRIPTION
## 功能概述
为 Trae CN / TraeWork 账号支持积分计费模式展示与每日签到。

### 积分额度展示
- Trae CN 已切换为积分计费：解析 v2 用量接口的 is_credits_billing 与
  usage_summary（consumed_amount / total_amount），积分模式下以其为权威数据渲染，
  账号列表与额度卡片同步适配
- 既有速通次数 / USD 渲染逻辑未改动，保留为旧版响应的回退路径

### 每日签到
- 账号页新增签到入口与弹窗，支持单账号 / 一键全部签到
- 适配官方接口：Cloud-IDE-JWT 认证头、状态接口 POST、x-device-id
- 设备 ID 优先复用本机 Trae 客户端注册的 ICDRS ID（storage.json），前后端共用，规避 9074 风控

### 自动签到
- 调度与配置/日志持久化下沉 Rust 后端，应用启动即生效，不依赖前端存活
- 时间窗内每账号随机时刻签到，失败指数退避重试（上限 1 小时），日志保留 30 天
- 领取失败自动复查状态，防风控误判

## 测试
- npm run release:preflight（locales + typecheck + build + cargo check）✅
- cargo test --lib trae_auto_checkin 8/8 ✅
- Windows 实机：签到 200 积分入账、积分卡片显示正常