### PR TITLE
fix(antigravity): 修复个人账号配额查询对齐官方IDE并剥离残留GCP标记 / align quota queries with official IDE for personal accounts and strip orphaned GCP tags

### DIFF
--- a/docs/TAURI_BUILD_GUIDE.md
+++ b/docs/TAURI_BUILD_GUIDE.md
@@ -1,0 +1,53 @@
+# Cockpit Tools 编译与打包硬性规范（避坑备忘录）
+
+> **【血的教训 · 严禁违背】**
+> **绝对禁止在本项目中直接执行 `cargo build --release` 来试图构建发布可执行文件！**
+
+---
+
+## 核心故障现象与根因
+
+### 1. 现象（"编译了一个 debug 的主页面没有的白屏程序"）
+如果直接在根目录或 `src-tauri` 目录执行 `cargo build --release --bin cockpit-tools`：
+- 生成的 `cockpit-tools.exe` 大小仅约 **88 MB**（正常包含前端的二进制约为 **93.6 MB**，缺失整整 5.3 MB 的前端静态资源）；
+- 打开程序后，主窗口是一个**纯白空白窗口**（内存占用仅 13 MB，正常渲染的主界面内存占用在 80~200 MB 以上）；
+- **根因**：Tauri 项目在 `tauri.conf.json` 中配置了 `"devUrl": "http://localhost:1420"`。直接使用 `cargo build` 时，Tauri 宏会保留开发期配置，将 Webview 指向开发服务器 `http://localhost:1420`；而此时本地根本没有启动 Vite 开发服务器，导致窗口载入失败全白！
+
+### 2. 为什么开发者/AI 容易误入歧途？
+- 在 Windows 环境下，`cargo.exe` 位于用户目录 `%USERPROFILE%\.cargo\bin`，有时未被包含在全局 Shell 的 `PATH` 中；
+- 运行 `npm run tauri build` 时，Tauri CLI 尝试调用 `cargo metadata`，若 PATH 缺失会报错：`program not found`；
+- 很多人一看到这个报错，偷懒直接用绝对路径去跑 `$env:USERPROFILE\.cargo\bin\cargo.exe build --release`，从而掉入**无主页面（白屏）**的致命陷阱！
+
+---
+
+## 唯一正确的发布编译命令
+
+本项目已在 `scripts/tauri.cjs` 中配置了工具链自愈逻辑（自动寻找 `%USERPROFILE%\.cargo\bin`、`Go\bin` 以及 Visual Studio 的 `vcvars64.bat`）：
+
+### 1. 编译并打包单可执行文件（推荐日常部署）：
+```powershell
+npm run tauri build -- --no-bundle
+```
+- 该命令会自动触发 `beforeBuildCommand`（即 `npm run build`，编译 TS 与 Vite 前端到 `dist/`）；
+- 自动剔除 `devUrl`，强制将 `frontendDist`（`dist/` 中的 HTML/CSS/JS）内嵌打包至二进制中；
+- 产物路径：`target/release/cockpit-tools.exe`（大小约 93.6 MB）。
+
+### 2. 构建包含完整安装包（NSIS / MSI）：
+```powershell
+npm run tauri build
+```
+
+---
+
+## 二进制有效性三步自检（动刀后必验）
+
+在将新生成的 `cockpit-tools.exe` 复制到部署目录 `C:\Users\zouta\AppData\Local\Cockpit Tools\` 前，必须按如下标准自检：
+
+1. **体积核对**：
+   - 包含前端的正常体积：**≥ 93 MB**（如 93,607,936 字节）；
+   - 若只有 **88 MB**，说明犯错走了直接 `cargo build`，严禁发布！
+2. **进程拉起内存检查**：
+   - 运行后执行 `Get-Process -Name cockpit-tools`；
+   - 正常加载前端的主进程 WorkingSet 必须达到 **80 MB 以上**；若只有 13 MB，必定是白屏！
+3. **子进程检查**：
+   - 正常运行必须伴随 `msedgewebview2.exe` 的渲染进程启动。

--- a/scripts/tauri.cjs
+++ b/scripts/tauri.cjs
@@ -5,11 +5,13 @@ const path = require('node:path');
 
 const repoRoot = path.resolve(__dirname, '..');
 const goBinPath = 'C:\\Program Files\\Go\\bin';
+const cargoBinPath = path.join(os.homedir(), '.cargo', 'bin');
 
-function withGoPath(options = {}) {
+function withToolchainPaths(options = {}) {
   const currentPath = process.env.PATH || '';
-  const pathValue = fs.existsSync(goBinPath)
-    ? `${goBinPath}${path.delimiter}${currentPath}`
+  const extraPaths = [cargoBinPath, goBinPath].filter((dir) => fs.existsSync(dir));
+  const pathValue = extraPaths.length > 0
+    ? `${extraPaths.join(path.delimiter)}${path.delimiter}${currentPath}`
     : currentPath;
 
   return {
@@ -27,7 +29,7 @@ function run(command, args, options = {}) {
     cwd: repoRoot,
     stdio: 'inherit',
     shell: false,
-    ...withGoPath(options),
+    ...withToolchainPaths(options),
   });
 
   if (result.error) {
@@ -44,7 +46,7 @@ function runFinal(command, args, options = {}) {
     cwd: repoRoot,
     stdio: 'inherit',
     shell: false,
-    ...withGoPath(options),
+    ...withToolchainPaths(options),
   });
 
   if (result.error) {
@@ -64,9 +66,15 @@ if (process.platform !== 'win32') {
   runFinal('npx', ['tauri', ...process.argv.slice(2)]);
 }
 
-const vcvars64Path = 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat';
+const vcvarsCandidates = [
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\VC\\Auxiliary\\Build\\vcvars64.bat',
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat',
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat',
+  'C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat',
+];
+const vcvars64Path = vcvarsCandidates.find((candidate) => fs.existsSync(candidate)) || '';
 
-if (!fs.existsSync(vcvars64Path)) {
+if (!vcvars64Path) {
   console.warn('vcvars64.bat not found, falling back to the existing shell environment.');
   runTauriDirect();
 }
@@ -88,7 +96,7 @@ const quotedArgs = tauriArgs.map((arg) => {
 });
 const scriptBody = [
   '@echo off',
-  `set "PATH=${goBinPath};%PATH%"`,
+  `set "PATH=${cargoBinPath};${goBinPath};%PATH%"`,
   `call "${vcvars64Path}"`,
   'if errorlevel 1 exit /b %errorlevel%',
   'call npm.cmd run sync-version',

--- a/src-tauri/src/modules/account.rs
+++ b/src-tauri/src/modules/account.rs
@@ -395,7 +395,25 @@ pub fn load_account(account_id: &str) -> Result<Account, String> {
     let content =
         fs::read_to_string(&account_path).map_err(|e| format!("读取账号数据失败: {}", e))?;
 
-    deserialize_account_from_storage(&account_path, &content)
+    let mut account = deserialize_account_from_storage(&account_path, &content)?;
+    if account.token.project_id.as_deref() == Some("aicode-consumers") {
+        account.token.project_id = None;
+    }
+    if let Some(ref mut q) = account.quota {
+        if q.project_id.as_deref() == Some("aicode-consumers") {
+            q.project_id = None;
+        }
+    }
+    // 若账号没有真实 project_id，清洗掉历史残留的 is_gcp_tos 假标记
+    if account.token.project_id.is_none() {
+        account.token.is_gcp_tos = None;
+    }
+    if let Some(ref mut q) = account.quota {
+        if q.project_id.is_none() {
+            q.is_gcp_tos = None;
+        }
+    }
+    Ok(account)
 }
 
 /// 保存账号数据
@@ -2012,11 +2030,25 @@ pub async fn fetch_quota_with_fresh_token(
                 if account.token.is_gcp_tos != Some(gcp_tos) {
                     account.token.is_gcp_tos = Some(gcp_tos);
                 }
+            } else if account.token.is_gcp_tos == Some(true) {
+                // 若配额不再标识 GCP ToS，重置先前误标的状态
+                account.token.is_gcp_tos = None;
+            }
+            // 清理历史残留的 aicode-consumers 脏数据
+            if account.token.project_id.as_deref() == Some("aicode-consumers") {
+                account.token.project_id = None;
             }
             if let Some(ref project_id) = payload.quota.project_id {
-                if account.token.project_id.as_deref() != Some(project_id.as_str()) {
-                    account.token.project_id = Some(project_id.clone());
+                let trimmed = project_id.trim();
+                if trimmed != "aicode-consumers" && !trimmed.is_empty() {
+                    if account.token.project_id.as_deref() != Some(trimmed) {
+                        account.token.project_id = Some(trimmed.to_string());
+                    }
+                } else {
+                    account.token.project_id = None;
                 }
+            } else {
+                account.token.project_id = None;
             }
             account.quota_error = payload.error.map(|err| QuotaErrorInfo {
                 code: err.code,

--- a/src-tauri/src/modules/db.rs
+++ b/src-tauri/src/modules/db.rs
@@ -69,7 +69,7 @@ pub fn inject_token_to_path(
     )
 }
 
-/// 推导账号的 is_gcp_tos 属性（优先使用 token 中的显式字段，若缺失则通过配额层级做静态推断兜底）
+/// 推导账号的 is_gcp_tos 属性（优先使用 token 中的显式字段，若缺失则通过配额层级返回的 is_gcp_tos 判定）
 pub fn resolve_account_is_gcp_tos(account: &Account) -> Option<bool> {
     if let Some(is_gcp_tos) = account.token.is_gcp_tos {
         return Some(is_gcp_tos);
@@ -78,33 +78,25 @@ pub fn resolve_account_is_gcp_tos(account: &Account) -> Option<bool> {
         if let Some(is_gcp_tos) = quota.is_gcp_tos {
             return Some(is_gcp_tos);
         }
-        if quota.tier_id.as_deref() == Some("standard-tier")
-            || quota.subscription_tier.as_deref() == Some("standard-tier")
-        {
-            return Some(true);
-        }
     }
     None
 }
 
-/// 推导账号的 project_id 属性（优先 token，其次 quota，若属于 GCP ToS 账号则兜底为 "aicode-consumers"）
+/// 推导账号的 project_id 属性（优先 token，其次 quota；无合法项目则返回 None，严格过滤无效的 aicode-consumers）
 pub fn resolve_account_project_id(account: &Account) -> Option<String> {
     if let Some(ref project_id) = account.token.project_id {
         let trimmed = project_id.trim();
-        if !trimmed.is_empty() {
+        if !trimmed.is_empty() && trimmed != "aicode-consumers" {
             return Some(trimmed.to_string());
         }
     }
     if let Some(ref quota) = account.quota {
         if let Some(ref project_id) = quota.project_id {
             let trimmed = project_id.trim();
-            if !trimmed.is_empty() {
+            if !trimmed.is_empty() && trimmed != "aicode-consumers" {
                 return Some(trimmed.to_string());
             }
         }
-    }
-    if resolve_account_is_gcp_tos(account) == Some(true) {
-        return Some("aicode-consumers".to_string());
     }
     None
 }
@@ -341,12 +333,12 @@ mod tests {
         let mut quota_tier = QuotaData::new();
         quota_tier.tier_id = Some("standard-tier".to_string());
         let acc_tier = make_test_account(None, Some(quota_tier));
-        assert_eq!(resolve_account_is_gcp_tos(&acc_tier), Some(true));
+        assert_eq!(resolve_account_is_gcp_tos(&acc_tier), None);
 
         let mut quota_sub = QuotaData::new();
         quota_sub.subscription_tier = Some("standard-tier".to_string());
         let acc_sub = make_test_account(None, Some(quota_sub));
-        assert_eq!(resolve_account_is_gcp_tos(&acc_sub), Some(true));
+        assert_eq!(resolve_account_is_gcp_tos(&acc_sub), None);
 
         let mut quota_free = QuotaData::new();
         quota_free.tier_id = Some("free-tier".to_string());
@@ -373,14 +365,16 @@ mod tests {
             Some("quota-project".to_string())
         );
 
-        // 3. GCP ToS 账号自动兜底 aicode-consumers
-        let acc_tos = make_test_account(Some(true), None);
-        assert_eq!(
-            resolve_account_project_id(&acc_tos),
-            Some("aicode-consumers".to_string())
-        );
+        // 3. 过滤历史脏数据 aicode-consumers
+        let mut acc_dirty = make_test_account(Some(true), None);
+        acc_dirty.token.project_id = Some("aicode-consumers".to_string());
+        assert_eq!(resolve_account_project_id(&acc_dirty), None);
 
-        // 4. 普通非 GCP ToS 个人账号返回 None
+        // 4. GCP ToS 账号若无真实项目 ID 也返回 None，绝不凭空捏造假项目
+        let acc_tos = make_test_account(Some(true), None);
+        assert_eq!(resolve_account_project_id(&acc_tos), None);
+
+        // 5. 普通非 GCP ToS 个人账号返回 None
         let acc_personal = make_test_account(Some(false), None);
         assert_eq!(resolve_account_project_id(&acc_personal), None);
     }

--- a/src-tauri/src/modules/quota.rs
+++ b/src-tauri/src/modules/quota.rs
@@ -39,7 +39,11 @@ pub struct QuotaCloudCodeContext {
 impl QuotaCloudCodeContext {
     pub fn from_token(token: &TokenData) -> Self {
         Self {
-            preferred_project_id: token.project_id.clone(),
+            preferred_project_id: token
+                .project_id
+                .as_ref()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty() && s != "aicode-consumers"),
             is_gcp_tos: token.is_gcp_tos.unwrap_or(false),
         }
     }
@@ -256,7 +260,7 @@ fn resolve_cloud_code_base_url(ctx: &QuotaCloudCodeContext) -> String {
         return override_url;
     }
 
-    if ctx.is_gcp_tos {
+    if ctx.is_gcp_tos && ctx.preferred_project_id.is_some() {
         return CLOUD_CODE_PROD_BASE_URL.to_string();
     }
 
@@ -662,7 +666,7 @@ pub async fn fetch_project_metadata_with_context(
     let mut allowed_tiers: Vec<AllowedTier> = Vec::new();
     let mut last_error: Option<String> = None;
     let mut credits: Vec<CreditInfo> = Vec::new();
-    let mut resolved_is_gcp_tos: Option<bool> = if ctx.is_gcp_tos { Some(true) } else { None };
+    let mut resolved_is_gcp_tos: Option<bool> = None;
     let base_url = resolve_cloud_code_base_url(ctx);
     let ua = load_code_assist_user_agent();
     let x_goog_api_client = load_code_assist_x_goog_api_client();
@@ -716,7 +720,7 @@ pub async fn fetch_project_metadata_with_context(
                                     subscription_tier =
                                         paid_tier_id.clone().or(current_tier_id.clone());
 
-                                    // 从 currentTier / allowedTiers 中解析 usesGcpTos
+                                    // 从 currentTier / allowedTiers 中解析 usesGcpTos（严格遵循 Google 返回的真实字段）
                                     let detected_gcp_tos = data
                                         .current_tier
                                         .as_ref()
@@ -728,16 +732,6 @@ pub async fn fetch_project_metadata_with_context(
                                                     .find(|t| t.is_default.unwrap_or(false))
                                                     .and_then(|t| t.uses_gcp_tos)
                                             })
-                                        })
-                                        .or_else(|| {
-                                            // standard-tier 订阅必定属于 GCP ToS 体系
-                                            if current_tier_id.as_deref() == Some("standard-tier")
-                                                || paid_tier_id.as_deref() == Some("standard-tier")
-                                            {
-                                                Some(true)
-                                            } else {
-                                                None
-                                            }
                                         });
                                     if detected_gcp_tos.is_some() {
                                         resolved_is_gcp_tos = detected_gcp_tos;
@@ -795,8 +789,11 @@ pub async fn fetch_project_metadata_with_context(
                                         );
                                     }
 
-                                    let response_project_id =
-                                        data.project.as_ref().and_then(extract_project_id);
+                                    let response_project_id = data
+                                        .project
+                                        .as_ref()
+                                        .and_then(extract_project_id)
+                                        .filter(|id| !id.trim().is_empty() && id.trim() != "aicode-consumers");
                                     if let Some(project_id) = response_project_id.clone() {
                                         return ProjectMetadataResult {
                                             project_id: Some(project_id),
@@ -826,7 +823,10 @@ pub async fn fetch_project_metadata_with_context(
                                         .await
                                         {
                                             Ok(project_id) => {
-                                                if let Some(project_id) = project_id {
+                                                let clean_project_id = project_id.filter(|id| {
+                                                    !id.trim().is_empty() && id.trim() != "aicode-consumers"
+                                                });
+                                                if let Some(project_id) = clean_project_id {
                                                     return ProjectMetadataResult {
                                                         project_id: Some(project_id),
                                                         subscription_tier,
@@ -1057,18 +1057,28 @@ pub async fn fetch_quota_with_context(
 
     let base_url = resolve_cloud_code_base_url(ctx);
     let meta = fetch_project_metadata_with_context(access_token, email, ctx).await;
-    let resolved_project_id = meta.project_id;
+    let resolved_project_id = meta
+        .project_id
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty() && id != "aicode-consumers");
     let subscription_tier = meta.subscription_tier;
     let credits = meta.credits;
     let is_gcp_tos = meta.is_gcp_tos;
     let effective_project_id = resolved_project_id
         .clone()
-        .or_else(|| ctx.preferred_project_id.clone());
+        .or_else(|| ctx.preferred_project_id.clone())
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty() && id != "aicode-consumers");
 
     // 保留缓存，但缓存命中前仍先执行与 Antigravity IDE.app 对齐的项目识别流程。
     if !skip_cache {
         if let Some(record) = read_api_cache("authorized", email) {
-            if is_api_cache_valid(&record) {
+            let is_dirty_cache = record
+                .project_id
+                .as_deref()
+                .map(|p| p.trim() == "aicode-consumers")
+                .unwrap_or(false);
+            if !is_dirty_cache && is_api_cache_valid(&record) {
                 crate::modules::logger::log_info(&format!(
                     "[QuotaApiCache] Using api cache for {} (age: {}s)",
                     email,
@@ -1104,6 +1114,7 @@ pub async fn fetch_quota_with_context(
     let client = create_client();
     let payload = effective_project_id
         .as_ref()
+        .filter(|id| !id.trim().is_empty() && id.trim() != "aicode-consumers")
         .map(|id| json!({ "project": id }))
         .unwrap_or_else(|| json!({}));
     let cloud_code_user_agent = build_cloud_code_user_agent();


### PR DESCRIPTION


### PR 标题 (Title)
`fix(antigravity): align quota queries with official IDE for personal accounts and strip orphaned GCP tags / 修复个人账号配额查询对齐官方IDE并剥离残留GCP标记`

---

### PR 正文 (Description)

#### 🇨🇳 中文说明

##### 背景与问题定位
在主线合入 `#2286` 解决 Antigravity 切换账号及多数据目录注入后，经过实际多账号场景复核，发现了两个影响个人付费订阅账号（`standard-tier` / Google One AI Premium）的配额与元数据缺陷：

1. **配额死锁 100%（与官方 IDE 行为不一致）**：
   - 逆向分析 Antigravity 官方 IDE 内核发现，官方对个人订阅账号查询 `retrieveUserQuotaSummary` 时，请求 body 为 `{}`（空 Payload，不带任何 project 参数）。Google 服务端收到后会自动绑定该 OAuth 用户的个人订阅真实配额。
   - 先前逻辑误以为只要是个人付费账号（`standard-tier`）就属于 GCP ToS 体系，并给没有绑定真实项目的账号自动塞入了一个虚拟占位项目 `"aicode-consumers"`。
   - 当向 Google 发送 `{ "project": "aicode-consumers" }` 时，Google 服务端会去查询该空项目的企业配额池，导致即使用户在 IDE 中已消耗了额度，Cockpit Tools 却始终显示为 100%（`remainingFraction: 1`）。
2. **端点错误路由与 GCP 标签自循环死锁**：
   - `fetch_project_metadata_with_context` 拿传入的上下文 `ctx.is_gcp_tos` 作为初始默认值。由于 Google 原生个人订阅响应中并不返回企业级 `usesGcpTos` 字段，导致账号一旦曾被标记过 `is_gcp_tos=true`，代码就永远无法覆盖重置它。
   - 受到该假标记影响，`resolve_cloud_code_base_url` 将请求错误路由到了企业生产端点（`cloudcode-pa.googleapis.com`）而非官方个人结算端点（`daily-cloudcode-pa.googleapis.com`），进一步加剧了配额失真，且卡片持续误显示【GCP ToS 账号】徽标。

##### 本次修复内容
1. **解耦 `standard-tier` 与 GCP 判定**：
   - 严格尊重 Google API 返回的真实 `usesGcpTos` 字段，绝不把个人 Pro 订阅（`standard-tier`）强行判定为 GCP 体系。
2. **对齐官方 IDE 查询 Payload**：
   - 彻底移除 `"aicode-consumers"` 虚拟项目占位符；无真实 GCP 项目的账号统一发送 `{}`，与官方 IDE 行为完全同源。
3. **纠正请求端点路由**：
   - 优化 `resolve_cloud_code_base_url`，只有在账号**既标记为 GCP ToS 又拥有真实 GCP Project ID** 时才发往生产端点；普通个人账号一律走默认的 `daily-cloudcode-pa`。
4. **历史脏数据主动清洗与兼容**：
   - 在 `load_account` 与配额刷新流程中，若账号无真实 Project ID，自动清洗剥离历史上误存的 `is_gcp_tos` 标记，实现平滑自愈。

---

#### 🇬🇧 English Description

##### Problem & Root Cause
Following the merge of PR `#2286` (which resolved account switching and multi-user-data injection for Antigravity), extensive real-world testing across multiple personal paid accounts (`standard-tier` / Google One AI Premium) revealed two key regressions:

1. **Quotas Stuck at 100% (Divergence from Official IDE)**:
   - Reverse engineering of the official Antigravity IDE core demonstrated that personal subscriber quotas (`retrieveUserQuotaSummary`) are queried with an empty payload `{}` without specifying a `project` attribute. Google's backend automatically maps this to the user's personal subscription usage.
   - The prior implementation mistakenly assumed all `standard-tier` accounts belonged to the GCP ToS system, injecting a placeholder project `"aicode-consumers"` when no GCP project was bound.
   - Sending `{ "project": "aicode-consumers" }` causes Google to query an unconsumed enterprise project pool, persistently reporting 100% remaining quota even when substantial quota has been used in the IDE.
2. **Erroneous Endpoint Routing and Sticky GCP ToS Tags**:
   - `fetch_project_metadata_with_context` initialized `resolved_is_gcp_tos` with `ctx.is_gcp_tos`. Because Google does not include the enterprise-only `usesGcpTos` field in personal account responses, an account once flagged as `is_gcp_tos=true` would permanently inherit the tag in a feedback loop.
   - This tag forced `resolve_cloud_code_base_url` to direct traffic to the enterprise production endpoint (`cloudcode-pa.googleapis.com`) instead of the official personal settlement endpoint (`daily-cloudcode-pa.googleapis.com`), causing the card to show a false `GCP ToS Account` badge and inaccurate quotas.

##### Key Changes in This PR
1. **Disentangle `standard-tier` from GCP ToS**:
   - Strictly respect upstream `usesGcpTos` returned by Google API; never infer GCP ToS solely from personal paid tiers.
2. **Align Quota Request Payload with Official IDE**:
   - Completely remove the `"aicode-consumers"` placeholder. Query personal accounts with empty payload `{}` so Google accurately returns individual consumption.
3. **Correct Endpoint Routing**:
   - Update `resolve_cloud_code_base_url` to only route to `cloudcode-pa.googleapis.com` if an account is both marked as GCP ToS **and** possesses a valid `project_id`. All other personal accounts use `daily-cloudcode-pa.googleapis.com`.
4. **Backward-Compatible Data Sanitization**:
   - In `load_account` and cache validation, automatically sanitize and reset stale `is_gcp_tos` tags when no valid `project_id` exists, ensuring seamless self-healing for existing installations.