### PR TITLE
修复 Windows 拖拽层遮挡工具栏点击

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -24,8 +24,8 @@
 }
 
 .app-container-windows .drag-region {
-  /* Windows 上拖拽层不能压过侧边菜单，否则缩放/布局变化后图标会被透明层截获点击。 */
-  z-index: 900;
+  /* Windows 使用原生标题栏；隐藏 WebView 拖拽层，避免其截获滚动到顶部的控件点击。 */
+  display: none;
 }
 
 .app-container-windows .side-nav,


### PR DESCRIPTION
## 中文说明

### 问题

Windows 使用原生标题栏，但页面内仍存在覆盖 WebView 顶部区域的透明拖拽层。当页面滚动后工具栏按钮进入该区域时，拖拽层会截获点击，导致按钮只有下半部分可以点击。

### 修复

- 在 Windows 上隐藏多余的 WebView 拖拽层，继续由原生标题栏负责窗口拖动
- 避免顶部工具栏按钮的点击区域被透明层遮挡
- 不改变其他平台的拖拽行为

### 验证

- `npm run typecheck`
- `npm run build`
- 已在 Windows 的 `Cockpit Tools Dev` 中手动验证：滚动到问题位置后，按钮完整区域均可点击

## English Summary

### Problem

Windows uses the native title bar, but a transparent WebView drag region still covers the top of the page. When toolbar controls scroll into that area, the drag region intercepts pointer input and leaves only the lower part of each button clickable.

### Fix

- hide the redundant WebView drag region on Windows while retaining native title-bar dragging
- keep the full toolbar click targets interactive near the top of the window
- leave drag behavior unchanged on other platforms

### Validation

- `npm run typecheck`
- `npm run build`
- manually verified in `Cockpit Tools Dev` on Windows at the affected scroll position
