### PR TITLE
fix(SideNav): Improve classic sidebar collapse behavior

### DIFF
--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -163,9 +163,9 @@ export function SideNav({
   const setHideClassicSwitchPrompt = useSideNavLayoutStore((state) => state.setHideClassicSwitchPrompt);
   const isClassicLayout = sideNavLayoutMode === 'classic';
   const isClassicCollapsed = isClassicLayout && classicCollapsed;
-  const showClassicLabels = isClassicLayout && !classicCollapsed;
   const rocketIdRef = useRef(0);
   const classicSwitchDontAskAgainRef = useRef(false);
+  const classicCollapseToggleAtRef = useRef(0);
   const sideNavRef = useRef<HTMLElement>(null);
   const updateEntryRef = useRef<HTMLDivElement>(null);
   const brandRef = useRef<HTMLDivElement>(null);
@@ -496,6 +496,12 @@ export function SideNav({
     };
 
     if (Math.abs(nextScale - classicAdaptiveScale) > CLASSIC_NAV_SCALE_EPSILON) {
+      if (Date.now() - classicCollapseToggleAtRef.current < 300) {
+        const overflow = navItemsElement.scrollHeight - navItemsElement.clientHeight;
+        const shouldScroll = overflow > CLASSIC_NAV_SCROLL_EPSILON;
+        setClassicNavNeedsScroll((prev) => (prev === shouldScroll ? prev : shouldScroll));
+        return;
+      }
       setClassicAdaptiveScale(Number(nextScale.toFixed(5)));
       window.requestAnimationFrame(updateScrollNeed);
       return;
@@ -503,6 +509,13 @@ export function SideNav({
 
     updateScrollNeed();
   }, [classicAdaptiveScale, isClassicLayout]);
+
+  useLayoutEffect(() => {
+    if (!isClassicLayout) {
+      return;
+    }
+    classicCollapseToggleAtRef.current = Date.now();
+  }, [classicCollapsed, isClassicLayout]);
 
   useLayoutEffect(() => {
     if (!isClassicLayout || typeof window === 'undefined') {
@@ -907,8 +920,13 @@ export function SideNav({
             )}
           </div>
 
-          {isClassicLayout && !isClassicCollapsed && (
-            <div className="side-nav-brand-title">{APP_DISPLAY_NAME}</div>
+          {isClassicLayout && (
+            <div
+              className={`side-nav-brand-title${isClassicCollapsed ? ' is-collapsed' : ''}`}
+              aria-hidden={isClassicCollapsed}
+            >
+              {APP_DISPLAY_NAME}
+            </div>
           )}
         </div>
 
@@ -945,11 +963,16 @@ export function SideNav({
           title={t('nav.dashboard')}
         >
           <GaugeCircle size={isClassicLayout ? classicMainIconSize : 20} />
-          {showClassicLabels ? (
-            <span className="nav-item-text">{t('nav.dashboard')}</span>
-          ) : !isClassicLayout ? (
+          {isClassicLayout ? (
+            <span
+              className={`nav-item-text${isClassicCollapsed ? ' is-collapsed' : ''}`}
+              aria-hidden={isClassicCollapsed}
+            >
+              {t('nav.dashboard')}
+            </span>
+          ) : (
             <span className="tooltip">{t('nav.dashboard')}</span>
-          ) : null}
+          )}
         </button>
 
         {sidebarMenuEntries.map((entry) => {
@@ -962,11 +985,16 @@ export function SideNav({
               title={entry.label}
             >
               {renderEntryIcon(entry, isClassicLayout ? classicMainIconSize : 20)}
-              {showClassicLabels ? (
-                <span className="nav-item-text">{entry.label}</span>
-              ) : !isClassicLayout ? (
+              {isClassicLayout ? (
+                <span
+                  className={`nav-item-text${isClassicCollapsed ? ' is-collapsed' : ''}`}
+                  aria-hidden={isClassicCollapsed}
+                >
+                  {entry.label}
+                </span>
+              ) : (
                 <span className="tooltip">{entry.label}</span>
-              ) : null}
+              )}
             </button>
           );
         })}
@@ -978,11 +1006,16 @@ export function SideNav({
           title={t('nav.morePlatforms', '更多平台')}
         >
           <LayoutGrid size={isClassicLayout ? classicMainIconSize : 20} />
-          {showClassicLabels ? (
-            <span className="nav-item-text">{t('nav.morePlatforms', '更多平台')}</span>
-          ) : !isClassicLayout ? (
+          {isClassicLayout ? (
+            <span
+              className={`nav-item-text${isClassicCollapsed ? ' is-collapsed' : ''}`}
+              aria-hidden={isClassicCollapsed}
+            >
+              {t('nav.morePlatforms', '更多平台')}
+            </span>
+          ) : (
             <span className="tooltip">{t('nav.morePlatforms', '更多平台')}</span>
-          ) : null}
+          )}
         </button>
 
         {morePopoverContent && (
@@ -1003,9 +1036,12 @@ export function SideNav({
             title={t('nav.2faManager', '2FA / MFA 管理')}
           >
             <ShieldCheck size={isClassicLayout ? classicMainIconSize : 20} />
-            {showClassicLabels ? (
-              <span className="nav-item-text">{t('nav.2faManager', '2FA / MFA 管理')}</span>
-            ) : null}
+            <span
+              className={`nav-item-text${isClassicCollapsed ? ' is-collapsed' : ''}`}
+              aria-hidden={isClassicCollapsed}
+            >
+              {t('nav.2faManager', '2FA / MFA 管理')}
+            </span>
           </button>
 
           <button
@@ -1014,9 +1050,12 @@ export function SideNav({
             title={t('nav.logs', '日志')}
           >
             <FileText size={isClassicLayout ? classicMainIconSize : 20} />
-            {showClassicLabels ? (
-              <span className="nav-item-text">{t('nav.logs', '日志')}</span>
-            ) : null}
+            <span
+              className={`nav-item-text${isClassicCollapsed ? ' is-collapsed' : ''}`}
+              aria-hidden={isClassicCollapsed}
+            >
+              {t('nav.logs', '日志')}
+            </span>
           </button>
 
           <button
@@ -1025,9 +1064,12 @@ export function SideNav({
             title={t('nav.settings')}
           >
             <Settings size={isClassicLayout ? classicMainIconSize : 20} />
-            {showClassicLabels ? (
-              <span className="nav-item-text">{t('nav.settings')}</span>
-            ) : null}
+            <span
+              className={`nav-item-text${isClassicCollapsed ? ' is-collapsed' : ''}`}
+              aria-hidden={isClassicCollapsed}
+            >
+              {t('nav.settings')}
+            </span>
           </button>
         </div>
       )}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -225,7 +225,7 @@
 }
 
 .nav-brand {
-  margin-bottom: 0px; 
+  margin-bottom: 0px;
 }
 
 .brand-logo {
@@ -469,9 +469,24 @@
   color: var(--text-primary);
   letter-spacing: 0.01em;
   min-width: 0;
+  max-width: 140px;
+  flex: 0 1 auto;
+  opacity: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: opacity 0.18s ease, max-width 0.2s ease;
+}
+
+.side-nav-brand-title.is-collapsed {
+  /* 脫離 flex 流：避免 max-width 收縮中間態把 logo 擠偏；直接藏到殼外並瞬隱 */
+  position: absolute;
+  left: 100%;
+  max-width: 0;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: none;
 }
 
 .side-nav.side-nav-classic .nav-items {
@@ -496,6 +511,16 @@
   gap: var(--side-nav-classic-nav-item-gap-scaled);
   padding: 0 var(--side-nav-classic-nav-item-padding-inline-scaled);
   border-radius: var(--side-nav-classic-nav-item-radius-scaled);
+  /* 只保留顏色類過渡，width/padding 跟宿主瞬切，避免背景先過窄再恢復 */
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+}
+
+.side-nav.side-nav-classic .nav-item > svg,
+.side-nav.side-nav-classic .nav-item > img,
+.side-nav.side-nav-classic .nav-item .nav-item-icon,
+.side-nav.side-nav-classic .nav-item .side-nav-group-icon {
+  flex: 0 0 auto;
 }
 
 .side-nav.side-nav-classic .nav-item:hover {
@@ -517,11 +542,30 @@
   display: inline-flex;
   align-items: center;
   min-width: 0;
+  max-width: 120px;
+  flex: 0 1 auto;
+  opacity: 1;
+  transform: none;
   font-size: var(--side-nav-classic-nav-item-text-size-scaled);
   font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: opacity 0.18s ease, max-width 0.2s ease, transform 0.2s ease;
+}
+
+.side-nav.side-nav-classic .nav-item-text.is-collapsed {
+  /* 脫離 flex 流：盒子已瞬切 44px，文字若仍在流內做 max-width 動畫會撐開內容、
+     把圖標擠到邊緣；改為絕對定位藏到框外並瞬隱，圖標每幀保持居中 */
+  position: absolute;
+  left: 100%;
+  top: auto;
+  transform: none;
+  max-width: 0;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: none;
 }
 
 .nav-bottom-actions {
@@ -665,10 +709,7 @@
 
 .side-nav.side-nav-classic.side-nav-classic-collapsed .side-nav-brand-main {
   flex: 0 0 auto;
-}
-
-.side-nav.side-nav-classic.side-nav-classic-collapsed .side-nav-brand-title {
-  display: none;
+  gap: 0;
 }
 
 .side-nav.side-nav-classic.side-nav-classic-collapsed .nav-items {
@@ -680,6 +721,7 @@
   width: var(--side-nav-classic-collapsed-item-width-scaled);
   padding: 0;
   justify-content: center;
+  gap: 0;
 }
 
 .side-nav.side-nav-classic.side-nav-classic-collapsed .nav-bottom-actions {


### PR DESCRIPTION
https://github.com/jlcodes99/cockpit-tools/issues/2383

### 更新内容

更改文件:
- SideNav.tsx
- layout.css

核心變更:

經典 SideNav 收起時讓選項文字脫離排版流並瞬間隱藏 ( 與修復前行爲保持一致 )、只保留顏色過渡，並消除關閉過程中的背景收窄問題。

### 修復對比

修復前:
<img width="902" height="832" alt="cockpit-tools_5RFvwtFrMS" src="https://github.com/user-attachments/assets/1c230678-4de5-4fda-a5cd-6d1a7e80fd55" />

修復後:
<img width="338" height="492" alt="cockpit-tools_77W39uG9PA" src="https://github.com/user-attachments/assets/25fe6b4e-f9df-499b-909e-2e983c70d198" />
