### PR TITLE
文档：让发布说明与当前 workflow 保持一致

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,14 +1,8 @@
-# Release Process (Open Source, No Code Signing)
+# Release Process
 
-> 适用于 Cockpit Tools 当前开源发布流程（未接入代码签名）。
+本文档描述仓库当前由 `.github/workflows/release.yml` 执行的发布流程。发布行为以 workflow 和 `scripts/release/` 下的脚本为准；如果两者与本文不一致，应先修正文档或 workflow，再发版。
 
-## 1. 目标
-
-- 保证每次发布可复现、可验证、可追溯。
-- 让用户可以通过哈希校验确认安装包未被篡改。
-- 单引擎误报（如 VirusTotal 1/72）时，可快速说明和处理。
-
-## 2. 发布前检查（Preflight）
+## 1. 发布前检查
 
 在仓库根目录执行：
 
@@ -16,126 +10,124 @@
 npm run release:preflight
 ```
 
-该命令会依次执行：
+当前 preflight 依次执行：
 
 1. `node scripts/check_locales.cjs`
 2. `npm run typecheck`
 3. `npm run build`
-4. `cargo check`（在 `src-tauri` 下）
+4. `cargo check`（`src-tauri`）
+5. `cargo test --lib`（`src-tauri`，`RUST_TEST_THREADS=1`）
 
-可选跳过参数（排障用，不建议正式发布时使用）：
-
-```bash
-node scripts/release/preflight.cjs --skip-locales --skip-typecheck --skip-build --skip-cargo
-```
-
-## 3. 打包产物（macOS / Windows；Homebrew 推荐）
-
-官方发布目标仅包含 macOS 与 Windows，不再构建或上传 Linux/Ubuntu 安装包。macOS 当前推荐使用 `universal` 安装包（同时兼容 Apple Silicon / Intel），并在上传 GitHub Release 后同步更新 Homebrew cask。
-
-推荐一键脚本（会执行 `universal.dmg` 构建、上传 GitHub Release 资产、更新 `Casks/cockpit-tools.rb`）：
+排障时可以跳过单项：
 
 ```bash
-npm run release:github-and-cask
+node scripts/release/preflight.cjs \
+  --skip-locales \
+  --skip-typecheck \
+  --skip-build \
+  --skip-cargo \
+  --skip-cargo-test
 ```
 
-若你已提前手动构建过 `universal.dmg`，可跳过构建步骤：
+正式发布不应为了绕过失败而随意使用 skip 参数。
 
-```bash
-npm run release:github-and-cask -- --skip-build
-```
+## 2. 版本与标签
 
-脚本前置条件：
-
-1. 已安装并登录 GitHub CLI（`gh auth status` 通过）
-2. 本机可执行 macOS Tauri 构建
-3. 已安装 Rust Intel target（首次需要）：
-
-```bash
-rustup target add x86_64-apple-darwin
-```
-
-## 4. 生成 SHA256 校验文件
-
-默认扫描 `src-tauri/target/release/bundle` 和 `dist`，输出到 `release-artifacts/SHA256SUMS.txt`：
-
-```bash
-npm run release:checksums
-```
-
-如果本次发布使用 `universal` 产物（Homebrew 场景，默认如此），建议显式指定 `universal` bundle 目录，确保 `*_universal.dmg` 被写入校验文件：
-
-```bash
-node scripts/release/gen_checksums.cjs \
-  --input src-tauri/target/universal-apple-darwin/release/bundle \
-  --input dist \
-  --output release-artifacts/SHA256SUMS.txt
-```
-
-也可按需指定其他输入目录和输出文件：
-
-```bash
-node scripts/release/gen_checksums.cjs \
-  --input src-tauri/target/release/bundle \
-  --output release-artifacts/SHA256SUMS.txt
-```
-
-## 5. Release 发布内容规范
-
-每次发布建议至少包含：
-
-1. 下载文件列表（macOS / Windows；macOS/Homebrew 场景建议包含 `*_universal.dmg`）
-2. `SHA256SUMS.txt`
-3. 更新日志（中英文）
-4. VirusTotal 链接（可选但推荐）
-5. 已知误报说明（如有）
-
-补充说明（Homebrew 自维护 Tap）：
-
-1. 先上传 GitHub Release 资产，再推送 `Casks/cockpit-tools.rb` 更新，避免 cask 链接短暂 404。
-2. `Casks/cockpit-tools.rb` 中的 `version`、`sha256` 必须与 Release 中实际 `*_universal.dmg` 一致。
-
-## 6. VirusTotal 单引擎误报处理
-
-当出现 `1/72` 这类结果时：
-
-1. 先在 Release 明确“仅单引擎命中，其他未检出”。
-2. 要求用户只从官方 Release 下载并核对 SHA256。
-3. 对命中厂商提交误报（附 hash、下载链接、仓库地址）。
-4. 误报修复后在 issue/release 回帖同步结果。
-
-## 7. Git 发版流程（远端完成）
-
-正式发版按“Git 远端完成”判定，建议顺序如下：
-
-1. 更新版本与更新日志（`package.json`、`CHANGELOG.md`、`CHANGELOG.zh-CN.md`）。
-2. 执行版本同步：
+`package.json.version` 是发布 workflow 读取的版本。创建发布标签前先执行：
 
 ```bash
 npm run sync-version
 ```
 
-3. 执行发布预检（阻断）：
+然后确认版本同步后的文件与 changelog 已提交。发布标签必须严格匹配：
+
+```text
+v<package.json.version>
+```
+
+例如 `package.json.version` 为 `1.3.40` 时，标签必须是 `v1.3.40`。workflow 会在版本或标签不一致时直接失败。
+
+## 3. GitHub Actions 发布目标
+
+当前 release workflow 构建并上传：
+
+- Windows
+- macOS Apple Silicon (`aarch64`)
+- macOS Intel (`x86_64`)
+- macOS Universal
+- Linux `x86_64`
+- Linux `aarch64`
+
+Linux release 同时包含 AppImage、deb 和 rpm updater targets。macOS Universal DMG 还会用于后续 Homebrew Cask 更新。
+
+Tauri release build 使用仓库配置的 updater signing secrets：
+
+- `TAURI_SIGNING_PRIVATE_KEY`
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+
+这里的 signing 指 Tauri updater artifact 签名；不要把它描述成已经完成 Apple notarization 或 Windows Authenticode，除非 workflow 另外明确实现了这些步骤。
+
+## 4. Release assets 与 updater manifests
+
+每个平台先通过 `scripts/release/stage_release_assets.cjs` 规范化允许上传的 release assets，再用 `scripts/release/build_target_latest_json.cjs` 生成各 target 的 updater manifest。
+
+所有平台完成后，`finalize-legacy-latest` job 会下载 release assets，并用：
 
 ```bash
+node scripts/release/build_merged_latest_json.cjs
+```
+
+生成完整 legacy `latest.json`。workflow 会检查其中至少包含：
+
+- `darwin-aarch64`
+- `darwin-x86_64`
+- `windows-x86_64`
+- `windows-x86_64-nsis`
+- Linux x86_64 / aarch64 的 AppImage、deb、rpm targets
+
+随后会通过 `scripts/release/verify_published_updater_manifests.cjs` 对公开 updater 状态做端到端验证。
+
+## 5. SHA256SUMS
+
+`upload-checksums` job 会重新下载该版本的 release assets，对文件逐个计算 SHA-256，并上传：
+
+```text
+SHA256SUMS.txt
+```
+
+不要依赖文档中不存在的 `npm run release:checksums` 命令。当前 checksum 的权威实现位于 release workflow 本身；`scripts/release/gen_checksums.cjs` 是可单独调用的脚本，但不是 `package.json` 中的标准 npm script。
+
+## 6. Homebrew Cask
+
+release workflow 会下载已发布的 Universal DMG，计算 SHA-256，然后更新：
+
+```text
+Casks/cockpit-tools.rb
+```
+
+该更新通过自动创建的 PR 提交，而不是本地 `npm run release:github-and-cask`。当前 `package.json` 没有这个 npm script，因此不要按旧文档中的本地一键脚本操作。
+
+## 7. 推荐发版顺序
+
+1. 更新 `package.json` 版本。
+2. 更新 `CHANGELOG.md` 与 `CHANGELOG.zh-CN.md`，确保存在对应版本段落。
+3. 执行：
+
+```bash
+npm run sync-version
 npm run release:preflight
 ```
 
-4. 提交发布改动。
-5. 创建与版本一致的标签（例如 `v0.9.2`）。
-6. 先推送分支，再推送标签：
+4. 提交并合并发布所需改动。
+5. 从期望发布的 commit 创建 `v<version>` 标签并推送标签。
+6. 检查 GitHub Actions 的 release workflow 完整成功。
+7. 检查 GitHub Release 的平台 assets、target manifests、`latest.json` 和 `SHA256SUMS.txt`。
+8. 检查 Homebrew Cask 自动 PR 的版本和 SHA-256 是否与 Universal DMG 一致。
 
-```bash
-git push origin <branch> && git push origin v<major>.<minor>.<patch>
-```
+仅有远端 branch 和 tag 并不代表发布已经成功。正式完成应以 release workflow 成功、预期 assets/manifests 可用以及 checksum 生成完成为准。
 
-完成判定（阻断）：
+## 8. 当前已知的发布状态问题
 
-1. 远端分支已更新（通常 `origin/main`）。
-2. 远端版本标签已存在，且与 `package.json.version` 一致。
-3. 满足以上两项即视为发版完成。
+当前 workflow 会在所有平台构建完成前就把 staged release 公开并标记为 latest，再在后续 job 中补齐完整 updater state 和 checksums。这样如果某个平台中途失败，公开 release 可能短时间或持续处于不完整状态。
 
-补充说明：
-
-1. GitHub Actions、GitHub Release 资产上传、`SHA256SUMS.txt`、Homebrew Cask 更新属于后置异步流程，不作为发版完成的阻断条件。
-2. 若需要，可在发版完成后继续观察 Actions 与 Release 资产状态。
+该问题应独立修复，不应通过文档把它描述成推荐设计。修复目标是：release 在所有平台 assets、完整 manifests 和 checksums 验证完成前保持 draft，最后一次性发布并再做公开 URL 验证。

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -69,7 +69,7 @@ Tauri release build 使用仓库配置的 updater signing secrets：
 
 ## 4. Release assets 与 updater manifests
 
-每个平台先通过 `scripts/release/stage_release_assets.cjs` 规范化允许上传的 release assets，再用 `scripts/release/build_target_latest_json.cjs` 生成各 target 的 updater manifest。
+Windows、macOS Apple Silicon/Intel 和 Linux 构建 job 会先通过 `scripts/release/stage_release_assets.cjs` 规范化允许上传的 release assets，再用 `scripts/release/build_target_latest_json.cjs` 生成各 updater target 的 manifest。macOS Universal job 只规范化并上传 Universal DMG，不生成 updater manifest；该 DMG 供后续 Homebrew Cask 更新使用。
 
 所有平台完成后，`finalize-legacy-latest` job 会下载 release assets，并用：
 


### PR DESCRIPTION
## 问题

`docs/release-process.md` 还在描述已经不存在的流程：只构建 macOS/Windows、没有 updater signing、使用已经不存在的 release npm 命令，并把 branch + tag 已存在视为发版完成。

这些内容已经和当前 `.github/workflows/release.yml`、`package.json` 不一致。

## 改动

- 补全当前 preflight，包括 `cargo test --lib` 和对应 skip flag。
- 记录当前实际发布目标：Windows、macOS aarch64/x86_64/universal、Linux x86_64/aarch64。
- 说明 Tauri updater signing secrets 的实际用途，避免和 OS code signing / notarization 混淆。
- 按当前 workflow 说明 target manifests、legacy `latest.json`、`SHA256SUMS.txt` 和 Homebrew 自动 PR。
- 删除已经不存在的 release npm 命令。
- 把“发版完成”改成以 release workflow 完成，以及 assets / manifests / checksum 齐全为准。
- 明确记录当前 release 过早公开的问题，并指向 #2269 / #2271。

这个 PR 只更新发布文档，不修改 release workflow 或产品代码。