### PR TITLE
feat(style): Support OLED Theme

### DIFF
--- a/src-tauri/src/modules/config.rs
+++ b/src-tauri/src/modules/config.rs
@@ -80,7 +80,7 @@ pub struct UserConfig {
     /// 应用主题
     #[serde(default = "default_theme")]
     pub theme: String,
-    /// 主题色套件：default / nord / tokyo-night / catppuccin / gruvbox / everforest
+    /// 主题色套件：default / nord / tokyo-night / catppuccin / gruvbox / everforest / oled
     #[serde(default = "default_theme_color")]
     pub theme_color: String,
     /// 是否允许受控外连：当前闸 WebDAV 同步与 OpenRouter 用量刷新（非全局网络 kill switch）
@@ -687,7 +687,7 @@ pub fn normalize_theme_color(raw: &str) -> String {
                 v
             }
         }
-        "catppuccin" | "gruvbox" | "everforest" | "ayu" | "one-dark" | "onedark" => {
+        "catppuccin" | "gruvbox" | "everforest" | "oled" | "ayu" | "one-dark" | "onedark" => {
             if v == "onedark" {
                 "one-dark".to_string()
             } else {
@@ -2506,6 +2506,7 @@ mod tests {
     fn normalize_theme_color_maps_aliases() {
         assert_eq!(super::normalize_theme_color("TokyoNight"), "tokyo-night");
         assert_eq!(super::normalize_theme_color("onedark"), "one-dark");
+        assert_eq!(super::normalize_theme_color("OLED"), "oled");
         assert_eq!(super::normalize_theme_color("nope"), "default");
     }
     use super::{acquire_config_file_lock, patch_runtime_state, RuntimeState, UserConfig};

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1088,6 +1088,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "السماح بالشبكة الخارجية",
       "externalNetworkDesc": "عند الإيقاف: يمنع WebDAV واستخدام OpenRouter والإعلانات وفحص التحديث التلقائي (المحلي يستمر).",
       "webdavAllowedDomains": "قائمة نطاقات WebDAV",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Povolit externí síť",
       "externalNetworkDesc": "Vypnuto: blokuje WebDAV, usage OpenRouter, oznámení a auto-kontrolu aktualizací (lokální běží).",
       "webdavAllowedDomains": "Whitelist domén WebDAV",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Externes Netz erlauben",
       "externalNetworkDesc": "Aus: blockiert WebDAV, OpenRouter-Nutzung, Ankündigungen und Auto-Update-Checks (lokal bleibt nutzbar).",
       "webdavAllowedDomains": "WebDAV-Domain-Whitelist",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1234,6 +1234,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Allow external network",
       "externalNetworkDesc": "When off, blocks WebDAV, OpenRouter usage refresh, remote announcements, and auto update checks (local features keep working).",
       "webdavAllowedDomains": "WebDAV domain allowlist",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1234,6 +1234,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Allow external network",
       "externalNetworkDesc": "When off, blocks WebDAV, OpenRouter usage refresh, remote announcements, and auto update checks (local features keep working).",
       "webdavAllowedDomains": "WebDAV domain allowlist",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Permitir red externa",
       "externalNetworkDesc": "Desactivado: bloquea WebDAV, uso de OpenRouter, anuncios y comprobaciones de actualización (lo local sigue).",
       "webdavAllowedDomains": "Lista blanca WebDAV",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Autoriser le réseau externe",
       "externalNetworkDesc": "Désactivé : bloque WebDAV, usage OpenRouter, annonces et vérif. de mise à jour (le local continue).",
       "webdavAllowedDomains": "Liste blanche domaines WebDAV",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -1088,6 +1088,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Izinkan jaringan eksternal",
       "externalNetworkDesc": "Mati: memblokir WebDAV, usage OpenRouter, pengumuman, dan cek pembaruan (fitur lokal tetap).",
       "webdavAllowedDomains": "Daftar domain WebDAV",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Consenti rete esterna",
       "externalNetworkDesc": "Disattivo: blocca WebDAV, uso OpenRouter, annunci e controlli aggiornamento (il locale continua).",
       "webdavAllowedDomains": "Whitelist domini WebDAV",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "外部通信を許可",
       "externalNetworkDesc": "オフ時は WebDAV・OpenRouter 使用量・お知らせ・自動更新チェックを遮断します（ローカル機能は継続）。",
       "webdavAllowedDomains": "WebDAV ドメイン許可リスト",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "외부 네트워크 허용",
       "externalNetworkDesc": "끄면 WebDAV, OpenRouter 사용량, 공지, 자동 업데이트 확인을 차단합니다(로컬 기능은 유지).",
       "webdavAllowedDomains": "WebDAV 도메인 허용 목록",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Zezwól na sieć zewnętrzną",
       "externalNetworkDesc": "Wył.: blokuje WebDAV, usage OpenRouter, ogłoszenia i auto-sprawdzanie aktualizacji (lokalne działa).",
       "webdavAllowedDomains": "Biała lista WebDAV",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Permitir rede externa",
       "externalNetworkDesc": "Desligado: bloqueia WebDAV, uso OpenRouter, avisos e checagens de atualização (local continua).",
       "webdavAllowedDomains": "Lista branca WebDAV",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Разрешить внешнюю сеть",
       "externalNetworkDesc": "Выкл.: блокирует WebDAV, usage OpenRouter, объявления и автопроверку обновлений (локальное работает).",
       "webdavAllowedDomains": "Белый список WebDAV",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Harici ağa izin ver",
       "externalNetworkDesc": "Kapalı: WebDAV, OpenRouter kullanımı, duyurular ve otomatik güncelleme kontrolünü engeller (yerel sürer).",
       "webdavAllowedDomains": "WebDAV alan adı listesi",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "Cho phép mạng ngoài",
       "externalNetworkDesc": "Tắt: chặn WebDAV, usage OpenRouter, thông báo và kiểm tra cập nhật (tính năng local vẫn chạy).",
       "webdavAllowedDomains": "Danh sách domain WebDAV",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1234,6 +1234,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "允许外连",
       "externalNetworkDesc": "关闭后阻断 WebDAV 同步、OpenRouter 用量刷新、远端公告与自动更新检查（不影响本地功能）",
       "webdavAllowedDomains": "WebDAV 域名白名单",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -1041,6 +1041,7 @@
       "themeColorCatppuccin": "Catppuccin",
       "themeColorGruvbox": "Gruvbox",
       "themeColorEverforest": "Everforest",
+      "themeColorOled": "OLED",
       "externalNetwork": "允許外連",
       "externalNetworkDesc": "關閉後阻斷 WebDAV 同步、OpenRouter 用量刷新、遠端公告與自動更新檢查（不影響本機功能）",
       "webdavAllowedDomains": "WebDAV 網域白名單",

--- a/src/pages/SettingsGeneralPanel.tsx
+++ b/src/pages/SettingsGeneralPanel.tsx
@@ -1093,6 +1093,9 @@ export function SettingsGeneralPanel(props: SettingsPageViewProps) {
                     <option value="everforest">
                       {t('settings.general.themeColorEverforest', 'Everforest')}
                     </option>
+                    <option value="oled">
+                      {t('settings.general.themeColorOled', 'OLED')}
+                    </option>
                   </select>
                 </div>
               </div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -126,6 +126,26 @@
   --bg-secondary: light-dark(#ffffff, #343f44);
   --text-primary: light-dark(#0f172a, #d3c6aa);
 }
+[data-theme-color="oled"] {
+  /* True black/white pack: primary/accent inherit the base blue/teal.
+     Borders/shadows keep base values (light borders separate pure surfaces). */
+  --bg-primary: light-dark(#ffffff, #000000);
+  --bg-secondary: light-dark(#ffffff, #000000);
+  --bg-tertiary: light-dark(#ffffff, #000000);
+  --bg-card: light-dark(#ffffff, #000000);
+  --bg-hover: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.08));
+  --text-primary: light-dark(#000000, #ffffff);
+  --text-secondary: light-dark(#3f3f3f, #a3a3a3);
+  --text-muted: #737373;
+  /* Flatten the body backdrop too, otherwise dark stays blue-black gradient */
+  --body-bg-start: light-dark(#ffffff, #000000);
+  --body-bg-end: light-dark(#ffffff, #000000);
+  --body-glow-1: transparent;
+  --body-glow-2: transparent;
+
+  --border: light-dark(#adb4a8, #757d72);
+  --border-light: light-dark(#adb4a8, #757d72);
+}
 
 * {
   box-sizing: border-box;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,6 +1,11 @@
 /* ============================================
    Cockpit Tools - Design System
    Brand Direction: floating dashboard with soft gradients
+   Theming: CSS `light-dark()` + `color-scheme`, driven by
+   `data-theme="light" | "dark"` on <html> (see App.tsx applyTheme;
+   `system` is resolved to light/dark before being written).
+   `light-dark()` follows the element's used `color-scheme`,
+   so flipping the attribute re-resolves every variable below.
    ============================================ */
 
 :root {
@@ -8,43 +13,50 @@
   --font-sans: 'Inter', 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', 'SFMono-Regular', monospace;
 
-  /* Brand Colors */
-  --primary: #1d4ed8;
-  --primary-hover: #1e40af;
-  --primary-light: rgba(29, 78, 216, 0.12);
-  --accent: #0ea5a5;
+  /* Brand Colors - slightly brighter second value for dark mode */
+  --primary: light-dark(#1d4ed8, #3b82f6);
+  --primary-hover: light-dark(#1e40af, #2563eb);
+  --primary-light: light-dark(rgba(29, 78, 216, 0.12), rgba(59, 130, 246, 0.15));
+  --accent: light-dark(#0ea5a5, #14b8a6);
 
-  /* Status Colors */
+  /* Status Colors - identical in both modes */
   --success: #22c55e;
   --warning: #f59e0b;
   --warning-strong: #f97316;
   --danger: #ef4444;
 
   /* Background Colors */
-  --bg-primary: #f6f5f2;
+  --bg-primary: light-dark(#f6f5f2, #0f172a);
   /* Solid surfaces: dialogs / dropdowns / menus (no transparency) */
-  --bg-secondary: #ffffff;
+  --bg-secondary: light-dark(#ffffff, #1e293b);
   --bg-surface: var(--bg-secondary);
   /* Soft panels: cards / list rows (slight transparency to show gradient) */
-  --bg-tertiary: #eef2f7;
-  --bg-card: rgba(255, 255, 255, 0.75);
-  --bg-hover: rgba(15, 23, 42, 0.06);
+  --bg-tertiary: light-dark(#eef2f7, #334155);
+  --bg-card: light-dark(rgba(255, 255, 255, 0.75), rgba(30, 41, 59, 0.85));
+  --bg-hover: light-dark(rgba(15, 23, 42, 0.06), rgba(255, 255, 255, 0.08));
 
   /* Text Colors */
-  --text-primary: #0f172a;
-  --text-secondary: #475569;
-  --text-muted: #94a3b8;
+  --text-primary: light-dark(#0f172a, #f1f5f9);
+  --text-secondary: light-dark(#475569, #94a3b8);
+  --text-muted: light-dark(#94a3b8, #64748b);
 
   /* Border Colors */
-  --border: rgba(15, 23, 42, 0.12);
-  --border-light: rgba(15, 23, 42, 0.08);
+  --border: light-dark(rgba(15, 23, 42, 0.12), rgba(255, 255, 255, 0.12));
+  --border-light: light-dark(rgba(15, 23, 42, 0.08), rgba(255, 255, 255, 0.06));
 
   /* Shadows */
-  --shadow-sm: 0 2px 6px rgba(15, 23, 42, 0.08);
-  --shadow-md: 0 12px 24px rgba(15, 23, 42, 0.12);
-  --shadow-lg: 0 20px 40px rgba(15, 23, 42, 0.18);
+  --shadow-sm: light-dark(0 2px 6px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(0, 0, 0, 0.25));
+  --shadow-md: light-dark(0 12px 24px rgba(15, 23, 42, 0.12), 0 12px 24px rgba(0, 0, 0, 0.35));
+  --shadow-lg: light-dark(0 20px 40px rgba(15, 23, 42, 0.18), 0 20px 40px rgba(0, 0, 0, 0.45));
 
-  /* Gradients */
+  /* Body backdrop stops (split out: light-dark() only accepts <color> args,
+     so whole gradients can't be passed to it directly) */
+  --body-glow-1: light-dark(rgba(29, 78, 216, 0.12), rgba(59, 130, 246, 0.15));
+  --body-glow-2: light-dark(rgba(14, 165, 165, 0.12), rgba(20, 184, 166, 0.12));
+  --body-bg-start: light-dark(#f8f7f4, #0f172a);
+  --body-bg-end: light-dark(#eef1f6, #1e293b);
+
+  /* Gradients - identical in both modes */
   --gradient-primary: linear-gradient(135deg, #1d4ed8 0%, #0ea5a5 100%);
   --gradient-success: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
   --gradient-danger: linear-gradient(135deg, #f97316 0%, #ef4444 100%);
@@ -60,98 +72,59 @@
   --modal-close-icon-size: 16px;
 }
 
-/* === Dark Theme === */
-[data-theme="dark"] {
-  /* Brand Colors - slightly brighter for dark mode */
-  --primary: #3b82f6;
-  --primary-hover: #2563eb;
-  --primary-light: rgba(59, 130, 246, 0.15);
-  --accent: #14b8a6;
-
-  /* Status Colors */
-  --success: #22c55e;
-  --warning: #f59e0b;
-  --warning-strong: #f97316;
-  --danger: #ef4444;
-
-  /* Background Colors - dark palette */
-  --bg-primary: #0f172a;
-  /* Solid surfaces: dialogs / dropdowns / menus (no transparency) */
-  --bg-secondary: #1e293b;
-  --bg-surface: var(--bg-secondary);
-  /* Soft panels: cards / list rows (slight transparency to show gradient) */
-  --bg-tertiary: #334155;
-  --bg-card: rgba(30, 41, 59, 0.85);
-  --bg-hover: rgba(255, 255, 255, 0.08);
-
-  /* Text Colors - inverted */
-  --text-primary: #f1f5f9;
-  --text-secondary: #94a3b8;
-  --text-muted: #64748b;
-
-  /* Border Colors */
-  --border: rgba(255, 255, 255, 0.12);
-  --border-light: rgba(255, 255, 255, 0.06);
-
-  /* Shadows - darker */
-  --shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.25);
-  --shadow-md: 0 12px 24px rgba(0, 0, 0, 0.35);
-  --shadow-lg: 0 20px 40px rgba(0, 0, 0, 0.45);
-
+:root {
+  color-scheme: light;
+}
+/* === Dark mode switch ===
+   Only flips color-scheme; every light-dark() variable above
+   (plus native form controls / scrollbars) follows automatically. */
+:root[data-theme="dark"] {
   color-scheme: dark;
 }
 
-/* Theme color packs (#1399) — layered on light/dark base */
+/* Theme color packs (#1399) — layered on light/dark base.
+   Mode-dependent tokens use light-dark() so each pack needs a single
+   rule now; `color-scheme` (controlled above) picks the dark value. */
 [data-theme-color="nord"] {
   --primary: #5e81ac;
   --primary-hover: #81a1c1;
   --accent: #88c0d0;
-}
-[data-theme-color="nord"][data-theme="dark"] {
-  --bg-primary: #2e3440;
-  --bg-secondary: #3b4252;
-  --bg-tertiary: #434c5e;
-  --text-primary: #eceff4;
-  --text-secondary: #d8dee9;
+  --bg-primary: light-dark(#f6f5f2, #2e3440);
+  --bg-secondary: light-dark(#ffffff, #3b4252);
+  --bg-tertiary: light-dark(#eef2f7, #434c5e);
+  --text-primary: light-dark(#0f172a, #eceff4);
+  --text-secondary: light-dark(#475569, #d8dee9);
 }
 [data-theme-color="tokyo-night"] {
   --primary: #7aa2f7;
   --primary-hover: #89b4fa;
   --accent: #bb9af7;
-}
-[data-theme-color="tokyo-night"][data-theme="dark"] {
-  --bg-primary: #1a1b26;
-  --bg-secondary: #24283b;
-  --bg-tertiary: #414868;
-  --text-primary: #c0caf5;
-  --text-secondary: #a9b1d6;
+  --bg-primary: light-dark(#f6f5f2, #1a1b26);
+  --bg-secondary: light-dark(#ffffff, #24283b);
+  --bg-tertiary: light-dark(#eef2f7, #414868);
+  --text-primary: light-dark(#0f172a, #c0caf5);
+  --text-secondary: light-dark(#475569, #a9b1d6);
 }
 [data-theme-color="catppuccin"] {
   --primary: #89b4fa;
   --accent: #cba6f7;
-}
-[data-theme-color="catppuccin"][data-theme="dark"] {
-  --bg-primary: #1e1e2e;
-  --bg-secondary: #313244;
-  --text-primary: #cdd6f4;
+  --bg-primary: light-dark(#f6f5f2, #1e1e2e);
+  --bg-secondary: light-dark(#ffffff, #313244);
+  --text-primary: light-dark(#0f172a, #cdd6f4);
 }
 [data-theme-color="gruvbox"] {
   --primary: #d79921;
   --accent: #689d6a;
-}
-[data-theme-color="gruvbox"][data-theme="dark"] {
-  --bg-primary: #282828;
-  --bg-secondary: #3c3836;
-  --text-primary: #ebdbb2;
+  --bg-primary: light-dark(#f6f5f2, #282828);
+  --bg-secondary: light-dark(#ffffff, #3c3836);
+  --text-primary: light-dark(#0f172a, #ebdbb2);
 }
 [data-theme-color="everforest"] {
   --primary: #a7c080;
   --accent: #7fbbb3;
-}
-[data-theme-color="everforest"][data-theme="dark"] {
-  --bg-primary: #2d353b;
-  --bg-secondary: #343f44;
-  --text-primary: #d3c6aa;
+  --bg-primary: light-dark(#f6f5f2, #2d353b);
+  --bg-secondary: light-dark(#ffffff, #343f44);
+  --text-primary: light-dark(#0f172a, #d3c6aa);
 }
 
 * {
@@ -162,22 +135,12 @@
 
 body {
   font-family: var(--font-sans);
-  background: radial-gradient(circle at 12% 10%, rgba(29, 78, 216, 0.12), transparent 45%),
-    radial-gradient(circle at 90% 5%, rgba(14, 165, 165, 0.12), transparent 40%),
-    linear-gradient(180deg, #f8f7f4 0%, #eef1f6 100%);
+  background: radial-gradient(circle at 12% 10%, var(--body-glow-1), transparent 45%),
+    radial-gradient(circle at 90% 5%, var(--body-glow-2), transparent 40%),
+    linear-gradient(180deg, var(--body-bg-start) 0%, var(--body-bg-end) 100%);
   color: var(--text-primary);
   line-height: 1.6;
-  color-scheme: light;
   -webkit-font-smoothing: antialiased;
-}
-
-/* Dark mode body background */
-[data-theme="dark"] body,
-html[data-theme="dark"] body {
-  background: radial-gradient(circle at 12% 10%, rgba(59, 130, 246, 0.15), transparent 45%),
-    radial-gradient(circle at 90% 5%, rgba(20, 184, 166, 0.12), transparent 40%),
-    linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
-  color-scheme: dark;
 }
 
 html[data-reduced-motion="true"] {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -225,7 +225,7 @@
 }
 
 .nav-brand {
-  margin-bottom: 0px; 
+  margin-bottom: 0px;
 }
 
 .brand-logo {
@@ -504,8 +504,8 @@
 }
 
 .side-nav.side-nav-classic .nav-item.active {
-  background: rgba(37, 99, 235, 0.12);
-  color: var(--primary);
+  background: var(--primary);
+  color: var(--text-primary);
   box-shadow: none;
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -418,6 +418,9 @@
     10px 0 28px -20px rgba(15, 23, 42, 0.35),
     0 1px 0 rgba(255, 255, 255, 0.55) inset;
 }
+[data-theme="dark"] .side-nav.side-nav-classic {
+  box-shadow: none;
+}
 
 .side-nav.side-nav-classic .side-nav-update-entry {
   position: static;
@@ -504,9 +507,13 @@
 }
 
 .side-nav.side-nav-classic .nav-item.active {
-  background: var(--primary);
+  background: color-mix(in srgb, var(--primary) 25%, transparent);
   color: var(--text-primary);
+  fill: currentColor;
   box-shadow: none;
+}
+[data-theme="dark"] .side-nav.side-nav-classic .nav-item.active {
+  background: color-mix(in srgb, var(--primary) 50%, transparent);
 }
 
 .side-nav.side-nav-classic .nav-item .tooltip {

--- a/src/styles/pages/sidebar.css
+++ b/src/styles/pages/sidebar.css
@@ -1,7 +1,7 @@
 /* ============================================
    New Sidebar Layout
    ============================================ */
-   
+
 .app-container.with-sidebar {
   flex-direction: row; /* 水平布局 */
   padding: 0;
@@ -61,11 +61,14 @@
 }
 
 .nav-item.active {
-  background: rgba(29, 78, 216, 0.08); /* Primary light */
-  color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 25%, transparent);
+  color: var(--text-primary);
+  fill: currentColor;
   font-weight: 600;
 }
-
+[data-theme="dark"] .nav-item.active {
+  background: color-mix(in srgb, var(--primary) 50%, transparent);
+}
 .sidebar-footer {
   margin-top: auto;
   padding-top: 20px;


### PR DESCRIPTION
https://github.com/jlcodes99/cockpit-tools/issues/2388

### 變更

將 base.css 的設計色票全面改為以 light-dark() 加上 html[data-theme] 的 color-scheme 來驅動，把原本分散在 :root 與 [data-theme="dark"] 的兩套重複定義合併為單一規則，並將 Nord、Tokyo Night、Catppuccin、Gruvbox、Everforest 等顏色主題包也收斂為單規則寫法；同時因 light-dark() 無法直接包裹漸層，將 body 背景拆成 glow 與起訖色變數，讓深淺色共用同一套背景語法並刪除深色 body 特例。

其次新增 OLED 純黑純白主題包，在後端 config.rs 的正規化邏輯與測試、前端設定頁的下拉選單、二十份語系檔的 themeColorOled 文案，以及 base.css 的 OLED 變數中完整接入，將背景壓為純黑白、glow 設為透明並重新調校邊框與文字對比，同時附帶將 classic 側欄的 active 樣式改為以 var(--primary) 為基底。

最後再針對深色模式下的 classic 側欄做修正，移除多餘陰影以避免層次過重，並將 active 背景改為以 color-mix 混合 var(--primary)，淺色用 25%、深色加深至 50%，文字改用 var(--text-primary)，使其在深色下清晰可見又不至於過亮。

### 示例

<img width="235" height="242" alt="image" src="https://github.com/user-attachments/assets/1f5cfa6b-1d0d-4e33-af3f-e092da8d3b38" />
<img width="902" height="904" alt="image" src="https://github.com/user-attachments/assets/08fe409f-ee59-4ad6-ac39-4307cdf5b209" />

<img width="902" height="904" alt="image" src="https://github.com/user-attachments/assets/bac7ad26-7d51-4212-b329-f7d987e09603" />
