### PR TITLE
fix(antigravity): add aicode OAuth scope for voice transcription support

### DIFF
--- a/crates/cockpit-core/src/modules/oauth.rs
+++ b/crates/cockpit-core/src/modules/oauth.rs
@@ -82,6 +82,7 @@ pub fn get_auth_url(redirect_uri: &str, state: Option<&str>) -> String {
         "https://www.googleapis.com/auth/userinfo.profile",
         "https://www.googleapis.com/auth/cclog",
         "https://www.googleapis.com/auth/experimentsandconfigs",
+        "https://www.googleapis.com/auth/aicode",
     ]
     .join(" ");
 

--- a/src-tauri/src/modules/oauth.rs
+++ b/src-tauri/src/modules/oauth.rs
@@ -82,6 +82,7 @@ pub fn get_auth_url(redirect_uri: &str, state: Option<&str>) -> String {
         "https://www.googleapis.com/auth/userinfo.profile",
         "https://www.googleapis.com/auth/cclog",
         "https://www.googleapis.com/auth/experimentsandconfigs",
+        "https://www.googleapis.com/auth/aicode",
     ]
     .join(" ");
 


### PR DESCRIPTION
### Problem Description

When authenticating Google Antigravity accounts through Cockpit Tools, standard text prompts and code assistance work as expected, but the built-in **Live Voice Transcription** (`streamAudioTranscription` via the microphone button or `Ctrl+Shift+M`) fails immediately within ~1 second.

Inspecting the Antigravity runtime console logs reveals:

```text
[AudioStreaming] Stream error: ConnectError: [internal] internal: failed to receive setup response from backend: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes. (error ID: ...)
[AudioStreaming] Failed to start: ConnectError: [internal] internal: failed to receive setup response from backend: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.
```

### Root Cause

In Cockpit Tools, the Google OAuth authorization URL (`get_auth_url`) requested only 6 scopes:
- `openid`
- `https://www.googleapis.com/auth/cloud-platform`
- `https://www.googleapis.com/auth/userinfo.email`
- `https://www.googleapis.com/auth/userinfo.profile`
- `https://www.googleapis.com/auth/cclog`
- `https://www.googleapis.com/auth/experimentsandconfigs`

Antigravity 2.0+ uses bidirectional gRPC audio streaming with Google's backend API, which strictly requires the Cloud Code AI scope: `https://www.googleapis.com/auth/aicode`. Because tokens minted by Cockpit Tools lacked this scope, Google's backend immediately rejected the audio stream with `PermissionDenied: Request had insufficient authentication scopes`.

### Changes Made

Added `"https://www.googleapis.com/auth/aicode"` to the OAuth `scopes` list in:
- `src-tauri/src/modules/oauth.rs`
- `crates/cockpit-core/src/modules/oauth.rs`

### Verification

- Verified that Google's OAuth consent endpoint with Client ID `1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com` accepts and grants `https://www.googleapis.com/auth/aicode`.
- Tested the authorization flow on Windows 11 with Antigravity v2.12.0:
  - Token exchange succeeded with `aicode` included in the granted scopes.
  - Live audio transcription / voice memo starts and transcribes spoken audio correctly in real-time.
  - Text prompts, agent actions, and account switching continue to function normally.