### PR TITLE
fix: add x-opencode-session for OpenCode Go

### DIFF
--- a/sidecars/cockpit-cliproxy/opencode_session_test.go
+++ b/sidecars/cockpit-cliproxy/opencode_session_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestEnsureOpenCodeSessionHeaderPreservesProvidedValue(t *testing.T) {
+	h := make(http.Header)
+	h.Set("X-OpenCode-Session", "client-session")
+	ensureOpenCodeSessionHeader(h)
+	if got := h.Get("X-OpenCode-Session"); got != "client-session" {
+		t.Fatalf("session = %q, want client-session", got)
+	}
+}
+
+func TestEnsureOpenCodeSessionHeaderDerivesStableIdentity(t *testing.T) {
+	h := make(http.Header)
+	h.Set("X-Session-ID", "conversation-42")
+	ensureOpenCodeSessionHeader(h)
+	want := h.Get("X-OpenCode-Session")
+	if want != "conversation-42" {
+		t.Fatalf("session = %q, want conversation-42", want)
+	}
+	h2 := make(http.Header)
+	h2.Set("X-Session-ID", "conversation-42")
+	ensureOpenCodeSessionHeader(h2)
+	if got := h2.Get("X-OpenCode-Session"); got != want {
+		t.Fatalf("session changed across turns: %q vs %q", got, want)
+	}
+}
+
+func TestEnsureOpenCodeSessionHeaderFallbackIsOpaque(t *testing.T) {
+	h := make(http.Header)
+	ensureOpenCodeSessionHeader(h)
+	got := h.Get("X-OpenCode-Session")
+	if !strings.HasPrefix(got, "cockpit-") || strings.ContainsAny(got, "\r\n") {
+		t.Fatalf("invalid fallback session %q", got)
+	}
+}
+
+func TestEnsureOpenCodeSessionHeaderRejectsControlValue(t *testing.T) {
+	h := make(http.Header)
+	h.Set("X-OpenCode-Session", "bad\r\nvalue")
+	ensureOpenCodeSessionHeader(h)
+	if got := h.Get("X-OpenCode-Session"); !strings.HasPrefix(got, "cockpit-") || strings.ContainsAny(got, "\r\n") {
+		t.Fatalf("session = %q, want safe fallback", got)
+	}
+}
+
+func TestIsOpenCodeGoEndpoint(t *testing.T) {
+	if !isOpenCodeGoEndpoint("https://opencode.ai/zen/go/v1") {
+		t.Fatal("expected OpenCode endpoint")
+	}
+	if isOpenCodeGoEndpoint("https://api.example.com/v1") {
+		t.Fatal("unexpected OpenCode endpoint match")
+	}
+}

--- a/sidecars/cockpit-cliproxy/provider_gateway.go
+++ b/sidecars/cockpit-cliproxy/provider_gateway.go
@@ -238,6 +238,12 @@ func (s *relayServer) handleProviderGatewayRequest(c *gin.Context, gateway *prov
 		req.Header.Set("Accept", "text/event-stream")
 	}
 	copyProviderGatewayDiagnosticHeaders(req.Header, c.Request.Header)
+	if isOpenCodeGoEndpoint(gateway.BaseURL) {
+		if supplied := c.Request.Header.Get("X-OpenCode-Session"); supplied != "" {
+			req.Header.Set("X-OpenCode-Session", supplied)
+		}
+		ensureOpenCodeSessionHeaderForBody(req.Header, body)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -320,6 +326,15 @@ func rewriteProviderGatewayBodyModel(body []byte, model string) []byte {
 		return body
 	}
 	return next
+}
+
+func isOpenCodeGoEndpoint(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return strings.Contains(host, "opencode")
 }
 
 func copyProviderGatewayDiagnosticHeaders(dst http.Header, src http.Header) {

--- a/sidecars/cockpit-cliproxy/stream_protocol.go
+++ b/sidecars/cockpit-cliproxy/stream_protocol.go
@@ -11,6 +11,9 @@ import (
 	"io"
 
 	"net/http"
+
+	"crypto/rand"
+	"encoding/hex"
 	"net/url"
 
 	"strings"
@@ -190,6 +193,64 @@ func buildExecutorRequest(c *gin.Context, body []byte, model string, sourceForma
 		Metadata:        metadata,
 	}
 	return req, opts
+}
+
+// ensureOpenCodeSessionHeader preserves a caller supplied session and otherwise
+// derives one from the stable client session identity, with an opaque fallback.
+func ensureOpenCodeSessionHeader(headers http.Header) {
+	ensureOpenCodeSessionHeaderForBody(headers, nil)
+}
+
+func ensureOpenCodeSessionHeaderForBody(headers http.Header, body []byte) {
+	if headers == nil {
+		return
+	}
+	if supplied := strings.TrimSpace(headers.Get("X-OpenCode-Session")); isSafeOpenCodeSessionValue(supplied) {
+		headers.Set("X-OpenCode-Session", supplied)
+		return
+	}
+	identity := strings.TrimSpace(headers.Get("X-Session-ID"))
+	if identity == "" {
+		identity = strings.TrimSpace(headers.Get("Session-Id"))
+	}
+	if identity == "" {
+		identity = strings.TrimSpace(headers.Get("X-Client-Request-Id"))
+	}
+	if identity == "" && len(body) > 0 {
+		var payload map[string]any
+		if json.Unmarshal(body, &payload) == nil {
+			for _, key := range []string{"conversation_id", "session_id", "previous_response_id"} {
+				if value, ok := payload[key].(string); ok && strings.TrimSpace(value) != "" {
+					identity = strings.TrimSpace(value)
+					break
+				}
+			}
+		}
+	}
+	if identity == "" {
+		b := make([]byte, 16)
+		if _, err := rand.Read(b); err == nil {
+			identity = "cockpit-" + hex.EncodeToString(b)
+		} else {
+			identity = "cockpit-session"
+		}
+	}
+	if !isSafeOpenCodeSessionValue(identity) {
+		identity = "cockpit-session"
+	}
+	headers.Set("X-OpenCode-Session", identity)
+}
+
+func isSafeOpenCodeSessionValue(value string) bool {
+	if value == "" || strings.ContainsAny(value, "\r\n") {
+		return false
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 func writeAPIError(c *gin.Context, status int, message, code string) {


### PR DESCRIPTION
## Summary

Cockpit's provider-gateway forwarding path omitted `x-opencode-session`, causing OpenCode Go to reject requests with `MissingSessionID`. Responses and Chat Completions protocol selection does not replace this required routing header.

This change detects OpenCode endpoints, preserves a valid client supplied value, derives a stable value from the Codex session/conversation identity, and generates an opaque fallback when no identity is available. The shared provider-gateway request path covers Responses, Chat Completions, and streaming requests.

## Validation

- `GOPROXY=https://proxy.golang.org,direct GOMODCACHE=/private/tmp/cockpit-go-cache GOCACHE=/private/tmp/cockpit-go-cache GOPATH=/private/tmp/cockpit-gopath go test ./...` — passed
- `git diff --check` — passed

## Remaining limits

- Full native build/type checks were not run; this fix is isolated to the Go sidecar.
