### PR TITLE
fix(proxy): do not inject no_proxy/NO_PROXY when no proxy is configured

### DIFF
--- a/src-tauri/src/modules/process_launch_candidates.rs
+++ b/src-tauri/src/modules/process_launch_candidates.rs
@@ -1593,6 +1593,31 @@ fn managed_proxy_env_pairs() -> Vec<(&'static str, String)> {
         crate::modules::logger::log_warn("[Proxy] 全局代理已启用，但代理地址为空，跳过注入");
     }
 
+    // no_proxy / NO_PROXY only make sense when a proxy is actually in play. When no managed
+    // proxy is configured and the current process carries no proxy variable either, injecting
+    // only the bypass list is harmful: Antigravity IDE then fails to open its HTTPS channel to
+    // the local language server (renderer reports "Failed to fetch", the LS never receives any
+    // chat request, and the Agent panel silently drops the first message). A manually launched
+    // IDE receives none of these variables and always works, so the managed launch must stay
+    // byte-for-byte identical to a manual launch in that case.
+    let inherited_proxy_present = [
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+    ]
+    .iter()
+    .any(|key| {
+        std::env::var(key)
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+    });
+    if pairs.is_empty() && !inherited_proxy_present {
+        return pairs;
+    }
+
     let no_proxy_seed = [
         std::env::var("no_proxy").unwrap_or_default(),
         std::env::var("NO_PROXY").unwrap_or_default(),


### PR DESCRIPTION
### 问题

`managed_proxy_env_pairs()` 在 `global_proxy_enabled == false` 时，仍然追加了本机直连白名单
（`no_proxy` / `NO_PROXY`）。结果是：**每一次"受管启动"都给子进程塞了一份"手动启动"永远不会有的环境变量**。

对 **Antigravity IDE** 而言，这会打断渲染进程与本机 Language Server 之间的通信通道：

- 渲染进程日志出现 `[unknown] Failed to fetch: ConnectError`
- Language Server **收不到任何**对话请求（`streamGenerateContent == 0`）
- 切换账户后的首个会话，Agent 面板会静默丢弃消息
  （用户只能关闭再重新打开 IDE 才能恢复）

### 复现

同一账户、同一状态数据库，唯一变量是启动方式：

| 启动方式 | 是否注入 no_proxy | 渲染进程 Failed-to-fetch | LS streamGenerateContent |
|---|---|---|---|
| 手动启动 | 否 | 0 | 2 |
| 手动启动 | 否 | 0 | 2 |
| 手动启动 | **是** | 1 | 0 |
| 受管启动（本工具） | **是** | 1 | 0 |

在启动**同一个** IDE 二进制之前**仅**注入 `no_proxy` / `NO_PROXY`，就足以复现该故障；
清除这两个变量后故障即消失。`--reuse-window` 参数与 Chromium net-log 抓包这两个变量，
均已被同一组对照实验排除。

### 修复

只有在"**确实存在代理**"时才输出代理相关环境变量：

- 已配置受管代理，或
- 当前进程本身已经带有代理变量（此时本机直连白名单仍然有益）

除此之外直接返回空列表，使**受管启动与手动启动的环境逐位一致**。

### 验证

在 `upstream/main`（`deacbe44`）之上执行 `cargo check -p cockpit-tools --lib` 通过。

说明：本机无法运行 `cargo test` —— lib 单元测试可执行文件启动即中止，
报 `STATUS_ENTRYPOINT_NOT_FOUND`（缺少 comctl32 v6 manifest）。
因此本次未添加单元测试。



### Problem

`managed_proxy_env_pairs()` appends the loopback bypass list (`no_proxy` / `NO_PROXY`)
even when `global_proxy_enabled == false`. As a result, every managed launch passes the
child an environment that a manually launched app never has.

For **Antigravity IDE** this breaks the channel between the renderer and the local
language server:

- renderer logs `[unknown] Failed to fetch: ConnectError`
- the language server receives **zero** chat requests (`streamGenerateContent == 0`)
- the Agent panel silently discards the first message after an account switch
  (the user must close and reopen the IDE to recover)

### Reproduction

Same account, same state DB — only the launch path differs:

| launch path | no_proxy injected | renderer Failed-to-fetch | LS streamGenerateContent |
|---|---|---|---|
| manual | no | 0 | 2 |
| manual | no | 0 | 2 |
| manual | **yes** | 1 | 0 |
| managed (this tool) | **yes** | 1 | 0 |

Injecting **only** `no_proxy` / `NO_PROXY` before starting the same IDE binary is
enough to reproduce it; clearing them makes it disappear. The `--reuse-window` flag
and Chromium net-log capture were both ruled out by the same experiment matrix.

### Fix

Emit proxy variables only when a proxy is actually in play:

- a managed proxy is configured, or
- the current process already carries a proxy variable (then the loopback bypass
  list is still useful)

Otherwise return an empty list, so a managed launch is **byte-for-byte identical**
to a manual launch.

### Verification

`cargo check -p cockpit-tools --lib` on top of `upstream/main` (`deacbe44`) passes.

Note: `cargo test` cannot run in the authoring environment — the lib test binary
aborts immediately with `STATUS_ENTRYPOINT_NOT_FOUND` (missing comctl32 v6 manifest).
No unit test is added for that reason.
