### PR TITLE
fix: 修复第三方网关丢失 Codex 子代理任务

### DIFF
--- a/sidecars/cockpit-cliproxy/provider_gateway.go
+++ b/sidecars/cockpit-cliproxy/provider_gateway.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	multiagentv2 "github.com/router-for-me/CLIProxyAPI/v7/internal/client/codex/optimize-multi-agent-v2"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 
 	responsesconverter "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses"
@@ -206,7 +207,10 @@ func (s *relayServer) handleProviderGatewayRequest(c *gin.Context, gateway *prov
 	if wireAPI == "chat_completions" {
 		switch {
 		case sourceFormatEqual(sourceFormat, sdktranslator.FormatOpenAIResponse):
-			upstreamBody = responsesconverter.ConvertOpenAIResponsesRequestToOpenAIChatCompletions(upstreamModel, body, stream)
+			// Provider gateways bypass the executor's Codex input normalization.
+			// Preserve delegated tasks before the generic chat translator drops agent_message items.
+			chatInput := multiagentv2.RewriteCodexMultiAgentV2Input(relayContext(c), c.Request.Header, body, s.cfg)
+			upstreamBody = responsesconverter.ConvertOpenAIResponsesRequestToOpenAIChatCompletions(upstreamModel, chatInput, stream)
 		case sourceFormatEqual(sourceFormat, sdktranslator.FormatOpenAI):
 			upstreamBody = rewriteProviderGatewayBodyModel(body, upstreamModel)
 		case sourceFormatEqual(sourceFormat, sdktranslator.FormatClaude), sourceFormatEqual(sourceFormat, sdktranslator.FormatGemini):

--- a/sidecars/cockpit-cliproxy/provider_gateway_multi_agent_test.go
+++ b/sidecars/cockpit-cliproxy/provider_gateway_multi_agent_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/tidwall/gjson"
+)
+
+func TestProviderGatewayCodexAgentMessages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const model = "gateway-test-model"
+	const baseline = `{"type":"message","role":"user","content":[{"type":"input_text","text":"baseline"}]}`
+	const previousReply = `{"type":"message","role":"assistant","content":[{"type":"output_text","text":"previous reply"}]}`
+	const agentTask = `{"type":"agent_message","id":"amsg_test","author":"/root","recipient":"/root/worker","content":[{"type":"input_text","text":"Message Type: NEW_TASK\nPayload:\n"},{"type":"encrypted_content","encrypted_content":"Review only the assigned passage. 校验码：任务送达"}]}`
+	const toolCall = `{"type":"function_call","call_id":"call_read","name":"read_passage","arguments":"{}"}`
+	const toolOutput = `{"type":"function_call_output","call_id":"call_read","output":"assigned passage"}`
+	const codexUA = "codex-tui/0.153.4 (Windows; x86_64)"
+
+	cases := []struct {
+		name       string
+		input      string
+		userAgent  string
+		enabled    bool
+		wireAPI    string
+		wantRoles  []string
+		wantTask   bool
+		wantToolID bool
+	}{
+		{"initial", baseline + "," + agentTask, codexUA, true, "chat_completions", []string{"user", "user"}, true, false},
+		{"followup", baseline + "," + previousReply + "," + agentTask, codexUA, true, "chat_completions", []string{"user", "assistant", "user"}, true, false},
+		{"after_tool_result", baseline + "," + toolCall + "," + toolOutput + "," + agentTask, codexUA, true, "chat_completions", []string{"user", "assistant", "tool", "user"}, true, true},
+		{"disabled", baseline + "," + agentTask, codexUA, false, "chat_completions", []string{"user"}, false, false},
+		{"other_client", baseline + "," + agentTask, "unrelated-client/1.0", true, "chat_completions", []string{"user"}, false, false},
+		{"ordinary_message", baseline, codexUA, true, "chat_completions", []string{"user"}, false, false},
+		{"responses_passthrough", baseline + "," + agentTask, codexUA, true, "responses", nil, false, false},
+	}
+	for _, tc := range cases {
+		for _, namespaced := range []bool{false, true} {
+			for _, stream := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/namespaced=%t/stream=%t", tc.name, namespaced, stream), func(t *testing.T) {
+					captured := make(chan []byte, 1)
+					upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						body, err := io.ReadAll(r.Body)
+						if err != nil {
+							t.Errorf("read upstream request: %v", err)
+							w.WriteHeader(http.StatusBadRequest)
+							return
+						}
+						captured <- body
+						wantPath := "/v1/chat/completions"
+						if tc.wireAPI == "responses" {
+							wantPath = "/v1/responses"
+						}
+						if r.URL.Path != wantPath || r.Header.Get("Authorization") != "Bearer upstream-key" {
+							t.Errorf("unexpected upstream path or auth: path=%s", r.URL.Path)
+						}
+						if tc.wireAPI == "responses" {
+							if stream {
+								w.Header().Set("Content-Type", "text/event-stream")
+								_, _ = io.WriteString(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_test\",\"status\":\"completed\",\"output\":[]}}\n\n")
+							} else {
+								w.Header().Set("Content-Type", "application/json")
+								_, _ = io.WriteString(w, `{"id":"resp_test","object":"response","status":"completed","output":[]}`)
+							}
+							return
+						}
+						if stream {
+							w.Header().Set("Content-Type", "text/event-stream")
+							_, _ = fmt.Fprintf(w, "data: {\"id\":\"chatcmpl_test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":%q,\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":null}]}\n\ndata: [DONE]\n\n", model)
+						} else {
+							w.Header().Set("Content-Type", "application/json")
+							_, _ = fmt.Fprintf(w, `{"id":"chatcmpl_test","object":"chat.completion","created":1,"model":%q,"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`, model)
+						}
+					}))
+					defer upstream.Close()
+
+					gateway := &providerGatewaySpec{BaseURL: upstream.URL, APIKey: "upstream-key", UpstreamModel: model, UpstreamModels: []string{model}, WireAPI: tc.wireAPI}
+					key := &apiKeySpec{ID: "test-key", Key: "client-key", Enabled: true, ProviderGateway: gateway}
+					clientModel := model
+					if namespaced {
+						key.ProviderGateway = nil
+						key.ModelRouting = &modelRoutingSpec{DefaultRoute: "oauth", FailurePolicy: "strict", Routes: []modelRouteSpec{{ID: "test-route", Namespace: "test", ProviderGateway: gateway}}}
+						clientModel = "test/" + model
+					}
+					m := &manifest{APIKeys: []apiKeySpec{*key}, ModelIDs: []string{clientModel}, apiKeyByValue: map[string]*apiKeySpec{"client-key": key}}
+					cfg := &config.Config{}
+					cfg.Codex.OptimizeMultiAgentV2 = tc.enabled
+					runtime := &fakeRuntime{}
+					router := (&relayServer{runtime: runtime, cfg: cfg, manifest: m, policy: &requestPolicy{manifest: m}}).router()
+					relay := httptest.NewServer(router)
+					defer relay.Close()
+					requestBody := fmt.Sprintf(`{"model":%q,"input":[%s],"stream":%t}`, clientModel, tc.input, stream)
+					req, err := http.NewRequest(http.MethodPost, relay.URL+"/v1/responses", strings.NewReader(requestBody))
+					if err != nil {
+						t.Fatal(err)
+					}
+					req.Header.Set("Authorization", "Bearer client-key")
+					req.Header.Set("Content-Type", "application/json")
+					req.Header.Set("User-Agent", tc.userAgent)
+					response, err := relay.Client().Do(req)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer response.Body.Close()
+					responseBody, err := io.ReadAll(response.Body)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if response.StatusCode != http.StatusOK {
+						t.Fatalf("status=%d body=%s", response.StatusCode, responseBody)
+					}
+					var body []byte
+					select {
+					case body = <-captured:
+					default:
+						t.Fatal("request did not reach provider gateway upstream")
+					}
+					if runtime.executeCalls != 0 || runtime.streamCalls != 0 {
+						t.Fatal("provider gateway must not enter the OAuth runtime")
+					}
+					if gjson.GetBytes(body, "model").String() != model || gjson.GetBytes(body, "stream").Bool() != stream {
+						t.Fatalf("model or stream flag changed: %s", body)
+					}
+					if tc.wireAPI == "responses" {
+						var before, after any
+						if err := json.Unmarshal([]byte("["+tc.input+"]"), &before); err != nil {
+							t.Fatal(err)
+						}
+						if err := json.Unmarshal([]byte(gjson.GetBytes(body, "input").Raw), &after); err != nil {
+							t.Fatal(err)
+						}
+						if !reflect.DeepEqual(before, after) {
+							t.Fatalf("native Responses input must remain untouched: %s", body)
+						}
+					} else {
+						messages := gjson.GetBytes(body, "messages").Array()
+						roles := make([]string, 0, len(messages))
+						for _, message := range messages {
+							roles = append(roles, message.Get("role").String())
+						}
+						if !reflect.DeepEqual(roles, tc.wantRoles) {
+							t.Fatalf("upstream roles=%v want=%v body=%s", roles, tc.wantRoles, body)
+						}
+						if tc.wantTask {
+							parts := messages[len(messages)-1].Get("content").Array()
+							if len(parts) != 2 || parts[0].Get("text").String() != "Message Type: NEW_TASK\nPayload:\n" || parts[1].Get("text").String() != "Review only the assigned passage. 校验码：任务送达" {
+								t.Fatalf("delegated task was changed or dropped: %s", body)
+							}
+						}
+						if tc.wantToolID && (messages[1].Get("tool_calls.0.id").String() != "call_read" || messages[2].Get("tool_call_id").String() != "call_read" || messages[2].Get("content").String() != "assigned passage") {
+							t.Fatalf("tool result pairing changed: %s", body)
+						}
+					}
+					if stream && !strings.Contains(string(responseBody), "event: response.completed\n") {
+						t.Fatalf("missing Responses stream completion: %s", responseBody)
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 问题

Codex 通过 Cockpit 的第三方 Provider Gateway 调用 Chat Completions 模型时，子代理的任务消息会在协议转换阶段被丢弃。

Codex 使用 `input[].type = "agent_message"` 传递任务，正文位于该消息的 `content[]` 中，内容块类型为 `encrypted_content`。本次复现中的字段值是明文任务。

Provider Gateway 在 `handleProviderGatewayRequest` 中直接调用 `ConvertOpenAIResponsesRequestToOpenAIChatCompletions`，绕过了常规 executor 已有的 Codex 多代理输入归一化。因此会出现两种症状：

- 首次创建子代理时，任务消失，模型只看到背景或旧消息，可能开始无关的工作区搜索。
- 对已经回答过的子代理补发任务时，转换后的请求停留在 assistant 消息，Gemini 上游报 `400: Requests ending with a model turn are not supported.`。

本问题已在 Cockpit Tools 1.3.47 和 Codex CLI 0.153.4 的 Windows 环境中复现。当前 main 中同一网关分支仍缺少此处理。`api-service-compatibility` 并非此问题的解决开关，该旧选项针对官方 OAuth API Service 的容量恢复与请求头行为。

## 修复

仅在 Provider Gateway 的 Responses → Chat Completions 分支中，调用已有的 `RewriteCodexMultiAgentV2Input`，随后继续使用原来的通用转换器。

- 复用现有 Codex 客户端识别与 `optimize-multi-agent-v2` 开关。
- 保留代理任务的文本与顺序，包括中文内容。
- 不改变原始 Responses 透传、其他客户端、关闭优化时的行为、认证、模型路由和 OAuth 账号池。
- 不全局展开 reasoning 的加密内容，不新增协议代理或用户配置。

## 测试

新增 `TestProviderGatewayCodexAgentMessages`，以本地 HTTP 上游检查真正发出的请求。覆盖 7 种场景 × 2 种路由 × 流式/非流式，共 28 个子测试：

1. 首次派发任务。
2. assistant 回答后的后续任务。
3. 工具结果后的任务，以及 tool_call_id 配对。
4. 优化关闭。
5. 非 Codex 客户端。
6. 普通用户消息。
7. 原生 Responses 输入保持不变。

修复前，前 3 种场景对应的 12 个子测试因任务缺失失败。修复后全部通过。

已执行：

```text
cd sidecars/cockpit-cliproxy
go test ./... -count=1

cd third_party/CLIProxyAPI
go test ./internal/client/codex/optimize-multi-agent-v2 -count=1
```

相同补丁已回移至 v1.3.47 并编译为 Windows amd64 辅助程序，在独立端口通过真实 Gemini 上游的首次任务、后续任务及流式请求测试。安装后，通过 Codex 直接创建无继承上下文的 Gemini 子代理，成功读取指定测试文件并审查，随后通过 `followup_task` 完成定点修正，不再出现任务丢失或上述 400。

另一次独立子代理测试成功通过工具新建短文测试文件，主代理已核对实际文件内容。上述端到端测试均使用合成材料，没有读取或发布用户的小说资料。

本 PR 不包含账号凭据、第三方服务地址、实际工作区资料或生成的二进制文件。
