### PR TITLE
feat(cli): add structured output foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,6 @@ dependencies = [
  "chrono",
  "clap",
  "cockpit-core",
- "colored",
  "serde",
  "serde_json",
  "tabled",
@@ -879,16 +878,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "combine"

--- a/crates/cockpit-cli/Cargo.toml
+++ b/crates/cockpit-cli/Cargo.toml
@@ -13,5 +13,4 @@ serde_json.workspace = true
 anyhow.workspace = true
 tokio.workspace = true
 chrono.workspace = true
-colored = "2.1"
 tabled = "0.15"

--- a/crates/cockpit-cli/src/cli.rs
+++ b/crates/cockpit-cli/src/cli.rs
@@ -1,0 +1,86 @@
+use clap::{Parser, Subcommand, ValueEnum};
+
+#[derive(Debug, Parser)]
+#[command(author, version, about = "Cockpit Tools CLI", long_about = None)]
+pub struct Cli {
+    /// Emit machine-readable JSON instead of human-readable output.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// List accounts for a platform.
+    List {
+        /// The platform.
+        #[arg(ignore_case = true)]
+        platform: Platform,
+    },
+    /// Switch accounts for a specific platform.
+    Switch {
+        /// The platform.
+        #[arg(ignore_case = true)]
+        platform: Platform,
+        /// The account ID or email to switch to.
+        account: String,
+    },
+    /// Show current quota for a platform.
+    Quota {
+        /// The platform.
+        #[arg(ignore_case = true)]
+        platform: Platform,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum Platform {
+    Cursor,
+    #[value(alias = "github-copilot", alias = "github_copilot")]
+    Copilot,
+}
+
+impl Platform {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cursor => "cursor",
+            Self::Copilot => "copilot",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, Commands, Platform};
+    use clap::Parser;
+
+    #[test]
+    fn parses_global_json_before_command() {
+        let cli = Cli::try_parse_from(["cockpit-cli", "--json", "list", "cursor"])
+            .expect("CLI arguments should parse");
+
+        assert!(cli.json);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::List {
+                platform: Platform::Cursor
+            })
+        ));
+    }
+
+    #[test]
+    fn preserves_copilot_platform_aliases() {
+        for alias in ["copilot", "github-copilot", "github_copilot"] {
+            let cli = Cli::try_parse_from(["cockpit-cli", "list", alias])
+                .expect("Copilot alias should parse");
+            assert!(matches!(
+                cli.command,
+                Some(Commands::List {
+                    platform: Platform::Copilot
+                })
+            ));
+        }
+    }
+}

--- a/crates/cockpit-cli/src/main.rs
+++ b/crates/cockpit-cli/src/main.rs
@@ -1,120 +1,138 @@
-use clap::{Parser, Subcommand};
+mod cli;
+mod output;
+
+use anyhow::Result;
+use clap::Parser;
+use cli::{Cli, Commands, Platform};
 use cockpit_core::modules::{cursor_account, github_copilot_account};
-use colored::*;
-use tabled::{Table, Tabled};
-
-#[derive(Parser)]
-#[command(author, version, about = "Cockpit Tools CLI", long_about = None)]
-struct Cli {
-    #[command(subcommand)]
-    command: Option<Commands>,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// List accounts for a platform
-    List {
-        /// The platform (cursor, copilot)
-        platform: String,
-    },
-    /// Switch accounts for a specific platform
-    Switch {
-        /// The platform (cursor, copilot)
-        platform: String,
-        /// The account ID or email to switch to
-        account: String,
-    },
-    /// Show current quota for a platform
-    Quota {
-        /// The platform (cursor, copilot)
-        platform: String,
-    },
-}
-
-#[derive(Tabled)]
-struct AccountDisplay {
-    #[tabled(rename = "ID")]
-    id: String,
-    #[tabled(rename = "Email")]
-    email: String,
-    #[tabled(rename = "Plan")]
-    plan: String,
-    #[tabled(rename = "Tags")]
-    tags: String,
-}
+use output::{AccountDisplay, CommandOutput, OutputEnvelope};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::List { platform }) => match platform.to_lowercase().as_str() {
-            "cursor" => {
-                let accounts = cursor_account::list_accounts();
-                display_accounts(
-                    accounts
-                        .iter()
-                        .map(|a| AccountDisplay {
-                            id: a.id.clone(),
-                            email: a.email.clone(),
-                            plan: a.membership_type.clone().unwrap_or_default(),
-                            tags: a.tags.as_ref().map(|t| t.join(", ")).unwrap_or_default(),
-                        })
-                        .collect(),
-                );
-            }
-            "copilot" | "github_copilot" => {
-                let accounts = github_copilot_account::list_accounts();
-                display_accounts(
-                    accounts
-                        .iter()
-                        .map(|a| AccountDisplay {
-                            id: a.id.clone(),
-                            email: a.github_email.clone().unwrap_or_default(),
-                            plan: a.copilot_plan.clone().unwrap_or_default(),
-                            tags: a.tags.as_ref().map(|t| t.join(", ")).unwrap_or_default(),
-                        })
-                        .collect(),
-                );
-            }
-            _ => println!("{} Unknown platform: {}", "Error:".red(), platform),
-        },
-        Some(Commands::Switch { platform, account }) => match platform.to_lowercase().as_str() {
-            "cursor" => {
-                if let Err(e) = cursor_account::inject_to_cursor(&account) {
-                    println!("{} {}", "Error:".red(), e);
-                } else {
-                    println!(
-                        "{} Successfully switched Cursor account to {}",
-                        "Success:".green(),
-                        account
-                    );
-                }
-            }
-            "copilot" | "github_copilot" => {
-                println!("{} GitHub Copilot switch is partially implemented in CLI. Use GUI for full instance sync.", "Info:".yellow());
-            }
-            _ => println!("{} Unknown platform: {}", "Error:".red(), platform),
-        },
-        Some(Commands::Quota { platform }) => match platform.to_lowercase().as_str() {
-            _ => println!(
-                "{} Quota command not yet implemented for {}",
-                "Info:".yellow(),
-                platform
-            ),
-        },
+        Some(Commands::List { platform }) => {
+            list_accounts(platform, cli.json)?;
+        }
+        Some(Commands::Switch { platform, account }) => {
+            switch_account(platform, &account, cli.json)?;
+        }
+        Some(Commands::Quota { platform }) => {
+            show_quota_status(platform, cli.json)?;
+        }
         None => {
-            println!("Welcome to Cockpit CLI! Use --help for commands.");
+            if cli.json {
+                print_json(&OutputEnvelope::new(CommandOutput::new(
+                    "root",
+                    "help",
+                    "ok",
+                    "Use --help for available commands.",
+                )))?;
+            } else {
+                println!("Welcome to Cockpit CLI! Use --help for commands.");
+            }
         }
     }
 
     Ok(())
 }
 
-fn display_accounts(accounts: Vec<AccountDisplay>) {
-    if accounts.is_empty() {
-        println!("No accounts found.");
+fn list_accounts(platform: Platform, json: bool) -> Result<()> {
+    let accounts = match platform {
+        Platform::Cursor => cursor_account::list_accounts()
+            .iter()
+            .map(|account| AccountDisplay {
+                id: account.id.clone(),
+                email: account.email.clone(),
+                plan: account.membership_type.clone().unwrap_or_default(),
+                tags: account
+                    .tags
+                    .as_ref()
+                    .map(|tags| tags.join(", "))
+                    .unwrap_or_default(),
+            })
+            .collect(),
+        Platform::Copilot => github_copilot_account::list_accounts()
+            .iter()
+            .map(|account| AccountDisplay {
+                id: account.id.clone(),
+                email: account.github_email.clone().unwrap_or_default(),
+                plan: account.copilot_plan.clone().unwrap_or_default(),
+                tags: account
+                    .tags
+                    .as_ref()
+                    .map(|tags| tags.join(", "))
+                    .unwrap_or_default(),
+            })
+            .collect(),
+    };
+
+    if json {
+        print_json(&OutputEnvelope::new(accounts))
     } else {
-        println!("{}", Table::new(accounts).to_string());
+        output::print_accounts(accounts);
+        Ok(())
     }
+}
+
+fn switch_account(platform: Platform, account: &str, json: bool) -> Result<()> {
+    match platform {
+        Platform::Cursor => {
+            cursor_account::inject_to_cursor(account)
+                .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+            print_operation(
+                json,
+                CommandOutput::new(
+                    "cursor",
+                    "switch",
+                    "ok",
+                    format!("Successfully switched Cursor account to {account}"),
+                ),
+            )?;
+        }
+        Platform::Copilot => {
+            print_operation(
+                json,
+                CommandOutput::new(
+                    "copilot",
+                    "switch",
+                    "unsupported",
+                    "GitHub Copilot switch is partially implemented in CLI. Use GUI for full instance sync.",
+                ),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn show_quota_status(platform: Platform, json: bool) -> Result<()> {
+    let provider = platform.as_str();
+    print_operation(
+        json,
+        CommandOutput::new(
+            provider,
+            "quota",
+            "not_implemented",
+            format!("Quota command is not yet implemented for {provider}"),
+        ),
+    )
+}
+
+fn print_operation(json: bool, output: CommandOutput) -> Result<()> {
+    if json {
+        print_json(&OutputEnvelope::new(output))
+    } else if output.status == "ok" {
+        println!("Success: {}", output.message);
+        Ok(())
+    } else {
+        println!("Info: {}", output.message);
+        Ok(())
+    }
+}
+
+fn print_json<T: serde::Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
 }

--- a/crates/cockpit-cli/src/output.rs
+++ b/crates/cockpit-cli/src/output.rs
@@ -1,0 +1,85 @@
+use serde::Serialize;
+use tabled::{Table, Tabled};
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize)]
+pub struct OutputEnvelope<T> {
+    pub schema_version: u32,
+    pub data: T,
+}
+
+impl<T> OutputEnvelope<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            data,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct CommandOutput {
+    pub provider: String,
+    pub operation: String,
+    pub status: String,
+    pub message: String,
+}
+
+impl CommandOutput {
+    pub fn new(
+        provider: impl Into<String>,
+        operation: impl Into<String>,
+        status: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: provider.into(),
+            operation: operation.into(),
+            status: status.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Tabled)]
+pub struct AccountDisplay {
+    #[tabled(rename = "ID")]
+    pub id: String,
+    #[tabled(rename = "Email")]
+    pub email: String,
+    #[tabled(rename = "Plan")]
+    pub plan: String,
+    #[tabled(rename = "Tags")]
+    pub tags: String,
+}
+
+pub fn print_accounts(accounts: Vec<AccountDisplay>) {
+    if accounts.is_empty() {
+        println!("No accounts found.");
+    } else {
+        println!("{}", Table::new(accounts));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AccountDisplay, OutputEnvelope, SCHEMA_VERSION};
+
+    #[test]
+    fn output_envelope_has_stable_schema_version() {
+        let output = OutputEnvelope::new(vec![AccountDisplay {
+            id: "account-1".into(),
+            email: "user@example.com".into(),
+            plan: "Plus".into(),
+            tags: String::new(),
+        }]);
+
+        let value = serde_json::to_value(output).expect("output should serialize");
+        assert_eq!(value["schema_version"], SCHEMA_VERSION);
+        assert_eq!(value["data"][0]["id"], "account-1");
+        assert!(value["data"][0].get("access_token").is_none());
+        assert!(value["data"][0].get("refresh_token").is_none());
+        assert!(value["data"][0].get("agent_private_key").is_none());
+    }
+}

--- a/crates/cockpit-cli/tests/cli.rs
+++ b/crates/cockpit-cli/tests/cli.rs
@@ -1,0 +1,108 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn isolated_data_dir() -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after Unix epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("cockpit-cli-test-{suffix}"));
+    fs::create_dir_all(&path).expect("test data directory should be created");
+    path
+}
+
+fn run_cli(args: &[&str]) -> (String, String, std::process::ExitStatus, PathBuf) {
+    let data_dir = isolated_data_dir();
+    let output = Command::new(env!("CARGO_BIN_EXE_cockpit-cli"))
+        .args(args)
+        .env("COCKPIT_TOOLS_DATA_DIR", &data_dir)
+        .output()
+        .expect("cockpit-cli should start");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    (stdout, stderr, output.status, data_dir)
+}
+
+#[test]
+fn root_json_output_has_stable_envelope() {
+    let (stdout, stderr, status, data_dir) = run_cli(&["--json"]);
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("stdout should be JSON");
+
+    assert!(status.success());
+    assert!(
+        stderr.is_empty(),
+        "JSON mode should not write diagnostics: {stderr}"
+    );
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["data"]["operation"], "help");
+    assert_eq!(value["data"]["status"], "ok");
+    fs::remove_dir_all(data_dir).expect("test data directory should be removable");
+}
+
+#[test]
+fn quota_json_output_is_machine_readable_without_core_access() {
+    let (stdout, stderr, status, data_dir) = run_cli(&["--json", "quota", "CURSOR"]);
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("stdout should be JSON");
+
+    assert!(status.success());
+    assert!(
+        stderr.is_empty(),
+        "JSON mode should not write diagnostics: {stderr}"
+    );
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["data"]["provider"], "cursor");
+    assert_eq!(value["data"]["operation"], "quota");
+    assert_eq!(value["data"]["status"], "not_implemented");
+    fs::remove_dir_all(data_dir).expect("test data directory should be removable");
+}
+
+#[test]
+fn copilot_switch_reports_unsupported_status_in_json() {
+    let (stdout, stderr, status, data_dir) =
+        run_cli(&["switch", "github-copilot", "account-1", "--json"]);
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("stdout should be JSON");
+
+    assert!(status.success());
+    assert!(
+        stderr.is_empty(),
+        "JSON mode should not write diagnostics: {stderr}"
+    );
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["data"]["provider"], "copilot");
+    assert_eq!(value["data"]["operation"], "switch");
+    assert_eq!(value["data"]["status"], "unsupported");
+    assert!(value["data"].get("access_token").is_none());
+    fs::remove_dir_all(data_dir).expect("test data directory should be removable");
+}
+
+#[test]
+fn empty_cursor_account_list_is_isolated_from_user_data() {
+    let (stdout, stderr, status, data_dir) = run_cli(&["--json", "list", "cursor"]);
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("stdout should be JSON");
+
+    assert!(status.success());
+    assert!(
+        stderr.is_empty(),
+        "JSON mode should not write diagnostics: {stderr}"
+    );
+    assert_eq!(value["schema_version"], 1);
+    assert!(value["data"]
+        .as_array()
+        .expect("data should be an array")
+        .is_empty());
+    assert!(data_dir.join("cursor_accounts.json").exists());
+    assert!(!data_dir.join("codex").exists());
+    fs::remove_dir_all(data_dir).expect("test data directory should be removable");
+}
+
+#[test]
+fn missing_cursor_account_returns_non_zero_without_secret_output() {
+    let (stdout, stderr, status, data_dir) = run_cli(&["switch", "cursor", "missing-account"]);
+
+    assert!(!status.success());
+    assert!(!stdout.contains("access_token"));
+    assert!(!stderr.contains("access_token"));
+    fs::remove_dir_all(data_dir).expect("test data directory should be removable");
+}


### PR DESCRIPTION
## Summary

This PR establishes the CLI/output foundation for the planned provider-capability commands without adding a provider-specific command namespace.

### Changes

- preserve the existing `list`, `switch`, and `quota` commands;
- add a typed, case-insensitive provider selector with existing Copilot aliases;
- add global `--json` output with `schema_version: 1`;
- expose presentation DTOs only, excluding credential fields from serialized account output;
- add isolated binary-level coverage for JSON output, aliases, unsupported operations, and error handling;
- remove the unused direct `colored` dependency.

### Scope boundary

No Codex account/instance behavior, credential writes, process launching, quota refresh, or AGY changes are included. This keeps the first CLI PR small and leaves the action-first surface ready for the next Codex read-only slice.

### Validation

- `cargo fmt --all`
- `cargo test -p cockpit-cli`
- `cargo test -p cockpit-core`
- `cargo clippy -p cockpit-cli --all-targets`
- `git diff --check`

All tests use `COCKPIT_TOOLS_DATA_DIR` pointing to a temporary directory and do not access the user's Codex home.
