### PR TITLE
feat(codex): show weekly quota reset on account cards

### DIFF
--- a/src/pages/useCodexAccountsRenderers.tsx
+++ b/src/pages/useCodexAccountsRenderers.tsx
@@ -1,7 +1,7 @@
 import { useEffect, type ReactElement } from "react";
 import { RefreshCw, Upload, Trash2, X, Power, Database, Copy, Check, Play, RotateCw, CircleAlert, Info, Calendar, Tag, Eye, EyeOff, FileText, ExternalLink, Pencil, FolderOpen, FolderPlus, ChevronRight, LogOut, Wrench, Terminal, Link2 } from "lucide-react";
 import { isCodexGroupQuotaRefreshInherit, resolveCodexGroupQuotaAutoRefreshMinutes } from "../services/codexAccountGroupService";
-import { isCodexApiKeyAccount, isCodexAgentIdentityAccount, isCodexChatCompletionsApiKeyAccount, isCodexNewApiAccount } from "../types/codex";
+import { formatCodexResetTime, formatCodexResetTimeAbsolute, getCodexWeeklyResetTime, isCodexApiKeyAccount, isCodexAgentIdentityAccount, isCodexChatCompletionsApiKeyAccount, isCodexNewApiAccount } from "../types/codex";
 import { isVerboseCodexQuotaErrorMessage, summarizeCodexQuotaErrorMessage } from "../utils/codexQuotaError";
 import { CodexQuotaMiniRows } from "../components/codex/CodexQuotaMiniRows";
 import { CodexTeamQuotaHistory } from "../components/codex/CodexTeamQuotaHistory";
@@ -751,6 +751,13 @@ export function useCodexAccountsRenderers(context: Pick<ReturnType<typeof useCod
           refreshingSubscriptionAccountId === account.id ||
           refreshing === account.id;
         const resetCreditControls = renderResetCreditControls(account);
+        const weeklyResetTime = getCodexWeeklyResetTime(account.quota);
+        const weeklyResetTimeText = formatCodexResetTimeAbsolute(weeklyResetTime);
+        const weeklyResetTimeTitle = weeklyResetTime
+          ? t("common.shared.quota.resetAt", {
+              time: formatCodexResetTime(weeklyResetTime, t),
+            })
+          : "";
         return (
           <div
             key={groupKey ? `${groupKey}-${account.id}` : account.id}
@@ -830,7 +837,8 @@ export function useCodexAccountsRenderers(context: Pick<ReturnType<typeof useCod
               isInLocalAccess ||
               canAddToLocalAccess ||
               (!isApiKeyAccount && hasCodexAccountNoteDetails(account)) ||
-              resetCreditControls) && (
+              resetCreditControls ||
+              weeklyResetTimeText) && (
               <div className="account-sub-line">
                 {meta.accountContextText && (
                   <span
@@ -877,6 +885,20 @@ export function useCodexAccountsRenderers(context: Pick<ReturnType<typeof useCod
                 )}
                 {!isApiKeyAccount && renderAccountNoteButton(account)}
                 {resetCreditControls}
+                {weeklyResetTimeText && (
+                  <span
+                    className="codex-weekly-reset-summary"
+                    title={weeklyResetTimeTitle}
+                  >
+                    <Calendar size={12} />
+                    <span>{t("codex.quota.weekly", "周配额")}</span>
+                    <strong>
+                      {t("common.shared.quota.resetAt", {
+                        time: weeklyResetTimeText,
+                      })}
+                    </strong>
+                  </span>
+                )}
               </div>
             )}
             {!isApiKeyAccount && (

--- a/src/styles/pages/codex-account-cards.css
+++ b/src/styles/pages/codex-account-cards.css
@@ -934,6 +934,36 @@
   min-width: 0;
 }
 
+.codex-account-card .codex-weekly-reset-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 24px;
+  padding: 3px 8px;
+  border: 1px solid color-mix(in srgb, var(--success) 28%, var(--border-light));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--success) 7%, var(--bg-secondary));
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.codex-account-card .codex-weekly-reset-summary svg {
+  flex: 0 0 auto;
+  color: var(--success);
+}
+
+.codex-account-card .codex-weekly-reset-summary strong {
+  min-width: 0;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--success) 76%, var(--text-primary));
+  font-weight: 700;
+  text-overflow: ellipsis;
+}
+
 .codex-reset-credit-main {
   display: flex;
   align-items: center;

--- a/src/types/codex.ts
+++ b/src/types/codex.ts
@@ -1515,6 +1515,23 @@ export function getCodexQuotaWindows(
   ];
 }
 
+/** 获取账号主周配额窗口的重置时间，不包含模型专项额度窗口。 */
+export function getCodexWeeklyResetTime(
+  quota: CodexQuota | undefined,
+): number | undefined {
+  const WEEK_MINUTES = 7 * 24 * 60;
+  const weeklyWindow = getCodexQuotaWindows(quota).find((window) => {
+    if (typeof window.windowMinutes === "number") {
+      return window.windowMinutes >= WEEK_MINUTES - 1;
+    }
+    return window.id === "secondary";
+  });
+  const resetTime = weeklyWindow?.resetTime;
+  return typeof resetTime === "number" && Number.isFinite(resetTime) && resetTime > 0
+    ? resetTime
+    : undefined;
+}
+
 /** 格式化重置时间显示（相对时间 + 绝对时间） */
 export function formatCodexResetTime(
   resetTime: number | undefined,

--- a/src/types/codexQuota.test.ts
+++ b/src/types/codexQuota.test.ts
@@ -5,6 +5,7 @@ import {
   getCodexAdditionalQuotaWindows,
   getCodexQuotaWindowLabel,
   getCodexMonthlyCreditUsage,
+  getCodexWeeklyResetTime,
   type CodexQuota,
 } from "./codex.ts";
 
@@ -39,6 +40,31 @@ test("uses 5h / Weekly / N Week window labels", () => {
   assert.equal(getCodexQuotaWindowLabel(50_400, "weekly"), "5 Week");
   assert.equal(getCodexQuotaWindowLabel(undefined, "weekly"), "Weekly");
   assert.equal(getCodexQuotaWindowLabel(undefined, "hourly"), "5h");
+});
+
+test("resolves the account-level weekly reset from either main window", () => {
+  assert.equal(
+    getCodexWeeklyResetTime({
+      hourly_percentage: 75,
+      weekly_percentage: 40,
+      hourly_window_present: true,
+      hourly_window_minutes: 10_080,
+      hourly_reset_time: 1_790_000_000,
+      weekly_window_present: false,
+    }),
+    1_790_000_000,
+  );
+  assert.equal(
+    getCodexWeeklyResetTime({
+      hourly_percentage: 75,
+      weekly_percentage: 40,
+      hourly_window_minutes: 300,
+      hourly_reset_time: 1_790_000_000,
+      weekly_window_minutes: 10_080,
+      weekly_reset_time: 1_790_500_000,
+    }),
+    1_790_500_000,
+  );
 });
 
 test("keeps upstream Spark-specific quota windows for the account card", () => {


### PR DESCRIPTION
## Summary
- Display the account-level weekly quota reset time beside the existing reset-credit controls on Codex account cards.
- Resolve the weekly reset correctly when the API reports the seven-day window as either the primary or secondary quota window.
- Keep model-specific additional windows, such as Codex Spark weekly quota, out of the account-level summary.
- Hide the summary when no valid weekly reset timestamp is available.

## Testing
- node --test src/types/codexQuota.test.ts
- npm run typecheck