### PR TITLE
fix: support Xcode 27 Swift package output paths

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -9,6 +9,24 @@ fn link_macos_swift_runtime_rpaths() {
     println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
 }
 
+#[cfg(target_os = "macos")]
+fn link_xcode_27_swift_package_products(package_name: &str) {
+    let configuration = if std::env::var("DEBUG").ok().as_deref() == Some("true") {
+        "Debug"
+    } else {
+        "Release"
+    };
+    let products_dir = PathBuf::from(
+        std::env::var("OUT_DIR").expect("OUT_DIR is required for Swift package linking"),
+    )
+    .join("swift-rs")
+    .join(package_name)
+    .join("out")
+    .join("Products")
+    .join(configuration);
+    println!("cargo:rustc-link-search=native={}", products_dir.display());
+}
+
 fn go_target_from_rust_target(target: &str) -> Option<(&'static str, &'static str)> {
     let goos = if target.contains("windows") {
         "windows"
@@ -173,6 +191,10 @@ fn main() {
         SwiftLinker::new("12.0")
             .with_package("MacosNativeMenuSwift", "native/macos-native-menu")
             .link();
+        // Swift 6.4 / Xcode 27 places static package products under
+        // out/Products/{Debug,Release}; swift-rs 1.0.7 still advertises the
+        // pre-Xcode-27 triple/configuration directory.
+        link_xcode_27_swift_package_products("MacosNativeMenuSwift");
         link_macos_swift_runtime_rpaths();
     }
 


### PR DESCRIPTION
## Summary

- add the Xcode 27 SwiftPM product directory to Cargo's native linker search paths
- select `Products/Debug` or `Products/Release` from Cargo's `DEBUG` environment value
- keep the existing `swift-rs` package integration and macOS Swift runtime rpath unchanged

## Problem

With Xcode 27 / Swift 6.4, SwiftPM places the `MacosNativeMenuSwift` static product under:

```text
$OUT_DIR/swift-rs/MacosNativeMenuSwift/out/Products/{Debug,Release}
```

`swift-rs` 1.0.7 still advertises the older triple/configuration output directory, so the final Rust/Tauri link step cannot find `libMacosNativeMenuSwift.a` even though SwiftPM built it successfully.

## Solution

Teach `src-tauri/build.rs` to add the actual Xcode 27 product directory with `cargo:rustc-link-search=native=...`. This is additive and preserves the existing search path, so older toolchain behavior remains available.

## Verification

Tested on macOS arm64 with Xcode 27.0 and Apple Swift 6.4:

- `npm run test:codex-api-key-scope` — 5 passed
- `npm run build` — passed, including typecheck and Vite production build
- `go test ./...` in `sidecars/cockpit-cliproxy` — passed
- full Rust suite — 1006 passed, 2 ignored, 0 failed
- `npm run tauri -- build --bundles app --target aarch64-apple-darwin --config src-tauri/tauri.ci.conf.json` — produced the macOS `.app` bundle successfully
- verified both bundled executables are arm64 Mach-O binaries
