### PR TITLE
发布：验证完成后再公开并标记为 latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,37 +117,7 @@ jobs:
 
           date -u +"%Y-%m-%dT%H:%M:%SZ" > published-at.txt
 
-      - name: 💾 Preserve previous legacy latest.json
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          PREVIOUS_TAG="$(
-            gh release list \
-              --limit 100 \
-              --json tagName,isDraft,isPrerelease \
-              --jq "[.[] | select(.isDraft == false and .isPrerelease == false and .tagName != \"${GITHUB_REF_NAME}\")][0].tagName // \"\""
-          )"
-          if [ -z "${PREVIOUS_TAG}" ]; then
-            echo "No previous published release was found; refusing to stage without a legacy updater manifest."
-            exit 1
-          fi
-
-          mkdir -p previous-release
-          gh release download "${PREVIOUS_TAG}" \
-            --pattern "latest.json" \
-            --dir previous-release \
-            --clobber
-          test -s previous-release/latest.json
-          cp previous-release/latest.json legacy-latest.json
-          echo "Preserved legacy latest.json from ${PREVIOUS_TAG}"
-
-      # Publish the release early (with previous complete latest.json) so parallel
-      # platform jobs can verify assets via public tag download URLs without
-      # waiting for Windows, and without reading the previous release's
-      # same-named target manifests through /releases/latest/.
-      - name: 🚀 Create or update staged release
+      - name: 🚀 Create or update draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -156,26 +126,14 @@ jobs:
           TAG="v${{ steps.app_version.outputs.VERSION }}"
           TITLE="Cockpit Tools v${{ steps.app_version.outputs.VERSION }}"
           if gh release view "${TAG}" > /dev/null 2>&1; then
-            gh release edit "${TAG}" \
-              --title "${TITLE}" \
-              --notes-file release-notes.md
+            IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
+            if [ "${IS_DRAFT}" != "true" ]; then
+              echo "Release ${TAG} is already published; refusing to mutate a public release."
+              exit 1
+            fi
+            gh release edit "${TAG}" --title "${TITLE}" --notes-file release-notes.md
           else
-            gh release create "${TAG}" \
-              --draft \
-              --title "${TITLE}" \
-              --notes-file release-notes.md
-          fi
-
-          IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
-          if [ "${IS_DRAFT}" = "true" ]; then
-            cp legacy-latest.json latest.json
-            gh release upload "${TAG}" latest.json --clobber
-            gh release edit "${TAG}" --draft=false --prerelease=false --latest
-            echo "Published staged release ${TAG} with legacy latest.json"
-          else
-            # Re-run after a prior publish: do not clobber a finalized latest.json.
-            echo "Release ${TAG} is already published; leaving latest.json as-is"
-            gh release edit "${TAG}" --prerelease=false --latest
+            gh release create "${TAG}" --draft --title "${TITLE}" --notes-file release-notes.md
           fi
 
       - name: 📤 Upload release metadata artifact
@@ -187,7 +145,6 @@ jobs:
           path: |
             release-notes.md
             published-at.txt
-            legacy-latest.json
 
   build-windows:
     name: "🏗️ Build: Windows"
@@ -289,37 +246,6 @@ jobs:
             --targets "windows-x86_64-msi,windows-x86_64-nsis" \
             --output-dir "target-manifests"
           gh release upload "v${VERSION}" target-manifests/*.json --clobber
-
-      # Fallback only: prepare should already have published with legacy latest.json.
-      - name: 🚀 Ensure staged release is published
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG="v${VERSION}"
-          IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
-          if [ "${IS_DRAFT}" = "true" ]; then
-            cp release-metadata/legacy-latest.json latest.json
-            gh release upload "${TAG}" latest.json --clobber
-            gh release edit "${TAG}" --draft=false --prerelease=false --latest
-            echo "Published staged release from Windows fallback with legacy latest.json"
-          else
-            echo "Release is already published; keeping its current latest.json"
-          fi
-
-      # Mid-stage verify uses the tag download URL so parallel jobs do not race
-      # on /releases/latest/ before this release is marked latest (or before
-      # other platforms finish). Public /latest/ is checked in finalize.
-      - name: 🔍 Verify published Windows updater manifests
-        shell: bash
-        run: |
-          set -euo pipefail
-          node scripts/release/verify_published_updater_manifests.cjs \
-            --version "${VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --targets "windows-x86_64-msi,windows-x86_64-nsis" \
-            --latest-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}"
 
   build-macos-aarch64:
     name: "🏗️ Build: macOS Apple Silicon"
@@ -427,17 +353,6 @@ jobs:
             --output-dir "target-manifests"
           gh release upload "v${VERSION}" target-manifests/*.json --clobber
 
-      # Tag URL (not /releases/latest/) — see Windows verify comment.
-      - name: 🔍 Verify published macOS Apple Silicon updater manifest
-        shell: bash
-        run: |
-          set -euo pipefail
-          node scripts/release/verify_published_updater_manifests.cjs \
-            --version "${VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --targets "darwin-aarch64-app" \
-            --latest-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}"
-
   build-macos-x86_64:
     name: "🏗️ Build: macOS Intel"
     # Parallel with Windows / macOS Apple Silicon after prepare.
@@ -543,17 +458,6 @@ jobs:
             --targets "darwin-x86_64-app" \
             --output-dir "target-manifests"
           gh release upload "v${VERSION}" target-manifests/*.json --clobber
-
-      # Tag URL (not /releases/latest/) — see Windows verify comment.
-      - name: 🔍 Verify published macOS Intel updater manifest
-        shell: bash
-        run: |
-          set -euo pipefail
-          node scripts/release/verify_published_updater_manifests.cjs \
-            --version "${VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --targets "darwin-x86_64-app" \
-            --latest-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}"
 
   build-macos-universal:
     name: "🏗️ Build: macOS Universal"
@@ -759,17 +663,6 @@ jobs:
             --output-dir "target-manifests"
           gh release upload "v${VERSION}" target-manifests/*.json --clobber
 
-      # Tag URL (not /releases/latest/) — see Windows verify comment.
-      - name: 🔍 Verify published Linux updater manifests
-        shell: bash
-        run: |
-          set -euo pipefail
-          node scripts/release/verify_published_updater_manifests.cjs \
-            --version "${VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --targets "${{ matrix.targets }}" \
-            --latest-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}"
-
   finalize-legacy-latest:
     name: 🏁 Finalize Legacy Updater Manifest
     # Wait for every platform build so latest.json is complete.
@@ -853,25 +746,13 @@ jobs:
           ' latest.json > /dev/null
           jq -r '.platforms | keys[]' latest.json
 
-      - name: 📤 Publish complete legacy latest.json
+      - name: 📤 Upload complete legacy latest.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
           gh release upload "v${VERSION}" latest.json --clobber
-          gh release edit "v${VERSION}" --draft=false --prerelease=false --latest
-
-      # End-to-end: user-facing /releases/latest/download (do not use tag URL here).
-      - name: 🔍 Verify complete published updater state
-        shell: bash
-        run: |
-          set -euo pipefail
-          node scripts/release/verify_published_updater_manifests.cjs \
-            --version "${VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --targets "darwin-aarch64-app,darwin-x86_64-app,windows-x86_64-msi,windows-x86_64-nsis,linux-x86_64-appimage,linux-x86_64-deb,linux-x86_64-rpm,linux-aarch64-appimage,linux-aarch64-deb,linux-aarch64-rpm" \
-            --legacy
 
   upload-checksums:
     name: 🔗 Publish SHA256SUMS
@@ -919,11 +800,56 @@ jobs:
           set -euo pipefail
           gh release upload "v${VERSION}" SHA256SUMS.txt --clobber
 
+  publish-release:
+    name: 🚀 Publish Verified Release
+    needs:
+      - prepare-release
+      - finalize-legacy-latest
+      - upload-checksums
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_REPO: ${{ github.repository }}
+      VERSION: ${{ needs.prepare-release.outputs.version }}
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Node.js setup
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: 🚀 Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+          IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
+          if [ "${IS_DRAFT}" != "true" ]; then
+            echo "Release ${TAG} is already public; refusing an ambiguous re-publish."
+            exit 1
+          fi
+          gh release edit "${TAG}" --draft=false --prerelease=false --latest
+
+      - name: 🔍 Verify complete published updater state
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/release/verify_published_updater_manifests.cjs \
+            --version "${VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --targets "darwin-aarch64-app,darwin-x86_64-app,windows-x86_64-msi,windows-x86_64-nsis,linux-x86_64-appimage,linux-x86_64-deb,linux-x86_64-rpm,linux-aarch64-appimage,linux-aarch64-deb,linux-aarch64-rpm" \
+            --legacy
+
   update-homebrew-cask:
     name: 🍺 Update Homebrew Cask
     needs:
       - prepare-release
-      - finalize-legacy-latest
+      - publish-release
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -829,11 +829,16 @@ jobs:
           set -euo pipefail
           TAG="v${VERSION}"
           IS_DRAFT="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
-          if [ "${IS_DRAFT}" != "true" ]; then
-            echo "Release ${TAG} is already public; refusing an ambiguous re-publish."
+          if [ "${IS_DRAFT}" = "true" ]; then
+            gh release edit "${TAG}" --draft=false --prerelease=false --latest
+          elif [ "${IS_DRAFT}" = "false" ]; then
+            # Re-running this job after public verification failed must reach
+            # verification again without changing the already public release.
+            echo "Release ${TAG} is already public; continuing to verification."
+          else
+            echo "Unexpected draft state for release ${TAG}: ${IS_DRAFT}"
             exit 1
           fi
-          gh release edit "${TAG}" --draft=false --prerelease=false --latest
 
       - name: 🔍 Verify complete published updater state
         shell: bash

--- a/scripts/release/release_workflow.test.cjs
+++ b/scripts/release/release_workflow.test.cjs
@@ -1,0 +1,39 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const workflowPath = path.join(__dirname, "..", "..", ".github", "workflows", "release.yml");
+const workflow = fs.readFileSync(workflowPath, "utf8");
+
+function jobBody(name, nextName) {
+  const startMarker = `  ${name}:`;
+  const start = workflow.indexOf(startMarker);
+  assert.notEqual(start, -1, `missing ${name} job`);
+  const end = nextName ? workflow.indexOf(`  ${nextName}:`, start + startMarker.length) : workflow.length;
+  assert.notEqual(end, -1, `missing ${nextName} job`);
+  return workflow.slice(start, end);
+}
+
+test("release remains draft until all assets, manifests, and checksums are ready", () => {
+  const prepare = jobBody("prepare-release", "build-windows");
+  const finalize = jobBody("finalize-legacy-latest", "upload-checksums");
+  const checksums = jobBody("upload-checksums", "publish-release");
+  const publish = jobBody("publish-release", "update-homebrew-cask");
+
+  assert.match(prepare, /gh release create "\$\{TAG\}" --draft/);
+  assert.doesNotMatch(prepare, /--draft=false/);
+  assert.doesNotMatch(finalize, /--draft=false/);
+  assert.doesNotMatch(checksums, /--draft=false/);
+  assert.match(publish, /needs:[\s\S]*finalize-legacy-latest[\s\S]*upload-checksums/);
+  assert.match(publish, /gh release edit "\$\{TAG\}" --draft=false --prerelease=false --latest/);
+});
+
+test("public updater verification and Homebrew run only after publication", () => {
+  const publish = jobBody("publish-release", "update-homebrew-cask");
+  const homebrew = jobBody("update-homebrew-cask");
+
+  assert.match(publish, /Verify complete published updater state/);
+  assert.match(publish, /verify_published_updater_manifests\.cjs/);
+  assert.match(homebrew, /needs:[\s\S]*publish-release/);
+});

--- a/scripts/release/release_workflow.test.cjs
+++ b/scripts/release/release_workflow.test.cjs
@@ -1,6 +1,7 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 const test = require("node:test");
 
 const workflowPath = path.join(__dirname, "..", "..", ".github", "workflows", "release.yml");
@@ -36,4 +37,73 @@ test("public updater verification and Homebrew run only after publication", () =
   assert.match(publish, /Verify complete published updater state/);
   assert.match(publish, /verify_published_updater_manifests\.cjs/);
   assert.match(homebrew, /needs:[\s\S]*publish-release/);
+});
+
+// Execute the actual workflow shell steps with fake external commands. This
+// catches early exits that textual ordering checks cannot detect.
+function runPublishJob(overrides = {}) {
+  const publish = jobBody("publish-release", "update-homebrew-cask");
+  const scripts = [...publish.matchAll(/        run: \|\r?\n((?:          .*\r?\n|\r?\n)+)/g)]
+    .map((match) => match[1].replace(/^          /gm, "").replace(/\r/g, ""));
+  assert.equal(scripts.length, 2, "expected publication and verification shell steps");
+  const bash = process.platform === "win32"
+    ? path.join(process.env.ProgramFiles, "Git", "bin", "bash.exe")
+    : "bash";
+  const result = spawnSync(bash, ["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", `
+    gh() {
+      case "$1 $2" in
+        "release view") printf '%s\\n' "$TEST_DRAFT"; return "$TEST_VIEW_STATUS" ;;
+        "release edit") echo "EDIT $*"; return "$TEST_EDIT_STATUS" ;;
+        *) echo "Unexpected gh command: $*" >&2; return 99 ;;
+      esac
+    }
+    node() { echo "VERIFY $*"; return "$TEST_VERIFY_STATUS"; }
+    ${scripts.join("\n")}
+  `], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      VERSION: "1.2.3",
+      GITHUB_REPOSITORY: "example/cockpit-tools",
+      TEST_DRAFT: "true",
+      TEST_VIEW_STATUS: "0",
+      TEST_EDIT_STATUS: "0",
+      TEST_VERIFY_STATUS: "0",
+      ...overrides,
+    },
+  });
+  assert.ifError(result.error);
+  return result;
+}
+
+test("failed public verification can be retried without republishing the release", () => {
+  const first = runPublishJob({ TEST_VERIFY_STATUS: "1" });
+  assert.equal(first.status, 1, first.stderr);
+  assert.match(first.stdout, /EDIT release edit v1\.2\.3 --draft=false --prerelease=false --latest/);
+  assert.match(first.stdout, /VERIFY scripts\/release\/verify_published_updater_manifests\.cjs/);
+
+  const retry = runPublishJob({ TEST_DRAFT: "false" });
+  assert.equal(retry.status, 0, retry.stderr);
+  assert.doesNotMatch(retry.stdout, /EDIT /);
+  assert.match(retry.stdout, /VERIFY scripts\/release\/verify_published_updater_manifests\.cjs --version 1\.2\.3 --repo example\/cockpit-tools/);
+  assert.match(retry.stdout, /--legacy/);
+});
+
+test("verification failure still fails a retry of an already public release", () => {
+  const result = runPublishJob({ TEST_DRAFT: "false", TEST_VERIFY_STATUS: "1" });
+  assert.equal(result.status, 1, result.stderr);
+  assert.doesNotMatch(result.stdout, /EDIT /);
+  assert.match(result.stdout, /VERIFY /);
+});
+
+test("release lookup and publication failures stop before public verification", () => {
+  for (const overrides of [
+    { TEST_VIEW_STATUS: "1" },
+    { TEST_EDIT_STATUS: "1" },
+    { TEST_DRAFT: "null" },
+  ]) {
+    const result = runPublishJob(overrides);
+    assert.equal(result.status, 1, result.stderr);
+    assert.doesNotMatch(result.stdout, /VERIFY /);
+  }
 });


### PR DESCRIPTION
修复 #2269。

## 问题

当前 release workflow 在 `prepare-release` 阶段就把新版本从 draft 发布并标记为 `latest`，然后 Windows、macOS、Linux 才继续上传完整 assets、updater manifests 和 checksum。任一平台中途失败，都可能留下一个已经公开但不完整的 latest release。

## 改动

- `prepare-release` 只创建或更新 draft release；如果同 tag 已经公开，则直接停止，不再改写公开 release。
- 删除复制上一版本 `latest.json` 并提前发布的 workaround。
- 各平台在 draft 阶段继续上传 assets 和 target manifests，不再依赖公开 tag URL 做中途验证。
- 所有平台完成后生成并上传完整 legacy `latest.json`，release 仍保持 draft。
- `SHA256SUMS.txt` 上传完成后，由独立 `publish-release` job 唯一一次执行 `--draft=false --latest`。
- 公开 updater 的端到端验证移到发布之后。
- Homebrew 更新依赖 `publish-release`。
- 新增两个 workflow regression tests，固定这套发布顺序。

## 验证

在 fork GitHub Actions runner 上执行：

`node --test scripts/release/*.test.cjs`

结果：**15/15 passed**，包括全部现有 release-script tests 和 2 个新增 workflow regression tests。

这个 PR 只修改 release workflow 和对应测试，不改产品代码或版本策略。