### PR TITLE
fix(workbuddy): 同步官方 WorkBuddy 5.4.5 Credits 额度查询

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to Cockpit Tools will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- **Sync WorkBuddy 5.4.5 official Credits quota query**: call `get-user-resource` with an empty body first and read `data.resources`, then fall back to `PackageStartTimeRange`. The old `PackageEndTimeRange` body is rejected with HTTP 403.
+
 ## [1.3.34] - 2026-08-28
 
 ### Added

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -7,6 +7,12 @@
 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)。
 
 ---
+## [Unreleased]
+
+### 修复
+
+- **同步官方 WorkBuddy 5.4.5 Credits 额度查询**：`get-user-resource` 改为先发空请求体读取 `data.resources`，失败再回退 `PackageStartTimeRange`。旧的 `PackageEndTimeRange` 会被上游 403 拒绝，导致额度查不出来。
+
 ## [1.3.34] - 2026-08-28
 
 ### 新增

--- a/crates/cockpit-core/src/modules/codebuddy_cn_oauth.rs
+++ b/crates/cockpit-core/src/modules/codebuddy_cn_oauth.rs
@@ -69,12 +69,26 @@ fn normalize_user_resource_status(status: &[i32]) -> Vec<i32> {
 }
 
 fn build_default_user_resource_time_range() -> (String, String) {
+    // Official WorkBuddy 5.4.5 / CodeBuddy web client uses PackageStartTimeRange
+    // from a fixed start date to now. PackageEndTimeRange is rejected with HTTP 403.
     let now = chrono::Local::now();
-    let begin = now.format("%Y-%m-%d %H:%M:%S").to_string();
-    let end = (now + chrono::Duration::days(365 * 101))
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string();
+    let begin = "2024-12-01 21:25:00".to_string();
+    let end = now.format("%Y-%m-%d %H:%M:%S").to_string();
     (begin, end)
+}
+
+fn user_resource_has_payload(body: &Value) -> bool {
+    let has_resources = body
+        .pointer("/data/resources")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    let has_accounts = body
+        .pointer("/data/Response/Data/Accounts")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    has_resources || has_accounts
 }
 
 fn clear_pending_login(login_id: &str) -> Result<(), String> {
@@ -561,20 +575,29 @@ pub async fn fetch_user_resource_with_access_token(
     page_number: i32,
     page_size: i32,
 ) -> Result<Value, String> {
-    let client = build_client()?;
-    let url = format!(
-        "{}/v2/billing/meter/get-user-resource",
-        CODEBUDDY_API_ENDPOINT
-    );
-
     let body = json!({
         "PageNumber": page_number,
         "PageSize": page_size,
         "ProductCode": product_code,
         "Status": status,
-        "PackageEndTimeRangeBegin": package_end_time_range_begin,
-        "PackageEndTimeRangeEnd": package_end_time_range_end
+        "PackageStartTimeRangeBegin": package_end_time_range_begin,
+        "PackageStartTimeRangeEnd": package_end_time_range_end
     });
+    post_user_resource(access_token, uid, enterprise_id, domain, body).await
+}
+
+async fn post_user_resource(
+    access_token: &str,
+    uid: Option<&str>,
+    enterprise_id: Option<&str>,
+    domain: Option<&str>,
+    body: Value,
+) -> Result<Value, String> {
+    let client = build_client()?;
+    let url = format!(
+        "{}/v2/billing/meter/get-user-resource",
+        CODEBUDDY_API_ENDPOINT
+    );
 
     let mut req = client
         .post(&url)
@@ -598,7 +621,7 @@ pub async fn fetch_user_resource_with_access_token(
         .json(&body)
         .send()
         .await
-        .map_err(|e| format!("请求 user resource（Token）失败: {}", e))?;
+        .map_err(|e| format!("请求 user resource（Token）失败:{}", e))?;
 
     let status_code = resp.status();
     let content_type = resp
@@ -618,7 +641,7 @@ pub async fn fetch_user_resource_with_access_token(
         .await
         .map_err(|e| {
             format!(
-                "解析 user resource（Token）响应失败: {} (http={}, url={}, has_uid={}, has_enterprise_id={}, content_type={}, content_encoding={})",
+                "解析 user resource（Token）响应失败:{} (http={}, url={}, has_uid={}, has_enterprise_id={}, content_type={}, content_encoding={})",
                 e,
                 status_code.as_u16(),
                 url,
@@ -665,23 +688,51 @@ async fn fetch_user_resource_with_access_token_default(
     enterprise_id: Option<&str>,
     domain: Option<&str>,
 ) -> Result<Value, String> {
+    // Official WorkBuddy desktop billing() posts an empty body and reads data.resources.
+    let mut empty_ok: Option<Value> = None;
+    let mut empty_err: Option<String> = None;
+    match post_user_resource(access_token, uid, enterprise_id, domain, json!({})).await {
+        Ok(body) if user_resource_has_payload(&body) => {
+            logger::log_info("[CodeBuddy CN][IDE Token] user_resource 使用官方空请求体 Credits 接口成功");
+            return Ok(body);
+        }
+        Ok(body) => {
+            logger::log_info(
+                "[CodeBuddy CN][IDE Token] 官方空请求体未返回资源，回退 PackageStartTimeRange",
+            );
+            empty_ok = Some(body);
+        }
+        Err(err) => {
+            logger::log_warn(&format!(
+                "[CodeBuddy CN][IDE Token] 官方空请求体失败，回退 PackageStartTimeRange: {}",
+                err
+            ));
+            empty_err = Some(err);
+        }
+    }
+
     let product_code = normalize_product_code(None);
     let status = normalize_user_resource_status(&[]);
-    let (package_end_time_range_begin, package_end_time_range_end) =
+    let (package_start_time_range_begin, package_start_time_range_end) =
         build_default_user_resource_time_range();
-    fetch_user_resource_with_access_token(
+    match fetch_user_resource_with_access_token(
         access_token,
         uid,
         enterprise_id,
         domain,
         product_code.as_str(),
         &status,
-        package_end_time_range_begin.as_str(),
-        package_end_time_range_end.as_str(),
+        package_start_time_range_begin.as_str(),
+        package_start_time_range_end.as_str(),
         1,
         100,
     )
     .await
+    {
+        Ok(body) if user_resource_has_payload(&body) => Ok(body),
+        Ok(body) => Ok(empty_ok.unwrap_or(body)),
+        Err(err) => empty_ok.ok_or_else(|| empty_err.unwrap_or(err)),
+    }
 }
 
 async fn refresh_payload_for_account_inner(

--- a/crates/cockpit-core/src/modules/codebuddy_oauth.rs
+++ b/crates/cockpit-core/src/modules/codebuddy_oauth.rs
@@ -65,12 +65,26 @@ fn normalize_user_resource_status(status: &[i32]) -> Vec<i32> {
 }
 
 fn build_default_user_resource_time_range() -> (String, String) {
+    // Official WorkBuddy 5.4.5 / CodeBuddy web client uses PackageStartTimeRange
+    // from a fixed start date to now. PackageEndTimeRange is rejected with HTTP 403.
     let now = chrono::Local::now();
-    let begin = now.format("%Y-%m-%d %H:%M:%S").to_string();
-    let end = (now + chrono::Duration::days(365 * 101))
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string();
+    let begin = "2024-12-01 21:25:00".to_string();
+    let end = now.format("%Y-%m-%d %H:%M:%S").to_string();
     (begin, end)
+}
+
+fn user_resource_has_payload(body: &Value) -> bool {
+    let has_resources = body
+        .pointer("/data/resources")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    let has_accounts = body
+        .pointer("/data/Response/Data/Accounts")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    has_resources || has_accounts
 }
 
 fn clear_pending_login(login_id: &str) -> Result<(), String> {
@@ -553,20 +567,29 @@ pub async fn fetch_user_resource_with_access_token(
     page_number: i32,
     page_size: i32,
 ) -> Result<Value, String> {
-    let client = build_client()?;
-    let url = format!(
-        "{}/v2/billing/meter/get-user-resource",
-        CODEBUDDY_API_ENDPOINT
-    );
-
     let body = json!({
         "PageNumber": page_number,
         "PageSize": page_size,
         "ProductCode": product_code,
         "Status": status,
-        "PackageEndTimeRangeBegin": package_end_time_range_begin,
-        "PackageEndTimeRangeEnd": package_end_time_range_end
+        "PackageStartTimeRangeBegin": package_end_time_range_begin,
+        "PackageStartTimeRangeEnd": package_end_time_range_end
     });
+    post_user_resource(access_token, uid, enterprise_id, domain, body).await
+}
+
+async fn post_user_resource(
+    access_token: &str,
+    uid: Option<&str>,
+    enterprise_id: Option<&str>,
+    domain: Option<&str>,
+    body: Value,
+) -> Result<Value, String> {
+    let client = build_client()?;
+    let url = format!(
+        "{}/v2/billing/meter/get-user-resource",
+        CODEBUDDY_API_ENDPOINT
+    );
 
     let mut req = client
         .post(&url)
@@ -590,7 +613,7 @@ pub async fn fetch_user_resource_with_access_token(
         .json(&body)
         .send()
         .await
-        .map_err(|e| format!("请求 user resource（Token）失败: {}", e))?;
+        .map_err(|e| format!("请求 user resource（Token）失败:{}", e))?;
 
     let status_code = resp.status();
     let content_type = resp
@@ -605,19 +628,21 @@ pub async fn fetch_user_resource_with_access_token(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_string();
-
-    let body: Value = resp.json().await.map_err(|e| {
-        format!(
-            "解析 user resource（Token）响应失败: {} (http={}, url={}, has_uid={}, has_enterprise_id={}, content_type={}, content_encoding={})",
-            e,
-            status_code.as_u16(),
-            url,
-            uid.is_some(),
-            enterprise_id.is_some(),
-            content_type,
-            content_encoding
-        )
-    })?;
+    let body: Value = resp
+        .json()
+        .await
+        .map_err(|e| {
+            format!(
+                "解析 user resource（Token）响应失败:{} (http={}, url={}, has_uid={}, has_enterprise_id={}, content_type={}, content_encoding={})",
+                e,
+                status_code.as_u16(),
+                url,
+                uid.is_some(),
+                enterprise_id.is_some(),
+                content_type,
+                content_encoding
+            )
+        })?;
 
     if !status_code.is_success() {
         let message = body
@@ -655,23 +680,51 @@ async fn fetch_user_resource_with_access_token_default(
     enterprise_id: Option<&str>,
     domain: Option<&str>,
 ) -> Result<Value, String> {
+    // Official WorkBuddy desktop billing() posts an empty body and reads data.resources.
+    let mut empty_ok: Option<Value> = None;
+    let mut empty_err: Option<String> = None;
+    match post_user_resource(access_token, uid, enterprise_id, domain, json!({})).await {
+        Ok(body) if user_resource_has_payload(&body) => {
+            logger::log_info("[CodeBuddy][IDE Token] user_resource 使用官方空请求体 Credits 接口成功");
+            return Ok(body);
+        }
+        Ok(body) => {
+            logger::log_info(
+                "[CodeBuddy][IDE Token] 官方空请求体未返回资源，回退 PackageStartTimeRange",
+            );
+            empty_ok = Some(body);
+        }
+        Err(err) => {
+            logger::log_warn(&format!(
+                "[CodeBuddy][IDE Token] 官方空请求体失败，回退 PackageStartTimeRange: {}",
+                err
+            ));
+            empty_err = Some(err);
+        }
+    }
+
     let product_code = normalize_product_code(None);
     let status = normalize_user_resource_status(&[]);
-    let (package_end_time_range_begin, package_end_time_range_end) =
+    let (package_start_time_range_begin, package_start_time_range_end) =
         build_default_user_resource_time_range();
-    fetch_user_resource_with_access_token(
+    match fetch_user_resource_with_access_token(
         access_token,
         uid,
         enterprise_id,
         domain,
         product_code.as_str(),
         &status,
-        package_end_time_range_begin.as_str(),
-        package_end_time_range_end.as_str(),
+        package_start_time_range_begin.as_str(),
+        package_start_time_range_end.as_str(),
         1,
         100,
     )
     .await
+    {
+        Ok(body) if user_resource_has_payload(&body) => Ok(body),
+        Ok(body) => Ok(empty_ok.unwrap_or(body)),
+        Err(err) => empty_ok.ok_or_else(|| empty_err.unwrap_or(err)),
+    }
 }
 
 async fn refresh_payload_for_account_inner(

--- a/crates/cockpit-core/src/modules/workbuddy_oauth.rs
+++ b/crates/cockpit-core/src/modules/workbuddy_oauth.rs
@@ -68,12 +68,26 @@ fn normalize_user_resource_status(status: &[i32]) -> Vec<i32> {
 }
 
 fn build_default_user_resource_time_range() -> (String, String) {
+    // Official WorkBuddy 5.4.5 / CodeBuddy web client uses PackageStartTimeRange
+    // from a fixed start date to now. PackageEndTimeRange is rejected with HTTP 403.
     let now = chrono::Local::now();
-    let begin = now.format("%Y-%m-%d %H:%M:%S").to_string();
-    let end = (now + chrono::Duration::days(365 * 101))
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string();
+    let begin = "2024-12-01 21:25:00".to_string();
+    let end = now.format("%Y-%m-%d %H:%M:%S").to_string();
     (begin, end)
+}
+
+fn user_resource_has_payload(body: &Value) -> bool {
+    let has_resources = body
+        .pointer("/data/resources")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    let has_accounts = body
+        .pointer("/data/Response/Data/Accounts")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    has_resources || has_accounts
 }
 
 fn clear_pending_login(login_id: &str) -> Result<(), String> {
@@ -545,32 +559,18 @@ pub async fn fetch_payment_type(
     Ok(body)
 }
 
-pub async fn fetch_user_resource_with_access_token(
+async fn post_user_resource(
     access_token: &str,
     uid: Option<&str>,
     enterprise_id: Option<&str>,
     domain: Option<&str>,
-    product_code: &str,
-    status: &[i32],
-    package_end_time_range_begin: &str,
-    package_end_time_range_end: &str,
-    page_number: i32,
-    page_size: i32,
+    body: Value,
 ) -> Result<Value, String> {
     let client = build_client()?;
     let url = format!(
         "{}/v2/billing/meter/get-user-resource",
         WORKBUDDY_API_ENDPOINT
     );
-
-    let body = json!({
-        "PageNumber": page_number,
-        "PageSize": page_size,
-        "ProductCode": product_code,
-        "Status": status,
-        "PackageEndTimeRangeBegin": package_end_time_range_begin,
-        "PackageEndTimeRangeEnd": package_end_time_range_end
-    });
 
     let mut req = client
         .post(&url)
@@ -655,29 +655,80 @@ pub async fn fetch_user_resource_with_access_token(
     Ok(body)
 }
 
+pub async fn fetch_user_resource_with_access_token(
+    access_token: &str,
+    uid: Option<&str>,
+    enterprise_id: Option<&str>,
+    domain: Option<&str>,
+    product_code: &str,
+    status: &[i32],
+    package_end_time_range_begin: &str,
+    package_end_time_range_end: &str,
+    page_number: i32,
+    page_size: i32,
+) -> Result<Value, String> {
+    let body = json!({
+        "PageNumber": page_number,
+        "PageSize": page_size,
+        "ProductCode": product_code,
+        "Status": status,
+        "PackageStartTimeRangeBegin": package_end_time_range_begin,
+        "PackageStartTimeRangeEnd": package_end_time_range_end
+    });
+    post_user_resource(access_token, uid, enterprise_id, domain, body).await
+}
+
 async fn fetch_user_resource_with_access_token_default(
     access_token: &str,
     uid: Option<&str>,
     enterprise_id: Option<&str>,
     domain: Option<&str>,
 ) -> Result<Value, String> {
+    // Official WorkBuddy desktop billing() posts an empty body and reads data.resources.
+    let mut empty_ok: Option<Value> = None;
+    let mut empty_err: Option<String> = None;
+    match post_user_resource(access_token, uid, enterprise_id, domain, json!({})).await {
+        Ok(body) if user_resource_has_payload(&body) => {
+            logger::log_info("[WorkBuddy][IDE Token] user_resource 使用官方空请求体 Credits 接口成功");
+            return Ok(body);
+        }
+        Ok(body) => {
+            logger::log_info(
+                "[WorkBuddy][IDE Token] 官方空请求体未返回资源，回退 PackageStartTimeRange",
+            );
+            empty_ok = Some(body);
+        }
+        Err(err) => {
+            logger::log_warn(&format!(
+                "[WorkBuddy][IDE Token] 官方空请求体失败，回退 PackageStartTimeRange: {}",
+                err
+            ));
+            empty_err = Some(err);
+        }
+    }
+
     let product_code = normalize_product_code(None);
     let status = normalize_user_resource_status(&[]);
-    let (package_end_time_range_begin, package_end_time_range_end) =
+    let (package_start_time_range_begin, package_start_time_range_end) =
         build_default_user_resource_time_range();
-    fetch_user_resource_with_access_token(
+    match fetch_user_resource_with_access_token(
         access_token,
         uid,
         enterprise_id,
         domain,
         product_code.as_str(),
         &status,
-        package_end_time_range_begin.as_str(),
-        package_end_time_range_end.as_str(),
+        package_start_time_range_begin.as_str(),
+        package_start_time_range_end.as_str(),
         1,
         100,
     )
     .await
+    {
+        Ok(body) if user_resource_has_payload(&body) => Ok(body),
+        Ok(body) => Ok(empty_ok.unwrap_or(body)),
+        Err(err) => empty_ok.ok_or_else(|| empty_err.unwrap_or(err)),
+    }
 }
 
 async fn refresh_payload_for_account_inner(

--- a/src-tauri/src/modules/codebuddy_cn_oauth.rs
+++ b/src-tauri/src/modules/codebuddy_cn_oauth.rs
@@ -71,12 +71,26 @@ fn normalize_user_resource_status(status: &[i32]) -> Vec<i32> {
 }
 
 fn build_default_user_resource_time_range() -> (String, String) {
+    // Official WorkBuddy 5.4.5 / CodeBuddy web client uses PackageStartTimeRange
+    // from a fixed start date to now. PackageEndTimeRange is rejected with HTTP 403.
     let now = chrono::Local::now();
-    let begin = now.format("%Y-%m-%d %H:%M:%S").to_string();
-    let end = (now + chrono::Duration::days(365 * 101))
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string();
+    let begin = "2024-12-01 21:25:00".to_string();
+    let end = now.format("%Y-%m-%d %H:%M:%S").to_string();
     (begin, end)
+}
+
+fn user_resource_has_payload(body: &Value) -> bool {
+    let has_resources = body
+        .pointer("/data/resources")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    let has_accounts = body
+        .pointer("/data/Response/Data/Accounts")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    has_resources || has_accounts
 }
 
 fn clear_pending_login(login_id: &str) -> Result<(), String> {
@@ -563,20 +577,29 @@ pub async fn fetch_user_resource_with_access_token(
     page_number: i32,
     page_size: i32,
 ) -> Result<Value, String> {
-    let client = build_client()?;
-    let url = format!(
-        "{}/v2/billing/meter/get-user-resource",
-        CODEBUDDY_API_ENDPOINT
-    );
-
     let body = json!({
         "PageNumber": page_number,
         "PageSize": page_size,
         "ProductCode": product_code,
         "Status": status,
-        "PackageEndTimeRangeBegin": package_end_time_range_begin,
-        "PackageEndTimeRangeEnd": package_end_time_range_end
+        "PackageStartTimeRangeBegin": package_end_time_range_begin,
+        "PackageStartTimeRangeEnd": package_end_time_range_end
     });
+    post_user_resource(access_token, uid, enterprise_id, domain, body).await
+}
+
+async fn post_user_resource(
+    access_token: &str,
+    uid: Option<&str>,
+    enterprise_id: Option<&str>,
+    domain: Option<&str>,
+    body: Value,
+) -> Result<Value, String> {
+    let client = build_client()?;
+    let url = format!(
+        "{}/v2/billing/meter/get-user-resource",
+        CODEBUDDY_API_ENDPOINT
+    );
 
     let mut req = client
         .post(&url)
@@ -600,7 +623,7 @@ pub async fn fetch_user_resource_with_access_token(
         .json(&body)
         .send()
         .await
-        .map_err(|e| format!("请求 user resource（Token）失败: {}", e))?;
+        .map_err(|e| format!("请求 user resource（Token）失败:{}", e))?;
 
     let status_code = resp.status();
     let content_type = resp
@@ -620,7 +643,7 @@ pub async fn fetch_user_resource_with_access_token(
         .await
         .map_err(|e| {
             format!(
-                "解析 user resource（Token）响应失败: {} (http={}, url={}, has_uid={}, has_enterprise_id={}, content_type={}, content_encoding={})",
+                "解析 user resource（Token）响应失败:{} (http={}, url={}, has_uid={}, has_enterprise_id={}, content_type={}, content_encoding={})",
                 e,
                 status_code.as_u16(),
                 url,
@@ -797,23 +820,51 @@ async fn fetch_user_resource_with_access_token_default(
     enterprise_id: Option<&str>,
     domain: Option<&str>,
 ) -> Result<Value, String> {
+    // Official WorkBuddy desktop billing() posts an empty body and reads data.resources.
+    let mut empty_ok: Option<Value> = None;
+    let mut empty_err: Option<String> = None;
+    match post_user_resource(access_token, uid, enterprise_id, domain, json!({})).await {
+        Ok(body) if user_resource_has_payload(&body) => {
+            logger::log_info("[CodeBuddy CN][IDE Token] user_resource 使用官方空请求体 Credits 接口成功");
+            return Ok(body);
+        }
+        Ok(body) => {
+            logger::log_info(
+                "[CodeBuddy CN][IDE Token] 官方空请求体未返回资源，回退 PackageStartTimeRange",
+            );
+            empty_ok = Some(body);
+        }
+        Err(err) => {
+            logger::log_warn(&format!(
+                "[CodeBuddy CN][IDE Token] 官方空请求体失败，回退 PackageStartTimeRange: {}",
+                err
+            ));
+            empty_err = Some(err);
+        }
+    }
+
     let product_code = normalize_product_code(None);
     let status = normalize_user_resource_status(&[]);
-    let (package_end_time_range_begin, package_end_time_range_end) =
+    let (package_start_time_range_begin, package_start_time_range_end) =
         build_default_user_resource_time_range();
-    fetch_user_resource_with_access_token(
+    match fetch_user_resource_with_access_token(
         access_token,
         uid,
         enterprise_id,
         domain,
         product_code.as_str(),
         &status,
-        package_end_time_range_begin.as_str(),
-        package_end_time_range_end.as_str(),
+        package_start_time_range_begin.as_str(),
+        package_start_time_range_end.as_str(),
         1,
         100,
     )
     .await
+    {
+        Ok(body) if user_resource_has_payload(&body) => Ok(body),
+        Ok(body) => Ok(empty_ok.unwrap_or(body)),
+        Err(err) => empty_ok.ok_or_else(|| empty_err.unwrap_or(err)),
+    }
 }
 
 async fn refresh_payload_for_account_inner(
@@ -908,11 +959,7 @@ async fn refresh_payload_for_account_inner(
             // 企业账号时 get-user-resource 可能返回空 Accounts，
             // 改用网页端真实的企业用量接口兜底
             if let Some(eid) = resolved_enterprise_id.as_deref() {
-                let accounts_empty = payload
-                    .pointer("/data/Response/Data/Accounts")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| arr.is_empty())
-                    .unwrap_or(true);
+                let accounts_empty = !user_resource_has_payload(&payload);
                 if accounts_empty {
                     match fetch_enterprise_user_usage(new_access_token.as_str(), eid).await {
                         Ok(enterprise_body) => {

--- a/src-tauri/src/modules/codebuddy_oauth.rs
+++ b/src-tauri/src/modules/codebuddy_oauth.rs
@@ -65,12 +65,26 @@ fn normalize_user_resource_status(status: &[i32]) -> Vec<i32> {
 }
 
 fn build_default_user_resource_time_range() -> (String, String) {
+    // Official WorkBuddy 5.4.5 / CodeBuddy web client uses PackageStartTimeRange
+    // from a fixed start date to now. PackageEndTimeRange is rejected with HTTP 403.
     let now = chrono::Local::now();
-    let begin = now.format("%Y-%m-%d %H:%M:%S").to_string();
-    let end = (now + chrono::Duration::days(365 * 101))
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string();
+    let begin = "2024-12-01 21:25:00".to_string();
+    let end = now.format("%Y-%m-%d %H:%M:%S").to_string();
     (begin, end)
+}
+
+fn user_resource_has_payload(body: &Value) -> bool {
+    let has_resources = body
+        .pointer("/data/resources")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    let has_accounts = body
+        .pointer("/data/Response/Data/Accounts")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    has_resources || has_accounts
 }
 
 fn clear_pending_login(login_id: &str) -> Result<(), String> {
@@ -553,20 +567,29 @@ pub async fn fetch_user_resource_with_access_token(
     page_number: i32,
     page_size: i32,
 ) -> Result<Value, String> {
-    let client = build_client()?;
-    let url = format!(
-        "{}/v2/billing/meter/get-user-resource",
-        CODEBUDDY_API_ENDPOINT
-    );
-
     let body = json!({
         "PageNumber": page_number,
         "PageSize": page_size,
         "ProductCode": product_code,
         "Status": status,
-        "PackageEndTimeRangeBegin": package_end_time_range_begin,
-        "PackageEndTimeRangeEnd": package_end_time_range_end
+        "PackageStartTimeRangeBegin": package_end_time_range_begin,
+        "PackageStartTimeRangeEnd": package_end_time_range_end
     });
+    post_user_resource(access_token, uid, enterprise_id, domain, body).await
+}
+
+async fn post_user_resource(
+    access_token: &str,
+    uid: Option<&str>,
+    enterprise_id: Option<&str>,
+    domain: Option<&str>,
+    body: Value,
+) -> Result<Value, String> {
+    let client = build_client()?;
+    let url = format!(
+        "{}/v2/billing/meter/get-user-resource",
+        CODEBUDDY_API_ENDPOINT
+    );
 
     let mut req = client
         .post(&url)
@@ -590,7 +613,7 @@ pub async fn fetch_user_resource_with_access_token(
         .json(&body)
         .send()
         .await
-        .map_err(|e| format!("请求 user resource（Token）失败: {}", e))?;
+        .map_err(|e| format!("请求 user resource（Token）失败:{}", e))?;
 
     let status_code = resp.status();
     let content_type = resp
@@ -605,19 +628,21 @@ pub async fn fetch_user_resource_with_access_token(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_string();
-
-    let body: Value = resp.json().await.map_err(|e| {
-        format!(
-            "解析 user resource（Token）响应失败: {} (http={}, url={}, has_uid={}, has_enterprise_id={}, content_type={}, content_encoding={})",
-            e,
-            status_code.as_u16(),
-            url,
-            uid.is_some(),
-            enterprise_id.is_some(),
-            content_type,
-            content_encoding
-        )
-    })?;
+    let body: Value = resp
+        .json()
+        .await
+        .map_err(|e| {
+            format!(
+                "解析 user resource（Token）响应失败:{} (http={}, url={}, has_uid={}, has_enterprise_id={}, content_type={}, content_encoding={})",
+                e,
+                status_code.as_u16(),
+                url,
+                uid.is_some(),
+                enterprise_id.is_some(),
+                content_type,
+                content_encoding
+            )
+        })?;
 
     if !status_code.is_success() {
         let message = body
@@ -655,23 +680,51 @@ async fn fetch_user_resource_with_access_token_default(
     enterprise_id: Option<&str>,
     domain: Option<&str>,
 ) -> Result<Value, String> {
+    // Official WorkBuddy desktop billing() posts an empty body and reads data.resources.
+    let mut empty_ok: Option<Value> = None;
+    let mut empty_err: Option<String> = None;
+    match post_user_resource(access_token, uid, enterprise_id, domain, json!({})).await {
+        Ok(body) if user_resource_has_payload(&body) => {
+            logger::log_info("[CodeBuddy][IDE Token] user_resource 使用官方空请求体 Credits 接口成功");
+            return Ok(body);
+        }
+        Ok(body) => {
+            logger::log_info(
+                "[CodeBuddy][IDE Token] 官方空请求体未返回资源，回退 PackageStartTimeRange",
+            );
+            empty_ok = Some(body);
+        }
+        Err(err) => {
+            logger::log_warn(&format!(
+                "[CodeBuddy][IDE Token] 官方空请求体失败，回退 PackageStartTimeRange: {}",
+                err
+            ));
+            empty_err = Some(err);
+        }
+    }
+
     let product_code = normalize_product_code(None);
     let status = normalize_user_resource_status(&[]);
-    let (package_end_time_range_begin, package_end_time_range_end) =
+    let (package_start_time_range_begin, package_start_time_range_end) =
         build_default_user_resource_time_range();
-    fetch_user_resource_with_access_token(
+    match fetch_user_resource_with_access_token(
         access_token,
         uid,
         enterprise_id,
         domain,
         product_code.as_str(),
         &status,
-        package_end_time_range_begin.as_str(),
-        package_end_time_range_end.as_str(),
+        package_start_time_range_begin.as_str(),
+        package_start_time_range_end.as_str(),
         1,
         100,
     )
     .await
+    {
+        Ok(body) if user_resource_has_payload(&body) => Ok(body),
+        Ok(body) => Ok(empty_ok.unwrap_or(body)),
+        Err(err) => empty_ok.ok_or_else(|| empty_err.unwrap_or(err)),
+    }
 }
 
 async fn refresh_payload_for_account_inner(

--- a/src-tauri/src/modules/workbuddy_oauth.rs
+++ b/src-tauri/src/modules/workbuddy_oauth.rs
@@ -70,12 +70,26 @@ fn normalize_user_resource_status(status: &[i32]) -> Vec<i32> {
 }
 
 fn build_default_user_resource_time_range() -> (String, String) {
+    // Official WorkBuddy 5.4.5 / CodeBuddy web client uses PackageStartTimeRange
+    // from a fixed start date to now. PackageEndTimeRange is rejected with HTTP 403.
     let now = chrono::Local::now();
-    let begin = now.format("%Y-%m-%d %H:%M:%S").to_string();
-    let end = (now + chrono::Duration::days(365 * 101))
-        .format("%Y-%m-%d %H:%M:%S")
-        .to_string();
+    let begin = "2024-12-01 21:25:00".to_string();
+    let end = now.format("%Y-%m-%d %H:%M:%S").to_string();
     (begin, end)
+}
+
+fn user_resource_has_payload(body: &Value) -> bool {
+    let has_resources = body
+        .pointer("/data/resources")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    let has_accounts = body
+        .pointer("/data/Response/Data/Accounts")
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false);
+    has_resources || has_accounts
 }
 
 fn clear_pending_login(login_id: &str) -> Result<(), String> {
@@ -559,20 +573,29 @@ pub async fn fetch_user_resource_with_access_token(
     page_number: i32,
     page_size: i32,
 ) -> Result<Value, String> {
-    let client = build_client()?;
-    let url = format!(
-        "{}/v2/billing/meter/get-user-resource",
-        WORKBUDDY_API_ENDPOINT
-    );
-
     let body = json!({
         "PageNumber": page_number,
         "PageSize": page_size,
         "ProductCode": product_code,
         "Status": status,
-        "PackageEndTimeRangeBegin": package_end_time_range_begin,
-        "PackageEndTimeRangeEnd": package_end_time_range_end
+        "PackageStartTimeRangeBegin": package_end_time_range_begin,
+        "PackageStartTimeRangeEnd": package_end_time_range_end
     });
+    post_user_resource(access_token, uid, enterprise_id, domain, body).await
+}
+
+async fn post_user_resource(
+    access_token: &str,
+    uid: Option<&str>,
+    enterprise_id: Option<&str>,
+    domain: Option<&str>,
+    body: Value,
+) -> Result<Value, String> {
+    let client = build_client()?;
+    let url = format!(
+        "{}/v2/billing/meter/get-user-resource",
+        WORKBUDDY_API_ENDPOINT
+    );
 
     let mut req = client
         .post(&url)
@@ -785,23 +808,51 @@ async fn fetch_user_resource_with_access_token_default(
     enterprise_id: Option<&str>,
     domain: Option<&str>,
 ) -> Result<Value, String> {
+    // Official WorkBuddy desktop billing() posts an empty body and reads data.resources.
+    let mut empty_ok: Option<Value> = None;
+    let mut empty_err: Option<String> = None;
+    match post_user_resource(access_token, uid, enterprise_id, domain, json!({})).await {
+        Ok(body) if user_resource_has_payload(&body) => {
+            logger::log_info("[WorkBuddy][IDE Token] user_resource 使用官方空请求体 Credits 接口成功");
+            return Ok(body);
+        }
+        Ok(body) => {
+            logger::log_info(
+                "[WorkBuddy][IDE Token] 官方空请求体未返回资源，回退 PackageStartTimeRange",
+            );
+            empty_ok = Some(body);
+        }
+        Err(err) => {
+            logger::log_warn(&format!(
+                "[WorkBuddy][IDE Token] 官方空请求体失败，回退 PackageStartTimeRange: {}",
+                err
+            ));
+            empty_err = Some(err);
+        }
+    }
+
     let product_code = normalize_product_code(None);
     let status = normalize_user_resource_status(&[]);
-    let (package_end_time_range_begin, package_end_time_range_end) =
+    let (package_start_time_range_begin, package_start_time_range_end) =
         build_default_user_resource_time_range();
-    fetch_user_resource_with_access_token(
+    match fetch_user_resource_with_access_token(
         access_token,
         uid,
         enterprise_id,
         domain,
         product_code.as_str(),
         &status,
-        package_end_time_range_begin.as_str(),
-        package_end_time_range_end.as_str(),
+        package_start_time_range_begin.as_str(),
+        package_start_time_range_end.as_str(),
         1,
         100,
     )
     .await
+    {
+        Ok(body) if user_resource_has_payload(&body) => Ok(body),
+        Ok(body) => Ok(empty_ok.unwrap_or(body)),
+        Err(err) => empty_ok.ok_or_else(|| empty_err.unwrap_or(err)),
+    }
 }
 
 async fn refresh_payload_for_account_inner(
@@ -896,11 +947,7 @@ async fn refresh_payload_for_account_inner(
             // 企业账号时 get-user-resource 可能返回空 Accounts，
             // 改用网页端真实的企业用量接口兜底
             if let Some(eid) = resolved_enterprise_id.as_deref() {
-                let accounts_empty = payload
-                    .pointer("/data/Response/Data/Accounts")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| arr.is_empty())
-                    .unwrap_or(true);
+                let accounts_empty = !user_resource_has_payload(&payload);
                 if accounts_empty {
                     match fetch_enterprise_user_usage(new_access_token.as_str(), eid).await {
                         Ok(enterprise_body) => {

--- a/src/utils/codebuddy-suite/parser.ts
+++ b/src/utils/codebuddy-suite/parser.ts
@@ -42,7 +42,12 @@ export function parseDateTimeToEpoch(value: unknown): number | null {
  */
 export function parseCycleTotal(a: Record<string, unknown>): number {
   return (
-    parseNumeric(a.CycleCapacitySizePrecise) ?? parseNumeric(a.CycleCapacitySize) ?? parseNumeric(a.CapacitySizePrecise) ?? parseNumeric(a.CapacitySize) ?? 0
+    parseNumeric(a.CycleCapacitySizePrecise) ??
+    parseNumeric(a.CycleCapacitySize) ??
+    parseNumeric(a.CapacitySizePrecise) ??
+    parseNumeric(a.CapacitySize) ??
+    parseNumeric(a.total) ??
+    0
   );
 }
 
@@ -51,7 +56,13 @@ export function parseCycleTotal(a: Record<string, unknown>): number {
  */
 export function parseCycleRemain(a: Record<string, unknown>): number {
   return (
-    parseNumeric(a.CycleCapacityRemainPrecise) ?? parseNumeric(a.CycleCapacityRemain) ?? parseNumeric(a.CapacityRemainPrecise) ?? parseNumeric(a.CapacityRemain) ?? 0
+    parseNumeric(a.CycleCapacityRemainPrecise) ??
+    parseNumeric(a.CycleCapacityRemain) ??
+    parseNumeric(a.CapacityRemainPrecise) ??
+    parseNumeric(a.CapacityRemain) ??
+    parseNumeric(a.remaining) ??
+    parseNumeric(a.remain) ??
+    0
   );
 }
 
@@ -59,8 +70,11 @@ export function parseCycleRemain(a: Record<string, unknown>): number {
  * 检查是否为活跃资源
  */
 export function isActiveResource(a: Record<string, unknown>): boolean {
-  const s = typeof a.Status === 'number' ? a.Status : -1;
-  return s === RESOURCE_STATUS.valid || s === RESOURCE_STATUS.usedUp;
+  const s = typeof a.Status === 'number' ? a.Status : null;
+  if (s === RESOURCE_STATUS.valid || s === RESOURCE_STATUS.usedUp) return true;
+  // Official WorkBuddy desktop credits resources may omit Status.
+  if (s == null && (parseCycleTotal(a) > 0 || parseCycleRemain(a) > 0)) return true;
+  return false;
 }
 
 /**
@@ -87,6 +101,40 @@ export function isProPackage(a: Record<string, unknown>): boolean {
   return code === PACKAGE_CODE.proMon || code === PACKAGE_CODE.proYear;
 }
 
+function mapDesktopCreditResource(raw: Record<string, unknown>): Record<string, unknown> {
+  const remaining = parseNumeric(raw.remaining) ?? parseNumeric(raw.remain) ?? parseCycleRemain(raw);
+  const total = parseNumeric(raw.total) ?? parseCycleTotal(raw) ?? remaining;
+  const name =
+    (typeof raw.name === 'string' && raw.name) ||
+    (typeof raw.PackageName === 'string' && raw.PackageName) ||
+    null;
+  const code =
+    (typeof raw.commodity_code === 'string' && raw.commodity_code) ||
+    (typeof raw.commodityCode === 'string' && raw.commodityCode) ||
+    (typeof raw.PackageCode === 'string' && raw.PackageCode) ||
+    null;
+  const inferredCode = code || (name?.includes('基础') ? PACKAGE_CODE.free : null);
+  const expire = raw.expire_at ?? raw.expireAt ?? raw.ExpiredTime ?? raw.CycleEndTime ?? null;
+  const expireText = expire == null ? null : String(expire);
+  const status =
+    typeof raw.Status === 'number' ? raw.Status : remaining > 0 ? RESOURCE_STATUS.valid : RESOURCE_STATUS.usedUp;
+
+  return {
+    ...raw,
+    PackageCode: inferredCode,
+    PackageName: name,
+    CycleCapacitySizePrecise: String(total),
+    CycleCapacityRemainPrecise: String(remaining),
+    CycleCapacitySize: total,
+    CycleCapacityRemain: remaining,
+    Status: status,
+    ExpiredTime: expireText,
+    DeductionEndTime: expire,
+    CycleEndTime: expireText,
+    __source: 'desktop-credits',
+  };
+}
+
 /**
  * 提取资源账号列表
  */
@@ -98,7 +146,19 @@ export function extractResourceAccounts(account: CodebuddySuiteAccountBase): Arr
   const response = asRecord(data?.Response);
   const payload = asRecord(response?.Data);
   const list = Array.isArray(payload?.Accounts) ? (payload!.Accounts as unknown[]) : [];
-  return list.filter((a): a is Record<string, unknown> => a != null && typeof a === 'object');
+  if (list.length > 0) {
+    return list.filter((a): a is Record<string, unknown> => a != null && typeof a === 'object');
+  }
+
+  // Official WorkBuddy desktop v5.4.5 billing() returns data.resources Credits rows.
+  const resources = Array.isArray(data?.resources)
+    ? data!.resources
+    : Array.isArray(userResource?.resources)
+      ? userResource!.resources
+      : [];
+  return resources
+    .filter((a): a is Record<string, unknown> => a != null && typeof a === 'object')
+    .map(mapDesktopCreditResource);
 }
 
 /**

--- a/src/utils/codebuddy-suite/quota-model.ts
+++ b/src/utils/codebuddy-suite/quota-model.ts
@@ -258,8 +258,10 @@ export function getOfficialQuotaModel(account: CodebuddySuiteAccountBase): Offic
   const mergedTrialOrFreeMon = aggregateCycleResources(trialOrFreeMon);
   const mergedFree = aggregateCycleResources(free);
   const mergedEnterprise = aggregateCycleResources(enterprise);
-  const ordered = [mergedTrialOrFreeMon, ...pro, ...activity, mergedEnterprise, mergedFree].filter(
-    (item): item is Record<string, unknown> => item != null && !!item.PackageCode,
+  const classified = new Set([...pro, ...extras, ...trialOrFreeMon, ...free, ...activity, ...enterprise]);
+  const leftovers = all.filter((item) => !classified.has(item));
+  const ordered = [mergedTrialOrFreeMon, ...pro, ...activity, mergedEnterprise, mergedFree, ...leftovers].filter(
+    (item): item is Record<string, unknown> => item != null && !!(item.PackageCode || item.PackageName),
   );
   const resources = ordered.map(toOfficialQuotaResource);
 
@@ -272,6 +274,7 @@ export function getOfficialQuotaModel(account: CodebuddySuiteAccountBase): Offic
  * 解析包名称
  */
 function resolvePackageName(resource: OfficialQuotaResource): string {
+  if (resource.packageName) return resource.packageName;
   if (resource.packageCode === PACKAGE_CODE.enterprise) return '企业版';
   if (resource.packageCode === PACKAGE_CODE.extra) return '加量包';
   if (resource.packageCode === PACKAGE_CODE.activity) return '活动赠送包';
@@ -281,7 +284,7 @@ function resolvePackageName(resource: OfficialQuotaResource): string {
   if (resource.packageCode === PACKAGE_CODE.proMon || resource.packageCode === PACKAGE_CODE.proYear) {
     return '专业版订阅';
   }
-  return resource.packageName || '基础包';
+  return '基础包';
 }
 
 /**
@@ -343,11 +346,19 @@ export function getQuotaCategoryGroups(account: CodebuddySuiteAccountBase, t: (k
 
   for (const resource of model.resources) {
     const code = resource.packageCode;
+    const name = resource.packageName || '';
     if (code === PACKAGE_CODE.enterprise) {
       baseItems.push(resource);
-    } else if (code === PACKAGE_CODE.free || code === PACKAGE_CODE.gift || code === PACKAGE_CODE.freeMon || code === PACKAGE_CODE.proMon || code === PACKAGE_CODE.proYear) {
+    } else if (
+      code === PACKAGE_CODE.free ||
+      code === PACKAGE_CODE.gift ||
+      code === PACKAGE_CODE.freeMon ||
+      code === PACKAGE_CODE.proMon ||
+      code === PACKAGE_CODE.proYear ||
+      name.includes('基础')
+    ) {
       baseItems.push(resource);
-    } else if (code === PACKAGE_CODE.activity) {
+    } else if (code === PACKAGE_CODE.activity || name.includes('赠')) {
       activityItems.push(resource);
     } else {
       otherItems.push(resource);


### PR DESCRIPTION
## 问题

官方 WorkBuddy 5.4.5 个人主页能查到 Credits（截图中累积剩余 7500、版本基础用量、权益赠包），Cockpit 刷新额度一直失败：

```
请求 user resource（Token）失败 (http=403): 请求不合法，如有疑问请联系客服
```

## 原因

Cockpit 调用 `POST /v2/billing/meter/get-user-resource` 时发送了旧参数：

- `PackageEndTimeRangeBegin` / `PackageEndTimeRangeEnd`
- `ProductCode` + `Status`

官方桌面端 `billing()` 已改为：

```js
http.post(`${this.billingPrefix}/billing/meter/get-user-resource`, {})
// resp.data.resources[].remaining / total / name / expire_at
```

网页端旧套餐接口则使用 `PackageStartTimeRangeBegin/End`，不再使用 EndTimeRange。

## 修复

- 先按官方桌面端发送空请求体，解析 `data.resources` Credits 列表
- 若无资源，再回退到官方网页端的 `PackageStartTimeRange` 请求
- 前端兼容 `data.resources`（remaining/total/name）和旧的 `data.Response.Data.Accounts`
- 同步到 WorkBuddy / CodeBuddy CN / CodeBuddy（同一套 billing 接口）

## 测试

- `cargo check -p cockpit-core` 通过
- 对照本地 `/Applications/WorkBuddy.app` 5.4.5 asar 中的 `DesktopAccountRepo.billing()` 实现