### PR TITLE
fix(codex): filter invalid generic item IDs

### DIFF
--- a/src-tauri/src/modules/codex_local_access_request_transform.rs
+++ b/src-tauri/src/modules/codex_local_access_request_transform.rs
@@ -1183,6 +1183,24 @@ fn sidecar_payload_default_service_tier(default_service_tier: Option<&str>) -> O
     Some(Value::Object(payload))
 }
 
+fn sidecar_payload_config(default_service_tier: Option<&str>) -> Value {
+    let mut payload = sidecar_payload_default_service_tier(default_service_tier)
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    payload.insert(
+        "filter".to_string(),
+        json!([{
+            "models": [{
+                "name": "*",
+                "protocol": "codex",
+                "from-protocol": "responses",
+            }],
+            "params": ["input.#(id%\"item_*\")#.id"],
+        }]),
+    );
+    Value::Object(payload)
+}
+
 fn prepare_gateway_request_with_default_service_tier(
     mut request: ParsedRequest,
     default_service_tier: Option<&str>,

--- a/src-tauri/src/modules/codex_local_access_sidecar_config.rs
+++ b/src-tauri/src/modules/codex_local_access_sidecar_config.rs
@@ -2363,9 +2363,10 @@ fn prepare_sidecar_launch_config_in_dir_sync(
             "beta-features": CODEX_RESPONSES_WEBSOCKET_BETA_HEADER_VALUE,
         }),
     );
-    if let Some(payload) = sidecar_payload_default_service_tier(default_service_tier) {
-        config.insert("payload".to_string(), payload);
-    }
+    config.insert(
+        "payload".to_string(),
+        sidecar_payload_config(default_service_tier),
+    );
 
     let config_path = sidecar_config_path(&base_dir);
     let manifest_path = sidecar_manifest_path(&base_dir);

--- a/src-tauri/src/modules/codex_local_access_tests_sidecar_gateway.rs
+++ b/src-tauri/src/modules/codex_local_access_tests_sidecar_gateway.rs
@@ -686,7 +686,8 @@
         sidecar_auth_account_is_scoped, sidecar_auth_file_name, sidecar_auth_json_for_account,
         sidecar_auths_dir, sidecar_client_api_keys, sidecar_codex_api_key_auth_id,
         sidecar_codex_key_config_value, sidecar_config_fingerprint,
-        sidecar_local_account_usable_for_start, sidecar_payload_default_service_tier,
+        sidecar_local_account_usable_for_start, sidecar_payload_config,
+        sidecar_payload_default_service_tier,
         sidecar_quota_reserve_snapshot_value, sidecar_routing_strategy_value, sidecar_stable_id,
         sidecar_usage_event_is_client_canceled, sidecar_usage_event_should_auto_restart,
         now_ms, stats_snapshot_without_events, supported_codex_model_ids,
@@ -1370,6 +1371,41 @@
         // standard/default should not force an explicit upstream field.
         assert!(sidecar_payload_default_service_tier(Some("standard")).is_none());
         assert!(sidecar_payload_default_service_tier(Some("default")).is_none());
+    }
+
+    #[test]
+    fn sidecar_payload_config_filters_generic_response_item_ids_at_standard_speed() {
+        let payload = sidecar_payload_config(None);
+        assert!(payload.get("default").is_none());
+        assert_eq!(
+            payload.get("filter"),
+            Some(&json!([{
+                "models": [{
+                    "name": "*",
+                    "protocol": "codex",
+                    "from-protocol": "responses"
+                }],
+                "params": ["input.#(id%\"item_*\")#.id"]
+            }]))
+        );
+    }
+
+    #[test]
+    fn sidecar_payload_config_preserves_fast_service_tier_default() {
+        let payload = sidecar_payload_config(Some("priority"));
+        assert_eq!(
+            payload
+                .pointer("/default/0/params/service_tier")
+                .and_then(Value::as_str),
+            Some("priority")
+        );
+        assert_eq!(
+            payload
+                .get("filter")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            Some(1)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- always emit a CLIProxyAPI payload filter for Codex Responses requests
- remove only direct `input[*].id` values matching the invalid generic `item_*` prefix
- preserve the existing Fast/priority `service_tier` payload default

This prevents resumed Codex conversations from failing with errors such as `invalid_id_prefix` when stored response items carry generic IDs that do not match their required typed prefixes (`rs`, `fc`, and others).

Fixes #1773

## Validation

- `cargo check -p cockpit-tools --tests` passes
- added unit coverage for standard-speed payload generation
- added unit coverage for coexistence with the Fast/priority service-tier default
- `git diff --check` passes

On this Windows host, the compiled Rust test executable is currently blocked before the test harness starts by system loader error `0xc0000139 (STATUS_ENTRYPOINT_NOT_FOUND)`. The test target itself compiles successfully; CI can execute it in a clean runner.
