### PR TITLE
fix(codebuddy): 恢复额度查询并修复切号后官方客户端会话失效

### DIFF
--- a/crates/cockpit-core/src/modules/codebuddy_account.rs
+++ b/crates/cockpit-core/src/modules/codebuddy_account.rs
@@ -952,6 +952,8 @@ fn payload_from_import_value(raw: Value) -> Result<CodebuddyOAuthCompletePayload
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    let expires_at = json_object_i64_field(obj, &["expires_at", "expiresAt"]);
+
     Ok(CodebuddyOAuthCompletePayload {
         email,
         uid,
@@ -961,7 +963,7 @@ fn payload_from_import_value(raw: Value) -> Result<CodebuddyOAuthCompletePayload
         access_token,
         refresh_token,
         token_type: Some("Bearer".to_string()),
-        expires_at: None,
+        expires_at,
         domain,
         plan_type: None,
         dosage_notify_code: None,

--- a/crates/cockpit-core/src/modules/codebuddy_cn_account.rs
+++ b/crates/cockpit-core/src/modules/codebuddy_cn_account.rs
@@ -985,6 +985,8 @@ fn payload_from_import_value(raw: Value) -> Result<CodebuddyOAuthCompletePayload
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    let expires_at = json_object_i64_field(obj, &["expires_at", "expiresAt"]);
+
     Ok(CodebuddyOAuthCompletePayload {
         email,
         uid,
@@ -994,7 +996,7 @@ fn payload_from_import_value(raw: Value) -> Result<CodebuddyOAuthCompletePayload
         access_token,
         refresh_token,
         token_type: Some("Bearer".to_string()),
-        expires_at: None,
+        expires_at,
         domain,
         plan_type: None,
         dosage_notify_code: None,

--- a/crates/cockpit-core/src/modules/codebuddy_cn_oauth.rs
+++ b/crates/cockpit-core/src/modules/codebuddy_cn_oauth.rs
@@ -40,8 +40,12 @@ fn generate_login_id() -> String {
     )
 }
 
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .user_agent(UA)
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))

--- a/crates/cockpit-core/src/modules/codebuddy_oauth.rs
+++ b/crates/cockpit-core/src/modules/codebuddy_oauth.rs
@@ -39,8 +39,12 @@ fn generate_login_id() -> String {
     )
 }
 
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .user_agent(UA)
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))

--- a/crates/cockpit-core/src/modules/workbuddy_account.rs
+++ b/crates/cockpit-core/src/modules/workbuddy_account.rs
@@ -951,6 +951,8 @@ fn payload_from_import_value(raw: Value) -> Result<WorkbuddyOAuthCompletePayload
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    let expires_at = json_object_i64_field(obj, &["expires_at", "expiresAt"]);
+
     Ok(WorkbuddyOAuthCompletePayload {
         email,
         uid,
@@ -960,7 +962,7 @@ fn payload_from_import_value(raw: Value) -> Result<WorkbuddyOAuthCompletePayload
         access_token,
         refresh_token,
         token_type: Some("Bearer".to_string()),
-        expires_at: None,
+        expires_at,
         domain,
         plan_type: None,
         dosage_notify_code: None,

--- a/crates/cockpit-core/src/modules/workbuddy_oauth.rs
+++ b/crates/cockpit-core/src/modules/workbuddy_oauth.rs
@@ -39,8 +39,12 @@ fn generate_login_id() -> String {
     )
 }
 
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .user_agent(UA)
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败:{}", e))

--- a/src-tauri/src/modules/codebuddy_account.rs
+++ b/src-tauri/src/modules/codebuddy_account.rs
@@ -1001,6 +1001,8 @@ fn payload_from_import_value(raw: Value) -> Result<CodebuddyOAuthCompletePayload
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    let expires_at = json_object_i64_field(obj, &["expires_at", "expiresAt"]);
+
     Ok(CodebuddyOAuthCompletePayload {
         email,
         uid,
@@ -1010,7 +1012,7 @@ fn payload_from_import_value(raw: Value) -> Result<CodebuddyOAuthCompletePayload
         access_token,
         refresh_token,
         token_type: Some("Bearer".to_string()),
-        expires_at: None,
+        expires_at,
         domain,
         plan_type: None,
         dosage_notify_code: None,

--- a/src-tauri/src/modules/codebuddy_cn_account.rs
+++ b/src-tauri/src/modules/codebuddy_cn_account.rs
@@ -1034,6 +1034,8 @@ fn payload_from_import_value(raw: Value) -> Result<CodebuddyOAuthCompletePayload
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    let expires_at = json_object_i64_field(obj, &["expires_at", "expiresAt"]);
+
     Ok(CodebuddyOAuthCompletePayload {
         email,
         uid,
@@ -1043,7 +1045,7 @@ fn payload_from_import_value(raw: Value) -> Result<CodebuddyOAuthCompletePayload
         access_token,
         refresh_token,
         token_type: Some("Bearer".to_string()),
-        expires_at: None,
+        expires_at,
         domain,
         plan_type: None,
         dosage_notify_code: None,

--- a/src-tauri/src/modules/codebuddy_cn_oauth.rs
+++ b/src-tauri/src/modules/codebuddy_cn_oauth.rs
@@ -42,8 +42,12 @@ fn generate_login_id() -> String {
     )
 }
 
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .user_agent(UA)
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))

--- a/src-tauri/src/modules/codebuddy_oauth.rs
+++ b/src-tauri/src/modules/codebuddy_oauth.rs
@@ -39,8 +39,12 @@ fn generate_login_id() -> String {
     )
 }
 
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .user_agent(UA)
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))

--- a/src-tauri/src/modules/workbuddy_account.rs
+++ b/src-tauri/src/modules/workbuddy_account.rs
@@ -1003,6 +1003,8 @@ fn payload_from_import_value(raw: Value) -> Result<WorkbuddyOAuthCompletePayload
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    let expires_at = json_object_i64_field(obj, &["expires_at", "expiresAt"]);
+
     Ok(WorkbuddyOAuthCompletePayload {
         email,
         uid,
@@ -1012,7 +1014,7 @@ fn payload_from_import_value(raw: Value) -> Result<WorkbuddyOAuthCompletePayload
         access_token,
         refresh_token,
         token_type: Some("Bearer".to_string()),
-        expires_at: None,
+        expires_at,
         domain,
         plan_type: None,
         dosage_notify_code: None,

--- a/src-tauri/src/modules/workbuddy_oauth.rs
+++ b/src-tauri/src/modules/workbuddy_oauth.rs
@@ -41,8 +41,12 @@ fn generate_login_id() -> String {
     )
 }
 
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
 fn build_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
+        .user_agent(UA)
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败:{}", e))


### PR DESCRIPTION
# PR：修复 CodeBuddy 系平台额度查询 403 与 JSON 导入账号切号后官方客户端会话失效

> 分支：`codebuddy_program`（基于 `main`）
> 提交：`fix(codebuddy): 恢复额度查询并修复切号后官方客户端会话失效`（12 files changed, +42 / −6）

---

## 一、背景

Cockpit Tools 中 CodeBuddy（国际站）、CodeBuddy CN（中国站）、WorkBuddy 三个平台共用同一套腾讯 CodeBuddy 账号体系（Keycloak realm：`copilot`）与计费网关：

- 账号额度：`POST /v2/billing/meter/get-user-resource`
- 用量状态：`POST /v2/billing/meter/get-dosage-notify`
- 订阅类型：`POST /v2/billing/meter/get-payment-type`

额度刷新链路：`refresh_account_token_once` → `refresh_payload_for_account` → `fetch_user_resource_with_access_token_default`，返回值写入账号的 `quota_raw` / `usage_raw`，由前端 `utils/codebuddy-suite/parser.ts` 按 `quota_raw.userResource.data.Response.Data.Accounts` 解析展示。

此外，工具支持将账号「切号」到官方 CodeBuddy CN 客户端：把账号凭据构造成官方 session JSON，写入客户端 `state.vscdb` 的 SecretStorage（`planning-genie.new.accessTokencn`）。

## 二、出现的问题

### 问题 1：三平台额度查询全部 403

2026-09-01 起，所有账号批量刷新额度时统一报错：

```text
WARN [CodeBuddy][IDE Token] 刷新 user_resource 失败:
请求 user resource（Token）失败 (http=403): 请求不合法，请检查请求系统头
```

- 账号 `quota_raw` keys 只剩 `["dosage", "payment"]`，**丢失 `userResource`**，前端显示「暂无可用配额数据」
- 同 token、同网关的 `get-dosage-notify` / `get-payment-type` 仍返回 200——这正是「用量状态正常、唯独额度没了」的原因

**根因**：计费网关对该接口新增了 **User-Agent 存在性校验**，而 Rust 侧 `reqwest::Client` 默认不发送 UA 头。用真实账号 token 实测的 UA 矩阵：

| User-Agent | HTTP | 响应 |
|---|---|---|
| 不发送 | 403 | `{"code":10085,"msg":"请求不合法，请检查请求系统头"}` |
| 空字符串 | 403 | 同上 |
| `x`（任意单字符） | 200 | `code:0, TotalCount:45` |
| `curl/8.4.0` | 200 | `TotalCount:45` |
| 浏览器 UA | 200 | `TotalCount:45` |

即网关只做 **UA 存在性校验**，任意非空 UA 均可通过。

**时间线**：最后一次成功 2026-08-31 17:29，首次 403 2026-09-01 00:27，属服务端新上线的校验。

### 问题 2：JSON 导入的账号切号后，官方客户端无法使用

用户通过「账号 JSON 文件导入」添加的 CodeBuddy CN 账号（文件内含 `access_token` / `refresh_token` / `expires_at`（毫秒时间戳）/ `domain`），在工具内切号到官方客户端后全部不可用，只有此前在客户端内自行登录的那条号保持正常。

**根因**：JSON 导入解析函数 `payload_from_import_value` 读取了 `refresh_token`、`domain` 等字段，但把 `expires_at` **硬编码丢弃**（`expires_at: None`）。切号注入时 `build_session_json` 执行 `account.expires_at.unwrap_or(0)`，写入官方客户端的 session 变成：

```json
{
  "refreshToken": "eyJ...",          // 有值
  "expiresAt": 0,                    // ← 客户端判定会话立即过期
  "auth": { "expiresAt": 0, "expiresIn": 0, ... }
}
```

官方客户端读到 `expiresAt: 0` 直接判定登录态无效，导致切号后客户端要求重新登录。

## 三、解决方法

1. **UA 修复**：在三个平台 oauth 模块的 `build_client()` 上统一补齐 `user_agent`，与仓库中 `windsurf_devin_oauth.rs` 已有的 `.user_agent(UA)` 写法保持一致。在 `Client::builder()` 层设置可一次覆盖这些模块发出的全部请求（OAuth、accounts、billing、签到等）。
2. **expires_at 修复**：JSON 导入时补读 `expires_at` / `expiresAt` 字段（兼容数字与字符串，复用既有 `json_object_i64_field` helper），使切号注入的 session 携带真实的过期时间。

两个修复同步应用于 `src-tauri`（桌面主程序）与 `crates/cockpit-core`（CLI 等复用 crate），保持两处实现一致。

## 四、修改的主要代码

### 1. `build_client()` 补齐 User-Agent（6 个文件）

`src-tauri/src/modules/codebuddy_cn_oauth.rs`、`codebuddy_oauth.rs`、`workbuddy_oauth.rs` 及 `crates/cockpit-core/src/modules/` 下对应三个模块：

```rust
const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
                  (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";

fn build_client() -> Result<reqwest::Client, String> {
    reqwest::Client::builder()
        .user_agent(UA)   // ← 新增
        .timeout(std::time::Duration::from_secs(30))
        .build()
        .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))
}
```

### 2. JSON 导入补读 `expires_at`（6 个文件）

`src-tauri/src/modules/codebuddy_cn_account.rs`（`payload_from_import_value`）、`codebuddy_account.rs`、`workbuddy_account.rs` 及 `crates/cockpit-core/src/modules/` 下对应三个模块：

```rust
let domain = obj
    .get("domain")
    .and_then(|v| v.as_str())
    .map(|s| s.to_string());

+ let expires_at = json_object_i64_field(obj, &["expires_at", "expiresAt"]);

Ok(CodebuddyOAuthCompletePayload {
    email,
    uid,
    nickname,
    enterprise_id,
    enterprise_name,
    access_token,
    refresh_token,
    token_type: Some("Bearer".to_string()),
-   expires_at: None,
+   expires_at,
    domain,
    ...
})
```

### 3. 下游受益：切号注入 session 携带真实过期时间

`src-tauri/src/commands/codebuddy_cn_instance.rs` 的 `build_session_json`（及 `modules/codebuddy_cn_account.rs` 的 `build_default_client_session_json`）无需改动，导入修复后自动生效：

```rust
let expires_at = account.expires_at.unwrap_or(0);
serde_json::json!({
    ...
    "refreshToken": refresh_token,
    "expiresAt": expires_at,      // 修复前恒为 0 → 客户端判定立即过期
    "auth": { "expiresAt": expires_at, "expiresIn": expires_at, ... }
})
```

## 五、文件清单（12 个）

| 路径 | 修复 |
|---|---|
| `src-tauri/src/modules/codebuddy_cn_oauth.rs` | UA |
| `src-tauri/src/modules/codebuddy_oauth.rs` | UA |
| `src-tauri/src/modules/workbuddy_oauth.rs` | UA |
| `src-tauri/src/modules/codebuddy_cn_account.rs` | expires_at |
| `src-tauri/src/modules/codebuddy_account.rs` | expires_at |
| `src-tauri/src/modules/workbuddy_account.rs` | expires_at |
| `crates/cockpit-core/src/modules/codebuddy_cn_oauth.rs` | UA |
| `crates/cockpit-core/src/modules/codebuddy_oauth.rs` | UA |
| `crates/cockpit-core/src/modules/workbuddy_oauth.rs` | UA |
| `crates/cockpit-core/src/modules/codebuddy_cn_account.rs` | expires_at |
| `crates/cockpit-core/src/modules/codebuddy_account.rs` | expires_at |
| `crates/cockpit-core/src/modules/workbuddy_account.rs` | expires_at |

## 六、验证

1. **编译**：`cargo check -p cockpit-core`、`cargo check -p cockpit-tools` 均通过，无新增错误与警告（仅仓库既有 unused 警告）。
2. **UA 修复实测**（真实账号 token）：修复前 `get-user-resource` 稳定 403（code 10085）；携带 UA 后返回 200 且包含完整额度数据（`Accounts`、`TotalCount`）。
3. **expires_at 修复实测**：重新导入账号 JSON 后，账号记录的 `expires_at` 恢复为 JSON 中的真实毫秒时间戳（如 `1793290793075`）；切号注入官方 CodeBuddy CN 客户端后，客户端正常进入账号，不再要求重新登录。

## 七、影响范围与兼容性

- UA 在 `Client::builder()` 层设置，覆盖 OAuth 登录、token 刷新、accounts 资料拉取、billing 额度/签到等该模块全部请求；网关仅做 UA 存在性校验，无版本指纹要求，风险低。
- `json_object_i64_field` 兼容数字与字符串两种时间戳格式；`apply_payload` 对已有账号无条件覆盖 `expires_at`，因此**重新导入一次 JSON 即可修复存量账号**。
- 不涉及数据库结构、前端类型与 API 变更，纯后端请求头与导入字段解析修复。

