### PR TITLE
fix(terminal): run Ghostty launch commands through bash

### DIFF
--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -1128,11 +1128,82 @@ mod tests {
 
         assert_eq!(plan.program, "osascript");
         assert_eq!(plan.terminal_name, "Ghostty");
+        assert_eq!(plan.display_command, "Ghostty → codex --version");
         assert_eq!(plan.args.len(), 2);
         assert_eq!(plan.args[0], "-e");
         assert!(plan.args[1].contains("tell application \"Ghostty\""));
         assert!(plan.args[1].contains("new surface configuration"));
-        assert!(plan.args[1].contains("set command of cfg to \"codex --version\""));
+        assert!(plan.args[1].contains("set command of cfg to \"/bin/bash -lc 'codex --version'\""));
+    }
+
+    #[cfg(unix)]
+    fn run_ghostty_launch_command(command: &str) -> std::process::Output {
+        let plan = build_macos_codex_terminal_launch_plan(command, "Ghostty").unwrap();
+        let literal = plan.args[1]
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("set command of cfg to "))
+            .expect("Ghostty surface command");
+        let mut chars = literal
+            .strip_prefix('"')
+            .unwrap()
+            .strip_suffix('"')
+            .unwrap()
+            .chars();
+        let mut surface_command = String::new();
+        while let Some(ch) = chars.next() {
+            surface_command.push(if ch == '\\' {
+                match chars.next().expect("complete AppleScript escape") {
+                    'n' => '\n',
+                    escaped => escaped,
+                }
+            } else {
+                ch
+            });
+        }
+
+        // Ghostty's macOS launcher prefixes the surface command with exec -l.
+        std::process::Command::new("/bin/bash")
+            .args(["--noprofile", "--norc", "-c"])
+            .arg(format!("exec -l {}", surface_command))
+            .output()
+            .expect("run Ghostty's shell entry point")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn macos_ghostty_runs_working_directory_and_environment_setup() {
+        let output = run_ghostty_launch_command(
+            r#"cd / && GHOSTTY_LAUNCH_TEST='profile with spaces' /bin/sh -c 'printf "%s|%s" "$PWD" "$GHOSTTY_LAUNCH_TEST"'"#,
+        );
+
+        assert!(output.status.success(), "{:?}", output);
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            "/|profile with spaces",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn macos_ghostty_preserves_quotes_and_literal_shell_characters() {
+        let output = run_ghostty_launch_command(
+            r#"GHOSTTY_LAUNCH_TEST='用户 / O'"'"'Brien "quoted" $HOME `uname` \n' /usr/bin/printenv GHOSTTY_LAUNCH_TEST"#,
+        );
+
+        assert!(output.status.success(), "{:?}", output);
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            "用户 / O'Brien \"quoted\" $HOME `uname` \\n\n",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn macos_ghostty_does_not_launch_after_failed_directory_change() {
+        let output = run_ghostty_launch_command("cd /dev/null/invalid && printf unexpected");
+
+        assert!(!output.status.success());
+        assert!(output.stdout.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands/codex_instance.rs
+++ b/src-tauri/src/commands/codex_instance.rs
@@ -1934,6 +1934,8 @@ fn build_macos_codex_terminal_launch_plan(
             ),
         )
     } else if is_ghostty {
+        // Ghostty prefixes this with exec, so cd and environment assignments need a shell.
+        let shell_command = format!("/bin/bash -lc '{}'", command.replace('\'', "'\\''"));
         (
             "Ghostty",
             format!(
@@ -1943,7 +1945,7 @@ fn build_macos_codex_terminal_launch_plan(
                     set command of cfg to \"{}\"
                     new window with configuration cfg
                 end tell",
-                escape_applescript(command)
+                escape_applescript(&shell_command)
             ),
         )
     } else if is_terminal_app {


### PR DESCRIPTION
我在 macOS 上使用 Cockpit Tools 时，遇到了从 Codex 实例弹窗选择 Ghostty 后无法启动的问题。排查后尝试加了一层 shell 包装，本地的定向测试和真实 Ghostty 启动验证都通过了，因此提交这个 PR，想请维护者帮忙看看修复方向和实现是否合适。

## Why

排查时发现，原实现把 `cd ... && CODEX_HOME=... <cli>` 直接写入 Ghostty surface 的 `command`。Ghostty 的 macOS 启动链添加 `exec -l` 后，目录切换后的命令不会执行；省略目录切换时，环境变量赋值会被当作可执行文件。

## Changes

- 仅在 Codex 的 Ghostty 分支添加 `/bin/bash -lc` 包装，先引用完整命令，再进行 AppleScript 转义。
- 保留原有命令预览。
- 补充实际执行生成命令的回归测试，覆盖工作目录、环境变量、引号和特殊字符，以及目录切换失败。

## Verification

- 从当前源码提取启动计划结构、AppleScript 转义函数、macOS 启动函数及对应测试，以 `rustc --edition=2021 --test` 独立编译：4 项测试通过。修复前已确认其中两项失败（未执行目标命令、环境赋值被当作程序）。
- 真实 Ghostty 1.3.1，通过生成的 AppleScript 创建临时窗口：修复前目标命令未执行；修复后执行成功，实际工作目录和 `CODEX_HOME` 均与输入一致。路径含空格、单引号、双引号及中文；使用无账号凭据的测试命令，测试窗口已关闭。
- `git diff --check`：通过。
- `cargo test -p cockpit-tools --lib macos_ghostty --locked`：上游未修改时即因 Cargo.lock 需要更新而退出，未进入编译。未修改锁文件；本机磁盘空间不足以构建完整 Tauri 应用，因此以上独立编译和真实终端验证不代表完整应用构建通过。

## Review

这次只验证了本机的 Ghostty 1.3.1，还没有完成整个应用的构建。想请维护者重点看看：这里显式使用 `/bin/bash -lc` 是否符合项目的终端启动方式，以及是否有其他版本或配置需要兼容。如果项目有更合适的处理方式，也欢迎指出。

## Related Issues

Closes #2312
