### PR TITLE
fix(ui): 修复会导致阅读困难的下拉菜单

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1258,8 +1258,10 @@ html[data-reduced-motion="true"] .platform-group-switcher-trigger.is-open .platf
 .codex-speed-menu {
   border: 1px solid var(--border);
   border-radius: 10px;
-  background: color-mix(in srgb, var(--bg-card) 90%, var(--bg-secondary));
-  backdrop-filter: blur(12px);
+  /* Dropdowns are solid surfaces; translucent card tokens let the page bleed through. */
+  background: var(--bg-surface);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   box-shadow:
     0 12px 28px rgba(15, 23, 42, 0.12),
     0 1px 0 rgba(255, 255, 255, 0.72) inset;


### PR DESCRIPTION
Codex 功能页中的速率下拉菜单底色是透明的，会导致阅读困难，故修改为纯色底色。

<img width="486" height="390" alt="52437627d47308c9d6f4d09de26ce70b" src="https://github.com/user-attachments/assets/7aaf79af-8908-4c9a-8c68-3bdcbf4cc80b" />

<img width="483" height="388" alt="ef6a2a50133122a62579d90ceb5ac84c" src="https://github.com/user-attachments/assets/48878562-78e6-4c15-8585-3baa85a33ea0" />
