### PR TITLE
fix(billing): add User-Agent header to fix quota API 403 (WorkBuddy / CodeBuddy / CodeBuddy CN)

### DIFF
--- a/src-tauri/src/modules/codebuddy_cn_oauth.rs
+++ b/src-tauri/src/modules/codebuddy_cn_oauth.rs
@@ -40,8 +40,15 @@ fn generate_login_id() -> String {
     )
 }
 
+/// The billing gateway rejects requests without a User-Agent header with
+/// HTTP 403 / code=10085 ("请求不合法，请检查请求系统头"), while `reqwest`
+/// sends none by default. Any non-empty UA passes the gateway check.
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .user_agent(UA)
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))

--- a/src-tauri/src/modules/codebuddy_oauth.rs
+++ b/src-tauri/src/modules/codebuddy_oauth.rs
@@ -39,8 +39,15 @@ fn generate_login_id() -> String {
     )
 }
 
+/// The billing gateway rejects requests without a User-Agent header with
+/// HTTP 403 / code=10085 ("请求不合法，请检查请求系统头"), while `reqwest`
+/// sends none by default. Any non-empty UA passes the gateway check.
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .user_agent(UA)
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))

--- a/src-tauri/src/modules/workbuddy_oauth.rs
+++ b/src-tauri/src/modules/workbuddy_oauth.rs
@@ -39,8 +39,15 @@ fn generate_login_id() -> String {
     )
 }
 
+/// The billing gateway rejects requests without a User-Agent header with
+/// HTTP 403 / code=10085 ("请求不合法，请检查请求系统头"), while `reqwest`
+/// sends none by default. Any non-empty UA passes the gateway check.
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .user_agent(UA)
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败:{}", e))


### PR DESCRIPTION
## 问题

WorkBuddy / CodeBuddy / CodeBuddy CN 的**额度（quota）获取全部失效**。

账号数据里 6/6 个账号都记录了同一条错误：

```
quota_query_last_error: 请求 user resource（Token）失败 (http=403): 请求不合法，请检查请求系统头
quota_raw keys: ["dosage", "payment"]     ← 丢失 "userResource"
```

## 根因

计费网关（`/v2/billing/meter/get-user-resource`）新增了 **`User-Agent` 存在性校验**，而 `reqwest` 默认不发送 `User-Agent` 头 → 请求被网关拒绝。

用真实账号实测的 UA 矩阵：

| User-Agent | HTTP | 响应 |
|---|---|---|
| 不发送 | **403** | `{"code":10085,"msg":"请求不合法，请检查请求系统头"}` |
| 空字符串 | **403** | 同上 |
| `x`（任意单字符） | **200** | `code:0`, `TotalCount:45` |
| `curl/8.4.0` | **200** | `TotalCount:45` |
| 浏览器 UA | **200** | `TotalCount:45` |

即网关只做 UA **存在性**校验，任意非空 UA 均可通过。

对照组：同 token、同网关的 `get-dosage-notify` / `get-payment-type` 仍返回 200（该校验暂未覆盖这两个端点），因此只有额度字段丢失，`dosage` / `payment` 一切正常——这也是问题表现为"额度没了但其他信息还在"的原因。

**时间线**：最后一次成功 `2026-08-31 17:29`，首次 403 `2026-09-01 00:27`，属服务端新上线的校验。

## 影响范围

`get-user-resource` 在三处被调用，三个平台均受影响：

- `src-tauri/src/modules/workbuddy_oauth.rs`
- `src-tauri/src/modules/codebuddy_oauth.rs`
- `src-tauri/src/modules/codebuddy_cn_oauth.rs`

## 修复

在三个模块的 `build_client()` 上设置 UA，覆盖这些模块发出的全部请求：

```rust
const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";

reqwest::Client::builder()
    .user_agent(UA)   // ← 新增
    .timeout(std::time::Duration::from_secs(30))
```

与 `windsurf_devin_oauth.rs` 中已有的 `.user_agent(UA)` 写法保持一致。

## 验证

- `cargo check` 通过，无 error（仅仓库既有的 unused 警告）
- 用用户真实账号 token 实测：修复前 403，带 UA 后 200 且返回完整额度数据

## 备注

这是服务端策略变更，任何用 `reqwest` 默认配置请求该端点的客户端都会中招，建议尽快合入。
