### PR TITLE
fix(antigravity): preserve is_gcp_tos for gmail domains and clear sta…

### DIFF
--- a/src-tauri/src/modules/db.rs
+++ b/src-tauri/src/modules/db.rs
@@ -165,6 +165,7 @@ fn inject_unified_oauth_token(
         .unwrap_or_default();
     let mut topic =
         protobuf::remove_unified_topic_entry(&current_topic, "oauthTokenInfoSentinelKey")?;
+    topic = protobuf::remove_unified_topic_entry(&topic, "authStateWithContextSentinelKey")?;
 
     // 创建 OAuthTokenInfo（二进制）
     let oauth_info = protobuf::create_oauth_info_with_metadata(

--- a/src-tauri/src/utils/protobuf.rs
+++ b/src-tauri/src/utils/protobuf.rs
@@ -94,13 +94,7 @@ pub fn create_oauth_info_with_metadata(
     id_token: Option<&str>,
     email: Option<&str>,
 ) -> Vec<u8> {
-    let mut is_gcp_tos = is_gcp_tos.unwrap_or(false);
-    if let Some(email) = email.map(str::trim).filter(|value| !value.is_empty()) {
-        let lower = email.to_ascii_lowercase();
-        if lower.ends_with("@gmail.com") || lower.ends_with("@googlemail.com") {
-            is_gcp_tos = false;
-        }
-    }
+    let is_gcp_tos = is_gcp_tos.unwrap_or(false);
 
     // Field 1: access_token (string, wire_type = 2)
     let field1 = encode_string_field(1, access_token);
@@ -296,3 +290,39 @@ fn extract_string_field(data: &[u8], target_field: u32) -> Option<String> {
 
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_oauth_info_with_metadata_gmail_gcp_tos() {
+        let payload = create_oauth_info_with_metadata(
+            "fake_access_token",
+            "fake_refresh_token",
+            1700000000,
+            Some(true),
+            Some("fake_id_token"),
+            Some("test-gcp-tos-user@gmail.com"),
+        );
+
+        let has_field_6 = payload.windows(2).any(|w| w == [0x30, 0x01]);
+        assert!(has_field_6, "Protobuf must encode field 6 when is_gcp_tos is Some(true)");
+    }
+
+    #[test]
+    fn test_create_oauth_info_with_metadata_gmail_personal() {
+        let payload = create_oauth_info_with_metadata(
+            "fake_access_token",
+            "fake_refresh_token",
+            1700000000,
+            None,
+            Some("fake_id_token"),
+            Some("test-personal-user@gmail.com"),
+        );
+
+        let has_field_6 = payload.windows(2).any(|w| w == [0x30, 0x01]);
+        assert!(!has_field_6, "Protobuf must NOT encode field 6 when is_gcp_tos is None");
+    }
+}
+


### PR DESCRIPTION
- Protobuf: Stop forcing is_gcp_tos = false for @gmail.com and @googlemail.com domains in create_oauth_info_with_metadata. Accounts with Standard Tier / GCP ToS subscriptions can use gmail addresses.

- Database: Clear stale authStateWithContextSentinelKey entry when injecting updated unified oauth token to prevent previous account session snapshot from corrupting new account initialization in Antigravity IDE.

- Tests: Add unit tests verifying protobuf field 6 encoding for GCP ToS vs personal accounts.