### PR TITLE
fix(cask): migrate deprecated verified/postflight to postflight_steps

### DIFF
--- a/Casks/cockpit-tools.rb
+++ b/Casks/cockpit-tools.rb
@@ -2,21 +2,20 @@ cask "cockpit-tools" do
   version "1.3.42"
   sha256 "7d94e6a4282247fee078532bd9d197262a65baa2daf6458240491fa295f0c119"
 
-  url "https://github.com/jlcodes99/cockpit-tools/releases/download/v#{version}/Cockpit.Tools_#{version}_universal.dmg",
-      verified: "github.com/jlcodes99/cockpit-tools/"
+  url "https://github.com/jlcodes99/cockpit-tools/releases/download/v#{version}/Cockpit.Tools_#{version}_universal.dmg"
   name "Cockpit Tools"
   desc "Account manager for AI IDEs (Antigravity and Codex)"
   homepage "https://github.com/jlcodes99/cockpit-tools"
 
   auto_updates true
 
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-cr", "#{appdir}/Cockpit Tools.app"],
-                   sudo: true
-  end
-
   app "Cockpit Tools.app"
+
+  postflight_steps do
+    run "/usr/bin/xattr",
+        args: ["-cr", "{{appdir}}/Cockpit Tools.app"],
+        sudo: true
+  end
 
   zap trash: [
     "~/Library/Application Support/com.jlcodes.cockpit-tools",


### PR DESCRIPTION
Homebrew 6 deprecates two stanzas used here; every brew command touching this cask prints both warnings:

- `verified` parameter in `url` (same host, covered by default verification — removed)
- `postflight do system_command ... end` → `postflight_steps do run ... end` (literal args, `{{appdir}}` token, `sudo: true` preserved)

Also moved `postflight_steps` after the `app` stanza per Cask Cookbook stanza order. Verified with `ruby -c`; behavior unchanged (same xattr -cr on the installed app).