### PR TITLE
安全：替换模板安全策略并为 Go sidecar 增加 CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,3 +37,34 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+
+  analyze-go:
+    name: Analyze Go sidecar
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: sidecars/cockpit-cliproxy/go.mod
+          cache-dependency-path: sidecars/cockpit-cliproxy/go.sum
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+          build-mode: manual
+
+      # The sidecar has its own go.mod, including a local SDK replacement.
+      # Rebuild cached packages so CodeQL observes the compiled source.
+      - name: Build Go sidecar
+        working-directory: sidecars/cockpit-cliproxy
+        run: go build -a ./...
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:go

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,30 @@
 # Security Policy
 
-## Supported Versions
+## Supported versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Security fixes target the latest stable release. Please include the exact Cockpit
+Tools version and operating system in a report, and check the latest release when
+it is safe to do so. Older releases may also be affected; report that information
+rather than assuming that an upgrade fixes the issue. There is no commitment to
+backport fixes to every older release.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+## Reporting a vulnerability
 
-## Reporting a Vulnerability
+Do not put vulnerability details, working exploits, or credentials in a public
+issue, pull request, or discussion.
 
-Use this section to tell people how to report a vulnerability.
+Open the upstream repository's **Security** tab. If **Report a vulnerability** is
+available, use it to submit a private report. If private reporting is unavailable
+and no private contact has been published, open an issue that only asks the
+maintainer for a private reporting channel. Do not include the vulnerability or
+its reproduction steps in that issue.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+In the private report, include the affected version/platform, expected and actual
+behavior, impact, and the smallest safe reproduction. Use dummy accounts and
+redacted examples. Never send live OAuth tokens, API keys, cookies, MFA secrets,
+account exports, or complete authentication files. Logs and screenshots can also
+contain these values; review them before sharing.
+
+Coordinate any public disclosure with the maintainer. This policy does not
+promise a response deadline or a fix date. Ordinary bugs that do not expose
+sensitive data or cross a security boundary can use the public issue tracker.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,29 +2,14 @@
 
 ## Supported versions
 
-Security fixes target the latest stable release. Please include the exact Cockpit
-Tools version and operating system in a report, and check the latest release when
-it is safe to do so. Older releases may also be affected; report that information
-rather than assuming that an upgrade fixes the issue. There is no commitment to
-backport fixes to every older release.
+This repository does not currently publish a supported-version matrix for security fixes. Please include the exact Cockpit Tools version and operating system in a report. If the issue also affects other releases, include the versions you have confirmed rather than assuming an upgrade fixes it.
 
 ## Reporting a vulnerability
 
-Do not put vulnerability details, working exploits, or credentials in a public
-issue, pull request, or discussion.
+Do not put vulnerability details, working exploits, or credentials in a public issue, pull request, or discussion.
 
-Open the upstream repository's **Security** tab. If **Report a vulnerability** is
-available, use it to submit a private report. If private reporting is unavailable
-and no private contact has been published, open an issue that only asks the
-maintainer for a private reporting channel. Do not include the vulnerability or
-its reproduction steps in that issue.
+Open this repository's **Security** tab. If **Report a vulnerability** is available, use it to submit a private report. If private reporting is unavailable and no private contact has been published, open an issue that only asks the maintainer for a private reporting channel. Do not include the vulnerability or its reproduction steps in that issue.
 
-In the private report, include the affected version/platform, expected and actual
-behavior, impact, and the smallest safe reproduction. Use dummy accounts and
-redacted examples. Never send live OAuth tokens, API keys, cookies, MFA secrets,
-account exports, or complete authentication files. Logs and screenshots can also
-contain these values; review them before sharing.
+In the private report, include the affected version/platform, expected and actual behavior, impact, and the smallest safe reproduction. Use dummy accounts and redacted examples. Never send live OAuth tokens, API keys, cookies, MFA secrets, account exports, or complete authentication files. Logs and screenshots can also contain these values; review them before sharing.
 
-Coordinate any public disclosure with the maintainer. This policy does not
-promise a response deadline or a fix date. Ordinary bugs that do not expose
-sensitive data or cross a security boundary can use the public issue tracker.
+Coordinate any public disclosure with the maintainer. This policy does not promise a response deadline, fix date, or backport policy. Ordinary bugs that do not expose sensitive data or cross a security boundary can use the public issue tracker.


### PR DESCRIPTION
## 问题

当前 `SECURITY.md` 还是 GitHub 模板，里面的 5.x / 4.x 版本示例与项目无关，也没有真正可用的漏洞报告说明。CodeQL 目前只覆盖 JavaScript/TypeScript 和 Rust，仓库里的 Go sidecar `cockpit-cliproxy` 没有进入静态分析。

## 改动

- 用实际可执行的安全报告说明替换模板内容。
- 优先引导使用 GitHub Security 的私密漏洞报告；如果仓库没有启用且没有公开私密联系方式，只在公开 issue 中询问私密报告渠道，不披露漏洞细节。
- 明确不要提交真实 OAuth token、API key、cookie、MFA secret 或完整认证文件。
- 保留现有 JavaScript/TypeScript 和 Rust CodeQL，并新增独立的 Go sidecar CodeQL job。
- Go job 使用 `sidecars/cockpit-cliproxy/go.mod` 指定的 Go 版本，并实际构建该 module 后执行分析。

## 验证

上游 PR 的 Go CodeQL job 已完整执行成功；JavaScript/TypeScript 分析也通过。

这个 PR 不修改产品代码、认证逻辑、发布流程或 LICENSE。