### PR TITLE
fix: preserve usage account attribution across retries

### DIFF
--- a/sidecars/cockpit-cliproxy/USAGE_ATTRIBUTION_REVIEW.md
+++ b/sidecars/cockpit-cliproxy/USAGE_ATTRIBUTION_REVIEW.md
@@ -1,0 +1,40 @@
+# Request Usage Attribution
+
+## Scope
+
+The HTTP/SSE request tracker chooses a usage callback to finalize a downstream
+request. That callback's tokens and account identity must travel together.
+Previously the last selected account unconditionally overwrote that identity;
+when no selection entry existed, the identity was cleared.
+
+This patch preserves the chosen usage callback's account. The selector remains
+a fallback for requests without usage callbacks, or for a missing account mapping
+when the callback AuthID matches the selected AuthID. Unmapped callbacks from a
+different auth remain unattributed instead of being charged to an unrelated account.
+
+The patch does not change account routing, retries, model pricing, quota querying,
+WebSocket execution IDs, or the existing choice of the last successful callback.
+It does not change already persisted request logs.
+
+## Verification
+
+Run from this directory:
+
+```sh
+go test . -run 'TestRequestUsageTracker|TestUsageAttribution|TestUnmappedUsage|TestMatchingSelectedAuth|TestWebsocketUsage' -count=1
+go test -race . -run 'TestRequestUsageTracker|TestUsageAttribution|TestUnmappedUsage|TestMatchingSelectedAuth|TestWebsocketUsage' -count=1
+```
+
+All regression data is synthetic. Tests reproduce a later selection on another
+account, missing selection state, unmapped AuthID disagreement, and matching
+AuthID fallback. No credentials or model calls are required.
+
+## Limitations
+
+This is a code-level reproduction, not proof that every difference between plan
+quota percentage and estimated API dollars was caused by this defect. Percent
+quota and API-equivalent cost are different measures.
+
+Restoring historical attribution requires original per-attempt evidence. A
+persisted row that already replaced its account identity cannot be reliably
+reassigned from amount, email, quota percentage, or timing alone.

--- a/sidecars/cockpit-cliproxy/manifest_policy.go
+++ b/sidecars/cockpit-cliproxy/manifest_policy.go
@@ -720,14 +720,15 @@ func (t *requestUsageTracker) finalize(requestID string, input usageFinalizeInpu
 	if strings.TrimSpace(payload.RequestKind) == "" {
 		payload.RequestKind = strings.TrimSpace(input.requestKind)
 	}
-	if selectedOK {
+	// Token usage belongs to the attempt that reported it, not the last account
+	// selected for this downstream request. Async callbacks and retries may differ.
+	canUseSelected := len(records) == 0 ||
+		(strings.TrimSpace(payload.AccountID) == "" && strings.TrimSpace(payload.AuthID) != "" &&
+			strings.EqualFold(strings.TrimSpace(payload.AuthID), strings.TrimSpace(selected.AuthID)))
+	if selectedOK && canUseSelected {
 		payload.AccountID = selected.AccountID
 		payload.AccountEmail = selected.AccountEmail
 		payload.AuthID = selected.AuthID
-	} else {
-		payload.AccountID = ""
-		payload.AccountEmail = ""
-		payload.AuthID = ""
 	}
 	if input.status > 0 {
 		payload.Status = input.status

--- a/sidecars/cockpit-cliproxy/manifest_policy_test.go
+++ b/sidecars/cockpit-cliproxy/manifest_policy_test.go
@@ -2602,7 +2602,7 @@ func TestRequestUsageTrackerFinalizesWithSelectedAccount(t *testing.T) {
 	}
 }
 
-func TestRequestUsageTrackerSelectedAccountOverridesUsageAccount(t *testing.T) {
+func TestRequestUsageTrackerUsageAccountOverridesLaterSelection(t *testing.T) {
 	tracker := newRequestUsageTracker()
 	tracker.recordSelectedAccount("req-usage", &accountSpec{
 		ID:    "account-selected",
@@ -2626,8 +2626,8 @@ func TestRequestUsageTrackerSelectedAccountOverridesUsageAccount(t *testing.T) {
 	if !ok {
 		t.Fatal("expected finalized usage payload")
 	}
-	if payload.AccountID != "account-selected" || payload.AccountEmail != "selected@example.com" || payload.AuthID != "auth-selected" {
-		t.Fatalf("selected account metadata should win, got %#v", payload)
+	if payload.AccountID != "account-usage" || payload.AccountEmail != "usage@example.com" || payload.AuthID != "auth-usage" {
+		t.Fatalf("usage account metadata must stay with its tokens, got %#v", payload)
 	}
 }
 

--- a/sidecars/cockpit-cliproxy/usage_attribution_test.go
+++ b/sidecars/cockpit-cliproxy/usage_attribution_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestUsageAttributionStaysWithRecordedAttempt(t *testing.T) {
+	for _, laterSelection := range []bool{false, true} {
+		t.Run(map[bool]string{false: "selection_missing", true: "selection_changed"}[laterSelection], func(t *testing.T) {
+			tracker := newRequestUsageTracker()
+			tracker.record(usagePayload{RequestID: "attribution", AccountID: "member-a-space-one", AccountEmail: "a@example.invalid", AuthID: "auth-a", Success: true,
+				Usage: usageDetails{InputTokens: 120, OutputTokens: 30, TotalTokens: 150}})
+			if laterSelection {
+				tracker.recordSelectedAccount("attribution", &accountSpec{ID: "member-b-space-one", Email: "b@example.invalid"}, "auth-b")
+			}
+			result, ok := tracker.finalize("attribution", usageFinalizeInput{status: http.StatusOK})
+			if !ok || result.AccountID != "member-a-space-one" || result.AuthID != "auth-a" || result.AccountEmail != "a@example.invalid" || result.Usage.TotalTokens != 150 {
+				t.Fatalf("usage attribution was overwritten: %+v", result)
+			}
+		})
+	}
+}
+
+func TestUnmappedUsageDoesNotBorrowDifferentSelectedAuth(t *testing.T) {
+	tracker := newRequestUsageTracker()
+	tracker.recordSelectedAccount("unknown", &accountSpec{ID: "account-b"}, "auth-b")
+	tracker.record(usagePayload{RequestID: "unknown", AuthID: "auth-a", Success: true, Usage: usageDetails{TotalTokens: 150}})
+	result, _ := tracker.finalize("unknown", usageFinalizeInput{status: http.StatusOK})
+	if result.AccountID != "" || result.AuthID != "auth-a" {
+		t.Fatalf("unknown usage must remain unattributed instead of charging account-b: %+v", result)
+	}
+}
+
+func TestMatchingSelectedAuthCanFillUnmappedUsage(t *testing.T) {
+	tracker := newRequestUsageTracker()
+	tracker.recordSelectedAccount("matched", &accountSpec{ID: "member-a-space-one", Email: "a@example.invalid"}, "auth-a")
+	tracker.record(usagePayload{RequestID: "matched", AuthID: "auth-a", Success: true, Usage: usageDetails{TotalTokens: 150}})
+	result, _ := tracker.finalize("matched", usageFinalizeInput{status: http.StatusOK})
+	if result.AccountID != "member-a-space-one" || result.AuthID != "auth-a" || result.Usage.TotalTokens != 150 {
+		t.Fatalf("matching selector should fill missing account mapping: %+v", result)
+	}
+}
+
+func TestLastSuccessfulUsageKeepsItsOwnAccount(t *testing.T) {
+	tracker := newRequestUsageTracker()
+	tracker.record(usagePayload{RequestID: "successes", AccountID: "space-a", AuthID: "auth-a", Success: true, Usage: usageDetails{TotalTokens: 10}})
+	tracker.record(usagePayload{RequestID: "successes", AccountID: "space-b", AuthID: "auth-b", Success: true, Usage: usageDetails{TotalTokens: 20}})
+	tracker.recordSelectedAccount("successes", &accountSpec{ID: "space-c"}, "auth-c")
+	result, _ := tracker.finalize("successes", usageFinalizeInput{status: http.StatusOK})
+	if result.AccountID != "space-b" || result.AuthID != "auth-b" || result.Usage.TotalTokens != 20 {
+		t.Fatalf("final selected usage and account must stay paired: %+v", result)
+	}
+}
+
+func TestAPIKeyUsageWithoutAuthIDPreservesAccount(t *testing.T) {
+	tracker := newRequestUsageTracker()
+	tracker.recordSelectedAccount("apikey", &accountSpec{ID: "other-account"}, "other-auth")
+	tracker.record(usagePayload{RequestID: "apikey", AccountID: "api-account", Success: true, Usage: usageDetails{TotalTokens: 25}})
+	result, _ := tracker.finalize("apikey", usageFinalizeInput{status: http.StatusOK, spec: &apiKeySpec{ID: "client-key", Label: "Test"}})
+	if result.AccountID != "api-account" || result.AuthID != "" || result.APIKeyID != "client-key" || result.Usage.TotalTokens != 25 {
+		t.Fatalf("API account and client API key are different identities: %+v", result)
+	}
+}


### PR DESCRIPTION
## Summary

- Keep request token usage attached to the account that produced the usage callback.
- Do not let a later retry or selector snapshot overwrite that account with another account.
- Preserve selector fallback only when no usage callback exists or the callback AuthID matches.
- Keep mismatched or unmapped usage unattributed rather than charging a different account.

## Scope

- Does not change routing, retries, model pricing, quota querying, WebSocket execution IDs, or existing request logs.
- Does not rewrite historical billing records; historical reassignment requires original request-level evidence.
- No credentials or private account data are included.

## Verification

- `go test ./...`
- `go test -race ./...` for the affected package
- Windows amd64 cross-compile test completed locally; CI remains the runtime verification surface.

The regression tests cover selector changes after usage, missing selector state, matching AuthID fallback, multiple successful usage records, and API-key attribution.
