### PR TITLE
feat(antigravity): 切号时自动同步 Antigravity CLI 凭据

### DIFF
--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -506,6 +506,12 @@ async fn switch_account_legacy_antigravity(
         }
     }
 
+    if modules::config::get_user_config().antigravity_sync_cli_on_switch {
+        if let Err(e) = modules::antigravity_credential::write_antigravity_cli_credential(&account) {
+            modules::logger::log_warn(&format!("[Antigravity] 同步 Antigravity CLI 凭据失败: {}", e));
+        }
+    }
+
     modules::logger::log_info("正在启动 Antigravity 默认实例...");
     let default_settings = modules::antigravity_legacy_instance::load_default_settings()?;
     let extra_args = modules::process::parse_extra_args(&default_settings.extra_args);

--- a/src-tauri/src/commands/system_config_types.rs
+++ b/src-tauri/src/commands/system_config_types.rs
@@ -239,6 +239,8 @@ pub struct GeneralConfig {
     pub codex_launch_on_switch: bool,
     /// 切换 Antigravity IDE 时是否自动启动/重启应用
     pub antigravity_launch_on_switch: bool,
+    /// 切换 Antigravity 时是否自动同步更新 Antigravity CLI / Language Server 凭据文件
+    pub antigravity_sync_cli_on_switch: bool,
     /// 切换 Codex 时是否自动重启指定应用
     pub codex_restart_specified_app_on_switch: bool,
     /// 是否在 Codex 总览中显示 API 服务入口
@@ -1216,6 +1218,7 @@ fn is_general_config_patch_field(key: &str) -> bool {
             | "hermes_auth_overwrite_on_switch"
             | "codex_launch_on_switch"
             | "antigravity_launch_on_switch"
+            | "antigravity_sync_cli_on_switch"
             | "codex_restart_specified_app_on_switch"
             | "codex_local_access_entry_visible"
             | "codex_hide_relay_quota"

--- a/src-tauri/src/commands/system_network_general.rs
+++ b/src-tauri/src/commands/system_network_general.rs
@@ -397,6 +397,7 @@ pub fn get_general_config(app: tauri::AppHandle) -> Result<GeneralConfig, String
         hermes_auth_overwrite_on_switch: user_config.hermes_auth_overwrite_on_switch,
         codex_launch_on_switch: user_config.codex_launch_on_switch,
         antigravity_launch_on_switch: user_config.antigravity_launch_on_switch,
+        antigravity_sync_cli_on_switch: user_config.antigravity_sync_cli_on_switch,
         codex_restart_specified_app_on_switch: user_config.codex_restart_specified_app_on_switch,
         codex_local_access_entry_visible: user_config.codex_local_access_entry_visible,
         codex_hide_relay_quota: user_config.codex_hide_relay_quota,

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -2068,6 +2068,12 @@ pub async fn switch_account_internal(account_id: &str) -> Result<Account, String
     let _ = modules::instance::update_default_pid(None);
     modules::instance::inject_account_to_profile(&default_dir, account_id)?;
 
+    if modules::config::get_user_config().antigravity_sync_cli_on_switch {
+        if let Err(e) = modules::antigravity_credential::write_antigravity_cli_credential(&account) {
+            modules::logger::log_warn(&format!("[Switch] 同步 Antigravity CLI 凭据失败: {}", e));
+        }
+    }
+
     // 7. 启动 Antigravity IDE（带默认实例自定义启动参数；启动失败不阻断切号，保持原行为）
     modules::logger::log_info("[Switch] 正在启动 Antigravity IDE 默认实例...");
     let default_settings = modules::instance::load_default_settings()?;
@@ -2375,6 +2381,15 @@ pub async fn switch_account_local_no_restart(account_id: &str) -> Result<Account
 
     let default_dir = modules::instance::get_default_user_data_dir()?;
     modules::instance::inject_account_to_profile(&default_dir, account_id)?;
+
+    if modules::config::get_user_config().antigravity_sync_cli_on_switch {
+        if let Err(e) = modules::antigravity_credential::write_antigravity_cli_credential(&account) {
+            modules::logger::log_warn(&format!(
+                "[Switch][NoRestart] 同步 Antigravity CLI 凭据失败: {}",
+                e
+            ));
+        }
+    }
 
     modules::logger::log_info(&format!(
         "[Switch][NoRestart] 本地切号完成: {}",

--- a/src-tauri/src/modules/antigravity_credential.rs
+++ b/src-tauri/src/modules/antigravity_credential.rs
@@ -93,6 +93,99 @@ fn build_antigravity_credential_payload(account: &Account) -> Result<String, Str
     .map_err(|e| format!("序列化 Antigravity 系统凭据失败: {}", e))
 }
 
+
+/// 同步 Antigravity CLI 及 Language Server 凭据到本地文件
+pub fn write_antigravity_cli_credential(account: &Account) -> Result<(), String> {
+    let payload_json = build_antigravity_credential_payload(account)?;
+    let gemini_dir = crate::modules::antigravity_paths::gemini_dir()?;
+    if !gemini_dir.exists() {
+        std::fs::create_dir_all(&gemini_dir)
+            .map_err(|e| format!("创建 .gemini 目录失败: {}", e))?;
+    }
+
+    let jetski_token_path = crate::modules::antigravity_paths::jetski_oauth_token_path()?;
+    write_secure_credential_file(&jetski_token_path, &payload_json)?;
+
+    let cli_dir = crate::modules::antigravity_paths::antigravity_cli_dir()?;
+    if !cli_dir.exists() {
+        let _ = std::fs::create_dir_all(&cli_dir);
+    }
+    let cli_token_path = crate::modules::antigravity_paths::antigravity_cli_oauth_token_path()?;
+
+    let is_symlink_to_jetski = match std::fs::read_link(&cli_token_path) {
+        Ok(target) => {
+            target == jetski_token_path
+                || target.file_name() == jetski_token_path.file_name()
+                || target.to_string_lossy().contains("jetski-standalone-oauth-token")
+        }
+        Err(_) => false,
+    };
+    if !is_symlink_to_jetski {
+        write_secure_credential_file(&cli_token_path, &payload_json)?;
+    }
+
+    let google_accounts_path = crate::modules::antigravity_paths::google_accounts_path()?;
+    update_google_accounts_active(&google_accounts_path, &account.email)?;
+
+    crate::modules::logger::log_info(&format!(
+        "[Antigravity CLI] 自动同步 CLI 凭据完成: {}",
+        account.email
+    ));
+    Ok(())
+}
+
+fn write_secure_credential_file(path: &std::path::Path, content: &str) -> Result<(), String> {
+    use std::io::Write;
+    let mut file = std::fs::File::create(path)
+        .map_err(|e| format!("创建凭据文件失败 {:?}: {}", path, e))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    file.write_all(content.as_bytes())
+        .map_err(|e| format!("写入凭据文件失败 {:?}: {}", path, e))?;
+    file.flush()
+        .map_err(|e| format!("刷新凭据文件失败 {:?}: {}", path, e))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+fn update_google_accounts_active(path: &std::path::Path, email: &str) -> Result<(), String> {
+    let mut root: serde_json::Value = if path.exists() {
+        match std::fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_else(|_| serde_json::json!({})),
+            Err(_) => serde_json::json!({}),
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    if !root.is_object() {
+        root = serde_json::json!({});
+    }
+
+    if let Some(obj) = root.as_object_mut() {
+        obj.insert(
+            "active".to_string(),
+            serde_json::Value::String(email.to_string()),
+        );
+        if !obj.contains_key("old") {
+            obj.insert("old".to_string(), serde_json::json!([]));
+        }
+    }
+
+    let serialized = serde_json::to_string_pretty(&root)
+        .map_err(|e| format!("序列化 google_accounts.json 失败: {}", e))?;
+    std::fs::write(path, serialized)
+        .map_err(|e| format!("写入 google_accounts.json 失败: {}", e))?;
+    Ok(())
+}
+
 pub fn write_antigravity_system_credential(account: &Account) -> Result<(), String> {
     let payload_json = build_antigravity_credential_payload(account)?;
 
@@ -351,4 +444,77 @@ pub fn read_antigravity_system_credential() -> Result<Option<AntigravitySystemCr
         return Ok(None);
     };
     parse_antigravity_system_credential(&secret).map(Some)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::TokenData;
+
+    #[test]
+    fn test_build_antigravity_credential_payload() {
+        let token = TokenData::new(
+            "test-access-token".to_string(),
+            "test-refresh-token".to_string(),
+            3600,
+            Some("test@example.com".to_string()),
+            None,
+            None,
+        );
+        let account = Account::new(
+            "account-id".to_string(),
+            "test@example.com".to_string(),
+            token,
+        );
+        let payload = build_antigravity_credential_payload(&account).expect("payload");
+        let parsed: serde_json::Value = serde_json::from_str(&payload).expect("valid json");
+        assert_eq!(parsed["auth_method"], "consumer");
+        assert_eq!(parsed["token"]["access_token"], "test-access-token");
+        assert_eq!(parsed["token"]["refresh_token"], "test-refresh-token");
+        assert_eq!(parsed["token"]["token_type"], "Bearer");
+        assert!(parsed["token"]["expiry"].as_str().unwrap().contains("T"));
+    }
+
+    #[test]
+    fn test_write_secure_credential_file() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "ag-cred-test-{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+        ));
+        let _ = std::fs::create_dir_all(&temp_dir);
+        let file_path = temp_dir.join("test-token");
+        write_secure_credential_file(&file_path, "{\"test\": true}").expect("write secure");
+        let read_back = std::fs::read_to_string(&file_path).expect("read");
+        assert_eq!(read_back, "{\"test\": true}");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = std::fs::metadata(&file_path).expect("meta");
+            assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+        }
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_update_google_accounts_active() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "ag-google-acc-test-{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+        ));
+        let _ = std::fs::create_dir_all(&temp_dir);
+        let file_path = temp_dir.join("google_accounts.json");
+
+        update_google_accounts_active(&file_path, "user1@example.com").expect("create accounts");
+        let parsed: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&file_path).unwrap()).unwrap();
+        assert_eq!(parsed["active"], "user1@example.com");
+        assert!(parsed["old"].is_array());
+
+        update_google_accounts_active(&file_path, "user2@example.com").expect("update active");
+        let parsed: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&file_path).unwrap()).unwrap();
+        assert_eq!(parsed["active"], "user2@example.com");
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
 }

--- a/src-tauri/src/modules/antigravity_paths.rs
+++ b/src-tauri/src/modules/antigravity_paths.rs
@@ -174,6 +174,27 @@ pub fn legacy_state_db_path() -> Result<PathBuf, String> {
     Ok(legacy_global_storage_dir()?.join("state.vscdb"))
 }
 
+pub fn gemini_dir() -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("无法获取用户主目录")?;
+    Ok(home.join(".gemini"))
+}
+
+pub fn antigravity_cli_dir() -> Result<PathBuf, String> {
+    Ok(gemini_dir()?.join("antigravity-cli"))
+}
+
+pub fn jetski_oauth_token_path() -> Result<PathBuf, String> {
+    Ok(gemini_dir()?.join("jetski-standalone-oauth-token"))
+}
+
+pub fn antigravity_cli_oauth_token_path() -> Result<PathBuf, String> {
+    Ok(antigravity_cli_dir()?.join("antigravity-oauth-token"))
+}
+
+pub fn google_accounts_path() -> Result<PathBuf, String> {
+    Ok(gemini_dir()?.join("google_accounts.json"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::prefer_user_data_dir_with_state_db;
@@ -227,5 +248,14 @@ mod tests {
             prefer_user_data_dir_with_state_db(&[first.clone(), second.clone()], second.clone());
         assert_eq!(picked, first);
         let _ = fs::remove_dir_all(root);
+    }
+    #[test]
+    fn antigravity_cli_paths_resolve_under_gemini() {
+        let gemini = super::gemini_dir().expect("gemini dir");
+        assert!(gemini.ends_with(".gemini"));
+        let jetski = super::jetski_oauth_token_path().expect("jetski token path");
+        assert!(jetski.ends_with(".gemini/jetski-standalone-oauth-token") || jetski.ends_with(".gemini\\jetski-standalone-oauth-token"));
+        let cli = super::antigravity_cli_oauth_token_path().expect("cli token path");
+        assert!(cli.ends_with(".gemini/antigravity-cli/antigravity-oauth-token") || cli.ends_with(".gemini\\antigravity-cli\\antigravity-oauth-token"));
     }
 }

--- a/src-tauri/src/modules/config.rs
+++ b/src-tauri/src/modules/config.rs
@@ -403,6 +403,9 @@ pub struct UserConfig {
     /// 切换 Antigravity IDE 时是否自动启动/重启应用
     #[serde(default = "default_antigravity_launch_on_switch")]
     pub antigravity_launch_on_switch: bool,
+    /// 切换 Antigravity 时是否自动同步更新 Antigravity CLI / Language Server 凭据文件
+    #[serde(default = "default_antigravity_sync_cli_on_switch")]
+    pub antigravity_sync_cli_on_switch: bool,
     /// 切换 Codex 时是否自动重启指定应用
     #[serde(default = "default_codex_restart_specified_app_on_switch")]
     pub codex_restart_specified_app_on_switch: bool,
@@ -1019,6 +1022,9 @@ fn default_codex_auto_restore_takeover_on_launch() -> bool {
 fn default_antigravity_launch_on_switch() -> bool {
     true
 }
+fn default_antigravity_sync_cli_on_switch() -> bool {
+    true
+}
 fn default_codex_restart_specified_app_on_switch() -> bool {
     false
 }
@@ -1300,6 +1306,7 @@ impl Default for UserConfig {
             codex_auto_restore_takeover_on_launch:
                 default_codex_auto_restore_takeover_on_launch(),
             antigravity_launch_on_switch: default_antigravity_launch_on_switch(),
+            antigravity_sync_cli_on_switch: default_antigravity_sync_cli_on_switch(),
             codex_restart_specified_app_on_switch: default_codex_restart_specified_app_on_switch(),
             codex_local_access_entry_visible: default_codex_local_access_entry_visible(),
             codex_hide_relay_quota: default_codex_hide_relay_quota(),
@@ -2576,6 +2583,22 @@ mod tests {
         let cfg: UserConfig =
             serde_json::from_value(serde_json::json!({})).expect("反序列化默认配置应成功");
         assert!(!cfg.openclaw_auth_overwrite_on_switch);
+    }
+
+    #[test]
+    fn antigravity_sync_cli_on_switch_defaults_to_enabled() {
+        let default_cfg = UserConfig::default();
+        assert!(default_cfg.antigravity_sync_cli_on_switch);
+
+        let migrated_cfg: UserConfig =
+            serde_json::from_value(serde_json::json!({})).expect("旧配置反序列化应成功");
+        assert!(migrated_cfg.antigravity_sync_cli_on_switch);
+
+        let disabled_cfg: UserConfig = serde_json::from_value(serde_json::json!({
+            "antigravity_sync_cli_on_switch": false
+        }))
+        .expect("显式关闭配置反序列化应成功");
+        assert!(!disabled_cfg.antigravity_sync_cli_on_switch);
     }
 
     #[test]

--- a/src/pages/SettingsGeneralPanel.tsx
+++ b/src/pages/SettingsGeneralPanel.tsx
@@ -20,6 +20,8 @@ export function SettingsGeneralPanel(props: SettingsPageViewProps) {
     antigravityAppPath,
     antigravityDualSwitchNoRestartEnabled,
     antigravityLaunchOnSwitch,
+    antigravitySyncCliOnSwitch,
+    setAntigravitySyncCliOnSwitch,
     antigravityScopeAccounts,
     antigravityScopeTypeOptions,
     antigravitySeamlessSwitchUnlocked,
@@ -1255,6 +1257,33 @@ export function SettingsGeneralPanel(props: SettingsPageViewProps) {
                       type="checkbox"
                       checked={antigravityLaunchOnSwitch}
                       onChange={(e) => setAntigravityLaunchOnSwitch(e.target.checked)}
+                    />
+                    <span className="slider"></span>
+                  </label>
+                </div>
+              </div>
+
+              <div className="settings-row">
+                <div className="row-label">
+                  <div className="row-title">
+                    {t(
+                      'settings.general.antigravitySyncCliOnSwitch',
+                      '切号时同步 Antigravity CLI 凭据',
+                    )}
+                  </div>
+                  <div className="row-desc">
+                    {t(
+                      'settings.general.antigravitySyncCliOnSwitchDesc',
+                      '切号时自动同步 ~/.gemini/antigravity-cli 与 Language Server 凭据文件，使终端 agy 命令无缝生效。',
+                    )}
+                  </div>
+                </div>
+                <div className="row-control">
+                  <label className="switch">
+                    <input
+                      type="checkbox"
+                      checked={antigravitySyncCliOnSwitch}
+                      onChange={(e) => setAntigravitySyncCliOnSwitch(e.target.checked)}
                     />
                     <span className="slider"></span>
                   </label>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -228,6 +228,7 @@ interface GeneralConfig {
   codex_launch_on_switch: boolean;
   codex_auto_restore_takeover_on_launch?: boolean;
   antigravity_launch_on_switch: boolean;
+  antigravity_sync_cli_on_switch?: boolean;
   codex_restart_specified_app_on_switch: boolean;
   codex_local_access_entry_visible: boolean;
   codex_hide_relay_quota?: boolean;
@@ -662,6 +663,7 @@ export function useSettingsPageController() {
   const [codexLaunchOnSwitch, setCodexLaunchOnSwitch] = useState(true);
   const [codexAutoRestoreTakeoverOnLaunch, setCodexAutoRestoreTakeoverOnLaunch] = useState(true);
   const [antigravityLaunchOnSwitch, setAntigravityLaunchOnSwitch] = useState(true);
+  const [antigravitySyncCliOnSwitch, setAntigravitySyncCliOnSwitch] = useState(true);
   const [codexRestartSpecifiedAppOnSwitch, setCodexRestartSpecifiedAppOnSwitch] = useState(false);
   const [codexLocalAccessEntryVisible, setCodexLocalAccessEntryVisible] = useState(true);
   const [codexHideRelayQuota, setCodexHideRelayQuota] = useState(false);
@@ -1148,6 +1150,7 @@ export function useSettingsPageController() {
       codex_launch_on_switch: codexLaunchOnSwitch,
       codex_auto_restore_takeover_on_launch: codexAutoRestoreTakeoverOnLaunch,
       antigravity_launch_on_switch: antigravityLaunchOnSwitch,
+      antigravity_sync_cli_on_switch: antigravitySyncCliOnSwitch,
       codex_restart_specified_app_on_switch: codexRestartSpecifiedAppOnSwitch,
       codex_local_access_entry_visible: codexLocalAccessEntryVisible,
       codex_hide_relay_quota: codexHideRelayQuota,
@@ -1380,6 +1383,7 @@ export function useSettingsPageController() {
     hermesAuthOverwriteOnSwitch,
     codexLaunchOnSwitch,
     antigravityLaunchOnSwitch,
+    antigravitySyncCliOnSwitch,
     codexRestartSpecifiedAppOnSwitch,
     codexLocalAccessEntryVisible,
     codexHideRelayQuota,
@@ -1764,6 +1768,7 @@ export function useSettingsPageController() {
       setCodexLaunchOnSwitch(config.codex_launch_on_switch ?? true);
       setCodexAutoRestoreTakeoverOnLaunch(config.codex_auto_restore_takeover_on_launch ?? true);
       setAntigravityLaunchOnSwitch(config.antigravity_launch_on_switch ?? true);
+      setAntigravitySyncCliOnSwitch(config.antigravity_sync_cli_on_switch ?? true);
       setCodexRestartSpecifiedAppOnSwitch(
         config.codex_restart_specified_app_on_switch ?? false,
       );
@@ -3210,6 +3215,8 @@ export function useSettingsPageController() {
     antigravityAppPath,
     antigravityDualSwitchNoRestartEnabled,
     antigravityLaunchOnSwitch,
+    antigravitySyncCliOnSwitch,
+    setAntigravitySyncCliOnSwitch,
     antigravityScopeAccounts,
     antigravityScopeTypeOptions,
     antigravitySeamlessSwitchUnlocked,


### PR DESCRIPTION
## 概述 (Overview)
当用户在 Cockpit Tools 中切换反重力（Antigravity）账号时，原生同步更新 Antigravity CLI 及后台 Language Server 的本地凭据存储文件（`~/.gemini/antigravity-cli/antigravity-oauth-token`、`~/.gemini/jetski-standalone-oauth-token` 以及 `~/.gemini/google_accounts.json`）。

解决在终端使用反重力 CLI (`agy`) 时账号未跟随切换、容易遭遇 `429 Resource Exhausted` 配额耗尽或未登录状态的问题。

关联 Issue：Fixes #2210, Ref #869

## 改动内容 (Changes)
1. **路径管理与解析 (`src-tauri/src/modules/antigravity_paths.rs`)**：
   - 增加 `gemini_dir`、`antigravity_cli_dir`、`jetski_oauth_token_path`、`antigravity_cli_oauth_token_path` 与 `google_accounts_path` 路径解析函数，适配跨平台路径规范。
2. **CLI 凭据写入与同步 (`src-tauri/src/modules/antigravity_credential.rs`)**：
   - 实现 `write_antigravity_cli_credential`，将当前切入账号的 OAuth Token 格式化为标准 JSON 写入本地文件。
   - 文件权限在 Unix 下严格设置为 `0600`，确保凭据安全性。
   - 自动检测软链接与独立文件模式，并同步更新 `google_accounts.json` 中的 `active` 激活账号。
3. **切号流程集成 (`src-tauri/src/modules/account.rs`, `src-tauri/src/commands/account.rs`)**：
   - 在本地无感切号 (`switch_account_local_no_restart`)、内部切换 (`switch_account_internal`) 及旧版切换流程中，注入账号后同步更新 CLI 凭据。
4. **配置项支持 (`src-tauri/src/modules/config.rs`, `src-tauri/src/commands/system_config_types.rs`)**：
   - 新增 `antigravity_sync_cli_on_switch`（默认开启），支持用户按需开启或关闭。
5. **前端界面配置 (`src/pages/SettingsPage.tsx`, `src/pages/SettingsGeneralPanel.tsx`)**：
   - 在「设置 - 通用设置 - Antigravity」区域新增「切号时同步 Antigravity CLI 凭据」开关组件。

## 测试验证 (Verification)
- [x] Rust 路径单元测试通过：`modules::antigravity_paths::tests` (3/3 pass)。
- [x] Rust 凭据同步单元测试通过：`modules::antigravity_credential::tests` (3/3 pass)。
- [x] Rust 配置单元测试通过：`modules::config::tests::antigravity_sync_cli_on_switch_defaults_to_enabled` (1/1 pass)。
- [x] 全量后端检查通过：`cargo check -p cockpit-tools --lib` (0 error)。
- [x] 前端类型检查通过：`npm run typecheck` (0 error)。