### PR TITLE
feat(antigravity): add Antigravity CLI account switching and switch-and-run support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
  "chrono",
  "clap",
  "cockpit-core",
+ "cockpit-tools",
  "colored",
  "serde",
  "serde_json",

--- a/crates/cockpit-cli/Cargo.toml
+++ b/crates/cockpit-cli/Cargo.toml
@@ -7,6 +7,7 @@ license = "CC-BY-NC-SA-4.0"
 
 [dependencies]
 cockpit-core = { path = "../cockpit-core" }
+cockpit-tools = { path = "../../src-tauri" }
 clap = { version = "4.5", features = ["derive", "env"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cockpit-cli/build.rs
+++ b/crates/cockpit-cli/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+    }
+}

--- a/crates/cockpit-cli/src/main.rs
+++ b/crates/cockpit-cli/src/main.rs
@@ -1,5 +1,8 @@
 use clap::{Parser, Subcommand};
 use cockpit_core::modules::{cursor_account, github_copilot_account};
+use antigravity_cockpit_tools_lib::modules::{
+    account as antigravity_account, antigravity_cli, provider_current_state,
+};
 use colored::*;
 use tabled::{Table, Tabled};
 
@@ -14,20 +17,36 @@ struct Cli {
 enum Commands {
     /// List accounts for a platform
     List {
-        /// The platform (cursor, copilot)
+        /// The platform (cursor, copilot, antigravity-cli, agy)
         platform: String,
     },
     /// Switch accounts for a specific platform
     Switch {
-        /// The platform (cursor, copilot)
+        /// The platform (cursor, copilot, antigravity-cli, agy)
         platform: String,
         /// The account ID or email to switch to
         account: String,
+    },
+    /// Show current account and status for a platform
+    Current {
+        /// The platform (antigravity-cli, agy)
+        platform: String,
     },
     /// Show current quota for a platform
     Quota {
         /// The platform (cursor, copilot)
         platform: String,
+    },
+    /// Run CLI tool for a platform
+    Run {
+        /// The platform (antigravity-cli, agy)
+        platform: String,
+        /// Account ID or email to switch to before running (optional)
+        #[arg(short, long)]
+        account: Option<String>,
+        /// Arguments forwarded to the platform binary
+        #[arg(last = true)]
+        args: Vec<String>,
     },
 }
 
@@ -37,7 +56,7 @@ struct AccountDisplay {
     id: String,
     #[tabled(rename = "Email")]
     email: String,
-    #[tabled(rename = "Plan")]
+    #[tabled(rename = "Plan/Tier")]
     plan: String,
     #[tabled(rename = "Tags")]
     tags: String,
@@ -77,7 +96,70 @@ async fn main() -> anyhow::Result<()> {
                         .collect(),
                 );
             }
+            "antigravity-cli" | "antigravity_cli" | "agy" => {
+                let accounts = antigravity_account::list_accounts().unwrap_or_default();
+                display_accounts(
+                    accounts
+                        .iter()
+                        .map(|a| AccountDisplay {
+                            id: a.id.clone(),
+                            email: a.email.clone(),
+                            plan: a
+                                .quota
+                                .as_ref()
+                                .and_then(|q| q.subscription_tier.clone())
+                                .unwrap_or_else(|| "FREE".to_string()),
+                            tags: a.tags.join(", "),
+                        })
+                        .collect(),
+                );
+            }
             _ => println!("{} Unknown platform: {}", "Error:".red(), platform),
+        },
+        Some(Commands::Current { platform }) => match platform.to_lowercase().as_str() {
+            "antigravity-cli" | "antigravity_cli" | "agy" => {
+                let status = match antigravity_cli::get_antigravity_cli_status() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        println!("{} Failed to get CLI status: {}", "Error:".red(), e);
+                        return Ok(());
+                    }
+                };
+                println!("{} Antigravity CLI Status:", "Info:".cyan());
+                println!(
+                    "  Installed:    {}",
+                    if status.installed {
+                        "Yes".green()
+                    } else {
+                        "No".red()
+                    }
+                );
+                println!(
+                    "  Binary Path:  {}",
+                    status.executable_path.as_deref().unwrap_or("Not found")
+                );
+                println!(
+                    "  Version:      {}",
+                    status.version.as_deref().unwrap_or("Unknown")
+                );
+                println!("  Auth Backend: {}", status.auth_backend);
+                if let Some(email) = &status.current_email {
+                    println!(
+                        "  Current Acct: {} ({})",
+                        email.green(),
+                        status.current_account_id.as_deref().unwrap_or("")
+                    );
+                } else {
+                    println!(
+                        "  Current Acct: {}",
+                        "None (no account bound to CLI)".yellow()
+                    );
+                }
+                if let Some(diag) = &status.diagnostic {
+                    println!("  Diagnostic:   {}", diag.yellow());
+                }
+            }
+            _ => println!("{} Current command not supported for platform: {}", "Error:".red(), platform),
         },
         Some(Commands::Switch { platform, account }) => match platform.to_lowercase().as_str() {
             "cursor" => {
@@ -92,9 +174,88 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
             "copilot" | "github_copilot" => {
-                println!("{} GitHub Copilot switch is partially implemented in CLI. Use GUI for full instance sync.", "Info:".yellow());
+                println!(
+                    "{} GitHub Copilot switch is partially implemented in CLI. Use GUI for full instance sync.",
+                    "Info:".yellow()
+                );
+            }
+            "antigravity-cli" | "antigravity_cli" | "agy" => {
+                let accounts = antigravity_account::list_accounts().unwrap_or_default();
+                let target = accounts.iter().find(|a| {
+                    a.id == account || a.email.eq_ignore_ascii_case(&account)
+                });
+                let target = match target {
+                    Some(a) => a,
+                    None => {
+                        println!("{} Antigravity account not found: {}", "Error:".red(), account);
+                        return Ok(());
+                    }
+                };
+
+                match antigravity_cli::switch_account_transaction(&target.id).await {
+                    Ok(switched) => {
+                        println!(
+                            "{} Successfully switched Antigravity CLI account to {} ({})",
+                            "Success:".green(),
+                            switched.email,
+                            switched.id
+                        );
+                    }
+                    Err(e) => {
+                        println!("{} Failed to switch Antigravity CLI account: {}", "Error:".red(), e);
+                    }
+                }
             }
             _ => println!("{} Unknown platform: {}", "Error:".red(), platform),
+        },
+        Some(Commands::Run { platform, account, args }) => match platform.to_lowercase().as_str() {
+            "antigravity-cli" | "antigravity_cli" | "agy" => {
+                let target_id = if let Some(acc) = account {
+                    let accounts = antigravity_account::list_accounts().unwrap_or_default();
+                    let found = accounts.iter().find(|a| {
+                        a.id == acc || a.email.eq_ignore_ascii_case(&acc)
+                    });
+                    match found {
+                        Some(a) => a.id.clone(),
+                        None => {
+                            println!("{} Antigravity account not found: {}", "Error:".red(), acc);
+                            return Ok(());
+                        }
+                    }
+                } else {
+                    match provider_current_state::get_current_account_id("antigravity_cli").ok().flatten() {
+                        Some(id) => id,
+                        None => {
+                            println!(
+                                "{} No current Antigravity CLI account selected. Please specify --account or switch first.",
+                                "Error:".red()
+                            );
+                            return Ok(());
+                        }
+                    }
+                };
+
+                let options = antigravity_cli::AntigravityCliRunOptions {
+                    cwd: None,
+                    args: if args.is_empty() { None } else { Some(args) },
+                    terminal: Some("direct".to_string()),
+                };
+
+                match antigravity_cli::run_antigravity_cli(&target_id, Some(options)).await {
+                    Ok(res) => {
+                        println!(
+                            "{} Antigravity CLI launched with account {} ({})",
+                            "Success:".green(),
+                            res.email,
+                            res.account_id
+                        );
+                    }
+                    Err(e) => {
+                        println!("{} Failed to run Antigravity CLI: {}", "Error:".red(), e);
+                    }
+                }
+            }
+            _ => println!("{} Run command not supported for platform: {}", "Error:".red(), platform),
         },
         Some(Commands::Quota { platform }) => match platform.to_lowercase().as_str() {
             _ => println!(

--- a/docs/design/antigravity-cli-account-switch.md
+++ b/docs/design/antigravity-cli-account-switch.md
@@ -1,0 +1,59 @@
+# Antigravity CLI Account Switch & Switch-and-Run Design Note
+
+## 1. agy Version Compatibility Matrix
+
+| Runtime Component | Inspected Environment Value | Notes |
+|---|---|---|
+| agy Executable Path | `~/.local/bin/agy` | Resolved via `which agy` / standard user PATH |
+| agy Version | `1.1.27` | Verified via `agy --version` |
+| Platform | macOS (Darwin arm64) | Tested on Apple Silicon |
+| Target Backend | macOS Keychain | Service: `gemini`, Account: `antigravity` |
+| Payload Format | `go-keyring-base64:<base64-json>` | `zalando/go-keyring` encoding wrapping standard OAuth payload |
+| Cockpit Writer Compatibility | 100% Compatible | Fresh `agy` immediately picks up switched account without browser login |
+
+## 2. Credential Backend Matrix
+
+- **macOS**: Keychain via `security` CLI / Keychain API. Key: service `gemini`, account `antigravity`. Value formatted as `go-keyring-base64:<base64(json)>`.
+- **Windows**: Windows Credential Manager via `advapi32`. Target: `gemini:antigravity`, User: `antigravity`. Value: JSON payload.
+- **Linux**: Secret Service via `secret-tool`. Service: `gemini`, Username: `antigravity`. Value: JSON payload.
+
+## 3. Transaction / Rollback Contract
+
+### Switch Account (`switch_account_transaction`)
+
+```text
+Load Selected Account
+       ↓
+Prepare & Refresh Token (fail -> abort, return TOKEN_REFRESH_FAILED)
+       ↓
+Snapshot Current CLI Credential
+       ↓
+Write Selected Credential to Native Credential Store (fail -> rollback snapshot, return CREDENTIAL_WRITE_FAILED)
+       ↓
+Read-back / Local Verify Account Email (fail -> rollback snapshot, return CREDENTIAL_VERIFY_FAILED)
+       ↓
+Commit antigravity_cli Current Account Binding
+       ↓
+Return Switched Account
+```
+
+### Switch-and-Run (`run_antigravity_cli`)
+
+```text
+Execute Switch Transaction
+       ↓
+Switch Failed?
+       ├─ Yes -> Stop immediately, do NOT launch agy, return switch error.
+       └─ No  -> Credential committed. Proceed to launch.
+                 Resolve agy executable
+                 Spawn fresh agy process
+                 Launch Failed?
+                     ├─ Yes -> DO NOT rollback credential! Keep switch committed.
+                     │         Return CLI_LAUNCH_FAILED error.
+                     └─ No  -> Success (PID returned).
+```
+
+## 4. Known Unsupported Cases
+
+- Hot-reloading active external `agy` sessions in other terminal tabs (guarantee is strictly for next / fresh launches).
+- Automatic round-robin / quota-based auto-switching across CLI invocations.

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -10,6 +10,7 @@ use tauri::Emitter;
 enum AntigravityRuntimeTarget {
     Legacy,
     Ide,
+    Cli,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,6 +19,7 @@ enum AntigravitySwitchFlow {
     LocalNoLaunch,
     DualNoRestart,
     Restart,
+    Cli,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,6 +31,7 @@ enum AntigravityDesktopAuthMode {
 fn normalize_antigravity_runtime_target(raw: Option<&str>) -> AntigravityRuntimeTarget {
     match raw.unwrap_or("").trim().to_ascii_lowercase().as_str() {
         "antigravity" => AntigravityRuntimeTarget::Legacy,
+        "antigravity_cli" | "antigravity-cli" | "cli" | "agy" => AntigravityRuntimeTarget::Cli,
         _ => AntigravityRuntimeTarget::Ide,
     }
 }
@@ -40,6 +43,7 @@ fn resolve_antigravity_switch_flow(
 ) -> AntigravitySwitchFlow {
     match runtime_target {
         AntigravityRuntimeTarget::Legacy => AntigravitySwitchFlow::Legacy,
+        AntigravityRuntimeTarget::Cli => AntigravitySwitchFlow::Cli,
         AntigravityRuntimeTarget::Ide if !launch_on_switch => AntigravitySwitchFlow::LocalNoLaunch,
         AntigravityRuntimeTarget::Ide if dual_switch_no_restart_enabled => {
             AntigravitySwitchFlow::DualNoRestart
@@ -289,6 +293,11 @@ pub async fn fetch_account_note_mail_url(
 #[tauri::command]
 pub async fn delete_account(account_id: String) -> Result<(), String> {
     modules::delete_account(&account_id)?;
+    if let Ok(Some(current_cli_id)) = modules::provider_current_state::get_current_account_id("antigravity_cli") {
+        if current_cli_id == account_id {
+            let _ = modules::provider_current_state::set_current_account_id("antigravity_cli", None);
+        }
+    }
     modules::websocket::broadcast_data_changed("account_deleted");
     Ok(())
 }
@@ -319,6 +328,26 @@ pub async fn get_current_account(
         AntigravityRuntimeTarget::Ide => modules::instance::load_default_settings()
             .ok()
             .and_then(|settings| settings.bind_account_id),
+        AntigravityRuntimeTarget::Cli => {
+            let account_id = modules::provider_current_state::get_current_account_id("antigravity_cli")
+                .ok()
+                .flatten();
+            if let Some(account_id) = account_id.as_deref() {
+                match modules::load_account(account_id) {
+                    Ok(mut account) => {
+                        let _ = modules::quota_cache::apply_cached_quota(&mut account, "authorized");
+                        return Ok(Some(account));
+                    }
+                    Err(error) => {
+                        modules::logger::log_warn(&format!(
+                            "[Antigravity CLI] 当前账号绑定已失效: account_id={}, error={}",
+                            account_id, error
+                        ));
+                    }
+                }
+            }
+            return Ok(None);
+        }
     };
 
     if let Some(account_id) = bound_account_id.as_deref() {
@@ -351,6 +380,7 @@ pub async fn set_current_account(
                 None,
                 Some(false),
             )?;
+            modules::set_current_account_id(&account_id)?;
         }
         AntigravityRuntimeTarget::Ide => {
             let _ = modules::instance::update_default_settings(
@@ -358,9 +388,15 @@ pub async fn set_current_account(
                 None,
                 Some(false),
             )?;
+            modules::set_current_account_id(&account_id)?;
+        }
+        AntigravityRuntimeTarget::Cli => {
+            modules::provider_current_state::set_current_account_id(
+                "antigravity_cli",
+                Some(&account_id),
+            )?;
         }
     }
-    modules::set_current_account_id(&account_id)?;
     let _ = crate::modules::tray::update_tray_menu(&app);
     Ok(())
 }
@@ -565,6 +601,13 @@ pub async fn switch_account(
     ) {
         AntigravitySwitchFlow::Legacy => {
             return switch_account_legacy_antigravity(app, account_id).await;
+        }
+        AntigravitySwitchFlow::Cli => {
+            let account = modules::antigravity_cli::switch_account_transaction(&account_id).await?;
+            modules::websocket::broadcast_account_switched(&account.id, &account.email);
+            modules::websocket::broadcast_data_changed("switch_account_cli");
+            let _ = crate::modules::tray::update_tray_menu(&app);
+            return Ok(account);
         }
         AntigravitySwitchFlow::LocalNoLaunch => {
             let result = modules::account::switch_account_local_no_restart(&account_id).await;
@@ -813,6 +856,24 @@ pub async fn save_account_groups(data: String) -> Result<(), String> {
         .map_err(|e| format!("Failed to write groups: {}", e))
 }
 
+#[tauri::command]
+pub async fn get_antigravity_cli_status() -> Result<modules::antigravity_cli::AntigravityCliStatus, String> {
+    modules::antigravity_cli::get_antigravity_cli_status()
+}
+
+#[tauri::command]
+pub async fn run_antigravity_cli(
+    app: AppHandle,
+    account_id: String,
+    options: Option<modules::antigravity_cli::AntigravityCliRunOptions>,
+) -> Result<modules::antigravity_cli::AntigravityCliRunResult, String> {
+    let result = modules::antigravity_cli::run_antigravity_cli(&account_id, options).await?;
+    modules::websocket::broadcast_account_switched(&result.account_id, &result.email);
+    modules::websocket::broadcast_data_changed("run_antigravity_cli");
+    let _ = crate::modules::tray::update_tray_menu(&app);
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -838,6 +899,18 @@ mod tests {
         assert_eq!(
             resolve_antigravity_switch_flow(AntigravityRuntimeTarget::Legacy, false, true),
             AntigravitySwitchFlow::Legacy
+        );
+    }
+
+    #[test]
+    fn antigravity_switch_flow_uses_cli_for_cli_target() {
+        assert_eq!(
+            resolve_antigravity_switch_flow(AntigravityRuntimeTarget::Cli, false, true),
+            AntigravitySwitchFlow::Cli
+        );
+        assert_eq!(
+            resolve_antigravity_switch_flow(AntigravityRuntimeTarget::Cli, true, false),
+            AntigravitySwitchFlow::Cli
         );
     }
 
@@ -878,6 +951,22 @@ mod tests {
         assert_eq!(
             normalize_antigravity_runtime_target(Some("antigravity")),
             AntigravityRuntimeTarget::Legacy
+        );
+        assert_eq!(
+            normalize_antigravity_runtime_target(Some("antigravity_cli")),
+            AntigravityRuntimeTarget::Cli
+        );
+        assert_eq!(
+            normalize_antigravity_runtime_target(Some("antigravity-cli")),
+            AntigravityRuntimeTarget::Cli
+        );
+        assert_eq!(
+            normalize_antigravity_runtime_target(Some("cli")),
+            AntigravityRuntimeTarget::Cli
+        );
+        assert_eq!(
+            normalize_antigravity_runtime_target(Some("agy")),
+            AntigravityRuntimeTarget::Cli
         );
     }
 }

--- a/src-tauri/src/commands/system_config_types.rs
+++ b/src-tauri/src/commands/system_config_types.rs
@@ -791,6 +791,7 @@ fn normalize_antigravity_metadata_target(target: Option<&str>) -> Option<&'stati
     match target.unwrap_or("").trim().to_ascii_lowercase().as_str() {
         "antigravity" => Some("antigravity"),
         "antigravity_ide" | "antigravity-ide" | "ide" => Some("antigravity_ide"),
+        "antigravity_cli" | "antigravity-cli" | "cli" | "agy" => Some("antigravity_cli"),
         _ => None,
     }
 }
@@ -1024,6 +1025,20 @@ fn resolve_antigravity_installed_version_info_for_target_with_mode(
     target: Option<&str>,
     scan_mode: AntigravityVersionScanMode,
 ) -> Option<AntigravityInstalledVersionInfo> {
+    if normalize_antigravity_metadata_target(target) == Some("antigravity_cli") {
+        if let Some(bin) = crate::modules::antigravity_cli::detect_agy_binary() {
+            let version = crate::modules::antigravity_cli::detect_agy_version(&bin)
+                .unwrap_or_else(|| "unknown".to_string());
+            return Some(AntigravityInstalledVersionInfo {
+                product_name: "Antigravity CLI".to_string(),
+                version,
+                app_path: bin.to_string_lossy().to_string(),
+                source: "agy-cli".to_string(),
+            });
+        }
+        return None;
+    }
+
     for root in antigravity_metadata_candidates(target, scan_mode) {
         if let Some(info) = read_antigravity_product_json_metadata(&root) {
             return Some(info);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,8 @@
 mod commands;
 pub mod error;
-mod models;
-mod modules;
-mod utils;
+pub mod models;
+pub mod modules;
+pub mod utils;
 
 use modules::config::CloseWindowBehavior;
 use modules::logger;
@@ -621,6 +621,8 @@ pub fn run() {
             commands::account::refresh_all_quotas,
             commands::account::refresh_current_quota,
             commands::account::switch_account,
+            commands::account::get_antigravity_cli_status,
+            commands::account::run_antigravity_cli,
             commands::account::load_antigravity_switch_history,
             commands::account::clear_antigravity_switch_history,
             commands::account::update_account_tags,

--- a/src-tauri/src/modules/antigravity_cli.rs
+++ b/src-tauri/src/modules/antigravity_cli.rs
@@ -1,0 +1,537 @@
+use crate::models::Account;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AntigravityCliStatus {
+    pub installed: bool,
+    pub executable_path: Option<String>,
+    pub version: Option<String>,
+    pub auth_backend: String,
+    pub current_account_id: Option<String>,
+    pub current_email: Option<String>,
+    pub diagnostic: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct AntigravityCliRunOptions {
+    pub cwd: Option<String>,
+    pub args: Option<Vec<String>>,
+    pub terminal: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AntigravityCliRunResult {
+    pub pid: Option<u32>,
+    pub executable_path: String,
+    pub account_id: String,
+    pub email: String,
+}
+
+fn find_in_path(binary_name: &str) -> Option<PathBuf> {
+    if let Some(paths) = std::env::var_os("PATH") {
+        for path in std::env::split_paths(&paths) {
+            let candidate = path.join(binary_name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+pub fn detect_agy_binary() -> Option<PathBuf> {
+    if let Some(path) = find_in_path("agy") {
+        return Some(path);
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        let candidates = [
+            home.join(".local/bin/agy"),
+            home.join(".gemini/antigravity-cli/bin/agy"),
+            home.join(".antigravity/antigravity-cli/bin/agy"),
+            PathBuf::from("/opt/homebrew/bin/agy"),
+            PathBuf::from("/usr/local/bin/agy"),
+            PathBuf::from("/usr/bin/agy"),
+        ];
+        for candidate in candidates {
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(path) = find_in_path("agy.exe") {
+            return Some(path);
+        }
+        if let Some(local_app_data) = dirs::data_local_dir() {
+            let win_candidate = local_app_data.join("Programs\\antigravity-cli\\agy.exe");
+            if win_candidate.is_file() {
+                return Some(win_candidate);
+            }
+        }
+        if let Some(home) = dirs::home_dir() {
+            let win_candidate = home.join(".local\\bin\\agy.exe");
+            if win_candidate.is_file() {
+                return Some(win_candidate);
+            }
+        }
+    }
+
+    None
+}
+
+pub fn detect_agy_version(bin: &Path) -> Option<String> {
+    let output = Command::new(bin).arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+    if !trimmed.is_empty() {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+pub fn get_antigravity_cli_status() -> Result<AntigravityCliStatus, String> {
+    let bin_path = detect_agy_binary();
+    let version = bin_path.as_ref().and_then(|p| detect_agy_version(p));
+    let installed = bin_path.is_some();
+    let auth_backend = crate::modules::antigravity_credential::detect_auth_backend();
+
+    let current_account_id =
+        crate::modules::provider_current_state::get_current_account_id("antigravity_cli")
+            .ok()
+            .flatten();
+
+    let current_email = if let Some(id) = current_account_id.as_deref() {
+        crate::modules::load_account(id).ok().map(|a| a.email)
+    } else {
+        None
+    };
+
+    let diagnostic = if !installed {
+        Some("CLI_NOT_INSTALLED: 未在系统 PATH 或标准路径中检测到 agy 可执行文件".to_string())
+    } else if auth_backend == "unknown" {
+        Some("AUTH_BACKEND_UNAVAILABLE: 未检测到支持的系统凭据存储后端".to_string())
+    } else {
+        None
+    };
+
+    Ok(AntigravityCliStatus {
+        installed,
+        executable_path: bin_path.map(|p| p.to_string_lossy().to_string()),
+        version,
+        auth_backend,
+        current_account_id,
+        current_email,
+        diagnostic,
+    })
+}
+
+/// 操作系统级跨进程文件锁，用于串行化 Cockpit GUI 与 cockpit-cli 等多独立进程对系统凭据库的并发操作。
+pub struct CrossProcessSwitchLock {
+    file: std::fs::File,
+    _path: PathBuf,
+}
+
+#[cfg(unix)]
+impl CrossProcessSwitchLock {
+    pub async fn acquire() -> Result<Self, String> {
+        use std::os::unix::io::AsRawFd;
+        let data_dir = crate::modules::account::get_data_dir()
+            .map_err(|e| format!("获取数据目录失败: {}", e))?;
+        let lock_path = data_dir.join("antigravity_cli_switch.lock");
+
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|e| format!("无法打开跨进程锁文件 ({}): {}", lock_path.display(), e))?;
+
+        let start = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(15);
+        let fd = file.as_raw_fd();
+
+        loop {
+            let res = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
+            if res == 0 {
+                return Ok(Self {
+                    file,
+                    _path: lock_path,
+                });
+            }
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() != Some(libc::EWOULDBLOCK) && err.raw_os_error() != Some(libc::EAGAIN) {
+                return Err(format!("获取跨进程文件锁异常: {}", err));
+            }
+            if start.elapsed() >= timeout {
+                return Err(
+                    "SWITCH_LOCK_TIMEOUT: 等待其他进程释放 Antigravity CLI 凭据切换锁超时 (15s)".to_string(),
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for CrossProcessSwitchLock {
+    fn drop(&mut self) {
+        use std::os::unix::io::AsRawFd;
+        unsafe {
+            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl CrossProcessSwitchLock {
+    pub async fn acquire() -> Result<Self, String> {
+        use std::os::windows::io::AsRawHandle;
+        use windows::Win32::Storage::FileSystem::{
+            LockFileEx, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+        };
+
+        let data_dir = crate::modules::account::get_data_dir()
+            .map_err(|e| format!("获取数据目录失败: {}", e))?;
+        let lock_path = data_dir.join("antigravity_cli_switch.lock");
+
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|e| format!("无法打开跨进程锁文件 ({}): {}", lock_path.display(), e))?;
+
+        let start = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(15);
+        let handle = windows::Win32::Foundation::HANDLE(file.as_raw_handle());
+
+        loop {
+            let mut overlapped = unsafe { std::mem::zeroed() };
+            let success = unsafe {
+                LockFileEx(
+                    handle,
+                    LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+                    0,
+                    1,
+                    0,
+                    &mut overlapped,
+                )
+            };
+            if success.is_ok() {
+                return Ok(Self {
+                    file,
+                    _path: lock_path,
+                });
+            }
+            if start.elapsed() >= timeout {
+                return Err(
+                    "SWITCH_LOCK_TIMEOUT: 等待其他进程释放 Antigravity CLI 凭据切换锁超时 (15s)".to_string(),
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for CrossProcessSwitchLock {
+    fn drop(&mut self) {
+        use std::os::windows::io::AsRawHandle;
+        use windows::Win32::Storage::FileSystem::UnlockFileEx;
+        let handle = windows::Win32::Foundation::HANDLE(self.file.as_raw_handle());
+        let mut overlapped = unsafe { std::mem::zeroed() };
+        let _ = unsafe { UnlockFileEx(handle, 0, 1, 0, &mut overlapped) };
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+impl CrossProcessSwitchLock {
+    pub async fn acquire() -> Result<Self, String> {
+        let data_dir = crate::modules::account::get_data_dir()
+            .map_err(|e| format!("获取数据目录失败: {}", e))?;
+        let lock_path = data_dir.join("antigravity_cli_switch.lock");
+        let file = std::fs::File::create(&lock_path)
+            .map_err(|e| format!("无法打开锁文件: {}", e))?;
+        Ok(Self { file, _path: lock_path })
+    }
+}
+
+static ANTIGRAVITY_CLI_SWITCH_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+pub async fn switch_account_transaction(account_id: &str) -> Result<Account, String> {
+    // 1. 本进程内协程串行化
+    let _switch_guard = ANTIGRAVITY_CLI_SWITCH_LOCK.lock().await;
+
+    // 2. 操作系统级跨进程文件互斥锁（覆盖 Cockpit GUI 与 cockpit-cli 独立进程）
+    let _cross_process_guard = CrossProcessSwitchLock::acquire().await?;
+
+    // 未知/不支持的凭据后端必须 fail-closed
+    let auth_backend = crate::modules::antigravity_credential::detect_auth_backend();
+    if auth_backend == "unknown" {
+        return Err("AUTH_BACKEND_UNAVAILABLE: 未检测到可用的系统凭据库，无法在当前系统执行 CLI 账号切换".to_string());
+    }
+
+    crate::modules::logger::log_info(&format!(
+        "[Antigravity CLI] 开始切换 CLI 账号事务: {}",
+        account_id
+    ));
+
+    // 1. 加载并准备目标账号（执行必要的 Token 刷新与重试逻辑）
+    let mut account = crate::modules::account::prepare_account_for_injection(account_id).await?;
+    crate::modules::logger::log_info(&format!(
+        "[Antigravity CLI] 准备注入账号凭据: {} (ID: {})",
+        account.email, account.id
+    ));
+
+    // 2. 快照当前 CLI 凭据
+    let snapshot = crate::modules::antigravity_credential::snapshot_antigravity_system_credential()
+        .map_err(|e| format!("AUTH_BACKEND_UNAVAILABLE: 读取凭据快照失败: {}", e))?;
+
+    // 3. 写入目标凭据
+    if let Err(write_err) =
+        crate::modules::antigravity_credential::write_antigravity_system_credential(&account)
+    {
+        crate::modules::logger::log_error(&format!(
+            "[Antigravity CLI] 写入目标凭据失败，正在回滚: {}",
+            write_err
+        ));
+        let rollback_result = crate::modules::antigravity_credential::restore_antigravity_system_credential(
+            snapshot.as_deref(),
+        );
+        if let Err(rollback_err) = rollback_result {
+            crate::modules::logger::log_error(&format!(
+                "[Antigravity CLI] 严重故障：凭据回滚失败: {}",
+                rollback_err
+            ));
+            return Err(format!(
+                "CREDENTIAL_ROLLBACK_FAILED: 凭据写入失败 ({}) 且回滚快照失败 ({})",
+                write_err, rollback_err
+            ));
+        }
+        return Err(format!("CREDENTIAL_WRITE_FAILED: {}", write_err));
+    }
+
+    // 4. 回读并校验目标凭据
+    if let Err(verify_err) =
+        crate::modules::antigravity_credential::verify_antigravity_system_credential(&account)
+    {
+        crate::modules::logger::log_error(&format!(
+            "[Antigravity CLI] 凭据校验未通过，正在回滚: {}",
+            verify_err
+        ));
+        let rollback_result = crate::modules::antigravity_credential::restore_antigravity_system_credential(
+            snapshot.as_deref(),
+        );
+        if let Err(rollback_err) = rollback_result {
+            crate::modules::logger::log_error(&format!(
+                "[Antigravity CLI] 严重故障：校验失败后回滚失败: {}",
+                rollback_err
+            ));
+            return Err(format!(
+                "CREDENTIAL_ROLLBACK_FAILED: 凭据校验失败 ({}) 且回滚快照失败 ({})",
+                verify_err, rollback_err
+            ));
+        }
+        return Err(format!("CREDENTIAL_VERIFY_FAILED: {}", verify_err));
+    }
+
+    // 5. 凭据校验成功后，持久化 antigravity_cli 绑定
+    if let Err(e) =
+        crate::modules::provider_current_state::set_current_account_id("antigravity_cli", Some(account_id))
+    {
+        crate::modules::logger::log_warn(&format!(
+            "[Antigravity CLI] 更新当前账号映射失败: {}",
+            e
+        ));
+    }
+    account.update_last_used();
+    let _ = crate::modules::save_account(&account);
+
+    crate::modules::logger::log_info(&format!(
+        "[Antigravity CLI] CLI 账号切换事务顺利完成: {}",
+        account.email
+    ));
+
+    Ok(account)
+}
+
+fn posix_quote(arg: &str) -> String {
+    format!("'{}'", arg.replace('\'', "'\\''"))
+}
+
+fn escape_applescript(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn spawn_fresh_agy_process(
+    agy_path: &Path,
+    args: &[String],
+    cwd: Option<&Path>,
+    terminal_preference: Option<&str>,
+) -> Result<Option<u32>, String> {
+    let pref = terminal_preference.unwrap_or("").trim();
+
+    #[cfg(target_os = "macos")]
+    {
+        // 如果明确指定 direct，则不通过终端应用包装
+        if pref.eq_ignore_ascii_case("direct") {
+            let mut cmd = Command::new(agy_path);
+            cmd.args(args);
+            if let Some(c) = cwd {
+                cmd.current_dir(c);
+            }
+            let child = cmd
+                .spawn()
+                .map_err(|e| format!("启动 agy 进程失败: {}", e))?;
+            return Ok(Some(child.id()));
+        }
+
+        // 默认或指定 Terminal 时，通过 macOS Terminal.app 打开交互窗口
+        let quoted_bin = posix_quote(&agy_path.to_string_lossy());
+        let quoted_args: Vec<String> = args.iter().map(|a| posix_quote(a)).collect();
+        let full_exec = if quoted_args.is_empty() {
+            quoted_bin
+        } else {
+            format!("{} {}", quoted_bin, quoted_args.join(" "))
+        };
+
+        let shell_command = if let Some(dir) = cwd {
+            format!("cd {} && exec {}", posix_quote(&dir.to_string_lossy()), full_exec)
+        } else {
+            format!("exec {}", full_exec)
+        };
+
+        let script = format!(
+            "tell application \"Terminal\"\nactivate\ndo script \"{}\"\nend tell",
+            escape_applescript(&shell_command)
+        );
+
+        let output = Command::new("osascript")
+            .args(["-e", &script])
+            .output()
+            .map_err(|e| format!("执行 osascript 启动 Terminal.app 失败: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("Terminal.app 启动失败: {}", stderr.trim()));
+        }
+
+        return Ok(None);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if pref.eq_ignore_ascii_case("direct") {
+            let mut cmd = Command::new(agy_path);
+            cmd.args(args);
+            if let Some(c) = cwd {
+                cmd.current_dir(c);
+            }
+            let child = cmd
+                .spawn()
+                .map_err(|e| format!("启动 agy 进程失败: {}", e))?;
+            return Ok(Some(child.id()));
+        }
+
+        // Windows 终端启动
+        let mut cmd = Command::new("cmd.exe");
+        cmd.arg("/c").arg("start").arg("cmd.exe").arg("/k");
+        cmd.arg(agy_path);
+        cmd.args(args);
+        if let Some(c) = cwd {
+            cmd.current_dir(c);
+        }
+        let child = cmd
+            .spawn()
+            .map_err(|e| format!("启动 Windows 终端失败: {}", e))?;
+        return Ok(Some(child.id()));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if pref.eq_ignore_ascii_case("direct") {
+            let mut cmd = Command::new(agy_path);
+            cmd.args(args);
+            if let Some(c) = cwd {
+                cmd.current_dir(c);
+            }
+            let child = cmd
+                .spawn()
+                .map_err(|e| format!("启动 agy 进程失败: {}", e))?;
+            return Ok(Some(child.id()));
+        }
+
+        let quoted_bin = posix_quote(&agy_path.to_string_lossy());
+        let quoted_args: Vec<String> = args.iter().map(|a| posix_quote(a)).collect();
+        let full_exec = if quoted_args.is_empty() {
+            quoted_bin
+        } else {
+            format!("{} {}", quoted_bin, quoted_args.join(" "))
+        };
+
+        let shell_command = if let Some(dir) = cwd {
+            format!("cd {} && {}; exec bash", posix_quote(&dir.to_string_lossy()), full_exec)
+        } else {
+            format!("{}; exec bash", full_exec)
+        };
+
+        let mut cmd = Command::new("x-terminal-emulator");
+        cmd.args(["-e", "bash", "-lc", &shell_command]);
+        let child = cmd
+            .spawn()
+            .map_err(|e| format!("启动 Linux 终端失败: {}", e))?;
+        return Ok(Some(child.id()));
+    }
+}
+
+pub async fn run_antigravity_cli(
+    account_id: &str,
+    options: Option<AntigravityCliRunOptions>,
+) -> Result<AntigravityCliRunResult, String> {
+    // 1. 先执行凭据切换事务（如失败，立即终止，绝不启动进程）
+    let switched_account = switch_account_transaction(account_id).await?;
+
+    // 2. 解析 agy 可执行文件
+    let agy_path = match detect_agy_binary() {
+        Some(p) => p,
+        None => {
+            return Err("CLI_NOT_INSTALLED: 未在系统中找到 agy 命令，请确保已安装 Antigravity CLI 并将其加入系统 PATH。".to_string());
+        }
+    };
+
+    // 3. 启动进程。注意：此时凭据切换已成功，启动进程失败时不回滚凭据！
+    let options = options.unwrap_or_default();
+    let args = options.args.unwrap_or_default();
+    let cwd = options.cwd.as_deref().map(Path::new);
+
+    match spawn_fresh_agy_process(&agy_path, &args, cwd, options.terminal.as_deref()) {
+        Ok(pid) => Ok(AntigravityCliRunResult {
+            pid,
+            executable_path: agy_path.to_string_lossy().to_string(),
+            account_id: switched_account.id,
+            email: switched_account.email,
+        }),
+        Err(err) => {
+            crate::modules::logger::log_warn(&format!(
+                "[Antigravity CLI] 账号已成功切换为 {}，但进程启动失败: {}",
+                switched_account.email, err
+            ));
+            Err(format!(
+                "CLI_LAUNCH_FAILED: 凭据已切换为 {}，但启动 agy 失败: {}",
+                switched_account.email, err
+            ))
+        }
+    }
+}

--- a/src-tauri/src/modules/antigravity_credential.rs
+++ b/src-tauri/src/modules/antigravity_credential.rs
@@ -14,7 +14,6 @@ struct AntigravityCredentialPayload {
     auth_method: String,
 }
 
-#[cfg(target_os = "windows")]
 #[derive(Debug, serde::Deserialize)]
 struct StoredAntigravityCredentialToken {
     access_token: Option<String>,
@@ -23,14 +22,12 @@ struct StoredAntigravityCredentialToken {
     expiry: Option<String>,
 }
 
-#[cfg(target_os = "windows")]
 #[derive(Debug, serde::Deserialize)]
 struct StoredAntigravityCredentialPayload {
     token: StoredAntigravityCredentialToken,
     auth_method: Option<String>,
 }
 
-#[cfg(target_os = "windows")]
 #[derive(Debug, Clone)]
 pub struct AntigravitySystemCredential {
     pub access_token: Option<String>,
@@ -40,7 +37,6 @@ pub struct AntigravitySystemCredential {
     pub auth_method: Option<String>,
 }
 
-#[cfg(target_os = "windows")]
 fn normalize_non_empty(value: Option<&str>) -> Option<String> {
     value
         .map(str::trim)
@@ -48,17 +44,28 @@ fn normalize_non_empty(value: Option<&str>) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-#[cfg(target_os = "windows")]
 fn normalize_antigravity_credential_secret(secret: &str) -> Result<String, String> {
     let trimmed = secret.trim();
     if trimmed.is_empty() {
         return Err("Antigravity 系统凭据为空".to_string());
     }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(b64) = trimmed.strip_prefix("go-keyring-base64:") {
+            use base64::{engine::general_purpose::STANDARD, Engine as _};
+            let decoded = STANDARD
+                .decode(b64)
+                .map_err(|e| format!("Base64 解码 Keychain 凭据失败: {}", e))?;
+            return String::from_utf8(decoded)
+                .map_err(|e| format!("解析 Keychain 凭据 UTF-8 失败: {}", e));
+        }
+    }
+
     Ok(trimmed.to_string())
 }
 
-#[cfg(target_os = "windows")]
-fn parse_antigravity_system_credential(
+pub fn parse_antigravity_system_credential(
     secret: &str,
 ) -> Result<AntigravitySystemCredential, String> {
     let payload_json = normalize_antigravity_credential_secret(secret)?;
@@ -104,197 +111,152 @@ pub fn write_antigravity_system_credential(account: &Account) -> Result<(), Stri
     #[cfg(target_os = "macos")]
     {
         use base64::{engine::general_purpose::STANDARD, Engine as _};
-        use std::process::Command;
-
         let encoded_payload = STANDARD.encode(&payload_json);
         let keychain_value = format!("go-keyring-base64:{}", encoded_payload);
-
-        let _ = Command::new("security")
-            .args([
-                "delete-generic-password",
-                "-s",
-                "gemini",
-                "-a",
-                "antigravity",
-            ])
-            .output();
-
-        let output = Command::new("security")
-            .args([
-                "add-generic-password",
-                "-s",
-                "gemini",
-                "-a",
-                "antigravity",
-                "-w",
-                &keychain_value,
-                "-A",
-            ])
-            .output()
-            .map_err(|e| format!("执行 macOS Keychain 写入命令失败: {}", e))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("写入 macOS Keychain 失败: {}", stderr.trim()));
-        }
+        write_raw_antigravity_system_credential(&keychain_value)?;
     }
 
     #[cfg(target_os = "windows")]
     {
-        use std::ffi::OsStr;
-        use std::os::windows::ffi::OsStrExt;
-        use std::ptr;
-
-        #[repr(C)]
-        struct FileTime {
-            dw_low_date_time: u32,
-            dw_high_date_time: u32,
-        }
-
-        #[repr(C)]
-        struct CredentialW {
-            flags: u32,
-            cred_type: u32,
-            target_name: *const u16,
-            comment: *const u16,
-            last_written: FileTime,
-            credential_blob_size: u32,
-            credential_blob: *const u8,
-            persist: u32,
-            attribute_count: u32,
-            attributes: *const std::ffi::c_void,
-            target_alias: *const u16,
-            user_name: *const u16,
-        }
-
-        #[link(name = "advapi32")]
-        extern "system" {
-            fn CredDeleteW(target_name: *const u16, type_: u32, flags: u32) -> i32;
-            fn CredWriteW(credential: *const CredentialW, flags: u32) -> i32;
-        }
-
-        const CRED_TYPE_GENERIC: u32 = 1;
-        const CRED_PERSIST_LOCAL_MACHINE: u32 = 2;
-
-        let target_wide: Vec<u16> = OsStr::new("gemini:antigravity")
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect();
-        let user_wide: Vec<u16> = OsStr::new("antigravity")
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect();
-        let secret = payload_json.as_bytes();
-
-        let credential = CredentialW {
-            flags: 0,
-            cred_type: CRED_TYPE_GENERIC,
-            target_name: target_wide.as_ptr(),
-            comment: ptr::null(),
-            last_written: FileTime {
-                dw_low_date_time: 0,
-                dw_high_date_time: 0,
-            },
-            credential_blob_size: secret.len() as u32,
-            credential_blob: secret.as_ptr(),
-            persist: CRED_PERSIST_LOCAL_MACHINE,
-            attribute_count: 0,
-            attributes: ptr::null(),
-            target_alias: ptr::null(),
-            user_name: user_wide.as_ptr(),
-        };
-
-        unsafe {
-            let _ = CredDeleteW(target_wide.as_ptr(), CRED_TYPE_GENERIC, 0);
-            if CredWriteW(&credential, 0) == 0 {
-                return Err(format!(
-                    "写入 Windows Credential Manager 失败: {}",
-                    std::io::Error::last_os_error()
-                ));
-            }
-        }
+        write_raw_antigravity_system_credential(&payload_json)?;
     }
 
     #[cfg(target_os = "linux")]
     {
-        use std::io::Write;
-        use std::process::{Command, Stdio};
-
-        let mut child = Command::new("secret-tool")
-            .args([
-                "store",
-                "--label=gemini",
-                "service",
-                "gemini",
-                "username",
-                "antigravity",
-            ])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| format!("启动 Linux secret-tool 失败: {}", e))?;
-
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(payload_json.as_bytes())
-                .map_err(|e| format!("写入 Linux secret-tool 输入失败: {}", e))?;
-        }
-
-        let output = child
-            .wait_with_output()
-            .map_err(|e| format!("等待 Linux secret-tool 失败: {}", e))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("Linux secret-tool 写入失败: {}", stderr.trim()));
-        }
+        write_raw_antigravity_system_credential(&payload_json)?;
     }
 
     crate::modules::logger::log_info("[Antigravity 2.0] 系统凭据写入完成");
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+pub fn read_antigravity_system_credential_secret() -> Result<Option<String>, String> {
+    use std::process::Command;
+    let output = Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            "gemini",
+            "-a",
+            "antigravity",
+            "-w",
+        ])
+        .output()
+        .map_err(|e| format!("执行 macOS Keychain 查找凭据失败: {}", e))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let secret = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if secret.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(secret))
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn write_raw_antigravity_system_credential(raw_secret: &str) -> Result<(), String> {
+    use std::process::Command;
+
+    let _ = Command::new("security")
+        .args([
+            "delete-generic-password",
+            "-s",
+            "gemini",
+            "-a",
+            "antigravity",
+        ])
+        .output();
+
+    let output = Command::new("security")
+        .args([
+            "add-generic-password",
+            "-s",
+            "gemini",
+            "-a",
+            "antigravity",
+            "-w",
+            raw_secret,
+            "-A",
+        ])
+        .output()
+        .map_err(|e| format!("执行 macOS Keychain 写入命令失败: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("写入 macOS Keychain 失败: {}", stderr.trim()));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn delete_antigravity_system_credential() -> Result<(), String> {
+    use std::process::Command;
+    let _ = Command::new("security")
+        .args([
+            "delete-generic-password",
+            "-s",
+            "gemini",
+            "-a",
+            "antigravity",
+        ])
+        .output();
+    Ok(())
+}
+
 #[cfg(target_os = "windows")]
-fn read_antigravity_system_credential_secret() -> Result<Option<String>, String> {
+#[repr(C)]
+struct FileTime {
+    dw_low_date_time: u32,
+    dw_high_date_time: u32,
+}
+
+#[cfg(target_os = "windows")]
+#[repr(C)]
+struct CredentialW {
+    flags: u32,
+    cred_type: u32,
+    target_name: *const u16,
+    comment: *const u16,
+    last_written: FileTime,
+    credential_blob_size: u32,
+    credential_blob: *const u8,
+    persist: u32,
+    attribute_count: u32,
+    attributes: *const std::ffi::c_void,
+    target_alias: *const u16,
+    user_name: *const u16,
+}
+
+#[cfg(target_os = "windows")]
+#[link(name = "advapi32")]
+extern "system" {
+    fn CredDeleteW(target_name: *const u16, type_: u32, flags: u32) -> i32;
+    fn CredWriteW(credential: *const CredentialW, flags: u32) -> i32;
+    fn CredReadW(
+        target_name: *const u16,
+        type_: u32,
+        flags: u32,
+        credential: *mut *mut CredentialW,
+    ) -> i32;
+    fn CredFree(buffer: *mut std::ffi::c_void);
+}
+
+#[cfg(target_os = "windows")]
+const CRED_TYPE_GENERIC: u32 = 1;
+#[cfg(target_os = "windows")]
+const CRED_PERSIST_LOCAL_MACHINE: u32 = 2;
+#[cfg(target_os = "windows")]
+const ERROR_NOT_FOUND: i32 = 1168;
+
+#[cfg(target_os = "windows")]
+pub fn read_antigravity_system_credential_secret() -> Result<Option<String>, String> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use std::ptr;
-
-    #[repr(C)]
-    struct FileTime {
-        dw_low_date_time: u32,
-        dw_high_date_time: u32,
-    }
-
-    #[repr(C)]
-    struct CredentialW {
-        flags: u32,
-        cred_type: u32,
-        target_name: *const u16,
-        comment: *const u16,
-        last_written: FileTime,
-        credential_blob_size: u32,
-        credential_blob: *const u8,
-        persist: u32,
-        attribute_count: u32,
-        attributes: *const std::ffi::c_void,
-        target_alias: *const u16,
-        user_name: *const u16,
-    }
-
-    #[link(name = "advapi32")]
-    extern "system" {
-        fn CredReadW(
-            target_name: *const u16,
-            type_: u32,
-            flags: u32,
-            credential: *mut *mut CredentialW,
-        ) -> i32;
-        fn CredFree(buffer: *mut std::ffi::c_void);
-    }
-
-    const CRED_TYPE_GENERIC: u32 = 1;
-    const ERROR_NOT_FOUND: i32 = 1168;
 
     let target_wide: Vec<u16> = OsStr::new("gemini:antigravity")
         .encode_wide()
@@ -346,9 +308,191 @@ fn read_antigravity_system_credential_secret() -> Result<Option<String>, String>
 }
 
 #[cfg(target_os = "windows")]
+pub fn write_raw_antigravity_system_credential(raw_secret: &str) -> Result<(), String> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr;
+
+    let target_wide: Vec<u16> = OsStr::new("gemini:antigravity")
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let user_wide: Vec<u16> = OsStr::new("antigravity")
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let secret = raw_secret.as_bytes();
+
+    let credential = CredentialW {
+        flags: 0,
+        cred_type: CRED_TYPE_GENERIC,
+        target_name: target_wide.as_ptr(),
+        comment: ptr::null(),
+        last_written: FileTime {
+            dw_low_date_time: 0,
+            dw_high_date_time: 0,
+        },
+        credential_blob_size: secret.len() as u32,
+        credential_blob: secret.as_ptr(),
+        persist: CRED_PERSIST_LOCAL_MACHINE,
+        attribute_count: 0,
+        attributes: ptr::null(),
+        target_alias: ptr::null(),
+        user_name: user_wide.as_ptr(),
+    };
+
+    unsafe {
+        let _ = CredDeleteW(target_wide.as_ptr(), CRED_TYPE_GENERIC, 0);
+        if CredWriteW(&credential, 0) == 0 {
+            return Err(format!(
+                "写入 Windows Credential Manager 失败: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub fn delete_antigravity_system_credential() -> Result<(), String> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+
+    let target_wide: Vec<u16> = OsStr::new("gemini:antigravity")
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    unsafe {
+        let _ = CredDeleteW(target_wide.as_ptr(), CRED_TYPE_GENERIC, 0);
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn read_antigravity_system_credential_secret() -> Result<Option<String>, String> {
+    use std::process::Command;
+    let output = Command::new("secret-tool")
+        .args([
+            "lookup",
+            "service",
+            "gemini",
+            "username",
+            "antigravity",
+        ])
+        .output()
+        .map_err(|e| format!("执行 Linux secret-tool 查找凭据失败: {}", e))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let secret = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if secret.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(secret))
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn write_raw_antigravity_system_credential(raw_secret: &str) -> Result<(), String> {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new("secret-tool")
+        .args([
+            "store",
+            "--label=gemini",
+            "service",
+            "gemini",
+            "username",
+            "antigravity",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("启动 Linux secret-tool 失败: {}", e))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(raw_secret.as_bytes())
+            .map_err(|e| format!("写入 Linux secret-tool 输入失败: {}", e))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("等待 Linux secret-tool 失败: {}", e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Linux secret-tool 写入失败: {}", stderr.trim()));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn delete_antigravity_system_credential() -> Result<(), String> {
+    use std::process::Command;
+    let _ = Command::new("secret-tool")
+        .args([
+            "clear",
+            "service",
+            "gemini",
+            "username",
+            "antigravity",
+        ])
+        .output();
+    Ok(())
+}
+
 pub fn read_antigravity_system_credential() -> Result<Option<AntigravitySystemCredential>, String> {
     let Some(secret) = read_antigravity_system_credential_secret()? else {
         return Ok(None);
     };
     parse_antigravity_system_credential(&secret).map(Some)
+}
+
+pub fn snapshot_antigravity_system_credential() -> Result<Option<String>, String> {
+    read_antigravity_system_credential_secret()
+}
+
+pub fn restore_antigravity_system_credential(snapshot: Option<&str>) -> Result<(), String> {
+    match snapshot {
+        Some(raw) => write_raw_antigravity_system_credential(raw),
+        None => delete_antigravity_system_credential(),
+    }
+}
+
+pub fn verify_antigravity_system_credential(expected: &Account) -> Result<(), String> {
+    let secret = read_antigravity_system_credential_secret()?
+        .ok_or_else(|| "CREDENTIAL_VERIFY_FAILED: 写入凭据后未能从系统凭据库读取".to_string())?;
+
+    let parsed = parse_antigravity_system_credential(&secret)?;
+    if parsed.refresh_token != expected.token.refresh_token {
+        return Err(format!(
+            "CREDENTIAL_VERIFY_FAILED: 凭据 refresh_token 不匹配 (预期账号: {})",
+            expected.email
+        ));
+    }
+    Ok(())
+}
+
+pub fn detect_auth_backend() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        "keyring".to_string()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "keyring".to_string()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use std::process::Command;
+        if Command::new("secret-tool").arg("--version").output().is_ok() {
+            "keyring".to_string()
+        } else {
+            "unknown".to_string()
+        }
+    }
 }

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,6 +1,7 @@
 pub mod account;
 pub mod account_index_repair;
 pub mod announcement;
+pub mod antigravity_cli;
 pub mod antigravity_credential;
 pub mod antigravity_legacy_instance;
 pub mod antigravity_paths;

--- a/src-tauri/src/modules/provider_current_state.rs
+++ b/src-tauri/src/modules/provider_current_state.rs
@@ -44,6 +44,7 @@ fn normalize_platform(platform: &str) -> Result<&'static str, String> {
         "trae_solo_cn" | "trae-solo-cn" => Ok("trae_solo_cn"),
         "workbuddy" => Ok("workbuddy"),
         "github_copilot" | "github-copilot" | "ghcp" => Ok("github_copilot"),
+        "antigravity_cli" | "antigravity-cli" | "agy" => Ok("antigravity_cli"),
         other => Err(format!("不支持的平台: {}", other)),
     }
 }

--- a/src-tauri/tests/antigravity_cli_integration_test.rs
+++ b/src-tauri/tests/antigravity_cli_integration_test.rs
@@ -1,0 +1,341 @@
+use antigravity_cockpit_tools_lib::models::account::Account;
+use antigravity_cockpit_tools_lib::modules::{
+    account,
+    antigravity_cli,
+    antigravity_credential,
+    provider_current_state,
+};
+use std::process::Command;
+
+fn get_test_accounts() -> (Account, Account) {
+    let accounts = account::list_accounts().expect("list_accounts must succeed");
+    assert!(
+        accounts.len() >= 2,
+        "Integration tests require at least 2 accounts configured in the account index"
+    );
+    (accounts[0].clone(), accounts[1].clone())
+}
+
+/// Test 1: 账号切换持久性与 agy 原生互认
+/// 准备账号 A 与账号 B，执行切换事务，验证原生 `agy models` 日志身份，再切回。
+#[tokio::test]
+async fn test_cli_account_switch_persistence_and_native_recognition() {
+    let (account_a, account_b) = get_test_accounts();
+    let account_a_id = &account_a.id;
+    let account_a_email = &account_a.email;
+    let account_b_id = &account_b.id;
+    let account_b_email = &account_b.email;
+
+    // 1. 快照当前初始凭据
+    let initial_snapshot = antigravity_credential::snapshot_antigravity_system_credential()
+        .expect("Snapshot initial credential");
+
+    // 2. 切换到 Account B
+    println!("[Test 1] Switching to Account B...");
+    let switched_b = antigravity_cli::switch_account_transaction(account_b_id)
+        .await
+        .expect("Switch to Account B transaction should succeed");
+    assert_eq!(&switched_b.id, account_b_id);
+    assert_eq!(&switched_b.email, account_b_email);
+
+    // 验证当前状态已绑定 Account B
+    let current_id = provider_current_state::get_current_account_id("antigravity_cli")
+        .expect("Read CLI current account ID")
+        .expect("CLI current account ID should be Some");
+    assert_eq!(&current_id, account_b_id);
+
+    // 3. 运行原生 agy 验证身份识别
+    let agy_path = antigravity_cli::detect_agy_binary().expect("detect agy binary");
+    let agy_out = Command::new(&agy_path)
+        .arg("models")
+        .output()
+        .expect("execute agy models");
+    if !agy_out.status.success() {
+        eprintln!("agy models failed! status: {}", agy_out.status);
+        eprintln!("stdout: {}", String::from_utf8_lossy(&agy_out.stdout));
+        eprintln!("stderr: {}", String::from_utf8_lossy(&agy_out.stderr));
+    }
+    assert!(agy_out.status.success(), "agy models should succeed: status={}", agy_out.status);
+
+    // 读取最近 agy 日志验证认证账号
+    let log_path = std::fs::read_link(
+        dirs::home_dir().unwrap().join(".gemini/antigravity-cli/cli.log")
+    ).map(|p| dirs::home_dir().unwrap().join(".gemini/antigravity-cli").join(p));
+
+    if let Ok(actual_log_path) = log_path {
+        let log_content = std::fs::read_to_string(&actual_log_path).unwrap_or_default();
+        let mut last_auth_line = None;
+        for line in log_content.lines() {
+            if line.contains("applyAuthResult: email=") {
+                last_auth_line = Some(line.to_string());
+            }
+        }
+        println!("[Test 1] agy last auth log: {:?}", last_auth_line);
+        assert!(
+            last_auth_line.as_ref().map(|l| l.contains(account_b_email)).unwrap_or(false),
+            "Expected agy to authenticate as Account B ({})", account_b_email
+        );
+    }
+
+    // 4. 切换回 Account A
+    println!("[Test 1] Switching back to Account A...");
+    let switched_a = antigravity_cli::switch_account_transaction(account_a_id)
+        .await
+        .expect("Switch back to Account A transaction should succeed");
+    assert_eq!(&switched_a.id, account_a_id);
+    assert_eq!(&switched_a.email, account_a_email);
+
+    let current_id_after = provider_current_state::get_current_account_id("antigravity_cli")
+        .expect("Read CLI current account ID")
+        .expect("CLI current account ID should be Some");
+    assert_eq!(&current_id_after, account_a_id);
+
+    // 验证切回后的 agy 原生身份
+    let agy_out_a = Command::new(&agy_path)
+        .arg("models")
+        .output()
+        .expect("execute agy models for Account A");
+    assert!(agy_out_a.status.success());
+
+    // 恢复快照保底
+    let _ = antigravity_credential::restore_antigravity_system_credential(initial_snapshot.as_deref());
+}
+
+/// Test 2: “一键运行”事务与故障隔离（Decoupled Launch Failure）
+/// 验证：凭据校验成功但进程拉起失败时，保留新账号绑定，返回 CLI_LAUNCH_FAILED，不触发凭据回滚
+#[tokio::test]
+async fn test_switch_and_run_decoupled_launch_failure() {
+    let (account_a, account_b) = get_test_accounts();
+    let account_a_id = &account_a.id;
+    let account_b_id = &account_b.id;
+
+    let initial_snapshot = antigravity_credential::snapshot_antigravity_system_credential()
+        .expect("Snapshot initial credential");
+
+    // 首先保证处于 Account A
+    let _ = antigravity_cli::switch_account_transaction(account_a_id).await;
+
+    // 运行一个必定失败的 terminal / command 选项（例如非法的 terminal 配置）
+    // 但凭据切换事务必须先成功执行
+    let options = antigravity_cli::AntigravityCliRunOptions {
+        cwd: Some("/non_existent_directory_for_launch_failure_testing_xyz".to_string()),
+        args: Some(vec!["models".to_string()]),
+        terminal: Some("direct".to_string()),
+    };
+
+    let result = antigravity_cli::run_antigravity_cli(account_b_id, Some(options)).await;
+    println!("[Test 2] Result with non-existent cwd: {:?}", result.is_err());
+
+    // 无论进程是否因为非法 cwd 报错（或者报错 CLI_LAUNCH_FAILED）：
+    // 关键断言：凭据必须已经顺利切换并提交为 Account B，绝不因为启动阶段问题回滚！
+    let current_id = provider_current_state::get_current_account_id("antigravity_cli")
+        .expect("Read CLI current account ID")
+        .expect("CLI current account ID should be Some");
+    assert_eq!(&current_id, account_b_id, "Current account must remain Account B");
+
+    // 还原回 Account A
+    let _ = antigravity_cli::switch_account_transaction(account_a_id).await;
+    let _ = antigravity_credential::restore_antigravity_system_credential(initial_snapshot.as_deref());
+}
+
+/// Test 3: 回滚保护（Rollback Integrity）
+/// 凭据回读校验失败时，读取快照成功回滚并返回 CREDENTIAL_VERIFY_FAILED
+#[tokio::test]
+async fn test_rollback_on_verify_failure() {
+    let (account_a, account_b) = get_test_accounts();
+    let account_a_id = &account_a.id;
+    let account_b_id = &account_b.id;
+
+    let initial_snapshot = antigravity_credential::snapshot_antigravity_system_credential()
+        .expect("Snapshot initial credential");
+
+    // 保证初始为 Account A
+    let _ = antigravity_cli::switch_account_transaction(account_a_id).await;
+    let baseline_id = provider_current_state::get_current_account_id("antigravity_cli")
+        .expect("Read CLI current account ID")
+        .expect("CLI current account ID should be Some");
+    assert_eq!(&baseline_id, account_a_id);
+
+    // 模拟构造一个与当前凭据不一致的 Account 触发 verify 失败
+    let mut invalid_account = account::load_account(account_b_id).expect("Load Account B");
+    // 故意将 token 置为空或篡改以让 verify 校验不匹配
+    invalid_account.token.access_token = "tampered_token_that_wont_match".to_string();
+
+    // 写入并校验
+    let verify_res = antigravity_credential::verify_antigravity_system_credential(&invalid_account);
+    assert!(verify_res.is_err(), "Verification should fail for tampered account token");
+
+    // 验证回滚函数在接收到快照时能正确还原
+    antigravity_credential::restore_antigravity_system_credential(initial_snapshot.as_deref())
+        .expect("Rollback to snapshot must succeed");
+
+    // 验证当前状态依然保持 Account A
+    let current_id = provider_current_state::get_current_account_id("antigravity_cli")
+        .expect("Read CLI current account ID")
+        .expect("CLI current account ID should be Some");
+    assert_eq!(&current_id, account_a_id, "Current account must remain unchanged Account A");
+}
+
+/// Test 4: 多 Runtime Target 状态隔离验证
+/// 验证：切换 CLI 到 Account B 时，IDE 与 Legacy 当前账号完全不受影响
+#[tokio::test]
+async fn test_multi_runtime_target_state_isolation() {
+    let (account_a, account_b) = get_test_accounts();
+    let account_a_id = &account_a.id;
+    let account_b_id = &account_b.id;
+
+    // 1. 设置 IDE 与 Legacy 绑定 Account A
+    let _ = antigravity_cockpit_tools_lib::modules::instance::update_default_settings(
+        Some(Some(account_a_id.to_string())),
+        None,
+        Some(false),
+    );
+    let _ = antigravity_cockpit_tools_lib::modules::antigravity_legacy_instance::update_default_settings(
+        Some(Some(account_a_id.to_string())),
+        None,
+        Some(false),
+    );
+
+    // 2. 切换 CLI 到 Account B
+    let _ = antigravity_cli::switch_account_transaction(account_b_id).await.expect("Switch CLI to B");
+
+    // 3. 验证状态隔离：
+    // CLI 为 Account B
+    let cli_id = provider_current_state::get_current_account_id("antigravity_cli")
+        .ok()
+        .flatten();
+    assert_eq!(cli_id.as_deref(), Some(account_b_id.as_str()));
+
+    // IDE 依然为 Account A
+    let ide_id = antigravity_cockpit_tools_lib::modules::instance::load_default_settings()
+        .ok()
+        .and_then(|s| s.bind_account_id);
+    assert_eq!(ide_id.as_deref(), Some(account_a_id.as_str()));
+
+    // Legacy 依然为 Account A
+    let legacy_id = antigravity_cockpit_tools_lib::modules::antigravity_legacy_instance::load_default_settings()
+        .ok()
+        .and_then(|s| s.bind_account_id);
+    assert_eq!(legacy_id.as_deref(), Some(account_a_id.as_str()));
+
+    // 4. 切回 CLI 到 Account A
+    let _ = antigravity_cli::switch_account_transaction(account_a_id).await.expect("Switch CLI back to A");
+}
+
+/// Test 5: 并发 A/B 切换互斥串行化验证
+/// 验证：并发发起 A→B 与 B→A 切换请求时，底层锁确保两笔事务串行完成，
+/// 最终当前账号与系统凭据完全一致，且匹配最后成功的事务。
+#[tokio::test]
+async fn test_concurrent_ab_switches_serialized() {
+    let (account_a, account_b) = get_test_accounts();
+    let account_a_id = account_a.id.clone();
+    let account_b_id = account_b.id.clone();
+
+    let initial_snapshot = antigravity_credential::snapshot_antigravity_system_credential()
+        .expect("Snapshot initial credential");
+
+    // 并发启动两个异步任务，分别尝试切到 Account A 和 Account B
+    let b_id = account_b_id.clone();
+    let handle_b = tokio::spawn(async move {
+        antigravity_cli::switch_account_transaction(&b_id).await
+    });
+    let a_id = account_a_id.clone();
+    let handle_a = tokio::spawn(async move {
+        antigravity_cli::switch_account_transaction(&a_id).await
+    });
+
+    let (res_b, res_a) = tokio::join!(handle_b, handle_a);
+    let res_b = res_b.expect("join handle_b");
+    let res_a = res_a.expect("join handle_a");
+
+    // 两笔事务都必须安全成功（互斥串行执行，没有死锁或校验冲突）
+    assert!(res_b.is_ok(), "Switch to B failed: {:?}", res_b.err());
+    assert!(res_a.is_ok(), "Switch to A failed: {:?}", res_a.err());
+
+    // 最终读取系统持久化状态与底层凭据
+    let final_bound_id = provider_current_state::get_current_account_id("antigravity_cli")
+        .expect("Read CLI current account ID")
+        .expect("CLI current account ID should be Some");
+
+    // 验证底层 Keychain 凭据与当前绑定一致
+    let expected_account = account::load_account(&final_bound_id).expect("Load expected account");
+    let verify_res = antigravity_credential::verify_antigravity_system_credential(&expected_account);
+    assert!(
+        verify_res.is_ok(),
+        "Keychain credential must match the final bound account (ID: {}, err: {:?})",
+        final_bound_id,
+        verify_res.err()
+    );
+
+    // 恢复初始快照
+    let _ = antigravity_credential::restore_antigravity_system_credential(initial_snapshot.as_deref());
+}
+
+/// Test 6: 跨进程并发切号互斥测试 (Cross-Process Switching Race)
+/// 验证：同时由当前测试进程和独立 child process (cockpit-cli) 发起并发切号时，
+/// 跨进程文件锁保证两笔事务严格串行执行，无死锁，无残留锁，且最终：
+/// credential active account == provider current account
+#[tokio::test]
+async fn test_cross_process_concurrent_switch() {
+    let (account_a, account_b) = get_test_accounts();
+    let account_a_id = account_a.id.clone();
+    let account_b_id = account_b.id.clone();
+
+    let initial_snapshot = antigravity_credential::snapshot_antigravity_system_credential()
+        .expect("Snapshot initial credential");
+
+    // 确定 cockpit-cli 可执行文件路径
+    let mut cli_path = std::env::current_exe()
+        .expect("current test exe path");
+    cli_path.pop(); // pop test binary name
+    if cli_path.ends_with("deps") {
+        cli_path.pop(); // pop deps dir
+    }
+    let cockpit_cli_bin = cli_path.join("cockpit-cli");
+    assert!(cockpit_cli_bin.exists(), "cockpit-cli binary must exist at {:?}", cockpit_cli_bin);
+
+    // 1. 异步启动一个独立 OS 子进程执行 `cockpit-cli switch agy <Account B>`
+    let b_id = account_b_id.clone();
+    let child_task = tokio::task::spawn_blocking(move || {
+        Command::new(&cockpit_cli_bin)
+            .args(["switch", "agy", &b_id])
+            .output()
+    });
+
+    // 2. 当前进程几乎同一时刻发起内部切换到 Account A
+    let current_proc_switch = antigravity_cli::switch_account_transaction(&account_a_id).await;
+
+    // 3. 等待子进程执行完毕
+    let child_output = child_task.await.expect("join child task").expect("execute child process");
+
+    println!("[Test 6] Child stdout: {}", String::from_utf8_lossy(&child_output.stdout));
+    println!("[Test 6] Child stderr: {}", String::from_utf8_lossy(&child_output.stderr));
+    println!("[Test 6] Current proc switch ok: {}", current_proc_switch.is_ok());
+
+    assert!(child_output.status.success(), "Child process switch must succeed");
+    assert!(current_proc_switch.is_ok(), "Current process switch must succeed");
+
+    // 4. 核心断言：最终状态必须满足 credential active account == provider current account
+    let final_bound_id = provider_current_state::get_current_account_id("antigravity_cli")
+        .expect("Read CLI current account ID")
+        .expect("CLI current account ID should be Some");
+
+    let expected_account = account::load_account(&final_bound_id).expect("Load final account");
+    let verify_res = antigravity_credential::verify_antigravity_system_credential(&expected_account);
+    assert!(
+        verify_res.is_ok(),
+        "Cross-process invariant failed! Credential in Keychain must match provider current account: final_bound_id={}, verify_err={:?}",
+        final_bound_id,
+        verify_res.err()
+    );
+
+    // 5. 验证锁文件未被死锁锁定，当前能即刻再次获取
+    let lock_probe = antigravity_cli::CrossProcessSwitchLock::acquire().await;
+    assert!(lock_probe.is_ok(), "Cross-process lock must be cleanly released and acquireable");
+    drop(lock_probe);
+
+    // 恢复初始凭据
+    let _ = antigravity_credential::restore_antigravity_system_credential(initial_snapshot.as_deref());
+}
+
+

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -122,7 +122,11 @@ function renderEntryIcon(entry: SideNavEntry, size: number) {
 }
 
 function isAntigravitySuitePlatformIds(platformIds: PlatformId[]): boolean {
-  return platformIds.includes('antigravity') && platformIds.includes('antigravity_ide');
+  return (
+    platformIds.includes('antigravity') ||
+    platformIds.includes('antigravity_ide') ||
+    platformIds.includes('antigravity_cli')
+  );
 }
 
 function isAntigravitySuitePage(page: Page): boolean {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1698,10 +1698,19 @@
       "viewError": "View error",
       "switch": "Switch account",
       "switchTo": "Switch to this account",
+      "run": "Run",
+      "runCli": "Run Antigravity CLI",
       "delete": "Delete",
       "deleteSelected": "Delete Selected",
       "export": "Export",
       "refreshAll": "Refresh All"
+    },
+    "cli": {
+      "run": "Run Antigravity CLI",
+      "launched": "Switched to {{email}} and launched Antigravity CLI",
+      "notInstalled": "agy binary not found. Please install Antigravity CLI and add it to your PATH.",
+      "launchFailed": "Credentials switched, but failed to launch agy: {{error}}",
+      "runFailed": "Failed to run Antigravity CLI: {{error}}"
     },
     "switchHistory": {
       "title": "Switch History",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1698,10 +1698,19 @@
       "viewError": "查看错误",
       "switch": "切换账号",
       "switchTo": "切换到此账号",
+      "run": "运行",
+      "runCli": "运行 Antigravity CLI",
       "delete": "删除",
       "deleteSelected": "删除选中",
       "export": "导出",
       "refreshAll": "刷新全部"
+    },
+    "cli": {
+      "run": "运行 Antigravity CLI",
+      "launched": "已切换为 {{email}} 并启动 Antigravity CLI",
+      "notInstalled": "未检测到 agy 命令，请先安装 Antigravity CLI 并将其加入系统 PATH",
+      "launchFailed": "账号凭据已切换，但启动 agy 终端失败：{{error}}",
+      "runFailed": "启动 Antigravity CLI 失败：{{error}}"
     },
     "switchHistory": {
       "title": "切换记录",

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -21,6 +21,7 @@ import {
   LogOut,
   Pencil,
   FileText,
+  Terminal,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useAccountStore } from '../stores/useAccountStore'
@@ -356,6 +357,7 @@ export function useAccountsPageController({ onNavigate }: AccountsPageProps) {
   const [refreshingAll, setRefreshingAll] = useState(false)
   const [wakeupRunning, setWakeupRunning] = useState(false)
   const [switching, setSwitching] = useState<string | null>(null)
+  const [runningCli, setRunningCli] = useState<string | null>(null)
   const [importing, setImporting] = useState(false)
   const [refreshWarnings, setRefreshWarnings] = useState<
     Record<string, { kind: 'auth' | 'error'; message: string }>
@@ -2035,6 +2037,55 @@ export function useAccountsPageController({ onNavigate }: AccountsPageProps) {
     setSwitching(null)
   }
 
+  const handleRunCli = async (accountId: string) => {
+    setMessage(null)
+    const targetAccount = accounts.find((account) => account.id === accountId)
+    if (isPendingAntigravityAccount(targetAccount)) {
+      if (targetAccount) openPendingOAuthAccount(targetAccount)
+      return
+    }
+    setRunningCli(accountId)
+    try {
+      const res = await accountService.runAntigravityCli(accountId)
+      await fetchCurrentAccount('antigravity_cli')
+      setMessage({
+        text: t('accounts.cli.launched', {
+          defaultValue: '已切换为 {{email}} 并启动 Antigravity CLI',
+          email: maskAccountText(res.email),
+        }),
+      })
+    } catch (e) {
+      const raw = String(e)
+      if (raw.includes('CLI_NOT_INSTALLED')) {
+        setMessage({
+          text: t('accounts.cli.notInstalled', {
+            defaultValue: '未检测到 agy 命令，请先安装 Antigravity CLI 并将其加入系统 PATH',
+          }),
+          tone: 'error',
+        })
+      } else if (raw.includes('CLI_LAUNCH_FAILED')) {
+        await fetchCurrentAccount('antigravity_cli')
+        setMessage({
+          text: t('accounts.cli.launchFailed', {
+            defaultValue: '账号凭据已切换，但启动 agy 终端失败：{{error}}',
+            error: raw.replace(/^.*CLI_LAUNCH_FAILED:\s*/, ''),
+          }),
+          tone: 'error',
+        })
+      } else {
+        setMessage({
+          text: t('accounts.cli.runFailed', {
+            defaultValue: '启动 Antigravity CLI 失败：{{error}}',
+            error: raw,
+          }),
+          tone: 'error',
+        })
+      }
+    } finally {
+      setRunningCli(null)
+    }
+  }
+
   const loadSwitchHistory = useCallback(async () => {
     setSwitchHistoryLoading(true)
     try {
@@ -3287,10 +3338,25 @@ export function useAccountsPageController({ onNavigate }: AccountsPageProps) {
               >
                 <FileText size={14} />
               </button>
+              {antigravityRuntimeTarget === 'antigravity_cli' && (
+                <button
+                  className="card-action-btn success"
+                  onClick={() => void handleRunCli(account.id)}
+                  disabled={Boolean(switching || runningCli)}
+                  title={t('accounts.cli.run', '运行 Antigravity CLI')}
+                  aria-label={t('accounts.cli.run', '运行 Antigravity CLI')}
+                >
+                  {runningCli === account.id ? (
+                    <RefreshCw size={14} className="loading-spinner" />
+                  ) : (
+                    <Terminal size={14} />
+                  )}
+                </button>
+              )}
               <button
                 className={`card-action-btn ${!isCurrent ? 'success' : ''}`}
                 onClick={() => handleSwitch(account.id)}
-                disabled={!!switching}
+                disabled={Boolean(switching || runningCli)}
                 title={
                   isCurrent
                     ? t('accounts.actions.switch')
@@ -3608,6 +3674,25 @@ export function useAccountsPageController({ onNavigate }: AccountsPageProps) {
               <FileText size={12} />
               <span>{hasAntigravityAccountNoteDetails(account) ? t('accounts.accountNote.short', '账号备注') : t('accounts.accountNote.addShort', '加备注')}</span>
             </button>
+            {antigravityRuntimeTarget === 'antigravity_cli' && (
+              <button
+                type="button"
+                className={styles.switchBtn}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  void handleRunCli(account.id)
+                }}
+                disabled={Boolean(isSwitching || runningCli)}
+                title={t('accounts.cli.run', '运行 Antigravity CLI')}
+                aria-label={t('accounts.cli.run', '运行 Antigravity CLI')}
+              >
+                {runningCli === account.id ? (
+                  <RefreshCw size={12} className="loading-spinner" />
+                ) : (
+                  <Terminal size={12} />
+                )}
+              </button>
+            )}
             <button
               type="button"
               className={styles.switchBtn}
@@ -3615,7 +3700,7 @@ export function useAccountsPageController({ onNavigate }: AccountsPageProps) {
                 e.stopPropagation()
                 handleSwitch(account.id)
               }}
-              disabled={isSwitching}
+              disabled={Boolean(isSwitching || runningCli)}
               title={
                 isCurrent
                   ? t('accounts.actions.switch')
@@ -3923,10 +4008,25 @@ export function useAccountsPageController({ onNavigate }: AccountsPageProps) {
               >
                 <FileText size={16} />
               </button>
+              {antigravityRuntimeTarget === 'antigravity_cli' && (
+                <button
+                  className="action-btn success"
+                  onClick={() => void handleRunCli(account.id)}
+                  disabled={Boolean(switching || runningCli)}
+                  title={t('accounts.cli.run', '运行 Antigravity CLI')}
+                  aria-label={t('accounts.cli.run', '运行 Antigravity CLI')}
+                >
+                  {runningCli === account.id ? (
+                    <div className="loading-spinner" style={{ width: 14, height: 14 }} />
+                  ) : (
+                    <Terminal size={16} />
+                  )}
+                </button>
+              )}
               <button
                 className={`action-btn ${!isCurrent ? 'success' : ''}`}
                 onClick={() => handleSwitch(account.id)}
-                disabled={!!switching}
+                disabled={Boolean(switching || runningCli)}
                 title={
                   isCurrent
                     ? t('accounts.actions.switch')

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -136,7 +136,7 @@ const DASHBOARD_DEFERRED_PREFETCH_BATCH_DELAY_MS = 1200;
 let dashboardStartupPrefetched = false;
 
 function normalizeDashboardCardPlatformId(platformId: PlatformId): PlatformId {
-  return platformId === 'antigravity_ide' ? 'antigravity' : platformId;
+  return platformId === 'antigravity_ide' || platformId === 'antigravity_cli' ? 'antigravity' : platformId;
 }
 
 function isTraeSuitePlatform(platformId: PlatformId): boolean {
@@ -2661,6 +2661,7 @@ export function DashboardPage({
   const platformCounts: Record<PlatformId, number> = {
     antigravity: stats.antigravity,
     antigravity_ide: stats.antigravity,
+    antigravity_cli: stats.antigravity,
     codex: stats.codex,
     codex_api_service: 0,
     claude_manager: stats.claude,
@@ -2690,7 +2691,7 @@ export function DashboardPage({
       const countedPlatformIds = new Set<PlatformId>();
       const count = platformIds.reduce((sum, platformId) => {
         const countPlatformId =
-          platformId === 'antigravity_ide'
+          platformId === 'antigravity_ide' || platformId === 'antigravity_cli'
             ? 'antigravity'
               : platformId;
         if (countedPlatformIds.has(countPlatformId)) {

--- a/src/pages/FloatingCardWindow.tsx
+++ b/src/pages/FloatingCardWindow.tsx
@@ -228,6 +228,7 @@ function resolveInstanceStoreApi(platformId: PlatformId): FloatingCardInstanceSt
       return useWorkbuddyInstanceStore.getState();
     case 'zcode':
       return useZcodeInstanceStore.getState();
+    case 'antigravity_cli':
     case 'zed':
       return null;
   }
@@ -463,7 +464,8 @@ export function FloatingCardWindow() {
     try {
       switch (platformId) {
         case 'antigravity':
-        case 'antigravity_ide': {
+        case 'antigravity_ide':
+        case 'antigravity_cli': {
           await Promise.allSettled([
             useAccountStore.getState().fetchAccounts(),
             useAccountStore.getState().fetchCurrentAccount(platformId),
@@ -833,6 +835,7 @@ export function FloatingCardWindow() {
     switch (selectedPlatform) {
       case 'antigravity':
       case 'antigravity_ide':
+      case 'antigravity_cli':
         return {
           accounts: agAccounts,
           actualCurrentAccount: agCurrentAccountsByTarget[selectedPlatform] ?? null,
@@ -971,6 +974,7 @@ export function FloatingCardWindow() {
     switch (selectedPlatform) {
       case 'antigravity':
       case 'antigravity_ide':
+      case 'antigravity_cli':
         return getRecommendedAntigravityAccount(agAccounts, effectiveCurrentId);
       case 'codex':
         return getRecommendedCodexAccount(codexAccounts, effectiveCurrentId);
@@ -1070,6 +1074,7 @@ export function FloatingCardWindow() {
     switch (selectedPlatform) {
       case 'antigravity':
       case 'antigravity_ide':
+      case 'antigravity_cli':
         return buildAntigravityAccountPresentation(viewedAccount as typeof agAccounts[number], displayGroups, t);
       case 'codex':
         return buildCodexAccountPresentation(viewedAccount as typeof codexAccounts[number], t);
@@ -1169,6 +1174,7 @@ export function FloatingCardWindow() {
         switch (selectedPlatform) {
           case 'antigravity':
           case 'antigravity_ide':
+          case 'antigravity_cli':
             await useAccountStore.getState().refreshQuota(viewedAccount.id, selectedPlatform);
             break;
           case 'codex':
@@ -1296,6 +1302,7 @@ export function FloatingCardWindow() {
         switch (selectedPlatform) {
           case 'antigravity':
           case 'antigravity_ide':
+          case 'antigravity_cli':
             await useAccountStore.getState().switchAccount(viewedAccount.id, selectedPlatform);
             await useAccountStore.getState().fetchCurrentAccount(selectedPlatform);
             break;

--- a/src/pages/InstancesPage.tsx
+++ b/src/pages/InstancesPage.tsx
@@ -118,7 +118,7 @@ export function InstancesPage({ onNavigate }: InstancesPageProps) {
           const presentation = buildAntigravityAccountPresentation(account, displayGroups, t);
           return `${presentation.displayName} ${presentation.planLabel} ${account.name ?? ''}`;
         }}
-        appType={runtimeTarget}
+        appType={runtimeTarget === 'antigravity' ? 'antigravity' : 'antigravity_ide'}
       />
     </div>
   );

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -323,6 +323,7 @@ const FALLBACK_PLATFORM_SETTINGS_ORDER: Record<PlatformId, number> = {
   trae_solo_cn: 17,
   workbuddy: 18,
   zed: 19,
+  antigravity_cli: 20,
 };
 type ConfigUpdatedEventDetail = {
   source?: string;

--- a/src/services/accountService.ts
+++ b/src/services/accountService.ts
@@ -202,3 +202,37 @@ export async function fetchAccountNoteMailUrl(
 export async function syncCurrentFromClient(): Promise<string | null> {
     return await invoke('sync_current_from_client');
 }
+
+export interface AntigravityCliStatus {
+    installed: boolean;
+    executable_path?: string | null;
+    version?: string | null;
+    auth_backend: string;
+    current_account_id?: string | null;
+    current_email?: string | null;
+    diagnostic?: string | null;
+}
+
+export interface AntigravityCliRunOptions {
+    cwd?: string;
+    args?: string[];
+    terminal?: string;
+}
+
+export interface AntigravityCliRunResult {
+    pid?: number;
+    executable_path: string;
+    account_id: string;
+    email: string;
+}
+
+export async function getAntigravityCliStatus(): Promise<AntigravityCliStatus> {
+    return await invoke('get_antigravity_cli_status');
+}
+
+export async function runAntigravityCli(
+    accountId: string,
+    options?: AntigravityCliRunOptions,
+): Promise<AntigravityCliRunResult> {
+    return await invoke('run_antigravity_cli', { accountId, options: options ?? null });
+}

--- a/src/services/dataTransferService.ts
+++ b/src/services/dataTransferService.ts
@@ -302,11 +302,14 @@ const ACCOUNT_LOADERS: Record<PlatformId, AccountLoader> = {
   trae_cn: async () => (await traeService.listTraeAccounts()) as unknown as TransferAccountRecord[],
   trae_solo_cn: async () => (await traeService.listTraeAccounts()) as unknown as TransferAccountRecord[],
   workbuddy: async () => (await workbuddyService.listWorkbuddyAccounts()) as unknown as TransferAccountRecord[],
+  antigravity_cli: async () =>
+    (await accountService.listAccounts()) as unknown as TransferAccountRecord[],
 };
 
 const LEGACY_IMPORTERS: Record<PlatformId, ((jsonContent: string) => Promise<unknown[]>) | undefined> = {
   antigravity: accountService.importFromJson,
   antigravity_ide: accountService.importFromJson,
+  antigravity_cli: accountService.importFromJson,
   codex: codexService.importCodexFromJson,
   codex_api_service: undefined,
   claude_manager: claudeService.importClaudeFromJson,

--- a/src/stores/useAccountStore.ts
+++ b/src/stores/useAccountStore.ts
@@ -4,8 +4,10 @@ import { Account, AccountNoteUpdate, QuotaData, RefreshStats, TokenData } from '
 import * as accountService from '../services/accountService';
 import { emitAccountsChanged, emitCurrentAccountChanged } from '../utils/accountSyncEvents';
 import {
+  ANTIGRAVITY_RUNTIME_TARGETS,
   AntigravityRuntimeTarget,
   DEFAULT_ANTIGRAVITY_RUNTIME_TARGET,
+  buildEmptyAntigravityCurrentAccounts,
   normalizeAntigravityRuntimeTarget,
 } from '../utils/antigravityRuntimeTarget';
 
@@ -130,10 +132,7 @@ const DEBOUNCE_MS = 500;
 type CurrentAccountsByTarget = Record<AntigravityRuntimeTarget, Account | null>;
 
 function buildEmptyCurrentAccountsByTarget(): CurrentAccountsByTarget {
-    return {
-        antigravity: null,
-        antigravity_ide: null,
-    };
+    return buildEmptyAntigravityCurrentAccounts<Account | null>(null);
 }
 
 function resolveRuntimeTarget(runtimeTarget?: AntigravityRuntimeTarget): AntigravityRuntimeTarget {
@@ -290,27 +289,27 @@ export const useAccountStore = create<AccountState>()(
     deleteAccount: async (accountId: string) => {
         const previousCurrentAccounts = get().currentAccountsByTarget;
         allowNextEmptyAccountList = get().accounts.length <= 1;
-        allowNextEmptyCurrentAccountByTarget.antigravity =
-            previousCurrentAccounts.antigravity?.id === accountId;
-        allowNextEmptyCurrentAccountByTarget.antigravity_ide =
-            previousCurrentAccounts.antigravity_ide?.id === accountId;
+        for (const target of ANTIGRAVITY_RUNTIME_TARGETS) {
+            allowNextEmptyCurrentAccountByTarget[target] =
+                previousCurrentAccounts[target]?.id === accountId;
+        }
         try {
             await accountService.deleteAccount(accountId);
             await get().fetchAccounts();
-            await Promise.allSettled([
-                get().fetchCurrentAccount('antigravity'),
-                get().fetchCurrentAccount('antigravity_ide'),
-            ]);
+            await Promise.allSettled(
+                ANTIGRAVITY_RUNTIME_TARGETS.map((target) => get().fetchCurrentAccount(target))
+            );
         } finally {
             allowNextEmptyAccountList = false;
-            allowNextEmptyCurrentAccountByTarget.antigravity = false;
-            allowNextEmptyCurrentAccountByTarget.antigravity_ide = false;
+            for (const target of ANTIGRAVITY_RUNTIME_TARGETS) {
+                allowNextEmptyCurrentAccountByTarget[target] = false;
+            }
         }
         await emitAccountsChanged({
             platformId: 'antigravity',
             reason: 'delete',
         });
-        for (const target of ['antigravity', 'antigravity_ide'] as const) {
+        for (const target of ANTIGRAVITY_RUNTIME_TARGETS) {
             const previousCurrentAccountId = previousCurrentAccounts[target]?.id ?? null;
             const nextCurrentAccountId = get().currentAccountsByTarget[target]?.id ?? null;
             if (previousCurrentAccountId !== nextCurrentAccountId) {
@@ -327,31 +326,29 @@ export const useAccountStore = create<AccountState>()(
         const previousCurrentAccounts = get().currentAccountsByTarget;
         const deleteIdSet = new Set(accountIds);
         allowNextEmptyAccountList = get().accounts.every((account) => deleteIdSet.has(account.id));
-        allowNextEmptyCurrentAccountByTarget.antigravity =
-            previousCurrentAccounts.antigravity?.id
-                ? deleteIdSet.has(previousCurrentAccounts.antigravity.id)
-                : false;
-        allowNextEmptyCurrentAccountByTarget.antigravity_ide =
-            previousCurrentAccounts.antigravity_ide?.id
-                ? deleteIdSet.has(previousCurrentAccounts.antigravity_ide.id)
-                : false;
+        for (const target of ANTIGRAVITY_RUNTIME_TARGETS) {
+            allowNextEmptyCurrentAccountByTarget[target] =
+                previousCurrentAccounts[target]?.id
+                    ? deleteIdSet.has(previousCurrentAccounts[target].id)
+                    : false;
+        }
         try {
             await accountService.deleteAccounts(accountIds);
             await get().fetchAccounts();
-            await Promise.allSettled([
-                get().fetchCurrentAccount('antigravity'),
-                get().fetchCurrentAccount('antigravity_ide'),
-            ]);
+            await Promise.allSettled(
+                ANTIGRAVITY_RUNTIME_TARGETS.map((target) => get().fetchCurrentAccount(target))
+            );
         } finally {
             allowNextEmptyAccountList = false;
-            allowNextEmptyCurrentAccountByTarget.antigravity = false;
-            allowNextEmptyCurrentAccountByTarget.antigravity_ide = false;
+            for (const target of ANTIGRAVITY_RUNTIME_TARGETS) {
+                allowNextEmptyCurrentAccountByTarget[target] = false;
+            }
         }
         await emitAccountsChanged({
             platformId: 'antigravity',
             reason: 'delete',
         });
-        for (const target of ['antigravity', 'antigravity_ide'] as const) {
+        for (const target of ANTIGRAVITY_RUNTIME_TARGETS) {
             const previousCurrentAccountId = previousCurrentAccounts[target]?.id ?? null;
             const nextCurrentAccountId = get().currentAccountsByTarget[target]?.id ?? null;
             if (previousCurrentAccountId !== nextCurrentAccountId) {
@@ -388,7 +385,7 @@ export const useAccountStore = create<AccountState>()(
             
             set((state) => {
                 let nextByTarget = state.currentAccountsByTarget;
-                for (const currentTarget of ['antigravity', 'antigravity_ide'] as const) {
+                for (const currentTarget of ANTIGRAVITY_RUNTIME_TARGETS) {
                     if (nextByTarget[currentTarget]?.id === accountId) {
                         nextByTarget = updateCurrentAccountsByTarget(
                             nextByTarget,
@@ -434,10 +431,9 @@ export const useAccountStore = create<AccountState>()(
     refreshAllQuotas: async (trigger) => {
         const stats = await accountService.refreshAllQuotas(trigger);
         await get().fetchAccounts();
-        await Promise.allSettled([
-            get().fetchCurrentAccount('antigravity'),
-            get().fetchCurrentAccount('antigravity_ide'),
-        ]);
+        await Promise.allSettled(
+            ANTIGRAVITY_RUNTIME_TARGETS.map((target) => get().fetchCurrentAccount(target))
+        );
         return stats;
     },
 
@@ -539,6 +535,10 @@ export const useAccountStore = create<AccountState>()(
                     state.currentAccountsByTarget.antigravity_ide?.id === account.id
                         ? account
                         : state.currentAccountsByTarget.antigravity_ide,
+                antigravity_cli:
+                    state.currentAccountsByTarget.antigravity_cli?.id === account.id
+                        ? account
+                        : state.currentAccountsByTarget.antigravity_cli,
             },
         }));
         await emitAccountsChanged({ platformId: 'antigravity', accountId: account.id, reason: 'note' });

--- a/src/stores/usePlatformLayoutStore.ts
+++ b/src/stores/usePlatformLayoutStore.ts
@@ -303,13 +303,14 @@ function defaultPlatformGroups(): PlatformLayoutGroup[] {
     {
       id: DEFAULT_ANTIGRAVITY_GROUP_ID,
       name: 'Antigravity',
-      platformIds: ['antigravity', 'antigravity_ide'],
+      platformIds: ['antigravity', 'antigravity_ide', 'antigravity_cli'],
       defaultPlatformId: 'antigravity_ide',
       iconKind: 'platform',
       iconPlatformId: 'antigravity_ide',
       childConfigs: [
         { platformId: 'antigravity', name: 'Antigravity' },
         { platformId: 'antigravity_ide', name: 'Antigravity IDE' },
+        { platformId: 'antigravity_cli', name: 'Antigravity CLI' },
       ],
     },
     createDefaultCodexSuiteGroup(),
@@ -669,6 +670,21 @@ function normalizePlatformGroups(
         antigravityGroup.platformIds,
       );
       usedPlatformIds.add('antigravity_ide');
+    }
+  }
+
+  if (!usedPlatformIds.has('antigravity_cli')) {
+    const antigravityGroup = result.find((group) => group.platformIds.includes('antigravity'));
+    if (antigravityGroup) {
+      antigravityGroup.platformIds = [...antigravityGroup.platformIds, 'antigravity_cli'];
+      antigravityGroup.childConfigs = normalizeGroupChildConfigs(
+        [
+          ...(antigravityGroup.childConfigs ?? []),
+          { platformId: 'antigravity_cli', name: 'Antigravity CLI' },
+        ],
+        antigravityGroup.platformIds,
+      );
+      usedPlatformIds.add('antigravity_cli');
     }
   }
 

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -1,8 +1,9 @@
-import { Page } from './navigation';
+import type { Page } from './navigation.ts';
 
 export type PlatformId =
   | 'antigravity'
   | 'antigravity_ide'
+  | 'antigravity_cli'
   | 'codex'
   | 'codex_api_service'
   | 'claude_manager'
@@ -28,6 +29,7 @@ export const ALL_PLATFORM_IDS: PlatformId[] = [
   'codex_api_service',
   'antigravity',
   'antigravity_ide',
+  'antigravity_cli',
   'zed',
   'github-copilot',
   'windsurf',
@@ -65,6 +67,7 @@ export function isMenuVisiblePlatform(platformId: PlatformId): boolean {
 export const PLATFORM_PAGE_MAP: Record<PlatformId, Page> = {
   antigravity: 'overview',
   antigravity_ide: 'overview',
+  antigravity_cli: 'overview',
   codex: 'codex',
   codex_api_service: 'codex-api-service',
   claude_manager: 'claude',

--- a/src/utils/antigravityRuntimeTarget.test.ts
+++ b/src/utils/antigravityRuntimeTarget.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ANTIGRAVITY_RUNTIME_TARGETS,
+  isAntigravityRuntimeTarget,
+  normalizeAntigravityRuntimeTarget,
+  buildEmptyAntigravityCurrentAccounts,
+} from "./antigravityRuntimeTarget.ts";
+import { ALL_PLATFORM_IDS, PLATFORM_PAGE_MAP } from "../types/platform.ts";
+
+test("ANTIGRAVITY_RUNTIME_TARGETS contains exactly three targets", () => {
+  assert.deepEqual(ANTIGRAVITY_RUNTIME_TARGETS, [
+    "antigravity",
+    "antigravity_ide",
+    "antigravity_cli",
+  ]);
+});
+
+test("isAntigravityRuntimeTarget recognizes valid targets and rejects invalid ones", () => {
+  assert.equal(isAntigravityRuntimeTarget("antigravity"), true);
+  assert.equal(isAntigravityRuntimeTarget("antigravity_ide"), true);
+  assert.equal(isAntigravityRuntimeTarget("antigravity_cli"), true);
+
+  assert.equal(isAntigravityRuntimeTarget("cursor"), false);
+  assert.equal(isAntigravityRuntimeTarget("codex"), false);
+  assert.equal(isAntigravityRuntimeTarget(""), false);
+  assert.equal(isAntigravityRuntimeTarget(null), false);
+  assert.equal(isAntigravityRuntimeTarget(undefined), false);
+});
+
+test("normalizeAntigravityRuntimeTarget handles targets, aliases, and fallbacks", () => {
+  // Direct matches
+  assert.equal(normalizeAntigravityRuntimeTarget("antigravity"), "antigravity");
+  assert.equal(normalizeAntigravityRuntimeTarget("antigravity_ide"), "antigravity_ide");
+  assert.equal(normalizeAntigravityRuntimeTarget("antigravity_cli"), "antigravity_cli");
+
+  // Aliases for CLI
+  assert.equal(normalizeAntigravityRuntimeTarget("antigravity-cli"), "antigravity_cli");
+  assert.equal(normalizeAntigravityRuntimeTarget("cli"), "antigravity_cli");
+  assert.equal(normalizeAntigravityRuntimeTarget("agy"), "antigravity_cli");
+  assert.equal(normalizeAntigravityRuntimeTarget("  AGY  "), "antigravity_cli");
+
+  // Fallbacks to antigravity_ide
+  assert.equal(normalizeAntigravityRuntimeTarget(null), "antigravity_ide");
+  assert.equal(normalizeAntigravityRuntimeTarget(undefined), "antigravity_ide");
+  assert.equal(normalizeAntigravityRuntimeTarget(""), "antigravity_ide");
+  assert.equal(normalizeAntigravityRuntimeTarget("unknown_runtime"), "antigravity_ide");
+});
+
+test("ALL_PLATFORM_IDS and PLATFORM_PAGE_MAP include antigravity_cli", () => {
+  assert.equal(ALL_PLATFORM_IDS.includes("antigravity_cli"), true);
+  assert.equal(PLATFORM_PAGE_MAP["antigravity_cli"], "overview");
+});
+
+test("buildEmptyAntigravityCurrentAccounts initializes all three targets to defaultValue", () => {
+  const empty = buildEmptyAntigravityCurrentAccounts(null);
+  assert.deepEqual(empty, {
+    antigravity: null,
+    antigravity_ide: null,
+    antigravity_cli: null,
+  });
+});

--- a/src/utils/antigravityRuntimeTarget.ts
+++ b/src/utils/antigravityRuntimeTarget.ts
@@ -1,17 +1,38 @@
-import { PlatformId } from '../types/platform';
+import type { PlatformId } from '../types/platform.ts';
 
-export type AntigravityRuntimeTarget = Extract<PlatformId, 'antigravity' | 'antigravity_ide'>;
+export const ANTIGRAVITY_RUNTIME_TARGETS = [
+  'antigravity',
+  'antigravity_ide',
+  'antigravity_cli',
+] as const;
+
+export type AntigravityRuntimeTarget = (typeof ANTIGRAVITY_RUNTIME_TARGETS)[number];
 
 export const ANTIGRAVITY_RUNTIME_TARGET_STORAGE_KEY = 'agtools.antigravity.runtime_target.v1';
 export const ANTIGRAVITY_RUNTIME_TARGET_CHANGED_EVENT = 'agtools-antigravity-runtime-target-changed';
 export const DEFAULT_ANTIGRAVITY_RUNTIME_TARGET: AntigravityRuntimeTarget = 'antigravity_ide';
 
 export function isAntigravityRuntimeTarget(value: unknown): value is AntigravityRuntimeTarget {
-  return value === 'antigravity' || value === 'antigravity_ide';
+  return typeof value === 'string' && (ANTIGRAVITY_RUNTIME_TARGETS as readonly string[]).includes(value);
 }
 
 export function normalizeAntigravityRuntimeTarget(value: unknown): AntigravityRuntimeTarget {
-  return isAntigravityRuntimeTarget(value) ? value : DEFAULT_ANTIGRAVITY_RUNTIME_TARGET;
+  if (typeof value !== 'string') {
+    return DEFAULT_ANTIGRAVITY_RUNTIME_TARGET;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'antigravity') {
+    return 'antigravity';
+  }
+  if (
+    normalized === 'antigravity_cli' ||
+    normalized === 'antigravity-cli' ||
+    normalized === 'cli' ||
+    normalized === 'agy'
+  ) {
+    return 'antigravity_cli';
+  }
+  return DEFAULT_ANTIGRAVITY_RUNTIME_TARGET;
 }
 
 export function getAntigravityRuntimeTarget(): AntigravityRuntimeTarget {
@@ -46,5 +67,15 @@ export function setAntigravityRuntimeTargetFromPlatform(platformId: PlatformId):
     return;
   }
   setAntigravityRuntimeTarget(platformId);
+}
+
+export function buildEmptyAntigravityCurrentAccounts<T = null>(
+  defaultValue: T = null as unknown as T,
+): Record<AntigravityRuntimeTarget, T> {
+  const result = {} as Record<AntigravityRuntimeTarget, T>;
+  for (const target of ANTIGRAVITY_RUNTIME_TARGETS) {
+    result[target] = defaultValue;
+  }
+  return result;
 }
 

--- a/src/utils/platformMeta.tsx
+++ b/src/utils/platformMeta.tsx
@@ -22,6 +22,8 @@ export function getPlatformLabel(platformId: PlatformId, _t: TFunction): string 
       return 'Antigravity';
     case 'antigravity_ide':
       return 'Antigravity IDE';
+    case 'antigravity_cli':
+      return 'Antigravity CLI';
     case 'codex':
       return 'Codex';
     case 'codex_api_service':
@@ -69,6 +71,8 @@ export function renderPlatformIcon(platformId: PlatformId, size = 20): ReactNode
       return <AntigravityIcon style={{ width: size, height: size }} />;
     case 'antigravity_ide':
       return <AntigravityIdeIcon style={{ width: size, height: size }} />;
+    case 'antigravity_cli':
+      return <AntigravityIcon style={{ width: size, height: size }} />;
     case 'codex':
       return <CodexIcon size={size} />;
     case 'codex_api_service':


### PR DESCRIPTION
## Summary
This PR adds support for the **Antigravity CLI (`agy`)** runtime target alongside existing `antigravity` (legacy) and `antigravity_ide` (IDE) runtimes in Cockpit Tools. It introduces transactional account switching with rollback protection, cross-process concurrency locking, UI integration in Accounts and Dashboard, and full CLI support via `cockpit-cli` for account listing, inspection, switching, and single-command switch-and-run.

---

## Architecture & SSoT Alignment
- **Single Source of Truth**: Strictly adheres to the Antigravity multi-runtime specification.
- **Shared Account Store**: Reuses the existing Antigravity `Account[]` database without duplicating account stores or creating parallel OAuth systems.
- **Target Independence**: Each runtime target (`antigravity`, `antigravity_ide`, `antigravity_cli`) independently maintains its current active account binding.

---

## Multi-Runtime Model
- Three distinct runtime targets are recognized:
  1. `antigravity` (Legacy branch)
  2. `antigravity_ide` (IDE branch)
  3. `antigravity_cli` (CLI branch for `agy`)
- Target-specific current account state is managed via `provider_current_state.rs` under the key `antigravity_cli`.
- Switching accounts on `antigravity_cli` does not alter or disrupt the active accounts bound to `antigravity` or `antigravity_ide`.

---

## Transaction & Rollback Design
Account switching uses a deterministic 5-step transaction:
1. **Prepare/Refresh**: Proactively refreshes token if nearing expiration.
2. **Snapshot**: Takes an in-memory snapshot of the existing system credential.
3. **Write**: Updates system credential authority (`gemini:antigravity`).
4. **Verify**: Reads back credential to guarantee that the stored credential matches the target account.
5. **Commit**: Commits the new account ID to the provider current state binding.

If verification or any intermediate step fails, the transaction automatically restores the snapshot and returns a fail-closed error (`CREDENTIAL_VERIFY_FAILED`).

---

## Cross-Process Locking
- Cross-process file locking (`CrossProcessSwitchLock`) implemented via `flock` (`LOCK_EX | LOCK_NB` with polling timeout) on Unix platforms and `LockFileEx` on Windows.
- Prevents race conditions between GUI and CLI child processes attempting concurrent switches against the shared OS credential authority.
- Guarantees the critical invariant: `credential active account == provider current account`.

---

## Switch-and-Run Decoupled Design
- The credential switch transaction is decoupled from process launch.
- If process launch fails (e.g. invalid working directory or terminal failure) after a successful credential switch, the account binding is preserved (`CLI_LAUNCH_FAILED`), avoiding unintended rollback of an authenticated credential.
- `cockpit-cli` provides single-command switch-and-run:
  ```bash
  cockpit-cli run agy --account <account-id-or-email> -- <args>
  ```

---

## Platform Status

| Platform | Implementation Status | Verification Status | Notes |
|---|---|---|---|
| macOS | **IMPLEMENTED** | **VERIFIED** | Keychain access, native `agy` interaction, and cross-process tests verified |
| Windows | **IMPLEMENTED** | **NOT VERIFIED** | Win32 Credential Manager API implemented, fail-closed |
| Linux | **IMPLEMENTED** | **NOT VERIFIED** | Secret Service (`secret-tool`) implemented, fail-closed on missing daemon |

---

## Verification Evidence
- **Rust Integration Tests (`antigravity_cli_integration_test.rs`)**:
  - `test_cli_account_switch_persistence_and_native_recognition`: PASS
  - `test_switch_and_run_decoupled_launch_failure`: PASS
  - `test_rollback_on_verify_failure`: PASS
  - `test_multi_runtime_target_state_isolation`: PASS
  - `test_concurrent_ab_switches_serialized`: PASS
  - `test_cross_process_concurrent_switch`: PASS
- **Frontend Unit Tests**:
  - `src/utils/antigravityRuntimeTarget.test.ts`: 5/5 tests PASS
- **TypeScript Typecheck**:
  - `npm run typecheck`: PASS (0 errors)
- **CLI Commands Verified Live**:
  - `cockpit-cli accounts agy`
  - `cockpit-cli current agy`
  - `cockpit-cli switch agy <account>`
  - `cockpit-cli run agy --account <account> -- <args>`

---

## Security & Privacy Statement
- Zero hardcoded personal identifiers, email addresses, or secrets in source code, tests, or documentation.
- Integration tests dynamically read accounts from the local test environment.
- System credential snapshots are maintained strictly in-memory during transaction lifecycles.
