### PR TITLE
fix: preserve per-execution WebSocket usage billing

### DIFF
--- a/sidecars/cockpit-cliproxy/auth_selection.go
+++ b/sidecars/cockpit-cliproxy/auth_selection.go
@@ -1376,7 +1376,7 @@ func (p *usagePlugin) HandleUsage(ctx context.Context, record coreusage.Record) 
 	}
 	status := record.Fail.StatusCode
 	success := !record.Failed
-	p.tracker.record(usagePayload{
+	payload := usagePayload{
 		Type:             "usage",
 		RequestID:        internallogging.GetRequestID(ctx),
 		Provider:         record.Provider,
@@ -1405,7 +1405,12 @@ func (p *usagePlugin) HandleUsage(ctx context.Context, record coreusage.Record) 
 			TokenBreakdown:  record.Detail.TokenBreakdown,
 		},
 		RequestedAtMS: record.RequestedAt.UnixMilli(),
-	})
+	}
+	if sink, ok := ctx.Value(websocketUsageContextKey).(*websocketUsageSink); ok {
+		sink.record(record, payload)
+		return
+	}
+	p.tracker.record(payload)
 }
 
 func (p *usagePlugin) accountForRecord(record coreusage.Record) *accountSpec {

--- a/sidecars/cockpit-cliproxy/manifest_policy.go
+++ b/sidecars/cockpit-cliproxy/manifest_policy.go
@@ -1042,6 +1042,13 @@ func (p *requestPolicy) middleware() gin.HandlerFunc {
 		startedAt := time.Now()
 		requestID := ensureRequestID(c)
 		spec := p.lookupAPIKey(c.Request)
+		if diagnosticTransport(c.Request) == "websocket" && p.emitter != nil {
+			sink := newWebsocketUsageSink(requestID, func(payload usagePayload) {
+				p.tokenLimiter.addUsage(spec, effectiveUsageTotalTokens(payload.Usage))
+				p.emitter.emit(payload)
+			})
+			c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), websocketUsageContextKey, sink))
+		}
 		requestKind := requestKindFromPath(c.Request.URL.Path)
 		clientInstanceID := extractClientInstanceID(c.Request)
 		if clientInstanceID != "" {
@@ -1251,6 +1258,17 @@ func (p *requestPolicy) emitRequestCompleted(c *gin.Context, requestID string, s
 		return
 	}
 	p.tracker.releaseImageJobs(requestID)
+	if _, ok := c.Request.Context().Value(websocketUsageContextKey).(*websocketUsageSink); ok && status < http.StatusBadRequest {
+		// Gorilla writes the 101 handshake after hijacking, leaving Gin's
+		// status at 200. Rejected handshakes must still reach finalization.
+		// Transport completion is diagnostic-only. Per-execution callbacks own
+		// usage and may arrive after this handler returns.
+		p.tracker.mu.Lock()
+		delete(p.tracker.records, requestID)
+		delete(p.tracker.selectedAccounts, requestID)
+		p.tracker.mu.Unlock()
+		return
+	}
 	if payload, ok := p.tracker.finalize(requestID, usageFinalizeInput{
 		spec:          spec,
 		requestKind:   requestKind,

--- a/sidecars/cockpit-cliproxy/websocket_usage.go
+++ b/sidecars/cockpit-cliproxy/websocket_usage.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+type websocketUsageKey struct{}
+
+var websocketUsageContextKey websocketUsageKey
+
+// Owned by the request context, so queued callbacks remain valid after the
+// socket closes without retaining connection state in the global tracker.
+type websocketUsageSink struct {
+	mu           sync.Mutex
+	connectionID string
+	seen         map[string]struct{}
+	emit         func(usagePayload)
+}
+
+func newWebsocketUsageSink(id string, emit func(usagePayload)) *websocketUsageSink {
+	return &websocketUsageSink{connectionID: id, seen: make(map[string]struct{}), emit: emit}
+}
+
+func (s *websocketUsageSink) record(record coreusage.Record, payload usagePayload) {
+	// The SDK has no response ID. Its per-execution start time has nanosecond
+	// precision; account and model distinguish separate upstream attempts.
+	identity, _ := json.Marshal([]string{s.connectionID, record.AuthID, record.Model, record.RequestedAt.UTC().Format("2006-01-02T15:04:05.000000000Z")})
+	if record.RequestedAt.IsZero() {
+		// Missing execution identity must not silently collapse independent usage.
+		identity = []byte(rand.Text())
+	}
+	id := fmt.Sprintf("%s:execution:%x", s.connectionID, sha256.Sum256(identity))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.seen[id]; ok {
+		return
+	}
+	s.seen[id] = struct{}{}
+	payload.RequestID = id
+	s.emit(payload)
+}

--- a/sidecars/cockpit-cliproxy/websocket_usage_test.go
+++ b/sidecars/cockpit-cliproxy/websocket_usage_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func TestWebsocketUsageEachExecutionAndDuplicate(t *testing.T) {
+	var emitted []usagePayload
+	sink := newWebsocketUsageSink("connection", func(p usagePayload) { emitted = append(emitted, p) })
+	ctx := context.WithValue(context.Background(), websocketUsageContextKey, sink)
+	tracker := newRequestUsageTracker()
+	plugin := &usagePlugin{tracker: tracker, manifest: &manifest{accountByAuthID: map[string]*accountSpec{
+		"a": {ID: "workspace-a", Email: "same@example.invalid"},
+		"b": {ID: "workspace-b", Email: "same@example.invalid"},
+	}}}
+	for i := 0; i < 12; i++ {
+		auth := "a"
+		if i >= 6 {
+			auth = "b"
+		}
+		r := coreusage.Record{AuthID: auth, Model: "test-model", RequestedAt: time.Unix(100, int64(i)), Detail: coreusage.Detail{InputTokens: 100, CachedTokens: 20, OutputTokens: 10, TotalTokens: 110}}
+		plugin.HandleUsage(ctx, r)
+		plugin.HandleUsage(ctx, r)
+	}
+	if len(emitted) != 12 {
+		t.Fatalf("want 12 immediately emitted executions, got %d", len(emitted))
+	}
+	ids := map[string]bool{}
+	for i, p := range emitted {
+		if ids[p.RequestID] {
+			t.Fatal("execution ID collision")
+		}
+		ids[p.RequestID] = true
+		want := "workspace-a"
+		if i >= 6 {
+			want = "workspace-b"
+		}
+		if p.AccountID != want || p.Usage.InputTokens != 100 {
+			t.Fatalf("wrong attribution/usage: %+v", p)
+		}
+	}
+	if len(tracker.records) != 0 {
+		t.Fatal("websocket usage must not enter connection finalization")
+	}
+}
+
+func TestWebsocketUsageLateCallbackAndFailure(t *testing.T) {
+	var emitted []usagePayload
+	sink := newWebsocketUsageSink("connection", func(p usagePayload) { emitted = append(emitted, p) })
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), websocketUsageContextKey, sink))
+	cancel()
+	plugin := &usagePlugin{tracker: newRequestUsageTracker()}
+	plugin.HandleUsage(ctx, coreusage.Record{Model: "test-model", RequestedAt: time.Unix(100, 0), Failed: true, Detail: coreusage.Detail{InputTokens: 40, OutputTokens: 2, TotalTokens: 42}})
+	if len(emitted) != 1 || emitted[0].Success || emitted[0].Usage.TotalTokens != 42 {
+		t.Fatalf("lost late failure usage: %+v", emitted)
+	}
+}
+
+func TestSSEUsageStillUsesExistingTracker(t *testing.T) {
+	tracker := newRequestUsageTracker()
+	plugin := &usagePlugin{tracker: tracker}
+	ctx := internallogging.WithRequestID(context.Background(), "sse")
+	plugin.HandleUsage(ctx, coreusage.Record{RequestedAt: time.Unix(100, 0), Detail: coreusage.Detail{InputTokens: 100}})
+	p, ok := tracker.finalize("sse", usageFinalizeInput{status: 200})
+	if !ok || p.Usage.InputTokens != 100 {
+		t.Fatal("SSE finalization changed")
+	}
+}
+
+func TestWebsocketUsageConcurrentDuplicate(t *testing.T) {
+	n := 0
+	sink := newWebsocketUsageSink("connection", func(usagePayload) { n++ })
+	record := coreusage.Record{RequestedAt: time.Unix(100, 0)}
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); sink.record(record, usagePayload{}) }()
+	}
+	wg.Wait()
+	if n != 1 {
+		t.Fatalf("duplicate billed %d times", n)
+	}
+}
+
+func TestWebsocketUsageMissingIdentityDoesNotMerge(t *testing.T) {
+	n := 0
+	sink := newWebsocketUsageSink("connection", func(usagePayload) { n++ })
+	for i := 0; i < 2; i++ {
+		sink.record(coreusage.Record{}, usagePayload{})
+	}
+	if n != 2 {
+		t.Fatal("unknown execution identities were merged")
+	}
+}
+
+func TestWebsocketMiddlewareLateUsageNoClosingBill(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tracker := newRequestUsageTracker()
+	policy := &requestPolicy{tracker: tracker, emitter: &eventEmitter{}}
+	plugin := &usagePlugin{tracker: tracker}
+	router := gin.New()
+	router.Use(policy.middleware())
+	var saved context.Context
+	router.GET("/v1/responses", func(ctx *gin.Context) { saved = ctx.Request.Context(); ctx.Status(http.StatusSwitchingProtocols) })
+	req := httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	req.Header.Set("Upgrade", "websocket")
+	out := captureStdout(t, func() {
+		router.ServeHTTP(httptest.NewRecorder(), req)
+		if saved == nil {
+			t.Fatal("handler not reached")
+		}
+		for i := 0; i < 3; i++ {
+			plugin.HandleUsage(saved, coreusage.Record{Model: "test", RequestedAt: time.Unix(100, int64(i)), Detail: coreusage.Detail{InputTokens: 10, TotalTokens: 10}})
+		}
+	})
+	count := 0
+	for _, line := range strings.Split(out, "\n") {
+		var e usagePayload
+		if json.Unmarshal([]byte(line), &e) == nil && e.Type == "usage" {
+			count++
+			if e.Usage.InputTokens != 10 {
+				t.Fatal("spurious connection-closing bill")
+			}
+		}
+	}
+	if count != 3 {
+		t.Fatalf("want 3 per-execution events, got %d", count)
+	}
+}
+
+func TestWebsocketRejectedHandshakeIsRecorded(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			tracker := newRequestUsageTracker()
+			policy := &requestPolicy{tracker: tracker, emitter: &eventEmitter{}}
+			router := gin.New()
+			router.Use(policy.middleware())
+			router.GET("/v1/responses", func(ctx *gin.Context) {
+				if status == http.StatusTooManyRequests {
+					policy.emitTokenLimitBlockedRequest(ctx, ensureRequestID(ctx), &apiKeySpec{ID: "test-key"}, "test-model", "responses", time.Now(), "test limit")
+				}
+				ctx.AbortWithStatus(status)
+			})
+			req := httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+			req.Header.Set("Upgrade", "websocket")
+			out := captureStdout(t, func() { router.ServeHTTP(httptest.NewRecorder(), req) })
+			count := 0
+			for _, line := range strings.Split(out, "\n") {
+				var payload usagePayload
+				if json.Unmarshal([]byte(line), &payload) != nil || payload.Type != "usage" {
+					continue
+				}
+				count++
+				if payload.Success || payload.Status != status || payload.Usage.TotalTokens != 0 {
+					t.Fatalf("wrong failure record: %+v", payload)
+				}
+				if status == http.StatusTooManyRequests && payload.ErrorCategory != "token_limit_exceeded" {
+					t.Fatalf("lost limit category: %+v", payload)
+				}
+			}
+			if count != 1 {
+				t.Fatalf("want one failure record, got %d", count)
+			}
+		})
+	}
+}
+
+func TestWebsocketRealUpgradeHasNoClosingBill(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	policy := &requestPolicy{tracker: newRequestUsageTracker(), emitter: &eventEmitter{}}
+	router := gin.New()
+	router.Use(policy.middleware())
+	done := make(chan struct{})
+	router.GET("/v1/responses", func(ctx *gin.Context) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(ctx.Writer, ctx.Request, nil)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		conn.Close()
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		router.ServeHTTP(w, r)
+		close(done)
+	}))
+	defer server.Close()
+	out := captureStdout(t, func() {
+		conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http")+"/v1/responses", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conn.Close()
+		<-done
+	})
+	for _, line := range strings.Split(out, "\n") {
+		var payload usagePayload
+		if json.Unmarshal([]byte(line), &payload) == nil && payload.Type == "usage" {
+			t.Fatal("real websocket upgrade produced a spurious closing bill")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Record each usage callback from long-lived Responses WebSocket sessions as its own usage event.
- Deduplicate repeated callbacks while preserving account/auth attribution.
- Keep failed handshakes and limit-blocked requests in the existing diagnostic path.

## Validation
- `go test ./...`
- `go test -race .`
- Additional WebSocket regression tests

No real account credentials or external model calls were used.