### PR TITLE
fix(codex): handle response.done in non-stream Responses

### DIFF
--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_done_test.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_done_test.go
@@ -1,0 +1,83 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexExecutorExecuteDoneTerminalStatus(t *testing.T) {
+	for _, test := range []struct {
+		name, eventType, state string
+		wantHTTP               int
+	}{
+		{"done_completed", "response.done", "completed", 200},
+		{"done_incomplete", "response.done", "incomplete", 200},
+		{"done_failed", "response.done", "failed", 502},
+		{"done_cancelled", "response.done", "cancelled", 408},
+		{"done_missing_status", "response.done", "", 408},
+		{"existing_completed", "response.completed", "completed", 200},
+		{"existing_incomplete", "response.incomplete", "incomplete", 200},
+		{"existing_failed", "response.failed", "failed", 502},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := map[string]any{
+				"id": "resp_synthetic", "model": "gpt-5.4", "output": []any{},
+				"usage": map[string]int{"input_tokens": 7, "output_tokens": 3, "total_tokens": 10},
+			}
+			if test.state != "" {
+				response["status"] = test.state
+			}
+			if test.state == "failed" {
+				response["error"] = map[string]string{"type": "upstream_error", "code": "synthetic_failure", "message": "Synthetic failure."}
+			}
+			if test.state == "incomplete" {
+				response["incomplete_details"] = map[string]string{"reason": "max_output_tokens"}
+			}
+			event, err := json.Marshal(map[string]any{"type": test.eventType, "response": response})
+			if err != nil {
+				t.Fatal(err)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(w, "data: "+string(event)+"\n\n")
+			}))
+			defer server.Close()
+			executor := NewCodexExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL, "api_key": "synthetic-test-only"}}
+			result, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+				Model: "gpt-5.4", Payload: []byte(`{"model":"gpt-5.4","input":"Synthetic test."}`),
+			}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: false})
+			if test.wantHTTP >= 400 {
+				var status interface{ StatusCode() int }
+				if err == nil || !errors.As(err, &status) || status.StatusCode() != test.wantHTTP {
+					t.Fatalf("error status mismatch: want %d; err=%v", test.wantHTTP, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := gjson.GetBytes(result.Payload, "status").String(); got != test.state {
+				t.Fatalf("status=%q, want %q", got, test.state)
+			}
+			if gjson.GetBytes(result.Payload, "id").String() != "resp_synthetic" || gjson.GetBytes(result.Payload, "usage.output_tokens").Int() != 3 {
+				t.Fatal("terminal response identity or usage changed")
+			}
+			if test.state == "incomplete" && gjson.GetBytes(result.Payload, "incomplete_details.reason").String() != "max_output_tokens" {
+				t.Fatal("incomplete reason changed")
+			}
+		})
+	}
+}

--- a/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_execute.go
+++ b/sidecars/cockpit-cliproxy/third_party/CLIProxyAPI/internal/runtime/executor/codex_executor_execute.go
@@ -176,6 +176,19 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		eventData := bytes.TrimSpace(line[5:])
 		eventData = helps.RestoreCodexMultiAgentV2Response(eventData, optimizeMultiAgentV2)
 		eventType := gjson.GetBytes(eventData, "type").String()
+		if eventType == "response.done" {
+			// A done event can also describe a failed or incomplete response.
+			status := gjson.GetBytes(eventData, "response.status").String()
+			switch status {
+			case "completed":
+				eventData = normalizeCodexWebsocketCompletion(eventData)
+			case "failed", "incomplete":
+				eventData, _ = sjson.SetBytes(eventData, "type", "response."+status)
+			default:
+				continue
+			}
+			eventType = gjson.GetBytes(eventData, "type").String()
+		}
 
 		if streamErr, terminalBody, ok := codexTerminalFailureErr(eventData); ok {
 			if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {


### PR DESCRIPTION
Codex HTTP non-stream Responses currently discards a terminal `response.done` event and returns HTTP 408, even when the upstream response is complete. This patch recognizes that alias while preserving failed and incomplete responses.

Closes #2328.

The change adds 13 lines before the existing terminal-failure handling:

- `done` with `status=completed` uses the existing completion normalizer.
- `done` with `status=failed` or `incomplete` enters the existing corresponding terminal path.
- Missing, unknown or cancelled states remain rejected as successful completion. Existing canonical terminal events keep their behavior.

The second changed file adds eight real-Executor `httptest` cases, including response status, identity, usage and incomplete-reason preservation. No dependency, API schema, application configuration or release files change.

**Validation**

- New regression: the unpatched implementation fails the three completed/incomplete/failed `done` cases; the patched implementation passes all eight cases.
- Responses translator package: 19 top-level tests pass.
- Wrapper package: 149 top-level tests pass.
- Built Linux amd64 gateway: 11 isolated synthetic-upstream cases pass, covering streaming/non-streaming completion, incomplete/failed states, absent terminal events and unknown/missing/cancelled status.
- Two short real Responses smoke checks (JSON and SSE) completed successfully. These are connectivity checks, not evidence that every historical long-request disconnect is fixed.
- `gofmt`, `git diff --check`, and both Go module checksum verifications pass.

The full Executor package is **not entirely green**: unpatched base plus the new regression gives 950 passing / 6 failing top-level tests; patched gives 951 passing / 5 failing. The same five unrelated failures remain, with no new failures. Both were run in an empty-home, cleared-environment, loopback-only namespace.

<details>
<summary>Unchanged baseline failures</summary>

- `TestApplyClaudeHeaders_DisableDeviceProfileStabilization`
- `TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForClaudeClients`
- `TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint`
- `TestCodexExecutorDirectOpenAIImageGenerationUsesImagesEndpoint`
- `TestKimiExecutorClaudeRequestPreservesInternalModelSemantics`

</details>

The PR is based on current upstream `main` (`4a5b0ab`). Its entire `sidecars/cockpit-cliproxy` tree is identical to the locally built and validated fix; focused tests, translator and wrapper checks were rerun from the PR worktree. The source diff contains only the implementation and regression test. Fixtures use synthetic data and local fake upstreams; no credentials, account data, private requests, generated works, deployment scripts or binaries are included.

Reproduce the targeted checks with Go 1.26.0:

```bash
cd sidecars/cockpit-cliproxy/third_party/CLIProxyAPI
go test -count=1 ./internal/runtime/executor -run '^TestCodexExecutorExecuteDoneTerminalStatus$'
go test -count=1 ./internal/translator/codex/openai/responses
```

From `sidecars/cockpit-cliproxy`, run `go test -count=1 .` for the wrapper. Full `go test -count=1 ./internal/runtime/executor` from the vendored module reproduces the baseline limitations above.

This PR fixes the reproducible terminal-alias bug in #2328. It does not claim that every report with the same generic disconnect message shares this cause.
