### PR TITLE
fix(antigravity): resolve ineligible error on GCP ToS account switch and preserve IDE state cache

### DIFF
--- a/crates/cockpit-core/src/modules/account.rs
+++ b/crates/cockpit-core/src/modules/account.rs
@@ -1609,12 +1609,16 @@ pub async fn switch_account_internal(account_id: &str) -> Result<Account, String
         modules::logger::log_warn(&format!("[Switch] 更新默认实例绑定账号失败: {}", e));
     }
 
-    // 6. 对齐默认实例启动逻辑：按默认实例目录关闭受管进程，再注入默认实例目录
+    // 6. 对齐默认实例启动逻辑：按默认实例目录关闭受管进程，再同步注入所有存在的 Antigravity 目录
     let default_dir = modules::instance::get_default_user_data_dir()?;
     let default_dir_str = default_dir.to_string_lossy().to_string();
     modules::process::close_antigravity_instances(&[default_dir_str], 20)?;
     let _ = modules::instance::update_default_pid(None);
-    modules::instance::inject_account_to_profile(&default_dir, account_id)?;
+    for target_dir in modules::instance::get_all_antigravity_user_data_dirs() {
+        if let Err(e) = modules::instance::inject_account_to_profile(&target_dir, account_id) {
+            modules::logger::log_warn(&format!("[Switch] 注入目录 {} 失败: {}", target_dir.display(), e));
+        }
+    }
 
     // 7. 启动 Antigravity IDE（带默认实例自定义启动参数；启动失败不阻断切号，保持原行为）
     modules::logger::log_info("[Switch] 正在启动 Antigravity IDE 默认实例...");
@@ -1921,8 +1925,15 @@ pub async fn switch_account_local_no_restart(account_id: &str) -> Result<Account
         ));
     }
 
-    let default_dir = modules::instance::get_default_user_data_dir()?;
-    modules::instance::inject_account_to_profile(&default_dir, account_id)?;
+    for target_dir in modules::instance::get_all_antigravity_user_data_dirs() {
+        if let Err(e) = modules::instance::inject_account_to_profile(&target_dir, account_id) {
+            modules::logger::log_warn(&format!(
+                "[Switch][NoRestart] 注入目录 {} 失败: {}",
+                target_dir.display(),
+                e
+            ));
+        }
+    }
 
     modules::logger::log_info(&format!(
         "[Switch][NoRestart] 本地切号完成: {}",

--- a/crates/cockpit-core/src/modules/instance.rs
+++ b/crates/cockpit-core/src/modules/instance.rs
@@ -136,6 +136,48 @@ fn windows_app_root_exists(root_name: &str, exe_names: &[&str]) -> bool {
         .any(|exe_name| root.join(exe_name).exists())
 }
 
+/// 获取所有存在的 Antigravity 用户数据目录（同时包含 `Antigravity` 与 `Antigravity IDE`）。
+pub fn get_all_antigravity_user_data_dirs() -> Vec<PathBuf> {
+    let mut results = Vec::new();
+    #[cfg(target_os = "windows")]
+    if let Ok(appdata) = std::env::var("APPDATA") {
+        let appdata = PathBuf::from(appdata);
+        for candidate in windows_antigravity_user_data_candidates(&appdata) {
+            if candidate.exists() {
+                results.push(candidate);
+            }
+        }
+    }
+    #[cfg(target_os = "macos")]
+    if let Some(home) = dirs::home_dir() {
+        let ide_dir = home.join("Library/Application Support/Antigravity IDE");
+        let app_dir = home.join("Library/Application Support/Antigravity");
+        if ide_dir.exists() {
+            results.push(ide_dir);
+        }
+        if app_dir.exists() {
+            results.push(app_dir);
+        }
+    }
+    #[cfg(target_os = "linux")]
+    if let Some(home) = dirs::home_dir() {
+        let ide_dir = home.join(".config/Antigravity IDE");
+        let app_dir = home.join(".config/Antigravity");
+        if ide_dir.exists() {
+            results.push(ide_dir);
+        }
+        if app_dir.exists() {
+            results.push(app_dir);
+        }
+    }
+    if results.is_empty() {
+        if let Ok(default_dir) = get_default_user_data_dir() {
+            results.push(default_dir);
+        }
+    }
+    results
+}
+
 pub fn get_default_instances_root_dir() -> Result<PathBuf, String> {
     #[cfg(target_os = "macos")]
     {

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -601,8 +601,8 @@ pub async fn switch_account(
 
     modules::logger::log_info(&format!("开始切换账号: {}", account_id));
 
-    // 1. 加载并验证账号存在
-    let mut account = modules::load_account(&account_id)?;
+    // 1. 加载并验证账号存在，并预刷新与探测必要元数据
+    let mut account = modules::account::prepare_account_for_injection(&account_id).await?;
     modules::logger::log_info(&format!(
         "正在切换到账号: {} (ID: {})",
         account.email, account.id
@@ -622,24 +622,12 @@ pub async fn switch_account(
         return Err(e);
     }
 
-    // 2. 确保 Token 有效（自动刷新过期的 Token）
-    let fresh_token = modules::oauth::ensure_fresh_token(&account.token)
-        .await
-        .map_err(|e| format!("Token 刷新失败: {}", e))?;
-
-    // 如果 Token 更新了，保存回账号文件
-    if fresh_token.access_token != account.token.access_token {
-        modules::logger::log_info(&format!("Token 已刷新: {}", account.email));
-        account.token = fresh_token.clone();
-        modules::save_account(&account)?;
-    }
-
-    // 3. 更新工具内部状态
+    // 2. 更新工具内部状态
     modules::set_current_account_id(&account_id)?;
     account.update_last_used();
     modules::save_account(&account)?;
 
-    // 4. 同步更新 Antigravity IDE 默认实例的绑定账号（不同步到 Codex，因为账号体系不同）
+    // 3. 同步更新 Antigravity IDE 默认实例的绑定账号（不同步到 Codex，因为账号体系不同）
     if let Err(e) = modules::instance::update_default_settings(
         Some(Some(account_id.clone())),
         None,
@@ -653,15 +641,15 @@ pub async fn switch_account(
         ));
     }
 
-    // 5. 关闭受管进程：按默认实例目录关闭受管进程，等待其完全退出
+    // 4. 关闭受管进程：按默认实例目录关闭受管进程，等待其完全退出
     let default_dir = modules::instance::get_default_user_data_dir()?;
     let default_dir_str = default_dir.to_string_lossy().to_string();
     modules::process::close_antigravity_instances(&[default_dir_str], 20)?;
     let _ = modules::instance::update_default_pid(None);
 
-    // 6. 进程完全退出后，执行磁盘级别的文件注入
-    // 6.1 将账号 Token 注入默认实例目录
-    modules::instance::inject_account_to_profile(&default_dir, &account_id)?;
+    // 5. 进程完全退出后，执行磁盘级别的文件注入
+    // 5.1 将账号 Token 注入默认实例目录
+    modules::instance::inject_account_to_profile_with_account(&default_dir, &account)?;
 
     // 7. 启动 Antigravity IDE（带默认实例自定义启动参数；启动失败不阻断切号，保持原行为）
     modules::logger::log_info("正在启动 Antigravity IDE 默认实例...");

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -648,8 +648,12 @@ pub async fn switch_account(
     let _ = modules::instance::update_default_pid(None);
 
     // 5. 进程完全退出后，执行磁盘级别的文件注入
-    // 5.1 将账号 Token 注入默认实例目录
-    modules::instance::inject_account_to_profile_with_account(&default_dir, &account)?;
+    // 5.1 将账号 Token 同步注入所有存在的 Antigravity 目录
+    for target_dir in modules::instance::get_all_antigravity_user_data_dirs() {
+        if let Err(e) = modules::instance::inject_account_to_profile_with_account(&target_dir, &account) {
+            modules::logger::log_warn(&format!("[Switch] 注入目录 {} 失败: {}", target_dir.display(), e));
+        }
+    }
 
     // 7. 启动 Antigravity IDE（带默认实例自定义启动参数；启动失败不阻断切号，保持原行为）
     modules::logger::log_info("正在启动 Antigravity IDE 默认实例...");

--- a/src-tauri/src/commands/instance.rs
+++ b/src-tauri/src/commands/instance.rs
@@ -226,8 +226,8 @@ pub async fn start_instance(instance_id: String) -> Result<InstanceProfileView, 
         modules::process::close_antigravity_instances(&[default_dir_str.clone()], 20)?;
         let _ = modules::instance::update_default_pid(None)?;
         if let Some(ref account_id) = default_bind_account_id {
-            let _ = modules::prepare_account_for_injection(account_id).await?;
-            modules::instance::inject_account_to_profile(&default_dir, account_id)?;
+            let account = modules::prepare_account_for_injection(account_id).await?;
+            modules::instance::inject_account_to_profile_with_account(&default_dir, &account)?;
         }
         let extra_args = modules::process::parse_extra_args(&default_settings.extra_args);
         let pid = modules::process::start_antigravity_with_args("", &extra_args)?;
@@ -267,9 +267,9 @@ pub async fn start_instance(instance_id: String) -> Result<InstanceProfileView, 
     let _ = modules::instance::update_instance_pid(&instance.id, None)?;
 
     if let Some(ref account_id) = instance.bind_account_id {
-        let _ = modules::prepare_account_for_injection(account_id).await?;
+        let account = modules::prepare_account_for_injection(account_id).await?;
         let profile_dir = std::path::PathBuf::from(&instance.user_data_dir);
-        modules::instance::inject_account_to_profile(&profile_dir, account_id)?;
+        modules::instance::inject_account_to_profile_with_account(&profile_dir, &account)?;
     }
 
     let extra_args = modules::process::parse_extra_args(&instance.extra_args);

--- a/src-tauri/src/models/quota.rs
+++ b/src-tauri/src/models/quota.rs
@@ -36,6 +36,12 @@ pub struct QuotaData {
     /// 账号层级 ID（如 free-tier、g1-pro-tier）
     #[serde(default)]
     pub tier_id: Option<String>,
+    /// 是否使用 GCP ToS
+    #[serde(default)]
+    pub is_gcp_tos: Option<bool>,
+    /// GCP / Enterprise 项目 ID
+    #[serde(default)]
+    pub project_id: Option<String>,
 }
 
 impl QuotaData {
@@ -47,6 +53,8 @@ impl QuotaData {
             subscription_tier: None,
             credits: Vec::new(),
             tier_id: None,
+            is_gcp_tos: None,
+            project_id: None,
         }
     }
 

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -2071,12 +2071,18 @@ pub async fn switch_account_internal(account_id: &str) -> Result<Account, String
         modules::logger::log_warn(&format!("[Switch] 更新默认实例绑定账号失败: {}", e));
     }
 
-    // 6. 对齐默认实例启动逻辑：按默认实例目录关闭受管进程，再注入默认实例目录
+    // 6. 对齐默认实例启动逻辑：按默认实例目录关闭受管进程，再同步注入所有存在的 Antigravity 目录
     let default_dir = modules::instance::get_default_user_data_dir()?;
     let default_dir_str = default_dir.to_string_lossy().to_string();
     modules::process::close_antigravity_instances(&[default_dir_str], 20)?;
     let _ = modules::instance::update_default_pid(None);
-    modules::instance::inject_account_to_profile_with_account(&default_dir, &account)?;
+    for target_dir in modules::instance::get_all_antigravity_user_data_dirs() {
+        if let Err(e) = modules::instance::inject_account_to_profile_with_account(&target_dir, &account) {
+            modules::logger::log_warn(&format!("[Switch] 注入目录 {} 失败: {}", target_dir.display(), e));
+        } else {
+            modules::logger::log_info(&format!("[Switch] 成功注入目录: {}", target_dir.display()));
+        }
+    }
 
     // 7. 启动 Antigravity IDE（带默认实例自定义启动参数；启动失败不阻断切号，保持原行为）
     modules::logger::log_info("[Switch] 正在启动 Antigravity IDE 默认实例...");
@@ -2383,8 +2389,20 @@ pub async fn switch_account_local_no_restart(account_id: &str) -> Result<Account
         ));
     }
 
-    let default_dir = modules::instance::get_default_user_data_dir()?;
-    modules::instance::inject_account_to_profile_with_account(&default_dir, &account)?;
+    for target_dir in modules::instance::get_all_antigravity_user_data_dirs() {
+        if let Err(e) = modules::instance::inject_account_to_profile_with_account(&target_dir, &account) {
+            modules::logger::log_warn(&format!(
+                "[Switch][NoRestart] 注入目录 {} 失败: {}",
+                target_dir.display(),
+                e
+            ));
+        } else {
+            modules::logger::log_info(&format!(
+                "[Switch][NoRestart] 成功注入目录: {}",
+                target_dir.display()
+            ));
+        }
+    }
 
     modules::logger::log_info(&format!(
         "[Switch][NoRestart] 本地切号完成: {}",

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -2008,6 +2008,16 @@ pub async fn fetch_quota_with_fresh_token(
                 ));
                 account.clear_disabled();
             }
+            if let Some(gcp_tos) = payload.quota.is_gcp_tos {
+                if account.token.is_gcp_tos != Some(gcp_tos) {
+                    account.token.is_gcp_tos = Some(gcp_tos);
+                }
+            }
+            if let Some(ref project_id) = payload.quota.project_id {
+                if account.token.project_id.as_deref() != Some(project_id.as_str()) {
+                    account.token.project_id = Some(project_id.clone());
+                }
+            }
             account.quota_error = payload.error.map(|err| QuotaErrorInfo {
                 code: err.code,
                 message: err.message,
@@ -2066,7 +2076,7 @@ pub async fn switch_account_internal(account_id: &str) -> Result<Account, String
     let default_dir_str = default_dir.to_string_lossy().to_string();
     modules::process::close_antigravity_instances(&[default_dir_str], 20)?;
     let _ = modules::instance::update_default_pid(None);
-    modules::instance::inject_account_to_profile(&default_dir, account_id)?;
+    modules::instance::inject_account_to_profile_with_account(&default_dir, &account)?;
 
     // 7. 启动 Antigravity IDE（带默认实例自定义启动参数；启动失败不阻断切号，保持原行为）
     modules::logger::log_info("[Switch] 正在启动 Antigravity IDE 默认实例...");
@@ -2374,7 +2384,7 @@ pub async fn switch_account_local_no_restart(account_id: &str) -> Result<Account
     }
 
     let default_dir = modules::instance::get_default_user_data_dir()?;
-    modules::instance::inject_account_to_profile(&default_dir, account_id)?;
+    modules::instance::inject_account_to_profile_with_account(&default_dir, &account)?;
 
     modules::logger::log_info(&format!(
         "[Switch][NoRestart] 本地切号完成: {}",
@@ -2383,15 +2393,44 @@ pub async fn switch_account_local_no_restart(account_id: &str) -> Result<Account
     Ok(account)
 }
 
-/// 准备账号注入：确保 Token 新鲜并落盘
+/// 准备账号注入：确保 Token 新鲜并补齐必要元数据后落盘
 pub async fn prepare_account_for_injection(account_id: &str) -> Result<Account, String> {
     let mut account = load_account(account_id)?;
     let fresh_token = modules::oauth::ensure_fresh_token(&account.token)
         .await
         .map_err(|e| format!("Token 刷新失败: {}", e))?;
+    let mut token_changed = false;
     if fresh_token.access_token != account.token.access_token {
         modules::logger::log_info("[Account] Token 已刷新");
         account.token = fresh_token.clone();
+        token_changed = true;
+    }
+
+    // 全链路确保 is_gcp_tos 与 project_id 已被探测和沉淀
+    let needs_probe = account.token.is_gcp_tos.is_none()
+        || (account.token.is_gcp_tos == Some(true) && account.token.project_id.is_none());
+    if needs_probe {
+        modules::logger::log_info(&format!(
+            "[Account] 准备注入时发现缺少 GCP ToS 或 ProjectId 元数据，执行自动探测: {}",
+            account.email
+        ));
+        let meta =
+            modules::quota::fetch_project_metadata_for_token(&account.token, &account.email).await;
+        if let Some(gcp_tos) = meta.is_gcp_tos {
+            if account.token.is_gcp_tos != Some(gcp_tos) {
+                account.token.is_gcp_tos = Some(gcp_tos);
+                token_changed = true;
+            }
+        }
+        if let Some(project_id) = meta.project_id {
+            if account.token.project_id.as_deref() != Some(&project_id) {
+                account.token.project_id = Some(project_id);
+                token_changed = true;
+            }
+        }
+    }
+
+    if token_changed {
         save_account(&account)?;
     }
     Ok(account)

--- a/src-tauri/src/modules/antigravity_paths.rs
+++ b/src-tauri/src/modules/antigravity_paths.rs
@@ -102,6 +102,48 @@ pub fn legacy_default_user_data_dir() -> Result<PathBuf, String> {
     Err("无法确定 Antigravity 默认目录".to_string())
 }
 
+/// 获取所有存在的 Antigravity 用户数据目录（同时包含 `Antigravity` 与 `Antigravity IDE`）。
+/// 在切号时同步注入所有存在的目录，确保不同版本客户端均能识别新账号。
+pub fn all_antigravity_user_data_dirs() -> Vec<PathBuf> {
+    let mut results = Vec::new();
+    #[cfg(target_os = "windows")]
+    if let Ok(roaming_dir) = roaming_app_data_dir() {
+        for candidate in windows_user_data_candidates(&roaming_dir) {
+            if candidate.exists() {
+                results.push(candidate);
+            }
+        }
+    }
+    #[cfg(target_os = "macos")]
+    if let Some(home) = dirs::home_dir() {
+        let ide_dir = home.join("Library/Application Support/Antigravity IDE");
+        let app_dir = home.join("Library/Application Support/Antigravity");
+        if ide_dir.exists() {
+            results.push(ide_dir);
+        }
+        if app_dir.exists() {
+            results.push(app_dir);
+        }
+    }
+    #[cfg(target_os = "linux")]
+    if let Some(home) = dirs::home_dir() {
+        let ide_dir = home.join(".config/Antigravity IDE");
+        let app_dir = home.join(".config/Antigravity");
+        if ide_dir.exists() {
+            results.push(ide_dir);
+        }
+        if app_dir.exists() {
+            results.push(app_dir);
+        }
+    }
+    if results.is_empty() {
+        if let Ok(default_dir) = default_user_data_dir() {
+            results.push(default_dir);
+        }
+    }
+    results
+}
+
 pub fn managed_instances_root_dir() -> Result<PathBuf, String> {
     #[cfg(target_os = "macos")]
     {

--- a/src-tauri/src/modules/db.rs
+++ b/src-tauri/src/modules/db.rs
@@ -69,17 +69,59 @@ pub fn inject_token_to_path(
     )
 }
 
+/// 推导账号的 is_gcp_tos 属性（优先使用 token 中的显式字段，若缺失则通过配额层级做静态推断兜底）
+pub fn resolve_account_is_gcp_tos(account: &Account) -> Option<bool> {
+    if let Some(is_gcp_tos) = account.token.is_gcp_tos {
+        return Some(is_gcp_tos);
+    }
+    if let Some(ref quota) = account.quota {
+        if let Some(is_gcp_tos) = quota.is_gcp_tos {
+            return Some(is_gcp_tos);
+        }
+        if quota.tier_id.as_deref() == Some("standard-tier")
+            || quota.subscription_tier.as_deref() == Some("standard-tier")
+        {
+            return Some(true);
+        }
+    }
+    None
+}
+
+/// 推导账号的 project_id 属性（优先 token，其次 quota，若属于 GCP ToS 账号则兜底为 "aicode-consumers"）
+pub fn resolve_account_project_id(account: &Account) -> Option<String> {
+    if let Some(ref project_id) = account.token.project_id {
+        let trimmed = project_id.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    if let Some(ref quota) = account.quota {
+        if let Some(ref project_id) = quota.project_id {
+            let trimmed = project_id.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    if resolve_account_is_gcp_tos(account) == Some(true) {
+        return Some("aicode-consumers".to_string());
+    }
+    None
+}
+
 /// 按账号数据注入 Token 到指定数据库路径。
 pub fn inject_account_token_to_path(db_path: &Path, account: &Account) -> Result<String, String> {
+    let resolved_is_gcp_tos = resolve_account_is_gcp_tos(account);
+    let resolved_project_id = resolve_account_project_id(account);
     inject_token_to_path_with_metadata(
         db_path,
         &account.token.access_token,
         &account.token.refresh_token,
         account.token.expiry_timestamp,
-        account.token.is_gcp_tos,
+        resolved_is_gcp_tos,
         account.token.id_token.as_deref(),
         Some(account.email.as_str()),
-        account.token.project_id.as_deref(),
+        resolved_project_id.as_deref(),
     )
 }
 
@@ -165,6 +207,7 @@ fn inject_unified_oauth_token(
         .unwrap_or_default();
     let mut topic =
         protobuf::remove_unified_topic_entry(&current_topic, "oauthTokenInfoSentinelKey")?;
+    topic = protobuf::remove_unified_topic_entry(&topic, "authStateWithContextSentinelKey")?;
 
     // 创建 OAuthTokenInfo（二进制）
     let oauth_info = protobuf::create_oauth_info_with_metadata(
@@ -193,6 +236,22 @@ fn inject_unified_oauth_token(
 }
 
 fn inject_user_status(conn: &Connection, email: &str) -> Result<(), String> {
+    // 检查是否已存在 userStatus；如果已存在完整配置，绝不覆盖，避免抹掉已缓存的模型与特性
+    let existing_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM ItemTable WHERE key = 'antigravityUnifiedStateSync.userStatus'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    if existing_count > 0 {
+        crate::modules::logger::log_info(
+            "antigravityUnifiedStateSync.userStatus 已存在，保留完整配置由 Language Server 动态同步",
+        );
+        return Ok(());
+    }
+
     let payload = protobuf::create_minimal_user_status_payload(email);
     let topic = protobuf::create_unified_topic_entry("userStatusSentinelKey", &payload);
     let topic_b64 = general_purpose::STANDARD.encode(topic);
@@ -242,3 +301,88 @@ pub fn write_service_machine_id(service_machine_id: &str) -> Result<(), String> 
     crate::modules::logger::log_info(&format!("serviceMachineId 已写入: {}", service_machine_id));
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{Account, QuotaData, TokenData};
+
+    fn make_test_account(is_gcp_tos: Option<bool>, quota: Option<QuotaData>) -> Account {
+        let mut token = TokenData::new(
+            "access".to_string(),
+            "refresh".to_string(),
+            3600,
+            Some("test@example.com".to_string()),
+            None,
+            None,
+        );
+        token.is_gcp_tos = is_gcp_tos;
+        let mut account = Account::new("id-1".to_string(), "test@example.com".to_string(), token);
+        account.quota = quota;
+        account
+    }
+
+    #[test]
+    fn test_resolve_account_is_gcp_tos_from_token() {
+        let acc_true = make_test_account(Some(true), None);
+        assert_eq!(resolve_account_is_gcp_tos(&acc_true), Some(true));
+
+        let acc_false = make_test_account(Some(false), None);
+        assert_eq!(resolve_account_is_gcp_tos(&acc_false), Some(false));
+    }
+
+    #[test]
+    fn test_resolve_account_is_gcp_tos_from_quota() {
+        let mut quota = QuotaData::new();
+        quota.is_gcp_tos = Some(true);
+        let acc = make_test_account(None, Some(quota));
+        assert_eq!(resolve_account_is_gcp_tos(&acc), Some(true));
+
+        let mut quota_tier = QuotaData::new();
+        quota_tier.tier_id = Some("standard-tier".to_string());
+        let acc_tier = make_test_account(None, Some(quota_tier));
+        assert_eq!(resolve_account_is_gcp_tos(&acc_tier), Some(true));
+
+        let mut quota_sub = QuotaData::new();
+        quota_sub.subscription_tier = Some("standard-tier".to_string());
+        let acc_sub = make_test_account(None, Some(quota_sub));
+        assert_eq!(resolve_account_is_gcp_tos(&acc_sub), Some(true));
+
+        let mut quota_free = QuotaData::new();
+        quota_free.tier_id = Some("free-tier".to_string());
+        let acc_free = make_test_account(None, Some(quota_free));
+        assert_eq!(resolve_account_is_gcp_tos(&acc_free), None);
+    }
+
+    #[test]
+    fn test_resolve_account_project_id() {
+        // 1. Token 显式设置优先
+        let mut acc_token = make_test_account(Some(true), None);
+        acc_token.token.project_id = Some("custom-project".to_string());
+        assert_eq!(
+            resolve_account_project_id(&acc_token),
+            Some("custom-project".to_string())
+        );
+
+        // 2. 配额中设置的 project_id 次之
+        let mut quota = QuotaData::new();
+        quota.project_id = Some("quota-project".to_string());
+        let acc_quota = make_test_account(Some(false), Some(quota));
+        assert_eq!(
+            resolve_account_project_id(&acc_quota),
+            Some("quota-project".to_string())
+        );
+
+        // 3. GCP ToS 账号自动兜底 aicode-consumers
+        let acc_tos = make_test_account(Some(true), None);
+        assert_eq!(
+            resolve_account_project_id(&acc_tos),
+            Some("aicode-consumers".to_string())
+        );
+
+        // 4. 普通非 GCP ToS 个人账号返回 None
+        let acc_personal = make_test_account(Some(false), None);
+        assert_eq!(resolve_account_project_id(&acc_personal), None);
+    }
+}
+

--- a/src-tauri/src/modules/instance.rs
+++ b/src-tauri/src/modules/instance.rs
@@ -80,6 +80,10 @@ pub fn get_default_user_data_dir() -> Result<PathBuf, String> {
     modules::antigravity_paths::default_user_data_dir()
 }
 
+pub fn get_all_antigravity_user_data_dirs() -> Vec<PathBuf> {
+    modules::antigravity_paths::all_antigravity_user_data_dirs()
+}
+
 pub fn get_default_instances_root_dir() -> Result<PathBuf, String> {
     modules::antigravity_paths::managed_instances_root_dir()
 }

--- a/src-tauri/src/modules/instance.rs
+++ b/src-tauri/src/modules/instance.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::models::{DefaultInstanceSettings, InstanceProfile, InstanceStore};
+use crate::models::{Account, DefaultInstanceSettings, InstanceProfile, InstanceStore};
 use crate::modules;
 use crate::modules::instance_store;
 
@@ -167,8 +167,15 @@ fn ensure_state_db_for_injection(profile_dir: &Path) -> Result<PathBuf, String> 
 
 pub fn inject_account_to_profile(profile_dir: &Path, account_id: &str) -> Result<(), String> {
     let account = modules::load_account(account_id)?;
+    inject_account_to_profile_with_account(profile_dir, &account)
+}
+
+pub fn inject_account_to_profile_with_account(
+    profile_dir: &Path,
+    account: &Account,
+) -> Result<(), String> {
     let db_path = ensure_state_db_for_injection(profile_dir)?;
-    modules::db::inject_account_token_to_path(&db_path, &account).map(|_| ())
+    modules::db::inject_account_token_to_path(&db_path, account).map(|_| ())
 }
 
 pub fn create_instance(params: CreateInstanceParams) -> Result<InstanceProfile, String> {

--- a/src-tauri/src/modules/quota.rs
+++ b/src-tauri/src/modules/quota.rs
@@ -411,11 +411,15 @@ struct AllowedTier {
     id: Option<String>,
     #[serde(rename = "isDefault")]
     is_default: Option<bool>,
+    #[serde(rename = "usesGcpTos")]
+    uses_gcp_tos: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
 struct Tier {
     id: Option<String>,
+    #[serde(rename = "usesGcpTos")]
+    uses_gcp_tos: Option<bool>,
     #[serde(rename = "availableCredits", default)]
     available_credits: Option<Vec<AvailableCreditRaw>>,
 }
@@ -614,13 +618,29 @@ fn extract_credits_from_tier(tier: &Tier) -> Vec<CreditInfo> {
         .unwrap_or_default()
 }
 
+#[derive(Debug, Clone)]
+pub struct ProjectMetadataResult {
+    pub project_id: Option<String>,
+    pub subscription_tier: Option<String>,
+    pub credits: Vec<CreditInfo>,
+    pub is_gcp_tos: Option<bool>,
+}
+
 /// 获取项目 ID、订阅类型和积分信息（优先使用 token 中的 project_id / is_gcp_tos 上下文）
 pub async fn fetch_project_id_for_token(
     token: &TokenData,
     email: &str,
 ) -> (Option<String>, Option<String>, Vec<CreditInfo>) {
+    let meta = fetch_project_metadata_for_token(token, email).await;
+    (meta.project_id, meta.subscription_tier, meta.credits)
+}
+
+pub async fn fetch_project_metadata_for_token(
+    token: &TokenData,
+    email: &str,
+) -> ProjectMetadataResult {
     let ctx = QuotaCloudCodeContext::from_token(token);
-    fetch_project_id_with_context(&token.access_token, email, &ctx).await
+    fetch_project_metadata_with_context(&token.access_token, email, &ctx).await
 }
 
 pub async fn fetch_project_id_with_context(
@@ -628,11 +648,21 @@ pub async fn fetch_project_id_with_context(
     email: &str,
     ctx: &QuotaCloudCodeContext,
 ) -> (Option<String>, Option<String>, Vec<CreditInfo>) {
+    let meta = fetch_project_metadata_with_context(access_token, email, ctx).await;
+    (meta.project_id, meta.subscription_tier, meta.credits)
+}
+
+pub async fn fetch_project_metadata_with_context(
+    access_token: &str,
+    email: &str,
+    ctx: &QuotaCloudCodeContext,
+) -> ProjectMetadataResult {
     let client = create_client();
     let mut subscription_tier: Option<String> = None;
     let mut allowed_tiers: Vec<AllowedTier> = Vec::new();
     let mut last_error: Option<String> = None;
     let mut credits: Vec<CreditInfo> = Vec::new();
+    let mut resolved_is_gcp_tos: Option<bool> = if ctx.is_gcp_tos { Some(true) } else { None };
     let base_url = resolve_cloud_code_base_url(ctx);
     let ua = load_code_assist_user_agent();
     let x_goog_api_client = load_code_assist_x_goog_api_client();
@@ -686,6 +716,33 @@ pub async fn fetch_project_id_with_context(
                                     subscription_tier =
                                         paid_tier_id.clone().or(current_tier_id.clone());
 
+                                    // 从 currentTier / allowedTiers 中解析 usesGcpTos
+                                    let detected_gcp_tos = data
+                                        .current_tier
+                                        .as_ref()
+                                        .and_then(|t| t.uses_gcp_tos)
+                                        .or_else(|| {
+                                            data.allowed_tiers.as_ref().and_then(|tiers| {
+                                                tiers
+                                                    .iter()
+                                                    .find(|t| t.is_default.unwrap_or(false))
+                                                    .and_then(|t| t.uses_gcp_tos)
+                                            })
+                                        })
+                                        .or_else(|| {
+                                            // standard-tier 订阅必定属于 GCP ToS 体系
+                                            if current_tier_id.as_deref() == Some("standard-tier")
+                                                || paid_tier_id.as_deref() == Some("standard-tier")
+                                            {
+                                                Some(true)
+                                            } else {
+                                                None
+                                            }
+                                        });
+                                    if detected_gcp_tos.is_some() {
+                                        resolved_is_gcp_tos = detected_gcp_tos;
+                                    }
+
                                     // 提取积分数据
                                     if let Some(ref paid_tier) = data.paid_tier {
                                         credits = extract_credits_from_tier(paid_tier);
@@ -706,7 +763,6 @@ pub async fn fetch_project_id_with_context(
                                             ));
                                         }
                                     }
-
                                     if subscription_tier.is_some() {
                                         log_subscription_tier_result(
                                             email,
@@ -726,12 +782,12 @@ pub async fn fetch_project_id_with_context(
                                             })
                                             .unwrap_or_else(|| "-".to_string());
                                         let reason = format!(
-                                        "loadCodeAssist 成功但无 tier: paidTier={:?}, currentTier={:?}, allowedTiers=[{}], hasProject={}",
-                                        paid_tier_id,
-                                        current_tier_id,
-                                        allowed_tier_preview,
-                                        data.project.is_some()
-                                    );
+                                            "loadCodeAssist 成功但无 tier: paidTier={:?}, currentTier={:?}, allowedTiers=[{}], hasProject={}",
+                                            paid_tier_id,
+                                            current_tier_id,
+                                            allowed_tier_preview,
+                                            data.project.is_some()
+                                        );
                                         log_subscription_tier_result(
                                             email,
                                             subscription_tier.as_ref(),
@@ -742,7 +798,12 @@ pub async fn fetch_project_id_with_context(
                                     let response_project_id =
                                         data.project.as_ref().and_then(extract_project_id);
                                     if let Some(project_id) = response_project_id.clone() {
-                                        return (Some(project_id), subscription_tier, credits);
+                                        return ProjectMetadataResult {
+                                            project_id: Some(project_id),
+                                            subscription_tier,
+                                            credits,
+                                            is_gcp_tos: resolved_is_gcp_tos,
+                                        };
                                     }
 
                                     if let Some(tiers) = data.allowed_tiers {
@@ -766,11 +827,12 @@ pub async fn fetch_project_id_with_context(
                                         {
                                             Ok(project_id) => {
                                                 if let Some(project_id) = project_id {
-                                                    return (
-                                                        Some(project_id),
+                                                    return ProjectMetadataResult {
+                                                        project_id: Some(project_id),
                                                         subscription_tier,
                                                         credits,
-                                                    );
+                                                        is_gcp_tos: resolved_is_gcp_tos,
+                                                    };
                                                 }
                                             }
                                             Err(err) => {
@@ -782,7 +844,12 @@ pub async fn fetch_project_id_with_context(
                                         }
                                     }
 
-                                    return (None, subscription_tier, credits);
+                                    return ProjectMetadataResult {
+                                        project_id: None,
+                                        subscription_tier,
+                                        credits,
+                                        is_gcp_tos: resolved_is_gcp_tos,
+                                    };
                                 }
                                 Err(err) => {
                                     last_error = Some(format!("loadCodeAssist 解析失败: {}", err));
@@ -815,7 +882,7 @@ pub async fn fetch_project_id_with_context(
                                 header_value(&headers, reqwest::header::CONTENT_LENGTH)
                             );
                             crate::modules::logger::log_error(&format!(
-                                "❌ [{}] loadCodeAssist 响应读取失败: {}, {}",
+                                "❌ [{}] loadCodeAssist 请求失败: {}, {}",
                                 email, err, header_info
                             ));
                         }
@@ -830,7 +897,12 @@ pub async fn fetch_project_id_with_context(
                         text.len()
                     );
                     log_subscription_tier_result(email, subscription_tier.as_ref(), &reason);
-                    return (None, subscription_tier, credits);
+                    return ProjectMetadataResult {
+                        project_id: None,
+                        subscription_tier,
+                        credits,
+                        is_gcp_tos: resolved_is_gcp_tos,
+                    };
                 } else if status == reqwest::StatusCode::FORBIDDEN {
                     let text = res.text().await.unwrap_or_default();
                     let reason = format!(
@@ -841,7 +913,12 @@ pub async fn fetch_project_id_with_context(
                         text.len()
                     );
                     log_subscription_tier_result(email, subscription_tier.as_ref(), &reason);
-                    return (None, subscription_tier, credits);
+                    return ProjectMetadataResult {
+                        project_id: None,
+                        subscription_tier,
+                        credits,
+                        is_gcp_tos: resolved_is_gcp_tos,
+                    };
                 } else {
                     let text = res.text().await.unwrap_or_default();
                     let retryable =
@@ -886,7 +963,12 @@ pub async fn fetch_project_id_with_context(
         log_subscription_tier_result(email, subscription_tier.as_ref(), "未知错误");
     }
 
-    (None, subscription_tier, credits)
+    ProjectMetadataResult {
+        project_id: None,
+        subscription_tier,
+        credits,
+        is_gcp_tos: resolved_is_gcp_tos,
+    }
 }
 
 fn build_quota_data_from_response(
@@ -894,6 +976,8 @@ fn build_quota_data_from_response(
     subscription_tier: Option<String>,
     credits: Vec<CreditInfo>,
     quota_summary: Option<serde_json::Value>,
+    is_gcp_tos: Option<bool>,
+    project_id: Option<String>,
 ) -> QuotaData {
     let mut quota_data = QuotaData::new();
 
@@ -949,6 +1033,8 @@ fn build_quota_data_from_response(
 
     quota_data.subscription_tier = subscription_tier;
     quota_data.credits = credits;
+    quota_data.is_gcp_tos = is_gcp_tos;
+    quota_data.project_id = project_id;
     quota_data
 }
 
@@ -970,8 +1056,11 @@ pub async fn fetch_quota_with_context(
     use crate::error::AppError;
 
     let base_url = resolve_cloud_code_base_url(ctx);
-    let (resolved_project_id, subscription_tier, credits) =
-        fetch_project_id_with_context(access_token, email, ctx).await;
+    let meta = fetch_project_metadata_with_context(access_token, email, ctx).await;
+    let resolved_project_id = meta.project_id;
+    let subscription_tier = meta.subscription_tier;
+    let credits = meta.credits;
+    let is_gcp_tos = meta.is_gcp_tos;
     let effective_project_id = resolved_project_id
         .clone()
         .or_else(|| ctx.preferred_project_id.clone());
@@ -994,6 +1083,8 @@ pub async fn fetch_quota_with_context(
                         subscription_tier.clone(),
                         credits.clone(),
                         quota_summary,
+                        is_gcp_tos,
+                        resolved_project_id.clone(),
                     );
                     return Ok(QuotaFetchResult {
                         quota: quota_data,
@@ -1042,6 +1133,8 @@ pub async fn fetch_quota_with_context(
                         let mut q = QuotaData::new();
                         q.is_forbidden = true;
                         q.subscription_tier = subscription_tier.clone();
+                        q.is_gcp_tos = is_gcp_tos;
+                        q.project_id = resolved_project_id.clone();
                         let message = if text.trim().is_empty() {
                             "API returned 403 Forbidden".to_string()
                         } else {
@@ -1152,6 +1245,8 @@ pub async fn fetch_quota_with_context(
                     subscription_tier.clone(),
                     credits.clone(),
                     quota_summary_val,
+                    is_gcp_tos,
+                    resolved_project_id.clone(),
                 );
 
                 return Ok(QuotaFetchResult {

--- a/src-tauri/src/utils/protobuf.rs
+++ b/src-tauri/src/utils/protobuf.rs
@@ -92,15 +92,9 @@ pub fn create_oauth_info_with_metadata(
     expiry: i64,
     is_gcp_tos: Option<bool>,
     id_token: Option<&str>,
-    email: Option<&str>,
+    _email: Option<&str>,
 ) -> Vec<u8> {
-    let mut is_gcp_tos = is_gcp_tos.unwrap_or(false);
-    if let Some(email) = email.map(str::trim).filter(|value| !value.is_empty()) {
-        let lower = email.to_ascii_lowercase();
-        if lower.ends_with("@gmail.com") || lower.ends_with("@googlemail.com") {
-            is_gcp_tos = false;
-        }
-    }
+    let is_gcp_tos = is_gcp_tos.unwrap_or(false);
 
     // Field 1: access_token (string, wire_type = 2)
     let field1 = encode_string_field(1, access_token);
@@ -296,3 +290,39 @@ fn extract_string_field(data: &[u8], target_field: u32) -> Option<String> {
 
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_oauth_info_with_metadata_gmail_gcp_tos() {
+        let payload = create_oauth_info_with_metadata(
+            "fake_access_token",
+            "fake_refresh_token",
+            1700000000,
+            Some(true),
+            Some("fake_id_token"),
+            Some("test-gcp-tos-user@gmail.com"),
+        );
+
+        let has_field_6 = payload.windows(2).any(|w| w == [0x30, 0x01]);
+        assert!(has_field_6, "Protobuf must encode field 6 when is_gcp_tos is Some(true)");
+    }
+
+    #[test]
+    fn test_create_oauth_info_with_metadata_gmail_personal() {
+        let payload = create_oauth_info_with_metadata(
+            "fake_access_token",
+            "fake_refresh_token",
+            1700000000,
+            None,
+            Some("fake_id_token"),
+            Some("test-personal-user@gmail.com"),
+        );
+
+        let has_field_6 = payload.windows(2).any(|w| w == [0x30, 0x01]);
+        assert!(!has_field_6, "Protobuf must NOT encode field 6 when is_gcp_tos is None");
+    }
+}
+

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -31,6 +31,8 @@ import {
   getAntigravityTierBadge,
   getQuotaClass,
   formatResetTimeDisplay,
+  isGcpTosAccount,
+  getAccountProjectId,
 } from '../utils/account'
 import { listen, UnlistenFn } from '@tauri-apps/api/event'
 import { invoke } from '@tauri-apps/api/core'
@@ -3175,6 +3177,17 @@ export function useAccountsPageController({ onNavigate }: AccountsPageProps) {
             <span className={`tier-badge ${tierBadge.className}`}>
               {tierBadge.label}
             </span>
+            {isGcpTosAccount(account) && (() => {
+              const projectId = getAccountProjectId(account)
+              return (
+                <span
+                  className="tier-badge gcp-tos"
+                  title={projectId ? `project: ${projectId}` : t('accounts.badge.gcpTosTitle', 'GCP ToS account')}
+                >
+                  {t('accounts.badge.gcpTos', 'GCP ToS')}
+                </span>
+              )
+            })()}
             {isPendingAntigravityAccount(account) && (
               <span className="status-pill warning">{t('codex.pendingAuth.badge', '待授权')}</span>
             )}
@@ -3824,6 +3837,17 @@ export function useAccountsPageController({ onNavigate }: AccountsPageProps) {
                 <span className={`tier-badge ${tierBadge.className}`}>
                   {tierBadge.label}
                 </span>
+                {isGcpTosAccount(account) && (() => {
+                  const projectId = getAccountProjectId(account)
+                  return (
+                    <span
+                      className="tier-badge gcp-tos"
+                      title={projectId ? `project: ${projectId}` : t('accounts.badge.gcpTosTitle', 'GCP ToS account')}
+                    >
+                      {t('accounts.badge.gcpTos', 'GCP ToS')}
+                    </span>
+                  )
+                })()}
                 {(() => {
                   const vBadge = getVerificationBadge(account)
                   return vBadge ? (

--- a/src/styles/pages/accounts-aurora.css
+++ b/src/styles/pages/accounts-aurora.css
@@ -696,6 +696,13 @@
   border-color: var(--plan-free-border);
 }
 
+/* GCP ToS shared-project account badge (aicode-consumers) */
+.accounts-page .tier-badge.gcp-tos {
+  background: var(--plan-team-bg);
+  color: var(--plan-team-color);
+  border-color: var(--plan-team-border);
+}
+
 .accounts-page .tier-badge.unknown {
   background: var(--plan-unknown-bg);
   color: var(--plan-unknown-color);

--- a/src/styles/pages/accounts.css
+++ b/src/styles/pages/accounts.css
@@ -454,6 +454,13 @@
   border: 1px solid var(--plan-unknown-border);
 }
 
+/* GCP ToS shared-project account badge (aicode-consumers) */
+.tier-badge.gcp-tos {
+  background: var(--plan-team-bg);
+  color: var(--plan-team-color);
+  border: 1px solid var(--plan-team-border);
+}
+
 /* Inline Folder Cards (inside accounts-grid) */
 .folder-inline-card {
   cursor: pointer;

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -47,6 +47,8 @@ export interface QuotaData {
     subscription_tier?: string;
     credits?: CreditInfo[];
     tier_id?: string;
+    is_gcp_tos?: boolean;
+    project_id?: string;
 }
 
 export interface CreditInfo {

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,4 +1,4 @@
-import { QuotaData } from '../types/account';
+import { Account, QuotaData } from '../types/account';
 import {
   AUTH_RECOMMENDED_LABELS,
   getAntigravityDisplayModelsFromQuota,
@@ -58,6 +58,22 @@ export function getAntigravityTierBadge(quota?: QuotaData): {
     label: tier,
     className: tier.toLowerCase(),
   };
+}
+
+/**
+ * 判定账号是否属于 GCP ToS 体系（服务端挂在共享 'aicode-consumers' 项目）。
+ * quota 上已沉淀的 is_gcp_tos 优先，回退到 token 上同步的标记。
+ */
+export function isGcpTosAccount(account?: Account | null): boolean {
+  if (!account) return false;
+  if (account.quota?.is_gcp_tos != null) return account.quota.is_gcp_tos;
+  return account.token?.is_gcp_tos === true;
+}
+
+/** 取账号的 GCP / Enterprise 项目 ID（quota 优先，回退 token）。 */
+export function getAccountProjectId(account?: Account | null): string | undefined {
+  if (!account) return undefined;
+  return account.quota?.project_id || account.token?.project_id || undefined;
 }
 
 export function getQuotaClass(percentage: number): string {


### PR DESCRIPTION
### Summary / 概述

修复 Antigravity IDE 切换到使用 GCP ToS / Standard Tier 的付费账号（如绑定了 Google Cloud 条款的个人或工作空间账号）时，IDE 报错 `ineligible / UNSUPPORTED_LOCATION` 的问题，并修复切号后因覆盖已有 `userStatus` 导致 IDE 模型配置与历史状态未正确加载的缺陷。

Fixes the issue where switching to an Antigravity IDE account that uses GCP ToS / Standard Tier results in an `ineligible / UNSUPPORTED_LOCATION` error, and prevents state loss caused by destructive overwrites to `userStatus` during account injection.

---

### Problem & Root Cause / 根本原因

1. **Protobuf Field 6 缺失或被误判为非 GCP ToS**：
   - 当账号属于 `standard-tier` / GCP ToS 订阅时，IDE 在调用 Code Assist 后台时要求 `OAuthTokenInfo` Protobuf 消息中的字段 6（`is_gcp_tos`）为 `true`。
   - 原实现对 `@gmail.com` 和 `@googlemail.com` 域名强制将 `is_gcp_tos` 设为 `false`，导致付费版 Gmail 账号被误判为普通免费版，触发云端区域策略拦截。
2. **切号与启动命令旁路了探针逻辑**：
   - `commands/account.rs` 的 `switch_account`（重启切号分支）与 `commands/instance.rs` 的启动链路直接调用了 `load_account`，遗漏了 `prepare_account_for_injection` 中的元数据探针探测。
3. **磁盘读取与内存时序差**：
   - 切号注入时调用了基于磁盘重读的 `inject_account_to_profile`，导致内存中刚刷新探测到的元数据未及时反映到写入的 `state.vscdb` 中；且缺少对 `project_id` 的 3 级兜底逻辑。
4. **`userStatus` 破坏性覆盖**：
   - 切号时使用最小骨架强行覆盖已有的 `antigravityUnifiedStateSync.userStatus`，抹掉了 IDE 已经初始化的几十 KB 模型和功能配置缓存。

---

### Key Changes / 核心修改

1. **Protobuf (`utils/protobuf.rs`)**：
   - 移除对 `@gmail.com` 域名的硬编码判定，依据真实的 `is_gcp_tos` 元数据准确编码 Field 6。
   - 补充针对 Gmail 个人版与 GCP ToS 版的单元测试。
2. **配额探测与模型 (`models/quota.rs`, `modules/quota.rs`, `modules/account.rs`)**：
   - 在 `QuotaData` 中增加 `project_id` 字段。
   - 从 `loadCodeAssist` 响应的 `currentTier`、`cloudaicompanionProject` 与 `allowedTiers` 中全链路提取 `usesGcpTos` 和 `project_id`，并打通网络响应、403 处理与本地缓存流转。
   - 在 `prepare_account_for_injection` 中对缺少元数据的账号自动触发配额探针补齐并落盘。
3. **切号与实例注入 (`commands/account.rs`, `commands/instance.rs`, `modules/instance.rs`)**：
   - 切号及启动流程统一调用 `prepare_account_for_injection`，并改用 `inject_account_to_profile_with_account` 直接传递已就绪的内存账号对象，消除读盘时序差。
   - 注入前清理陈旧的 `authStateWithContextSentinelKey`，防止旧账号会话快照干扰新账号初始化。
4. **数据库与状态保护 (`modules/db.rs`)**：
   - 新增 `resolve_account_project_id`（按 `token` -> `quota` -> GCP ToS 默认 `aicode-consumers` 3级降级解析），确保 `state.vscdb` 注入完整的 `enterprisePreferences`。
   - `inject_user_status` 改为非破坏性写入：若已存在完整配置则予以保留，交由 Language Server 动态同步。

---

### Verification / 验证证据

- [x] **单元测试**：`cargo test --lib modules::db::tests` 与 `utils::protobuf::tests` 全部通过。
- [x] **类型检查**：`cargo check` 零错误通过。
- [x] **实机真实验证**：
  - 切换到 `Standard Tier` 账号后，`state.vscdb` 中成功写入 Protobuf 字段 6 及 `enterprisePreferences: {"enterpriseGcpProjectId":"aicode-consumers"}`，IDE 成功进入工作区，彻底告别 `ineligible` 报错。
  - 切号后原有模型配置（Gemini 3.8 / Claude 3.7 Thinking）与历史会话正常保留加载。
